### PR TITLE
ci: ThreadSanitizer + miri + concurrent stress harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,35 @@ jobs:
       # unmaintained/unsound deps surface as warnings without failing the build.
       - name: Audit dependencies
         run: cargo audit
+
+  tsan:
+    name: tsan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rust-src
+      - uses: Swatinem/rust-cache@v2
+      - name: ThreadSanitizer (stress harness)
+        env:
+          RUSTFLAGS: "-Zsanitizer=thread"
+          RUSTDOCFLAGS: "-Zsanitizer=thread"
+        run: |
+          cargo +nightly test -Z build-std --target x86_64-unknown-linux-gnu \
+            concurrent_pacing_stress -- --test-threads=1 --nocapture
+
+  # miri (UB detection), best-effort/informational. Scoped to pure leaf modules
+  # (no network/fs) since miri can't execute real I/O. continue-on-error keeps a
+  # miri gap from blocking merges — a signal, not a required gate.
+  miri:
+    name: miri
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+      - name: miri (pure tests)
+        run: "cargo +nightly miri test model:: account_uuid:: quota::"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,5 +79,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: miri
+      # cargo test takes ONE filter positional; run each pure module separately.
+      # disable-isolation lets miri tolerate time/env access in the pure tests.
       - name: miri (pure tests)
-        run: "cargo +nightly miri test model:: account_uuid:: quota::"
+        env:
+          MIRIFLAGS: -Zmiri-disable-isolation
+        run: |
+          cargo +nightly miri test model::
+          cargo +nightly miri test account_uuid::
+          cargo +nightly miri test quota::

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -3563,4 +3563,94 @@ mod tests {
             "a freshly-warmed account is no longer a target"
         );
     }
+
+    /// Multi-thread stress: RACE `select()` / `enter_in_flight()` / guard-drop
+    /// against the other account-lock writers (`mark_rate_limited` /
+    /// `record_served`) across 8 threads on one shared `Arc<Manager>` with pacing
+    /// ON. This is the race surface ThreadSanitizer watches in CI (the `tsan` job
+    /// filters on this test name); TSan is unrunnable on arm64-macOS, so under
+    /// normal `cargo test` this proves two things TSan does not: the harness runs
+    /// without panicking, and the shared `in_flight` counter is *balanced* — every
+    /// account returns to `in_flight == 0` once all guards drop. A leak, a
+    /// double-decrement, or a lost increment across the check-then-act-across-locks
+    /// path shows up here as a nonzero residual even without instrumentation.
+    #[test]
+    fn concurrent_pacing_stress() {
+        const THREADS: usize = 8;
+        const ITERS: usize = 2000;
+
+        let pacing = PacingConfig {
+            max_in_flight_per_account: Some(2),
+            min_spacing_ms: None,
+        };
+        let manager = build_manager(
+            config_with_pacing(
+                vec![
+                    account("a0", 0),
+                    account("a1", 0),
+                    account("a2", 0),
+                    account("a3", 0),
+                ],
+                pacing,
+            ),
+            Arc::new(CountingRefresher {
+                calls: Arc::new(AtomicUsize::new(0)),
+            }),
+        );
+
+        let handles: Vec<_> = (0..THREADS)
+            .map(|t| {
+                let manager = Arc::clone(&manager);
+                std::thread::spawn(move || {
+                    let empty: HashSet<usize> = HashSet::new();
+                    for i in 0..ITERS {
+                        let now = OffsetDateTime::now_utc();
+                        // Vary the session key per thread AND per iteration so
+                        // affinity pins spread across accounts and the pin map
+                        // churns — maximising concurrent affinity-lock traffic.
+                        let session_key = Some((t as u64) << 32 | (i as u64 % 16));
+                        if let Some(idx) = manager.select(&empty, now, None, session_key) {
+                            // Take the in-flight slot, hold it briefly to widen the
+                            // window where a concurrent select/writer observes a
+                            // nonzero count, then drop the guard (decrement).
+                            let guard = manager.enter_in_flight(idx);
+                            for _ in 0..8 {
+                                std::hint::spin_loop();
+                            }
+                            // Occasionally fire the other account-lock writers so
+                            // TSan sees select/enter racing real mutation, not just
+                            // the in_flight path.
+                            if i % 17 == 0 {
+                                manager.record_served(idx, now, session_key, SessionKind::Fallback);
+                            }
+                            if i % 53 == 0 {
+                                // Short hold so accounts recover and stay selectable
+                                // for the rest of the run.
+                                manager.mark_rate_limited(idx, 1);
+                            }
+                            drop(guard);
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            // A panic in any thread (e.g. a poisoned lock from an unwind under the
+            // write-lock) propagates here and fails the test.
+            h.join().expect("stress thread panicked");
+        }
+
+        // Every guard has dropped, so the counter MUST be balanced back to zero on
+        // every account. A nonzero residual is a real concurrency bug (leaked or
+        // double-counted in_flight) — surface it, never silence it.
+        let accounts = manager.accounts.read().expect("accounts lock poisoned");
+        for (idx, account) in accounts.iter().enumerate() {
+            assert_eq!(
+                account.in_flight, 0,
+                "account {idx} ({}) leaked in_flight={} after all guards dropped",
+                account.name, account.in_flight
+            );
+        }
+    }
 }


### PR DESCRIPTION
Adds the two deeper checks:
- **tsan** — Linux-only ThreadSanitizer over a new multi-thread `concurrent_pacing_stress` harness that races `select()`/`enter_in_flight()`/guard-drop + account-lock writers on a shared Manager (the pacing in_flight counter + lock surface). Can't run on arm64-macOS, so CI is its first verification.
- **miri** — best-effort UB scan over the pure leaf modules (continue-on-error; can't run I/O tests).

Both are separate, non-required jobs (branch protection still gates only `ci`+`audit`). The harness itself is verified green under normal cargo test.