### PR TITLE
feat: load-balancing pin migration (spread stacked sessions, keep lone ones warm)

### DIFF
--- a/src/manager.rs
+++ b/src/manager.rs
@@ -669,22 +669,56 @@ impl Manager {
                         }
                     };
                     if let Some((target, migrate_names)) = decision {
-                        if let Some((x_name, y_name)) = migrate_names {
-                            tracing::info!(
-                                "affinity: migrate session off {} (n={}) -> {}",
-                                x_name,
-                                count_x,
-                                y_name
-                            );
+                        // (3) UNDER THE AFFINITY LOCK ONLY: commit the pin. Accounts
+                        // lock already dropped — never nest.
+                        //
+                        // TOCTOU close: the `counts` driving the migration decision
+                        // were read in section (1) and the lock was then dropped, so a
+                        // concurrent select on another session stacked on the same X
+                        // could have decided the SAME idle Y in parallel. Committing
+                        // both blindly would OVER-migrate (Y over-stacks, X empties —
+                        // the inverse of the goal, and it can oscillate). So for a
+                        // MIGRATION we RE-VALIDATE against FRESH counts re-tallied from
+                        // the live map under this same lock that mutates it: the pin
+                        // must still be X AND `count(target)+1 < count(X)` must still
+                        // hold. If not, ABORT the move and keep the existing pin. No
+                        // accounts lock is taken here (the re-check needs only the
+                        // affinity-map counts + the already-chosen target; the next
+                        // select re-checks eligibility anyway).
+                        let mut pins = self.affinity.lock().expect("affinity lock poisoned");
+                        let mut committed = target;
+                        if target != idx {
+                            let still_pinned_x = pins.get(&key).map(|&(i, _)| i) == Some(idx);
+                            let mut count_x_now = 0usize;
+                            let mut count_t_now = 0usize;
+                            for &(i, _) in pins.values() {
+                                if i == idx {
+                                    count_x_now += 1;
+                                }
+                                if i == target {
+                                    count_t_now += 1;
+                                }
+                            }
+                            // Strictly-improves-balance guard, re-checked on fresh state.
+                            if still_pinned_x && count_t_now + 1 < count_x_now {
+                                if let Some((x_name, y_name)) = migrate_names {
+                                    tracing::info!(
+                                        "affinity: migrate session off {} (n={}) -> {}",
+                                        x_name,
+                                        count_x_now,
+                                        y_name
+                                    );
+                                }
+                            } else {
+                                // The decision went stale between sections (a sibling
+                                // select already rebalanced): keep the current pin.
+                                committed = idx;
+                            }
                         }
-                        // (3) UNDER THE AFFINITY LOCK ONLY: re-pin the session to the
-                        // target (initial-honour or migration) and refresh its
-                        // last-touch. Accounts lock already dropped — never nest.
-                        self.affinity
-                            .lock()
-                            .expect("affinity lock poisoned")
-                            .insert(key, (target, now_ms));
-                        return Some(target);
+                        // Re-pin the session (migration target, or the honoured/kept X)
+                        // and refresh its last-touch for LRU eviction.
+                        pins.insert(key, (committed, now_ms));
+                        return Some(committed);
                     }
                 }
             }
@@ -3902,5 +3936,79 @@ mod tests {
                 account.name, account.in_flight
             );
         }
+    }
+
+    /// TOCTOU regression (concurrency) — the migration feature's OWN target workload.
+    /// Several sessions start STACKED on one account with idle, eligible accounts
+    /// alongside. `N` threads select for those sessions in lockstep: a `Barrier`
+    /// forces every round to fire simultaneously, which is the exact interleaving the
+    /// adversarial review flagged — two concurrent selects both reading `count(Y)=0`
+    /// for the same idle `Y` and BOTH migrating onto it, over-stacking `Y` to 2 while
+    /// `X` empties to 0 (the inverse of the goal) and oscillating 0→1→0.
+    ///
+    /// The fix — re-validating `count(target)+1 < count(X)` against FRESH counts under
+    /// the affinity lock in section 3, aborting the move if it no longer holds — makes
+    /// each committed migration strictly reduce the load's sum-of-squares, so the
+    /// system converges to exactly one session per account and STAYS there. Under the
+    /// pre-fix code the stale-count commit over-migrates and the final distribution is
+    /// NOT balanced. (Asserted on a balanced fleet — no pacing / rate-limit churn — so
+    /// the only force acting on the distribution is the migration logic under test.)
+    #[test]
+    fn concurrent_stacked_sessions_do_not_over_migrate() {
+        const N: usize = 4; // sessions == accounts → balanced fixed point is one-each
+        const ROUNDS: usize = 100;
+
+        let manager = build_manager(
+            config_with(vec![
+                account("a0", 0),
+                account("a1", 0),
+                account("a2", 0),
+                account("a3", 0),
+            ]),
+            Arc::new(CountingRefresher {
+                calls: Arc::new(AtomicUsize::new(0)),
+            }),
+        );
+        // Pathological start: ALL N sessions pinned to account 0.
+        for key in 0..N as u64 {
+            pin_session(&manager, key, 0);
+        }
+
+        let barrier = Arc::new(std::sync::Barrier::new(N));
+        let handles: Vec<_> = (0..N as u64)
+            .map(|key| {
+                let manager = Arc::clone(&manager);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    let empty: HashSet<usize> = HashSet::new();
+                    for _ in 0..ROUNDS {
+                        // Synchronise so all N selects contend on the same stacked
+                        // account in the same instant — maximising the TOCTOU window.
+                        barrier.wait();
+                        let now = OffsetDateTime::now_utc();
+                        manager.select(&empty, now, None, Some(key));
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().expect("migration stress thread panicked");
+        }
+
+        // Every session is still pinned (none lost), and the distribution converged
+        // to exactly one-per-account. An account holding >=2 while another sits at 0
+        // is the over-migration / oscillation the re-validation exists to prevent.
+        let pins = manager.affinity.lock().expect("affinity lock poisoned");
+        assert_eq!(pins.len(), N, "every session must remain pinned");
+        let mut per_account = [0usize; N];
+        for &(idx, _) in pins.values() {
+            per_account[idx] += 1;
+        }
+        assert_eq!(
+            per_account,
+            [1, 1, 1, 1],
+            "stacked sessions must converge to one-per-account without over-migrating \
+             (got {per_account:?}) — a stale-count commit would over-stack one account"
+        );
     }
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -562,19 +562,36 @@ impl Manager {
         // the pin under the affinity lock, then DROP that lock before taking the
         // accounts lock (never nest the two — that is the documented deadlock).
         if let Some(key) = affinity {
-            let pinned = {
+            // (1) UNDER THE AFFINITY LOCK ONLY: read this session's pin `X` and, in
+            // the same critical section, tally the per-account pinned-session counts
+            // that the load-balancing decision needs. Drop this lock before taking
+            // the accounts lock — the two are NEVER held simultaneously (the
+            // documented deadlock).
+            let (pinned, counts) = {
                 let pins = self.affinity.lock().expect("affinity lock poisoned");
-                pins.get(&key).map(|&(idx, _)| idx)
+                let pinned = pins.get(&key).map(|&(idx, _)| idx);
+                let mut counts: HashMap<usize, usize> = HashMap::new();
+                for &(idx, _) in pins.values() {
+                    *counts.entry(idx).or_insert(0) += 1;
+                }
+                (pinned, counts)
             };
             if let Some(idx) = pinned {
                 if !tried.contains(&idx) {
-                    let usable = {
+                    let count_x = counts.get(&idx).copied().unwrap_or(0);
+                    // (2) UNDER THE ACCOUNTS LOCK ONLY: confirm the pin `X` is still
+                    // usable, then — and only when >=2 sessions stack on `X` — look
+                    // for the least-loaded ELIGIBLE account `Y` that strictly improves
+                    // balance (`count(Y)+1 < count(X)`). Stamp whichever we settle on.
+                    // `None` means `X` is ineligible → fall through to the normal
+                    // pick/re-pin path (which already handles a dead pin).
+                    let decision: Option<(usize, Option<(String, String)>)> = {
                         let mut accounts = self.accounts.write().expect("accounts lock poisoned");
                         // Respect pacing on the pin: a saturated pinned account
                         // temporarily YIELDS here and the LRU pick below (with its
                         // soft fallback) steers to a cooler account, so a session's
                         // concurrent burst spreads instead of all slamming one pin.
-                        let usable = accounts.get(idx).is_some_and(|a| {
+                        let x_usable = accounts.get(idx).is_some_and(|a| {
                             Self::eligible(
                                 a,
                                 self.global_threshold,
@@ -585,24 +602,89 @@ impl Manager {
                                 is_fable,
                             )
                         });
-                        if usable {
-                            // Stamp the pinned account too, so a second session's LRU
-                            // steers away from an account already busy under a pin.
+                        if !x_usable {
+                            None
+                        } else {
+                            // Default: honour the pin. When `count_x < 2` (a LONE
+                            // session) `target` stays `idx` and nothing below runs, so
+                            // this path is byte-identical to the pre-migration
+                            // behaviour — a lone session's warm cache is never moved.
+                            let mut target = idx;
+                            let mut migrate_names: Option<(String, String)> = None;
+                            if count_x >= 2 {
+                                // Least-loaded eligible target, ordered by
+                                // (pinned-session-count asc, in_flight asc,
+                                // last_selected_seq asc / LRU). A candidate qualifies
+                                // ONLY if it strictly improves balance — this guard
+                                // prevents thrash and equal-swaps.
+                                let mut best: Option<usize> = None;
+                                let mut best_key: Option<(usize, u32, u64)> = None;
+                                for (cand, account) in accounts.iter().enumerate() {
+                                    if cand == idx {
+                                        continue;
+                                    }
+                                    let count_y = counts.get(&cand).copied().unwrap_or(0);
+                                    if count_y + 1 >= count_x {
+                                        continue;
+                                    }
+                                    // Only migrate onto an ELIGIBLE account — the same
+                                    // gate the pin honours (disabled/error/rate-limit/
+                                    // quota/pacing), so a throttled `Y` is never chosen.
+                                    if !Self::eligible(
+                                        account,
+                                        self.global_threshold,
+                                        &self.pacing,
+                                        true,
+                                        now,
+                                        now_ms,
+                                        is_fable,
+                                    ) {
+                                        continue;
+                                    }
+                                    let cand_key =
+                                        (count_y, account.in_flight, account.last_selected_seq);
+                                    if best_key.is_none_or(|b| cand_key < b) {
+                                        best = Some(cand);
+                                        best_key = Some(cand_key);
+                                    }
+                                }
+                                if let Some(y) = best {
+                                    let x_name = accounts
+                                        .get(idx)
+                                        .map(|a| a.name.clone())
+                                        .unwrap_or_default();
+                                    let y_name =
+                                        accounts.get(y).map(|a| a.name.clone()).unwrap_or_default();
+                                    migrate_names = Some((x_name, y_name));
+                                    target = y;
+                                }
+                            }
+                            // Stamp the chosen account so a second session's LRU steers
+                            // away from an account already busy under a pin.
                             let tick = self.select_seq.fetch_add(1, Ordering::Relaxed);
-                            if let Some(account) = accounts.get_mut(idx) {
+                            if let Some(account) = accounts.get_mut(target) {
                                 account.last_selected_seq = tick;
                             }
+                            Some((target, migrate_names))
                         }
-                        usable
                     };
-                    if usable {
-                        // Refresh the pin's last-touch so LRU eviction keeps live
-                        // sessions. Accounts lock already dropped — never nest the two.
+                    if let Some((target, migrate_names)) = decision {
+                        if let Some((x_name, y_name)) = migrate_names {
+                            tracing::info!(
+                                "affinity: migrate session off {} (n={}) -> {}",
+                                x_name,
+                                count_x,
+                                y_name
+                            );
+                        }
+                        // (3) UNDER THE AFFINITY LOCK ONLY: re-pin the session to the
+                        // target (initial-honour or migration) and refresh its
+                        // last-touch. Accounts lock already dropped — never nest.
                         self.affinity
                             .lock()
                             .expect("affinity lock poisoned")
-                            .insert(key, (idx, now_ms));
-                        return Some(idx);
+                            .insert(key, (target, now_ms));
+                        return Some(target);
                     }
                 }
             }
@@ -3312,6 +3394,174 @@ mod tests {
         assert!(
             pins.contains_key(&((AFFINITY_CAP + 1) as u64)),
             "the just-inserted pin is present"
+        );
+    }
+
+    /// Directly pin `key` to account `idx` in the affinity map (last-touch = now),
+    /// bypassing a select() call — lets a migration test set up an arbitrary stacked
+    /// starting layout without depending on how the initial pins were formed.
+    fn pin_session(manager: &Manager, key: u64, idx: usize) {
+        manager
+            .affinity
+            .lock()
+            .expect("affinity lock poisoned")
+            .insert(key, (idx, crate::now_ms()));
+    }
+
+    /// Read the account a session key is currently pinned to (None if unpinned).
+    fn pin_of(manager: &Manager, key: u64) -> Option<usize> {
+        manager
+            .affinity
+            .lock()
+            .expect("affinity lock poisoned")
+            .get(&key)
+            .map(|&(idx, _)| idx)
+    }
+
+    /// Migration #1 — a LONE session is NEVER migrated: its warm cache is preserved
+    /// even when an idle, eligible account sits right next to it. `count(X) < 2` must
+    /// be byte-identical to honouring the pin.
+    #[test]
+    fn lone_session_never_migrates() {
+        let refresher = Arc::new(CountingRefresher {
+            calls: Arc::new(AtomicUsize::new(0)),
+        });
+        let manager = build_manager(
+            config_with(vec![account("a", 0), account("b", 0)]),
+            refresher,
+        );
+        let now = OffsetDateTime::now_utc();
+        // One session pinned to acct 0; acct 1 is idle and eligible.
+        pin_session(&manager, 100, 0);
+        for _ in 0..6 {
+            assert_eq!(
+                manager.select(&HashSet::new(), now, None, Some(100)),
+                Some(0),
+                "a lone session must stay on its warm account (no migration)"
+            );
+        }
+        assert_eq!(pin_of(&manager, 100), Some(0), "the pin never moved");
+    }
+
+    /// Migration #2 — two sessions stacked on acct 0 with acct 1 idle+eligible:
+    /// selecting for one of them migrates it to acct 1, and the affinity map records
+    /// the new pin.
+    #[test]
+    fn stacked_session_migrates_to_idle() {
+        let refresher = Arc::new(CountingRefresher {
+            calls: Arc::new(AtomicUsize::new(0)),
+        });
+        let manager = build_manager(
+            config_with(vec![account("a", 0), account("b", 0)]),
+            refresher,
+        );
+        let now = OffsetDateTime::now_utc();
+        pin_session(&manager, 10, 0);
+        pin_session(&manager, 11, 0);
+        // count(0)=2, count(1)=0 → 0+1 < 2, so migrate this session onto acct 1.
+        assert_eq!(
+            manager.select(&HashSet::new(), now, None, Some(10)),
+            Some(1),
+            "a stacked session migrates to the idle eligible account"
+        );
+        assert_eq!(
+            pin_of(&manager, 10),
+            Some(1),
+            "the affinity map now pins the migrated session to acct 1"
+        );
+    }
+
+    /// Migration #3 — convergence, no thrash: after #2's migration the layout is
+    /// balanced (one session each), so further selects for BOTH sessions are stable —
+    /// neither bounces back.
+    #[test]
+    fn migration_converges_no_thrash() {
+        let refresher = Arc::new(CountingRefresher {
+            calls: Arc::new(AtomicUsize::new(0)),
+        });
+        let manager = build_manager(
+            config_with(vec![account("a", 0), account("b", 0)]),
+            refresher,
+        );
+        let now = OffsetDateTime::now_utc();
+        pin_session(&manager, 10, 0);
+        pin_session(&manager, 11, 0);
+        // The one migration from #2.
+        assert_eq!(
+            manager.select(&HashSet::new(), now, None, Some(10)),
+            Some(1)
+        );
+        // Now 1-and-1: every further select is a lone session on its account.
+        for _ in 0..5 {
+            assert_eq!(
+                manager.select(&HashSet::new(), now, None, Some(10)),
+                Some(1),
+                "the migrated session stays put (no bounce back)"
+            );
+            assert_eq!(
+                manager.select(&HashSet::new(), now, None, Some(11)),
+                Some(0),
+                "the remaining session stays put"
+            );
+        }
+    }
+
+    /// Migration #4 — no eligible emptier account, no migration: two sessions stack on
+    /// acct 0 and the only other account is errored, so the stacked session honours
+    /// its pin rather than migrating onto a throttled/dead account.
+    #[test]
+    fn no_migration_when_no_emptier_eligible() {
+        let refresher = Arc::new(CountingRefresher {
+            calls: Arc::new(AtomicUsize::new(0)),
+        });
+        let manager = build_manager(
+            config_with(vec![account("a", 0), account("b", 0)]),
+            refresher,
+        );
+        let now = OffsetDateTime::now_utc();
+        pin_session(&manager, 20, 0);
+        pin_session(&manager, 21, 0);
+        manager.mark_error(1); // the only alternative is ineligible
+        for _ in 0..5 {
+            assert_eq!(
+                manager.select(&HashSet::new(), now, None, Some(20)),
+                Some(0),
+                "no eligible emptier account → honour the pin, never migrate onto a dead one"
+            );
+        }
+        assert_eq!(pin_of(&manager, 20), Some(0), "the pin never moved");
+    }
+
+    /// Migration #5 — three sessions stacked on acct 0 with accts 1,2 idle spread to
+    /// one-each after a round of selects (convergence across three accounts).
+    #[test]
+    fn three_sessions_spread_across_three_idle() {
+        let refresher = Arc::new(CountingRefresher {
+            calls: Arc::new(AtomicUsize::new(0)),
+        });
+        let manager = build_manager(
+            config_with(vec![account("a", 0), account("b", 0), account("c", 0)]),
+            refresher,
+        );
+        let now = OffsetDateTime::now_utc();
+        pin_session(&manager, 1, 0);
+        pin_session(&manager, 2, 0);
+        pin_session(&manager, 3, 0);
+        // A round of selects, one per session.
+        for key in [1u64, 2, 3] {
+            manager.select(&HashSet::new(), now, None, Some(key));
+        }
+        let mut homes = [
+            pin_of(&manager, 1),
+            pin_of(&manager, 2),
+            pin_of(&manager, 3),
+        ]
+        .map(|p| p.expect("each session stays pinned"));
+        homes.sort_unstable();
+        assert_eq!(
+            homes,
+            [0, 1, 2],
+            "three stacked sessions spread to one-per-account after a round of selects"
         );
     }
 


### PR DESCRIPTION
sessionAffinity pinned multiple heavy sessions onto one account (formed during uneven-pool windows like throttle storms) and never rebalanced — so one account ground while others idled. This adds load-balancing pin migration to `select()`.

**Policy:** a lone session is never migrated (warm cache preserved); only when ≥2 sessions stack on one account **and** an eligible account hosts strictly fewer do we migrate *one* — converging toward balance without thrash.

**Concurrency:** an adversarial review caught a TOCTOU (counts frozen under the affinity lock in section 1, re-pin committed on stale counts in section 3 → two concurrent migrations could both target the same idle account, inverting the goal). Fixed by re-validating against **fresh counts re-tallied under the affinity lock** at commit — only migrate if the move still strictly improves balance and the pin is unchanged. Every committed move strictly decreases load variance ⇒ monotonic convergence, no oscillation. Verified with a barrier-synchronized `concurrent_stacked_sessions_do_not_over_migrate` test (the exact flagged interleaving), 40× no flakes + a local 20× release flake-loop.

Three non-overlapping critical sections; affinity and accounts locks never co-held. 6 new tests (5 policy + 1 concurrency).