### PR TITLE
fix: make the TUI's disable durable and stop keep-warm bursting at boot

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -656,6 +656,122 @@ fn merge_tokens(doc: &mut Map<String, Value>, memory: &Config) -> Result<MergeRe
     Ok(report)
 }
 
+/// What a targeted [`save_disabled`] did to the on-disk document. Reported
+/// rather than swallowed so the caller can say, in one line, whether a benched
+/// account will actually still be benched after a restart.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DisabledWrite {
+    /// The flag was set (or dropped) on the matching entry and the file rewritten.
+    Updated,
+    /// The document already said exactly this, so nothing was written and the
+    /// file is byte-identical. A file holding single-use refresh tokens is
+    /// rewritten only when it must be.
+    Unchanged,
+    /// Nothing on disk carries that identity — the entry was deleted or renamed
+    /// while the proxy ran — or the document has no usable `accounts` array.
+    /// Nothing was written, so the flag will NOT survive a restart.
+    NoEntry,
+}
+
+impl std::fmt::Display for DisabledWrite {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Updated => "updated",
+            Self::Unchanged => "unchanged",
+            Self::NoEntry => "no matching entry on disk",
+        })
+    }
+}
+
+/// Persist ONLY the `disabled` flag of the one account matching `target`'s
+/// identity into the file at `path`, leaving every other key — and every other
+/// account — exactly as the user left it.
+///
+/// Same read-modify-write shape as [`save_tokens`], and for the same reason: the
+/// running server's `Config` is a boot-time snapshot, so writing it whole (what
+/// [`save`] does) reverts every setting the user edited while the proxy ran. The
+/// edit therefore runs on the file's RAW JSON document and never on a `Config`
+/// round-trip, so a key the user just deleted cannot reappear as its serde
+/// default.
+///
+/// `disabled == false` REMOVES the key rather than writing `false` — matching
+/// the CLI contract pinned by `cli::tests::set_enabled_false_drops_the_disabled_key`
+/// and the JS `delete account.disabled` it was ported from. A stale `false`
+/// already on disk is dropped for the same reason.
+///
+/// Unlike [`save_tokens`] there is deliberately NO whole-config fallback when the
+/// file is unreadable or malformed. A rotated refresh token is single-use, so
+/// losing one is unrecoverable and worth the clobber risk; a lost `disabled` flag
+/// costs one un-benched account and is fixed by pressing `d` again. Writing a
+/// whole boot-time snapshot over a file we could not even parse is the exact
+/// clobber this module exists to prevent, so the error comes back instead.
+pub fn save_disabled(
+    path: &Path,
+    target: &Account,
+    disabled: bool,
+) -> Result<DisabledWrite, ConfigError> {
+    let mut doc = read_document(path)?;
+    let outcome = merge_disabled(&mut doc, target, disabled);
+    if outcome == DisabledWrite::Updated {
+        write_atomic(path, &serde_json::to_string_pretty(&doc)?)?;
+    }
+    Ok(outcome)
+}
+
+/// Set or remove `disabled` on the one entry in `doc` matching `target`. Reports
+/// whether the document actually changed, so the caller can skip a pointless
+/// rewrite of a credential file.
+fn merge_disabled(doc: &mut Map<String, Value>, target: &Account, disabled: bool) -> DisabledWrite {
+    let Some(entry) = find_account_entry(doc, target) else {
+        return DisabledWrite::NoEntry;
+    };
+    // `true` writes the key; `false` DROPS it (never a `false` literal).
+    let desired = disabled.then_some(Value::Bool(true));
+    if entry.get("disabled").cloned() == desired {
+        return DisabledWrite::Unchanged;
+    }
+    match desired {
+        Some(value) => entry.insert("disabled".to_string(), value),
+        None => entry.remove("disabled"),
+    };
+    DisabledWrite::Updated
+}
+
+/// The on-disk `accounts` entry whose identity matches `target`.
+///
+/// Matching reuses the [`DiskIdentity`] probe + [`crate::identity::same_identity`]
+/// pairing that [`merge_tokens`] uses, so a rotated credential and a disabled
+/// flag can never land on two different entries. The first match wins:
+/// `same_identity` is unique per identity in a well-formed config, and the CLI
+/// already refuses an ambiguous query outright rather than guessing.
+///
+/// `None` covers every "nothing to write into" shape — no `accounts` key, an
+/// `accounts` that is not an array, or no entry carrying that identity.
+fn find_account_entry<'a>(
+    doc: &'a mut Map<String, Value>,
+    target: &Account,
+) -> Option<&'a mut Map<String, Value>> {
+    for entry in doc.get_mut("accounts")?.as_array_mut()? {
+        let Some(object) = entry.as_object_mut() else {
+            continue;
+        };
+        let Ok(stored) = serde_json::from_value::<DiskIdentity>(Value::Object(object.clone()))
+        else {
+            continue;
+        };
+        let probe = crate::identity::probe(
+            &stored.name,
+            stored.account_uuid,
+            stored.org_uuid,
+            stored.org_name,
+        );
+        if crate::identity::same_identity(target, &probe) {
+            return Some(object);
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1237,6 +1353,284 @@ mod tests {
         // …and the fallback.
         fs::remove_file(&path).unwrap();
         save_tokens(&path, &memory).unwrap();
+        assert_eq!(
+            fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    // --- save_disabled (the TUI's `d`/`e`, made durable) -------------------
+
+    /// A file carrying keys the server does not model, plus a second account, so
+    /// a targeted flag write can be checked for collateral damage.
+    const DISABLE_SAMPLE: &str = r#"{
+      "warmupSeconds": 900,
+      "pacing": { "maxInFlightPerAccount": 3 },
+      "routes": [{ "name": "r1", "match": "*fable*" }],
+      "accounts": [
+        { "name": "acct-a", "type": "oauth", "accessToken": "at-a",
+          "refreshToken": "rt-a", "expiresAt": 1, "models": ["claude-fable-5"] },
+        { "name": "acct-b", "type": "oauth", "accessToken": "at-b",
+          "refreshToken": "rt-b", "expiresAt": 2 }
+      ]
+    }"#;
+
+    /// An identity probe in the legacy (no-uuid) shape every real config uses,
+    /// where `same_identity` reduces to name equality.
+    fn by_name(name: &str) -> Account {
+        crate::identity::probe(name, None, None, None)
+    }
+
+    /// Disabling writes `"disabled": true` onto the right entry and changes
+    /// NOTHING else — the whole point of editing the raw document instead of
+    /// round-tripping a boot-time `Config`. Strip the one key we asked for and
+    /// the document must be identical to what the user had.
+    #[test]
+    fn disable_writes_the_flag_and_changes_nothing_else() {
+        let path = tmp_path("disable-write");
+        fs::write(&path, DISABLE_SAMPLE).unwrap();
+
+        assert_eq!(
+            save_disabled(&path, &by_name("acct-a"), true).unwrap(),
+            DisabledWrite::Updated
+        );
+
+        let mut after = read_json(&path);
+        assert_eq!(after["accounts"][0]["disabled"], json!(true));
+        after["accounts"][0]
+            .as_object_mut()
+            .expect("the entry is an object")
+            .remove("disabled");
+        let before: Value = serde_json::from_str(DISABLE_SAMPLE).unwrap();
+        assert_eq!(
+            after, before,
+            "the write touched something other than the disabled flag"
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    /// Re-enabling DROPS the key rather than writing `false`, matching the CLI
+    /// contract pinned by `cli::tests::set_enabled_false_drops_the_disabled_key`.
+    /// A full disable→enable round trip must leave the file as it started.
+    #[test]
+    fn re_enable_drops_the_key_and_round_trips_the_document() {
+        let path = tmp_path("disable-roundtrip");
+        fs::write(&path, DISABLE_SAMPLE).unwrap();
+
+        save_disabled(&path, &by_name("acct-a"), true).unwrap();
+        assert_eq!(
+            save_disabled(&path, &by_name("acct-a"), false).unwrap(),
+            DisabledWrite::Updated
+        );
+
+        let after = read_json(&path);
+        assert!(
+            after["accounts"][0].get("disabled").is_none(),
+            "re-enable must DROP the disabled key, not write false: {after}"
+        );
+        let before: Value = serde_json::from_str(DISABLE_SAMPLE).unwrap();
+        assert_eq!(
+            after, before,
+            "a disable→enable round trip must leave the document as it started"
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    /// The unrelated account and the unmodelled keys (`warmupSeconds`, `pacing`,
+    /// `routes`, per-account `models`) survive the write untouched. Named
+    /// separately from the equality check above so weakening that one still trips
+    /// a gate on the preserve-unknown-keys guarantee.
+    #[test]
+    fn disable_leaves_other_accounts_and_unmodelled_keys_untouched() {
+        let path = tmp_path("disable-collateral");
+        fs::write(&path, DISABLE_SAMPLE).unwrap();
+
+        save_disabled(&path, &by_name("acct-a"), true).unwrap();
+
+        let after = read_json(&path);
+        assert_eq!(after["warmupSeconds"], json!(900));
+        assert_eq!(after["pacing"]["maxInFlightPerAccount"], json!(3));
+        assert!(after["routes"].is_array());
+        assert_eq!(after["accounts"][0]["models"], json!(["claude-fable-5"]));
+        // The account we did NOT name keeps its credentials and gains no flag.
+        assert_eq!(after["accounts"][1]["name"], json!("acct-b"));
+        assert_eq!(after["accounts"][1]["accessToken"], json!("at-b"));
+        assert_eq!(after["accounts"][1]["refreshToken"], json!("rt-b"));
+        assert!(
+            after["accounts"][1].get("disabled").is_none(),
+            "the unrelated account was flagged too: {after}"
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    /// A redundant write — the document already says exactly this — reports
+    /// `Unchanged` and does not rewrite the file. A file holding single-use
+    /// refresh tokens is not rewritten to say what it already said.
+    #[test]
+    fn redundant_write_reports_unchanged_and_leaves_the_file_alone() {
+        let path = tmp_path("disable-noop");
+        fs::write(&path, DISABLE_SAMPLE).unwrap();
+
+        // Already enabled (no key at all) → re-enabling is a no-op.
+        assert_eq!(
+            save_disabled(&path, &by_name("acct-a"), false).unwrap(),
+            DisabledWrite::Unchanged
+        );
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            DISABLE_SAMPLE,
+            "an Unchanged write must leave the file byte-identical, not reformat it"
+        );
+
+        // And once disabled, disabling again is a no-op too.
+        save_disabled(&path, &by_name("acct-a"), true).unwrap();
+        let disabled_text = fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            save_disabled(&path, &by_name("acct-a"), true).unwrap(),
+            DisabledWrite::Unchanged
+        );
+        assert_eq!(fs::read_to_string(&path).unwrap(), disabled_text);
+        fs::remove_file(&path).ok();
+    }
+
+    /// A `"disabled": false` already on disk is normalized away on re-enable
+    /// rather than left sitting there — same end state the CLI produces.
+    #[test]
+    fn stale_disabled_false_on_disk_is_dropped() {
+        let path = tmp_path("disable-stale-false");
+        fs::write(
+            &path,
+            r#"{ "accounts": [ { "name": "acct-a", "accessToken": "at-a", "disabled": false } ] }"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            save_disabled(&path, &by_name("acct-a"), false).unwrap(),
+            DisabledWrite::Updated
+        );
+        let after = read_json(&path);
+        assert!(
+            after["accounts"][0].get("disabled").is_none(),
+            "a stale false must be dropped, not kept: {after}"
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    /// No on-disk entry carries that identity (deleted or renamed while the proxy
+    /// ran): report `NoEntry` and write NOTHING, so the caller can warn that the
+    /// flag will not survive a restart instead of silently believing it landed.
+    #[test]
+    fn disable_with_no_matching_entry_writes_nothing() {
+        let path = tmp_path("disable-no-entry");
+        fs::write(&path, DISABLE_SAMPLE).unwrap();
+
+        assert_eq!(
+            save_disabled(&path, &by_name("acct-gone"), true).unwrap(),
+            DisabledWrite::NoEntry
+        );
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            DISABLE_SAMPLE,
+            "a no-match write must leave the file byte-identical"
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    /// A document with no usable `accounts` list is `NoEntry`, never a fallback
+    /// that writes a whole config over it — the clobber `save_tokens` accepts for
+    /// a single-use token is NOT worth it for a flag that can be re-set by hand.
+    #[test]
+    fn disable_with_no_usable_accounts_list_writes_nothing() {
+        for document in [r#"{ "upstream": "x" }"#, r#"{ "accounts": "nope" }"#] {
+            let path = tmp_path("disable-unusable");
+            fs::write(&path, document).unwrap();
+            assert_eq!(
+                save_disabled(&path, &by_name("acct-a"), true).unwrap(),
+                DisabledWrite::NoEntry
+            );
+            assert_eq!(fs::read_to_string(&path).unwrap(), document);
+            fs::remove_file(&path).ok();
+        }
+    }
+
+    /// An unreadable or malformed file surfaces the ERROR rather than taking
+    /// `save_tokens`' whole-config fallback. Writing a boot-time snapshot over a
+    /// file we could not parse is the clobber this module exists to prevent.
+    #[test]
+    fn disable_surfaces_errors_instead_of_clobbering() {
+        let missing = tmp_path("disable-missing");
+        assert!(!missing.exists());
+        assert!(matches!(
+            save_disabled(&missing, &by_name("acct-a"), true),
+            Err(ConfigError::Io(_))
+        ));
+        assert!(
+            !missing.exists(),
+            "a missing config must not be created by a flag write"
+        );
+
+        let malformed = tmp_path("disable-malformed");
+        fs::write(&malformed, "{ not json").unwrap();
+        assert!(matches!(
+            save_disabled(&malformed, &by_name("acct-a"), true),
+            Err(ConfigError::Parse(_))
+        ));
+        assert_eq!(
+            fs::read_to_string(&malformed).unwrap(),
+            "{ not json",
+            "a malformed config must be left exactly as found"
+        );
+        fs::remove_file(&malformed).ok();
+    }
+
+    /// The flag lands on the right ORG when one email is logged into two — the
+    /// same identity matching `merge_tokens` uses, so a rotated credential and a
+    /// disabled flag can never land on two different entries.
+    #[test]
+    fn disable_picks_the_right_entry_when_one_email_has_two_orgs() {
+        let path = tmp_path("disable-two-orgs");
+        fs::write(
+            &path,
+            r#"{ "accounts": [
+                { "name": "me@example.com", "accessToken": "at-a", "accountUuid": "uuid-person",
+                  "orgUuid": "org-a", "orgName": "Org A" },
+                { "name": "me@example.com", "accessToken": "at-b", "accountUuid": "uuid-person",
+                  "orgUuid": "org-b", "orgName": "Org B" }
+            ] }"#,
+        )
+        .unwrap();
+
+        let target = crate::identity::probe(
+            "me@example.com",
+            Some("uuid-person".to_string()),
+            Some("org-b".to_string()),
+            Some("Org B".to_string()),
+        );
+        assert_eq!(
+            save_disabled(&path, &target, true).unwrap(),
+            DisabledWrite::Updated
+        );
+
+        let after = read_json(&path);
+        assert!(
+            after["accounts"][0].get("disabled").is_none(),
+            "the flag landed on the wrong org: {after}"
+        );
+        assert_eq!(after["accounts"][1]["disabled"], json!(true));
+        fs::remove_file(&path).ok();
+    }
+
+    /// The flag write goes through the same atomic 0600 path as every other
+    /// write, so it can never leave the token file world-readable.
+    #[test]
+    fn save_disabled_writes_owner_only_permissions() {
+        let path = tmp_path("disable-perm");
+        fs::write(&path, DISABLE_SAMPLE).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        save_disabled(&path, &by_name("acct-a"), true).unwrap();
+
         assert_eq!(
             fs::metadata(&path).unwrap().permissions().mode() & 0o777,
             0o600

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -666,6 +666,66 @@ impl Manager {
         }
     }
 
+    /// Flush account `idx`'s `disabled` flag to the config file, so an account
+    /// deliberately benched from the TUI is still benched after a restart.
+    ///
+    /// Takes the SAME `self.config` lock as [`Self::persist_tokens`], for the same
+    /// reason: that lock is what serializes this file write against a concurrent
+    /// token rotation's whole read-modify-write. Writing outside it lets this
+    /// write's snapshot of the document clobber a refresh token that rotated in
+    /// between — and a refresh token is single-use, so the clobbered account 400s
+    /// (`invalid_grant`) on its next refresh and is dead until re-authed by hand.
+    ///
+    /// Writes the flag ONLY, via [`config::save_disabled`], never the whole config:
+    /// the in-memory `Config` is a boot-time snapshot, so flushing it whole would
+    /// revert every setting the user edited while the proxy was running.
+    ///
+    /// A missing `config_path` (tests, `tcr demo`, `tcr status --probe`) is a
+    /// SILENT no-op — those managers must never touch a real config file.
+    fn persist_disabled(&self, idx: usize, target: &config::Account, disabled: bool) {
+        let Some(path) = &self.config_path else {
+            return;
+        };
+        let mut config = self.config.lock().expect("config lock poisoned");
+        // Keep the boot-time snapshot in step with the file so the two views of
+        // the flag cannot diverge. Matched by identity, exactly as persist_tokens
+        // matches, so both land on the same entry.
+        if let Some(account) = config
+            .accounts
+            .iter_mut()
+            .find(|a| crate::identity::same_identity(a, target))
+        {
+            account.disabled = if disabled { Some(true) } else { None };
+        }
+        match config::save_disabled(path, target, disabled) {
+            Ok(config::DisabledWrite::Updated) => tracing::info!(
+                account = %target.name,
+                index = idx,
+                disabled,
+                "persisted account disabled flag to config"
+            ),
+            Ok(config::DisabledWrite::Unchanged) => tracing::debug!(
+                account = %target.name,
+                index = idx,
+                disabled,
+                "config already carries this disabled state; nothing written"
+            ),
+            Ok(config::DisabledWrite::NoEntry) => tracing::warn!(
+                account = %target.name,
+                index = idx,
+                path = %path.display(),
+                "no config entry carries this account's identity; the disabled flag will NOT survive a restart"
+            ),
+            Err(err) => tracing::error!(
+                error = %err,
+                account = %target.name,
+                index = idx,
+                path = %path.display(),
+                "failed to persist the disabled flag to config"
+            ),
+        }
+    }
+
     /// Sideline account `idx` on a proven-dead credential. Arms the recovery backoff
     /// with it, so even a hand-sidelined row is re-probed rather than stuck forever.
     pub fn mark_error(&self, idx: usize) {
@@ -679,15 +739,33 @@ impl Manager {
     }
 
     /// Enable/disable account `idx`. Re-enabling clears a stuck error/hold.
+    ///
+    /// The flag is also PERSISTED (see [`Self::persist_disabled`]) — memory-only
+    /// was the bug: a restart silently returned a deliberately benched account to
+    /// rotation, because the server writes nothing but credentials back.
     pub fn set_disabled(&self, idx: usize, disabled: bool) {
-        let mut accounts = self.accounts.write().expect("accounts lock poisoned");
-        if let Some(account) = accounts.get_mut(idx) {
+        // Take the identity out under the accounts lock and RELEASE that lock
+        // before persisting. The persist path takes the config lock, and holding
+        // both at once here would invert the order `warm_targets` reads them in
+        // (config, then accounts) — the shape a deadlock is made of.
+        let target = {
+            let mut accounts = self.accounts.write().expect("accounts lock poisoned");
+            let Some(account) = accounts.get_mut(idx) else {
+                return;
+            };
             account.disabled = disabled;
             if !disabled && account.status == AccountStatus::Error {
                 account.status = AccountStatus::Active;
                 account.rate_limited_until_ms = None;
             }
-        }
+            crate::identity::probe(
+                &account.name,
+                account.account_uuid.clone(),
+                account.org_uuid.clone(),
+                account.org_name.clone(),
+            )
+        };
+        self.persist_disabled(idx, &target, disabled);
     }
 
     /// Record which account actually served the most recent request.
@@ -1085,6 +1163,29 @@ mod tests {
         warmer: Arc<dyn AccountWarmer>,
     ) -> Arc<Manager> {
         Manager::new(config, refresher, Arc::new(NoProber), warmer, None)
+    }
+
+    /// A manager that DOES have a config file behind it — the live server's shape.
+    /// Every other builder here passes `config_path = None`, which makes each
+    /// persist a silent no-op.
+    fn build_manager_with_path(config: Config, path: PathBuf) -> Arc<Manager> {
+        Manager::new(
+            config,
+            Arc::new(CountingRefresher {
+                calls: Arc::new(AtomicUsize::new(0)),
+            }),
+            Arc::new(NoProber),
+            Arc::new(NoWarmer),
+            Some(path),
+        )
+    }
+
+    /// A unique temp path per test — the suite runs tests in parallel threads of
+    /// ONE process, so a pid-only name collides.
+    fn tmp_config_path(tag: &str) -> PathBuf {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("tcr-mgr-{tag}-{}-{seq}.json", std::process::id()))
     }
 
     /// Drive account `idx`'s 5-hour window to `util` with a reset `hours_from_now`
@@ -4119,6 +4220,127 @@ mod tests {
             assert!(seen.insert(key), "session keys must be unique");
             prev = key;
         }
+    }
+
+    // ---- durable disable (the TUI's `d`/`e` survives a restart) ----
+
+    /// A config file for `accounts`, in the on-disk shape, carrying an unmodelled
+    /// top-level key so collateral damage is visible.
+    fn write_account_file(path: &std::path::Path, names: &[&str]) {
+        let entries: Vec<String> = names
+            .iter()
+            .map(|n| {
+                format!(
+                    r#"{{ "name": "{n}", "type": "oauth", "accessToken": "at-{n}", "refreshToken": "rt-{n}" }}"#
+                )
+            })
+            .collect();
+        std::fs::write(
+            path,
+            format!(
+                r#"{{ "warmupSeconds": 900, "accounts": [ {} ] }}"#,
+                entries.join(", ")
+            ),
+        )
+        .expect("write test config");
+    }
+
+    fn read_config_json(path: &std::path::Path) -> serde_json::Value {
+        serde_json::from_str(&std::fs::read_to_string(path).expect("read test config"))
+            .expect("test config is valid JSON")
+    }
+
+    /// THE regression guard for this fix. Benching an account from the TUI wrote
+    /// memory only, so a restart silently returned it to rotation. `set_disabled`
+    /// must reach the file — and `e` must remove the key again, not write `false`.
+    #[test]
+    fn set_disabled_persists_through_to_the_config_file() {
+        let path = tmp_config_path("durable-disable");
+        write_account_file(&path, &["acct-a", "acct-b"]);
+        let manager = build_manager_with_path(
+            config_with(vec![account("acct-a", 0), account("acct-b", 0)]),
+            path.clone(),
+        );
+
+        manager.set_disabled(0, true);
+
+        let after = read_config_json(&path);
+        assert_eq!(after["accounts"][0]["disabled"], serde_json::json!(true));
+        assert!(
+            after["accounts"][1].get("disabled").is_none(),
+            "the unrelated account was flagged too: {after}"
+        );
+        assert_eq!(
+            after["warmupSeconds"],
+            serde_json::json!(900),
+            "an unmodelled key was dropped by the flag write"
+        );
+        // The in-memory config must agree with the file, so the two views of the
+        // flag cannot diverge.
+        assert_eq!(
+            manager.config.lock().unwrap().accounts[0].disabled,
+            Some(true)
+        );
+
+        // Re-enabling DROPS the key (the CLI contract), never writes false.
+        manager.set_disabled(0, false);
+        let after = read_config_json(&path);
+        assert!(
+            after["accounts"][0].get("disabled").is_none(),
+            "re-enable must drop the key, not write false: {after}"
+        );
+        assert_eq!(manager.config.lock().unwrap().accounts[0].disabled, None);
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// A manager with NO `config_path` — every test here, `tcr demo`, and
+    /// `tcr status --probe` — must write nothing at all. The demo drives
+    /// `set_disabled` on rows that have no config file behind them.
+    ///
+    /// Differential against the test above: same fixture, same call, and the only
+    /// difference is the absent path. Without the pair, "the file did not change"
+    /// would prove nothing.
+    #[test]
+    fn set_disabled_writes_nothing_without_a_config_path() {
+        let path = tmp_config_path("durable-disable-none");
+        write_account_file(&path, &["acct-a"]);
+        let before = std::fs::read_to_string(&path).unwrap();
+
+        let manager = build_manager(
+            config_with(vec![account("acct-a", 0)]),
+            Arc::new(CountingRefresher {
+                calls: Arc::new(AtomicUsize::new(0)),
+            }),
+        );
+        assert!(manager.config_path.is_none());
+
+        manager.set_disabled(0, true);
+
+        // The runtime row still flips — only the disk write is suppressed.
+        assert!(manager.snapshot(OffsetDateTime::now_utc()).accounts[0].disabled);
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            before,
+            "a manager with no config_path must never write to disk"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// An out-of-range index is a no-op on both halves: nothing flips in memory
+    /// and nothing is written, rather than persisting a flag for an account that
+    /// does not exist.
+    #[test]
+    fn set_disabled_out_of_range_writes_nothing() {
+        let path = tmp_config_path("durable-disable-oob");
+        write_account_file(&path, &["acct-a"]);
+        let before = std::fs::read_to_string(&path).unwrap();
+        let manager =
+            build_manager_with_path(config_with(vec![account("acct-a", 0)]), path.clone());
+
+        manager.set_disabled(9, true);
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), before);
+        std::fs::remove_file(&path).ok();
     }
 
     // ---- keep-warm (opt-in idle-account warming) ----

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -1232,6 +1232,33 @@ mod tests {
         config
     }
 
+    /// Build a config carrying an unmodelled top-level `quotaProbeSeconds` value.
+    /// `0` turns probing OFF, which is what makes the keep-warm boot gate fall
+    /// back to its pre-gate behaviour.
+    fn config_with_probe_seconds(accounts: Vec<Account>, probe_seconds: i64) -> Config {
+        let mut config = config_with(accounts);
+        config.extra.insert(
+            "quotaProbeSeconds".to_string(),
+            serde_json::Value::from(probe_seconds),
+        );
+        config
+    }
+
+    /// Mark every account as having been probed at least once.
+    ///
+    /// `warm_targets` skips a never-probed account while probing is enabled (a
+    /// blank quota is unknown, not known-cold), and `config_with` leaves
+    /// `quotaProbeSeconds` at its default 75 — so without this, every keep-warm
+    /// test below would be measuring the boot gate instead of the predicate it is
+    /// actually about. `update_quota` (which `set_5h`/`set_7d` drive) deliberately
+    /// does not touch `probe_status`; only a real probe does.
+    fn mark_all_probed(manager: &Manager) {
+        let mut accounts = manager.accounts.write().expect("accounts lock poisoned");
+        for account in accounts.iter_mut() {
+            account.probe_status = ProbeStatus::Ok;
+        }
+    }
+
     // ---- hard account lock (`lockAccount`; no failover) -----------------------
 
     fn lock_refresher() -> Arc<CountingRefresher> {
@@ -4384,6 +4411,7 @@ mod tests {
             ]),
             refresher,
         );
+        mark_all_probed(&manager); // isolate from the never-probed boot gate
         manager.set_disabled(1, true);
         manager.mark_error(2);
         manager.mark_rate_limited(3, 300); // → Throttled
@@ -4411,6 +4439,7 @@ mod tests {
             ]),
             refresher,
         );
+        mark_all_probed(&manager); // isolate from the never-probed boot gate
         set_5h(&manager, 0, "0.10", 3); // live: low util, reset 3h out → already warm
                                         // account 1 (cold): no 5h data at all
         set_5h(&manager, 2, "0.10", -1); // past: reset 1h ago → window elapsed
@@ -4434,6 +4463,7 @@ mod tests {
             config_with(vec![account("full", 0), account("idle", 0)]),
             refresher,
         );
+        mark_all_probed(&manager); // isolate from the never-probed boot gate
         set_7d(&manager, 0, "0.95"); // over the 0.90 threshold
 
         assert_eq!(
@@ -4464,6 +4494,7 @@ mod tests {
             refresher,
             warmer,
         );
+        mark_all_probed(&manager); // isolate from the never-probed boot gate
         set_5h(&manager, 1, "0.10", 3); // live window → already warm
         manager.set_disabled(2, true);
         manager.mark_error(3);
@@ -4514,7 +4545,8 @@ mod tests {
         });
         let manager =
             build_manager_with_warmer(config_with(vec![account("cold", 0)]), refresher, warmer);
-        // Before: no 5h window, so this account is a target.
+        mark_all_probed(&manager); // isolate from the never-probed boot gate
+                                   // Before: no 5h window, so this account is a target.
         assert_eq!(manager.warm_targets(), vec![0]);
 
         manager.warm_account(0).await;
@@ -4533,6 +4565,91 @@ mod tests {
         assert!(
             manager.warm_targets().is_empty(),
             "a freshly-warmed account is no longer a target"
+        );
+    }
+
+    /// THE boot gate. At startup every account's quota is blank (`from_config`
+    /// seeds `Quota::default()` and nothing restores it), so before the gate every
+    /// probeable account looked cold and the warm loop's immediate first tick
+    /// would have fired a real quota-spending request at all of them — including
+    /// accounts whose 5h window is genuinely live. A never-probed account's blank
+    /// quota is unknown, not known-cold, so with probing on there are no targets.
+    #[test]
+    fn warm_targets_is_empty_at_boot_while_probing_is_enabled() {
+        let refresher = Arc::new(CountingRefresher {
+            calls: Arc::new(AtomicUsize::new(0)),
+        });
+        let manager = build_manager(
+            config_with(vec![account("a", 0), account("b", 0), account("c", 0)]),
+            refresher,
+        );
+        // Boot state, untouched: probing on by default (75s), nothing probed yet.
+        assert!(manager.probe_interval_seconds() > 0);
+
+        assert!(
+            manager.warm_targets().is_empty(),
+            "a never-probed account's blank quota is unknown, not known-cold"
+        );
+    }
+
+    /// Once the probe has actually spoken, a genuinely cold or expired window IS
+    /// warmed again — the gate defers the first sweep, it does not disable
+    /// keep-warm. A probed account with a LIVE window stays skipped.
+    #[test]
+    fn warm_targets_resumes_once_the_probe_has_reported() {
+        let refresher = Arc::new(CountingRefresher {
+            calls: Arc::new(AtomicUsize::new(0)),
+        });
+        let manager = build_manager(
+            config_with(vec![
+                account("cold", 0),
+                account("live", 0),
+                account("dark", 0),
+            ]),
+            refresher,
+        );
+        // Only the first two have been probed; the third is still `Never`.
+        {
+            let mut accounts = manager.accounts.write().unwrap();
+            accounts[0].probe_status = ProbeStatus::Ok;
+            accounts[1].probe_status = ProbeStatus::Ok;
+        }
+        set_5h(&manager, 0, "0.10", -1); // probed, window expired → genuinely cold
+        set_5h(&manager, 1, "0.10", 3); // probed, window live → already warm
+
+        assert_eq!(
+            manager.warm_targets(),
+            vec![0],
+            "a probed account with an expired window is a target; a live one and an unprobed one are not"
+        );
+    }
+
+    /// The dark-feature guard. With `quotaProbeSeconds: 0` no probe task is ever
+    /// spawned, so `probe_status` stays `Never` forever. Gating on it
+    /// unconditionally would make keep-warm structurally unable to fire while
+    /// still reading as enabled — so with probing off, the gate does not apply.
+    #[test]
+    fn warm_targets_ignores_the_boot_gate_when_probing_is_disabled() {
+        let refresher = Arc::new(CountingRefresher {
+            calls: Arc::new(AtomicUsize::new(0)),
+        });
+        let manager = build_manager(
+            config_with_probe_seconds(vec![account("a", 0), account("b", 0)], 0),
+            refresher,
+        );
+        assert_eq!(manager.probe_interval_seconds(), 0);
+        // Nothing has been (or ever will be) probed.
+        assert!(manager
+            .accounts
+            .read()
+            .unwrap()
+            .iter()
+            .all(|a| a.probe_status == ProbeStatus::Never));
+
+        assert_eq!(
+            manager.warm_targets(),
+            vec![0, 1],
+            "with the probe off there is nothing to wait for; keep-warm must not go dark"
         );
     }
 

--- a/src/manager/warm.rs
+++ b/src/manager/warm.rs
@@ -13,8 +13,27 @@ impl Manager {
     ///
     /// A cold account (no 5h data) or one whose 5h reset has already passed IS a
     /// target — those are exactly the accounts whose window we want to (re)start.
+    ///
+    /// …with one exception, and it only bites at BOOT. `AccountRuntime::from_config`
+    /// starts every account on `Quota::default()` and nothing restores the last
+    /// known windows, so for the first probe cycle every account's 5h window reads
+    /// blank. Blank is *unknown*, not *known-cold* — and the warm loop's ticker
+    /// fires its first tick immediately, so without a gate the first sweep spends a
+    /// real upstream request on every probeable account, including ones whose 5h
+    /// window is genuinely live and ones sitting at 100% weekly. A never-probed
+    /// account is therefore not a target: we do not warm on quota we have not read.
+    ///
+    /// The gate applies ONLY while probing is actually enabled. With
+    /// `quotaProbeSeconds == 0` no probe task is ever spawned, so `probe_status`
+    /// would stay `Never` forever and gating on it unconditionally would make
+    /// keep-warm structurally unable to fire — a dark feature that looks enabled.
+    /// With the probe off there is nothing to wait for, so today's behaviour stands.
     pub fn warm_targets(&self) -> Vec<usize> {
         let now = OffsetDateTime::now_utc();
+        // Read the probe cadence BEFORE taking the accounts lock: this touches the
+        // config lock, and holding both at once here would invert the order
+        // `set_disabled` takes them in (accounts, then config).
+        let awaiting_first_probe = self.probe_interval_seconds() > 0;
         let accounts = self.accounts.read().expect("accounts lock poisoned");
         accounts
             .iter()
@@ -25,6 +44,9 @@ impl Manager {
                     && !a.disabled
                     && a.status != AccountStatus::Error
                     && a.status != AccountStatus::Throttled
+                    // Never probed while the probe is running: its blank quota is
+                    // unknown, not known-cold. Wait for the first probe to speak.
+                    && !(awaiting_first_probe && a.probe_status == ProbeStatus::Never)
                     // A live future 5h reset means the session window is already running.
                     && a.quota.five_hour.and_then(|w| w.live_reset(now)).is_none()
                     // Warming an at/over-threshold account is wasted spend.


### PR DESCRIPTION
Two independent fixes for state that exists only in memory and dies on restart. Phase 1 of a restart-durability design; deliberately the part that needs no new file and no new format.

## 1. The TUI's disable didn't survive a restart

`tui.rs` maps `d`/`e` to `Manager::set_disabled`, which wrote **memory only**. The one thing the server ever wrote back to the config was three credential fields via `save_tokens` → `merge_tokens`. So a deliberately benched account quietly returned to rotation on the next restart.

Observed live before the fix: `henrysec@token.security` read `disabled=true` from the running server while `~/.config/teamclaude.json` carried no `disabled` key for it at all.

`config::save_disabled` is a targeted **raw-document** merge in the same shape as `save_tokens` — read the on-disk JSON, find the one entry by identity, set or remove the key, write through the existing `write_atomic`. Every other key in the document is preserved. Re-enabling **drops** the key rather than writing `false`, matching the contract the CLI already pins in `set_enabled_false_drops_the_disabled_key`.

Two things this deliberately does *not* do:

- It does not reuse `cli::set_enabled` / `cli::edit_account`. Those `println!` (would corrupt the TUI) and do a **whole-config** write, which is the exact clobber shape this project has already been bitten by.
- It does not widen `merge_tokens`. Carrying the flag there would re-create the boot-snapshot clobber and revert a live hand-edit on the next token rotation.

`persist_disabled` takes the same `self.config` lock `persist_tokens` takes, so the write serializes against a concurrent token rotation. That lock is load-bearing: refresh tokens are single-use, and losing a freshly rotated one kills the account. `config_path == None` (tests, demo, `tcr status --probe`) is a silent no-op. A write that finds no matching config entry logs a warning saying the flag will not survive a restart, rather than failing silently.

## 2. Keep-warm would have fired a quota-spending burst at boot

`warm_targets` treats an account with no live 5h window as "cold — warm it". At boot `AccountRuntime::from_config` sets `quota: Quota::default()` and nothing restores it, so *every* account looks cold, and the warm loop's ticker fires its first tick immediately. The first sweep would have spent a real upstream request on every probeable account — including ones whose 5h window is genuinely live and ones sitting at 100% weekly.

Currently latent, not live: `warmupSeconds` is absent from the config, so no warm task is spawned at all. Fixed before it is ever switched on.

A never-probed account is no longer a target: blank quota is *unknown*, not *known-cold*.

The gate applies **only while probing is enabled**. Gating unconditionally on `probe_status != Never` would make keep-warm structurally unable to fire whenever `quotaProbeSeconds == 0`, since no probe task spawns and the status stays `Never` forever — a feature that looks armed and can never fire. `probe_interval_seconds()` is read *before* the accounts lock is taken, because it acquires the config lock and `set_disabled` acquires accounts-then-config.

## Verification

- `cargo test --lib` — **392 passed, 0 failed** (up from 376).
- `cargo clippy --lib --all-targets` — clean. `cargo fmt --check` — clean.
- Both new gates were proven to **fail** before being trusted: inverting the warm-gate predicate failed exactly `warm_targets_is_empty_at_boot_while_probing_is_enabled` and `warm_targets_resumes_once_the_probe_has_reported`, and nothing else; restoring it returned the suite to 392 green.

New coverage includes the negative cases: re-enable drops the key, unmodelled top-level keys survive the write, other accounts are untouched, a redundant write leaves the file alone, a stale `disabled: false` already on disk is dropped, the right entry is chosen when one email exists in two orgs, errors surface instead of clobbering, and the file lands 0600.

Built with Henry and Gil <1435669+dhkts1@users.noreply.github.com>
