### PR TITLE
fix: refuse to write a credential into a guessed entry, and derive the keep-warm gate

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -461,6 +461,14 @@ enum SkipReason {
     /// signature of an account renamed on disk while the proxy was running,
     /// which is exactly the live-edit workflow [`save_tokens`] exists to support.
     NoMemoryMatch,
+    /// The entry is well-formed and has a loaded account it could belong to, but
+    /// the pairing is not unique: either several loaded accounts carry its
+    /// identity, or another on-disk entry carries the same identity and nothing
+    /// stored says which entry is which. Writing here means picking one of them at
+    /// random and stamping a rotated credential over another account's own
+    /// single-use refresh token, so nothing is written and the entry keeps what it
+    /// had. See [`crate::identity::resolve`].
+    Ambiguous,
     /// The credential triple would not serialize. Structurally unreachable —
     /// reported rather than swallowed precisely because reaching it would mean an
     /// assumption this module rests on has broken.
@@ -473,6 +481,9 @@ impl std::fmt::Display for SkipReason {
             Self::NotAnObject => "the entry is not a JSON object",
             Self::NoIdentity => "the entry has no readable account name",
             Self::NoMemoryMatch => "no loaded account has that identity (renamed on disk?)",
+            Self::Ambiguous => {
+                "that identity does not pick out one loaded account and one entry, so no credential could be chosen"
+            }
             Self::CredentialEncoding => "the credentials would not serialize",
         })
     }
@@ -572,11 +583,23 @@ impl MergeReport {
 /// one write. A skipped entry is not an error for the others — the merge runs to
 /// the end of the list either way.
 fn merge_tokens(doc: &mut Map<String, Value>, memory: &Config) -> Result<MergeReport, Unmergeable> {
-    let Some(accounts) = doc.get_mut("accounts") else {
+    // Plan against an IMMUTABLE view first. Deciding one entry at a time under a
+    // mutable borrow is what made the old first-match resolution unfixable: the
+    // assignment for entry N depends on which accounts the other entries claim,
+    // which a single mutable pass cannot see. Same split, and for the same reason,
+    // as `locate_account_entry` vs `find_account_entry`.
+    let Some(accounts) = doc.get("accounts") else {
         return Err(Unmergeable::Missing);
     };
-    let Some(accounts) = accounts.as_array_mut() else {
+    let Some(entries) = accounts.as_array() else {
         return Err(Unmergeable::NotAnArray);
+    };
+    let plan = plan_merge(entries, &memory.accounts);
+
+    let Some(accounts) = doc.get_mut("accounts").and_then(Value::as_array_mut) else {
+        // The immutable read above already proved both of these; this is the
+        // total-function tail, not a reachable outcome.
+        return Err(Unmergeable::Missing);
     };
 
     let mut report = MergeReport::default();
@@ -584,47 +607,22 @@ fn merge_tokens(doc: &mut Map<String, Value>, memory: &Config) -> Result<MergeRe
     // afterwards — a rename shows up here as well as in `skipped`.
     let mut placed = vec![false; memory.accounts.len()];
 
-    for (index, entry) in accounts.iter_mut().enumerate() {
-        let Some(object) = entry.as_object_mut() else {
-            report.skipped.push(SkippedEntry {
-                index,
-                name: None,
-                reason: SkipReason::NotAnObject,
-            });
-            continue;
+    for (index, (entry, (name, plan))) in accounts.iter_mut().zip(plan).enumerate() {
+        let position = match plan {
+            EntryPlan::Skip(reason) => {
+                report.skipped.push(SkippedEntry {
+                    index,
+                    name,
+                    reason,
+                });
+                continue;
+            }
+            EntryPlan::Write(position) => position,
         };
-        // Read the name BEFORE the identity parse, so a half-edited entry that
-        // fails to deserialize can still be named in the warning.
-        let name = object
-            .get("name")
-            .and_then(Value::as_str)
-            .map(str::to_string);
-        let Ok(stored) = serde_json::from_value::<DiskIdentity>(Value::Object(object.clone()))
+        // A `Write` plan only comes from an entry the planner parsed, so both of
+        // these hold by construction.
+        let (Some(object), Some(fresh)) = (entry.as_object_mut(), memory.accounts.get(position))
         else {
-            report.skipped.push(SkippedEntry {
-                index,
-                name,
-                reason: SkipReason::NoIdentity,
-            });
-            continue;
-        };
-        let probe = crate::identity::probe(
-            &stored.name,
-            stored.account_uuid,
-            stored.org_uuid,
-            stored.org_name,
-        );
-        let Some((position, fresh)) = memory
-            .accounts
-            .iter()
-            .enumerate()
-            .find(|(_, a)| crate::identity::same_identity(a, &probe))
-        else {
-            report.skipped.push(SkippedEntry {
-                index,
-                name,
-                reason: SkipReason::NoMemoryMatch,
-            });
             continue;
         };
         let credentials = Credentials {
@@ -654,6 +652,153 @@ fn merge_tokens(doc: &mut Map<String, Value>, memory: &Config) -> Result<MergeRe
         .map(|(account, _)| account.name.clone())
         .collect();
     Ok(report)
+}
+
+/// What the read-only planning pass decided about one on-disk entry.
+enum EntryPlan {
+    /// Write the loaded account at this position into the entry.
+    Write(usize),
+    /// Leave the entry's credentials exactly as they are, for this reason.
+    Skip(SkipReason),
+}
+
+/// Decide, for the whole `accounts` array at once, which loaded account owns each
+/// on-disk entry — paired with the entry's readable `name` for the report.
+///
+/// An entry is written ONLY when the pairing is unambiguous in BOTH directions:
+/// the entry resolves to exactly one loaded account, AND that account is claimed
+/// by exactly one entry. One direction is not enough. Resolving each entry
+/// independently — which is what a first-match search does — let two entries both
+/// take the same loaded account, stamping that account's freshly rotated
+/// credential onto an entry belonging to a DIFFERENT account and destroying that
+/// account's own single-use refresh token. And an entry that has only one
+/// candidate is still a guess when that candidate has two suitors: writing picks
+/// one of two entries to be "the real one" on nothing.
+///
+/// Pairings are committed REPEATEDLY until no more can be, because each commitment
+/// removes an account from one pool and an entry from the other, which can break a
+/// tie that was unbreakable a moment ago. That is what keeps the legacy two-org
+/// shape working — one person, two orgs, where the older entry predates org UUIDs
+/// and so carries none. The org-carrying entry pairs off first (it is the only
+/// *exact* match on either side), and the pre-org entry, which matched BOTH
+/// accounts while they were both in the pool, is then left facing exactly one.
+/// Resolved in a single pass it would tie forever and neither account would ever
+/// have its rotated token persisted. Iterating also makes the result independent
+/// of the order the entries happen to sit in the file.
+///
+/// Whatever is still unpaired when the fixed point is reached is reported, never
+/// guessed.
+fn plan_merge(entries: &[Value], memory: &[Account]) -> Vec<(Option<String>, EntryPlan)> {
+    // Parse each entry's identity once. A `None` probe is an entry no match can
+    // reach, and its plan is already final — so `plan[i].is_some()` is exactly
+    // "this entry is settled", for both the unmatchable and the paired.
+    let mut probes: Vec<Option<Account>> = Vec::with_capacity(entries.len());
+    let mut names: Vec<Option<String>> = Vec::with_capacity(entries.len());
+    let mut plan: Vec<Option<EntryPlan>> = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let Some(object) = entry.as_object() else {
+            probes.push(None);
+            names.push(None);
+            plan.push(Some(EntryPlan::Skip(SkipReason::NotAnObject)));
+            continue;
+        };
+        // Read the name BEFORE the identity parse, so a half-edited entry that
+        // fails to deserialize can still be named in the warning.
+        let name = object
+            .get("name")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        names.push(name);
+        let Ok(stored) = serde_json::from_value::<DiskIdentity>(Value::Object(object.clone()))
+        else {
+            probes.push(None);
+            plan.push(Some(EntryPlan::Skip(SkipReason::NoIdentity)));
+            continue;
+        };
+        probes.push(Some(crate::identity::probe(
+            &stored.name,
+            stored.account_uuid,
+            stored.org_uuid,
+            stored.org_name,
+        )));
+        plan.push(None);
+    }
+
+    let mut claimed = vec![false; memory.len()];
+
+    // Commit the mutually-unambiguous pairings until there are none left. Each
+    // round settles at least one entry or ends the loop, so this terminates in at
+    // most `entries.len()` rounds.
+    loop {
+        let mut progressed = false;
+        for index in 0..probes.len() {
+            let Some(probe) = probes[index].as_ref().filter(|_| plan[index].is_none()) else {
+                continue;
+            };
+            // Which unclaimed account does this entry point at?
+            let crate::identity::Resolved::One(position) = crate::identity::resolve(
+                memory
+                    .iter()
+                    .enumerate()
+                    .filter(|(position, _)| !claimed[*position]),
+                probe,
+            ) else {
+                continue;
+            };
+            // …and does that account point back at this entry alone? Any other
+            // unsettled entry with the same identity makes the write a coin flip.
+            let mutual = crate::identity::resolve(
+                probes
+                    .iter()
+                    .enumerate()
+                    .filter(|(other, _)| plan[*other].is_none())
+                    .filter_map(|(other, probe)| probe.as_ref().map(|probe| (other, probe))),
+                &memory[position],
+            ) == crate::identity::Resolved::One(index);
+            if mutual {
+                plan[index] = Some(EntryPlan::Write(position));
+                claimed[position] = true;
+                progressed = true;
+            }
+        }
+        if !progressed {
+            break;
+        }
+    }
+
+    // Everything the fixed point could not settle. An entry with no candidate left
+    // at all is the rename/removal case the report already had a name for; an entry
+    // that still has candidates is one this function refused to guess between.
+    for index in 0..probes.len() {
+        let Some(probe) = probes[index].as_ref().filter(|_| plan[index].is_none()) else {
+            continue;
+        };
+        let unmatched = crate::identity::resolve(
+            memory
+                .iter()
+                .enumerate()
+                .filter(|(position, _)| !claimed[*position]),
+            probe,
+        ) == crate::identity::Resolved::None;
+        plan[index] = Some(EntryPlan::Skip(if unmatched {
+            SkipReason::NoMemoryMatch
+        } else {
+            SkipReason::Ambiguous
+        }));
+    }
+
+    names
+        .into_iter()
+        .zip(plan)
+        // Every slot was assigned above: unmatchable at parse, paired in the fixed
+        // point, or classified in the sweep. This is the total-function tail.
+        .map(|(name, plan)| {
+            (
+                name,
+                plan.unwrap_or(EntryPlan::Skip(SkipReason::NoMemoryMatch)),
+            )
+        })
+        .collect()
 }
 
 /// What a targeted [`save_disabled`] did to the on-disk document. Reported
@@ -1144,6 +1289,148 @@ mod tests {
         assert_eq!(value["accounts"][1]["accessToken"], json!("at-a-new"));
         assert_eq!(value["accounts"][1]["expiresAt"], json!(11));
         fs::remove_file(&path).ok();
+    }
+
+    /// **THE token-clobber guard.** Two on-disk entries whose identities both match
+    /// one loaded account, with nothing stored to tell them apart. The old
+    /// first-match resolution walked the array and stamped the SAME account's
+    /// freshly rotated credential onto both, so the second entry's own single-use
+    /// refresh token was destroyed on disk — its next refresh 400s
+    /// (`invalid_grant`) and the account is dead until re-authed by hand.
+    ///
+    /// Nothing may be written into either entry: an unbreakable tie is reported,
+    /// never guessed. The entries keep the credentials they already held, which is
+    /// recoverable; a foreign account's token in their place is not.
+    #[test]
+    fn persist_refuses_to_write_a_credential_into_an_ambiguous_entry() {
+        let path = tmp_path("persist-ambiguous");
+        let memory: Config = serde_json::from_str(
+            r#"{ "accounts": [
+                   { "name": "acct-a", "accessToken": "at-new", "refreshToken": "rt-new", "expiresAt": 99 } ] }"#,
+        )
+        .unwrap();
+        // Two entries share the name and carry no UUID, so `same_identity` matches
+        // the loaded account against both. Entry 1 holds its OWN refresh token.
+        fs::write(
+            &path,
+            r#"{ "accounts": [
+                   { "name": "acct-a", "accessToken": "at-one-old", "refreshToken": "rt-one-old" },
+                   { "name": "acct-a", "accessToken": "at-two-old", "refreshToken": "rt-two-old" } ] }"#,
+        )
+        .unwrap();
+        save_tokens(&path, &memory).unwrap();
+
+        let value = read_json(&path);
+        assert_eq!(
+            value["accounts"][1]["refreshToken"],
+            json!("rt-two-old"),
+            "the second entry's own single-use refresh token was overwritten: {value}"
+        );
+        assert_eq!(value["accounts"][1]["accessToken"], json!("at-two-old"));
+        assert_eq!(
+            value["accounts"][0]["refreshToken"],
+            json!("rt-one-old"),
+            "a tie is refused on BOTH sides — picking the earlier entry is still a guess: {value}"
+        );
+        assert_eq!(value["accounts"][0]["accessToken"], json!("at-one-old"));
+        fs::remove_file(&path).ok();
+    }
+
+    /// The refusal above is reported, not silent: both entries come back as
+    /// skipped, and the loaded account comes back as having found no home — which
+    /// is what makes `save_tokens` warn by name that a rotated credential did not
+    /// reach the file.
+    #[test]
+    fn an_ambiguous_entry_is_reported_as_skipped() {
+        let memory: Config = serde_json::from_str(
+            r#"{ "accounts": [ { "name": "acct-a", "accessToken": "at-new" } ] }"#,
+        )
+        .unwrap();
+        let mut doc: Map<String, Value> = serde_json::from_str(
+            r#"{ "accounts": [ { "name": "acct-a" }, { "name": "acct-a" } ] }"#,
+        )
+        .unwrap();
+
+        let report = merge_tokens(&mut doc, &memory).unwrap();
+
+        assert_eq!(
+            report.skipped,
+            vec![
+                SkippedEntry {
+                    index: 0,
+                    name: Some("acct-a".to_string()),
+                    reason: SkipReason::Ambiguous,
+                },
+                SkippedEntry {
+                    index: 1,
+                    name: Some("acct-a".to_string()),
+                    reason: SkipReason::Ambiguous,
+                },
+            ]
+        );
+        assert_eq!(report.absent_from_disk, vec!["acct-a".to_string()]);
+    }
+
+    /// The legacy two-org shape must keep working: one person, two orgs, where the
+    /// older entry predates org UUIDs and so carries none. `same_identity` matches
+    /// the pre-org entry against BOTH accounts, so resolving each entry
+    /// independently ties forever and neither account's rotated token is ever
+    /// persisted. The exact pairing settles first and leaves the pre-org entry
+    /// facing exactly one unclaimed account.
+    ///
+    /// Asserted in BOTH disk orders — the real config has the older (pre-org) entry
+    /// first, which is precisely the order a single forward pass gets wrong.
+    #[test]
+    fn persist_places_both_tokens_on_the_legacy_two_org_shape() {
+        let memory: Config = serde_json::from_str(
+            r#"{ "accounts": [
+                   { "name": "me@example.com", "accountUuid": "u1", "orgUuid": "org-a",
+                     "accessToken": "at-a-new", "refreshToken": "rt-a-new" },
+                   { "name": "me@example.com", "accountUuid": "u1",
+                     "accessToken": "at-legacy-new", "refreshToken": "rt-legacy-new" } ] }"#,
+        )
+        .unwrap();
+
+        for (label, disk) in [
+            (
+                "org-carrying entry first",
+                r#"{ "accounts": [
+                       { "name": "me@example.com", "accountUuid": "u1", "orgUuid": "org-a", "accessToken": "at-a-old" },
+                       { "name": "me@example.com", "accountUuid": "u1", "accessToken": "at-legacy-old" } ] }"#,
+            ),
+            (
+                "pre-org entry first",
+                r#"{ "accounts": [
+                       { "name": "me@example.com", "accountUuid": "u1", "accessToken": "at-legacy-old" },
+                       { "name": "me@example.com", "accountUuid": "u1", "orgUuid": "org-a", "accessToken": "at-a-old" } ] }"#,
+            ),
+        ] {
+            let path = tmp_path("persist-two-org");
+            fs::write(&path, disk).unwrap();
+            save_tokens(&path, &memory).unwrap();
+
+            let value = read_json(&path);
+            let by_org = |org: Option<&str>| {
+                value["accounts"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .find(|e| e.get("orgUuid").and_then(Value::as_str) == org)
+                    .unwrap_or_else(|| panic!("no entry with orgUuid {org:?} ({label}): {value}"))
+                    .clone()
+            };
+            assert_eq!(
+                by_org(Some("org-a"))["refreshToken"],
+                json!("rt-a-new"),
+                "the org-carrying entry missed its rotated token ({label}): {value}"
+            );
+            assert_eq!(
+                by_org(None)["refreshToken"],
+                json!("rt-legacy-new"),
+                "the pre-org entry missed its rotated token ({label}): {value}"
+            );
+            fs::remove_file(&path).ok();
+        }
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -680,7 +680,7 @@ enum EntryPlan {
 /// tie that was unbreakable a moment ago. That is what keeps the legacy two-org
 /// shape working — one person, two orgs, where the older entry predates org UUIDs
 /// and so carries none. The org-carrying entry pairs off first (it is the only
-/// *exact* match on either side), and the pre-org entry, which matched BOTH
+/// *strict* match on either side), and the pre-org entry, which matched BOTH
 /// accounts while they were both in the pool, is then left facing exactly one.
 /// Resolved in a single pass it would tie forever and neither account would ever
 /// have its rotated token persisted. Iterating also makes the result independent
@@ -816,16 +816,23 @@ pub enum DisabledWrite {
     /// while the proxy ran — or the document has no usable `accounts` array.
     /// Nothing was written, so the flag will NOT survive a restart.
     NoEntry,
-    /// MORE than one entry carries that identity, so no entry can be chosen
-    /// without guessing. Nothing was written.
+    /// More than one entry carries that identity and nothing stored breaks the
+    /// tie, so no entry can be chosen without guessing. Nothing was written.
     ///
     /// [`crate::identity::same_identity`] falls back to name equality when either
-    /// side lacks a uuid and treats an unknown org as a match, so two entries
-    /// sharing a name both match either runtime row. The caller selects by ROW
-    /// INDEX (the TUI does), so silently taking the first match lands the flag on
-    /// whichever entry happens to be earlier — benching a healthy account and
-    /// returning an exhausted one to rotation, with the TUI showing the opposite.
-    /// Refusing is the same posture the CLI takes on an ambiguous query.
+    /// side lacks a uuid, so two entries sharing a name both match either runtime
+    /// row. The caller selects by ROW INDEX (the TUI does), so silently taking the
+    /// first match lands the flag on whichever entry happens to be earlier —
+    /// benching a healthy account and returning an exhausted one to rotation, with
+    /// the TUI showing the opposite. Refusing is the same posture the CLI takes on
+    /// an ambiguous query.
+    ///
+    /// This is now genuine ambiguity only. `same_identity` ALSO treats an unknown
+    /// org as a match, which used to make the legacy two-org shape (an entry with
+    /// an org beside a pre-org entry that has none) report `Ambiguous` even though
+    /// the two entries are trivially distinguishable — so neither of two real
+    /// accounts could ever be durably benched. [`crate::identity::resolve`] breaks
+    /// that tie on the org key; see [`find_account_entry`].
     Ambiguous,
 }
 
@@ -918,38 +925,48 @@ fn locate_account_entry(doc: &Map<String, Value>, target: &Account) -> EntryMatc
     let Some(entries) = doc.get("accounts").and_then(Value::as_array) else {
         return EntryMatch::None;
     };
-    let mut found: Option<usize> = None;
-    for (index, entry) in entries.iter().enumerate() {
-        let Some(object) = entry.as_object() else {
-            continue;
-        };
-        let Ok(stored) = serde_json::from_value::<DiskIdentity>(Value::Object(object.clone()))
-        else {
-            continue;
-        };
-        let probe = crate::identity::probe(
-            &stored.name,
-            stored.account_uuid,
-            stored.org_uuid,
-            stored.org_name,
-        );
-        if crate::identity::same_identity(target, &probe) {
-            if found.is_some() {
-                return EntryMatch::Many;
-            }
-            found = Some(index);
-        }
-    }
-    match found {
-        Some(index) => EntryMatch::One(index),
-        None => EntryMatch::None,
+    // Parse every entry's identity first, then resolve over the whole set at once.
+    // Returning `Many` on the second `same_identity` hit — which is what a single
+    // scanning pass can do — refuses the LEGACY TWO-ORG SHAPE, where entry
+    // `{name, uuid U, orgUuid "org-a"}` sits beside a pre-org entry `{name, uuid
+    // U}` written before org UUIDs were stored. Those are two real accounts, one
+    // person in two orgs, and `same_identity` matches the pre-org entry against
+    // both of them because an unknown org is deliberately tolerated. Refused that
+    // way, NEITHER account can ever be durably benched.
+    //
+    // `resolve` breaks exactly that tie and only that tie: when one candidate
+    // matches on fully known identity and the rest matched only because something
+    // was missing, the known one wins. A tie with nothing stricter to prefer is
+    // still `Many`, and still refused.
+    let probes: Vec<(usize, Account)> = entries
+        .iter()
+        .enumerate()
+        .filter_map(|(index, entry)| {
+            let object = entry.as_object()?;
+            let stored =
+                serde_json::from_value::<DiskIdentity>(Value::Object(object.clone())).ok()?;
+            Some((
+                index,
+                crate::identity::probe(
+                    &stored.name,
+                    stored.account_uuid,
+                    stored.org_uuid,
+                    stored.org_name,
+                ),
+            ))
+        })
+        .collect();
+    match crate::identity::resolve(probes.iter().map(|(index, probe)| (*index, probe)), target) {
+        crate::identity::Resolved::One(index) => EntryMatch::One(index),
+        crate::identity::Resolved::None => EntryMatch::None,
+        crate::identity::Resolved::Many => EntryMatch::Many,
     }
 }
 
 /// The on-disk `accounts` entry whose identity matches `target`, or the
 /// [`DisabledWrite`] refusal explaining why there is no single entry to write.
 ///
-/// Matching reuses the [`DiskIdentity`] probe + [`crate::identity::same_identity`]
+/// Matching reuses the [`DiskIdentity`] probe + [`crate::identity::resolve`]
 /// pairing that [`merge_tokens`] uses, so a rotated credential and a disabled flag
 /// can never land on two different entries.
 ///
@@ -961,6 +978,12 @@ fn locate_account_entry(doc: &Map<String, Value>, target: &Account) -> EntryMatc
 /// side lacks a uuid, so two entries sharing a name match either runtime row: the
 /// flag would land on whichever is earlier in the file, benching a healthy account
 /// while the TUI shows the other one disabled.
+///
+/// Refused, but only where the tie is real — which is not the same as "a second
+/// entry satisfied `same_identity`". `resolve` first tries the org key, so the
+/// legacy two-org shape (one entry with an org, one written before org UUIDs
+/// existed and carrying none) resolves both of its rows instead of locking both
+/// out of ever being benched.
 fn find_account_entry<'a>(
     doc: &'a mut Map<String, Value>,
     target: &Account,
@@ -1375,8 +1398,8 @@ mod tests {
     /// older entry predates org UUIDs and so carries none. `same_identity` matches
     /// the pre-org entry against BOTH accounts, so resolving each entry
     /// independently ties forever and neither account's rotated token is ever
-    /// persisted. The exact pairing settles first and leaves the pre-org entry
-    /// facing exactly one unclaimed account.
+    /// persisted. The strict pairing settles it: each side has exactly one partner
+    /// whose org key it actually equals.
     ///
     /// Asserted in BOTH disk orders — the real config has the older (pre-org) entry
     /// first, which is precisely the order a single forward pass gets wrong.
@@ -2058,6 +2081,93 @@ mod tests {
         );
         let after = read_json(&path);
         assert_eq!(after["accounts"][0]["disabled"], json!(true));
+        assert!(after["accounts"][1].get("disabled").is_none());
+        fs::remove_file(&path).ok();
+    }
+
+    /// The shape the test above does NOT cover, and the one the refusal actually
+    /// broke: the older entry predates org UUIDs and carries none, so its org key
+    /// is `(None)` while its sibling's is `Some("org-a")`. `same_identity`
+    /// deliberately treats an unknown org as a match — that is what lets a
+    /// freshly-profiled login backfill a legacy entry — which also means the
+    /// pre-org entry matches BOTH runtime rows. These are two real accounts, one
+    /// person in two orgs, and refusing on the second `same_identity` hit left
+    /// NEITHER of them durably benchable.
+    ///
+    /// Each row must reach its own entry: the org-carrying row by the exact match,
+    /// and the pre-org row by name — it is the only entry with no org at all.
+    #[test]
+    fn a_pre_org_entry_beside_its_org_carrying_sibling_is_not_ambiguous() {
+        let path = tmp_path("disable-legacy-backfill");
+        let file = r#"{ "accounts": [
+                { "name": "me@example.com", "accessToken": "at-a", "accountUuid": "uuid-person",
+                  "orgUuid": "org-a", "orgName": "Org A" },
+                { "name": "me@example.com", "accessToken": "at-legacy", "accountUuid": "uuid-person" }
+            ] }"#;
+
+        // The org-carrying row: both entries match it loosely, one matches exactly.
+        fs::write(&path, file).unwrap();
+        let with_org = crate::identity::probe(
+            "me@example.com",
+            Some("uuid-person".to_string()),
+            Some("org-a".to_string()),
+            Some("Org A".to_string()),
+        );
+        assert_eq!(
+            save_disabled(&path, &with_org, true).unwrap(),
+            DisabledWrite::Updated,
+            "the fully-known identity resolves to the entry that carries the same org"
+        );
+        let after = read_json(&path);
+        assert_eq!(after["accounts"][0]["disabled"], json!(true));
+        assert!(
+            after["accounts"][1].get("disabled").is_none(),
+            "the flag must not land on the pre-org sibling: {after}"
+        );
+
+        // And the pre-org row, whose own org is still unknown, resolves to the one
+        // entry that likewise has none.
+        fs::write(&path, file).unwrap();
+        let pre_org = crate::identity::probe(
+            "me@example.com",
+            Some("uuid-person".to_string()),
+            None,
+            None,
+        );
+        assert_eq!(
+            save_disabled(&path, &pre_org, true).unwrap(),
+            DisabledWrite::Updated
+        );
+        let after = read_json(&path);
+        assert_eq!(after["accounts"][1]["disabled"], json!(true));
+        assert!(
+            after["accounts"][0].get("disabled").is_none(),
+            "the flag must not land on the org-carrying sibling: {after}"
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    /// The refusal still fires where it must. Two entries that share a name and
+    /// carry no UUID at all are genuinely indistinguishable — there is no stricter
+    /// fact to prefer one by — so nothing is written and the caller is told.
+    #[test]
+    fn two_entries_with_nothing_to_tell_them_apart_are_still_refused() {
+        let path = tmp_path("disable-truly-ambiguous");
+        fs::write(
+            &path,
+            r#"{ "accounts": [
+                { "name": "me@example.com", "accessToken": "at-one" },
+                { "name": "me@example.com", "accessToken": "at-two" }
+            ] }"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            save_disabled(&path, &by_name("me@example.com"), true).unwrap(),
+            DisabledWrite::Ambiguous
+        );
+        let after = read_json(&path);
+        assert!(after["accounts"][0].get("disabled").is_none());
         assert!(after["accounts"][1].get("disabled").is_none());
         fs::remove_file(&path).ok();
     }

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -56,6 +56,7 @@ fn base(name: &str, priority: i64) -> AccountRuntime {
         // their quota reads as READ too — otherwise every demo row would render as
         // a permanently un-warmable account.
         quota_known: true,
+        consecutive_probe_failures: 0,
         input_tokens: 0,
         output_tokens: 0,
         cache_read_tokens: 0,

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -56,26 +56,25 @@ pub fn same_identity(a: &Account, b: &Account) -> bool {
     }
 }
 
-/// Whether two records match on FULLY KNOWN identity: both carry an account UUID,
-/// both carry an org key, and both agree on each.
+/// Whether two records match with the org tolerance REMOVED: the account UUID is
+/// known on both sides and equal, and the org discriminators are equal — both
+/// known and the same, or both absent.
 ///
-/// This is [`same_identity`] with its tolerance removed, and it exists only to
-/// break ties. `same_identity` treats an unknown org as a match so a
+/// This exists only to break ties, and it is exactly [`same_identity`] minus its
+/// one asymmetry. `same_identity` calls an unknown org a match so a
 /// freshly-profiled login can backfill a legacy entry written before org UUIDs
-/// were stored — which necessarily means that one legacy entry also matches
-/// EVERY other org of the same person. A record that matches with nothing left
-/// unknown matches on evidence; the others match only on absence. See [`resolve`].
+/// were stored; the price is that such an entry then matches EVERY org of that
+/// person. Under this comparison a record with an org matches only records with
+/// the same org, and a record without one matches only records that likewise have
+/// none — so in the two-org shape each side has exactly one strict partner, which
+/// is what [`resolve`] needs to tell them apart.
 ///
-/// Records with no UUID on either side are never exact: `same_identity` falls back
-/// to name equality there, and two entries sharing a name are genuinely
-/// indistinguishable — there is no stricter fact to prefer one by.
-pub fn same_identity_exact(a: &Account, b: &Account) -> bool {
-    match (uuid_key(a), uuid_key(b)) {
-        (Some(ua), Some(ub)) if ua == ub => {
-            matches!((org_key(a), org_key(b)), (Some(ka), Some(kb)) if ka == kb)
-        }
-        _ => false,
-    }
+/// Records with no UUID are never strict-equal. `same_identity` falls back to name
+/// equality there, and two entries sharing a name are genuinely indistinguishable
+/// — there is no stricter fact to prefer one by.
+pub fn same_identity_strict(a: &Account, b: &Account) -> bool {
+    matches!((uuid_key(a), uuid_key(b)), (Some(ua), Some(ub)) if ua == ub)
+        && org_key(a) == org_key(b)
 }
 
 /// Which of a set of candidate records an identity resolves to.
@@ -96,9 +95,9 @@ pub enum Resolved {
 /// One loose match is the answer. Several loose matches are the legacy two-org
 /// shape far more often than a real ambiguity: an entry stored before org UUIDs
 /// existed carries a UUID and no org, so `same_identity` matches it against every
-/// org of that person. When exactly one of the tied candidates matches on fully
-/// known identity ([`same_identity_exact`]) the rest matched only because
-/// something was missing, so the exact one is the answer.
+/// org of that person. When exactly one of the tied candidates also matches
+/// strictly ([`same_identity_strict`]) the rest matched only on the org tolerance,
+/// so the strict one is the answer.
 ///
 /// An unbreakable tie is [`Resolved::Many`] and every caller REFUSES rather than
 /// guesses. Guessing is not a cosmetic error here: stamping account A's rotated
@@ -114,7 +113,7 @@ where
     for (index, candidate) in candidates {
         if same_identity(target, candidate) {
             loose.push(index);
-            if same_identity_exact(target, candidate) {
+            if same_identity_strict(target, candidate) {
                 exact.push(index);
             }
         }
@@ -308,7 +307,7 @@ mod tests {
     }
 
     #[test]
-    fn exact_match_needs_both_sides_fully_known() {
+    fn a_strict_match_drops_the_unknown_org_tolerance() {
         let full = acct("me@example.com", Some("u1"), Some("org-a"), Some("Corp"));
         let legacy = acct("me@example.com", Some("u1"), None, None);
         let other_org = acct(
@@ -319,28 +318,33 @@ mod tests {
         );
         let no_uuid = acct("me@example.com", None, None, None);
 
-        assert!(same_identity_exact(&full, &full.clone()));
+        assert!(same_identity_strict(&full, &full.clone()));
         assert!(
-            !same_identity_exact(&full, &legacy),
-            "an unknown org on one side is a LOOSE match, never an exact one"
+            !same_identity_strict(&full, &legacy),
+            "an unknown org on ONE side is a loose match only — that is the tolerance"
         );
         assert!(
             same_identity(&full, &legacy),
-            "…but it is still loose-equal"
+            "…and loosely they are still the same, which is what backfill needs"
         );
-        assert!(!same_identity_exact(&full, &other_org));
         assert!(
-            !same_identity_exact(&no_uuid, &no_uuid.clone()),
-            "name equality is never exact — two same-named entries are indistinguishable"
+            same_identity_strict(&legacy, &legacy.clone()),
+            "unknown on BOTH sides is agreement, not tolerance: the org keys are equal"
+        );
+        assert!(!same_identity_strict(&full, &other_org));
+        assert!(
+            !same_identity_strict(&no_uuid, &no_uuid.clone()),
+            "no UUID is never strict — two same-named entries are indistinguishable"
         );
     }
 
     /// The legacy two-org shape, which is the whole reason `resolve` prefers the
-    /// exact match: entry `{uuid, org-a}` and entry `{uuid}` (written before org
-    /// UUIDs were stored) are TWO REAL ACCOUNTS, and `same_identity` matches the
-    /// org-carrying target against both.
+    /// strict match: entry `{uuid, org-a}` and entry `{uuid}` (written before org
+    /// UUIDs were stored) are TWO REAL ACCOUNTS, and `same_identity` matches
+    /// EITHER target against both of them. Each target has exactly one strict
+    /// partner, so both resolve — refusing them was what left neither benchable.
     #[test]
-    fn resolve_breaks_the_legacy_tie_on_the_exact_match() {
+    fn resolve_breaks_the_legacy_tie_in_both_directions() {
         let candidates = [
             acct("me@example.com", Some("u1"), Some("org-a"), Some("Corp")),
             acct("me@example.com", Some("u1"), None, None),
@@ -351,13 +355,37 @@ mod tests {
         assert_eq!(
             resolve(indexed(), &corp),
             Resolved::One(0),
-            "both candidates match loosely; only one matches on fully known identity"
+            "both candidates match loosely; only one carries the same org"
         );
 
-        // The same target with its org still unknown has nothing stricter to
-        // prefer either candidate by — that tie is real.
         let legacy = acct("me@example.com", Some("u1"), None, None);
-        assert_eq!(resolve(indexed(), &legacy), Resolved::Many);
+        assert_eq!(
+            resolve(indexed(), &legacy),
+            Resolved::One(1),
+            "a target with no org resolves to the candidate that likewise has none"
+        );
+    }
+
+    /// The tolerance is only dropped where dropping it decides something. One
+    /// pre-org entry against a person who really is in two orgs stays a refusal:
+    /// neither candidate shares the target's (absent) org key, so nothing is
+    /// stricter and the tie is real.
+    #[test]
+    fn resolve_still_refuses_when_the_strict_pass_decides_nothing() {
+        let candidates = [
+            acct("me@example.com", Some("u1"), Some("org-a"), Some("Corp")),
+            acct(
+                "me@example.com",
+                Some("u1"),
+                Some("org-b"),
+                Some("Personal"),
+            ),
+        ];
+        let legacy = acct("me@example.com", Some("u1"), None, None);
+        assert_eq!(
+            resolve(candidates.iter().enumerate(), &legacy),
+            Resolved::Many
+        );
     }
 
     #[test]

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -27,6 +27,12 @@ pub fn org_key(a: &Account) -> Option<&str> {
         .or_else(|| a.org_name.as_deref().filter(|s| !s.is_empty()))
 }
 
+/// The account UUID of a record, when one is actually stored (an empty string is
+/// treated as absent, exactly as [`org_key`] treats an empty org).
+fn uuid_key(a: &Account) -> Option<&str> {
+    a.account_uuid.as_deref().filter(|s| !s.is_empty())
+}
+
 /// Whether two account records refer to the same account+org.
 ///
 /// - Both have an `account_uuid`: it must match. If both org keys are known they
@@ -36,10 +42,7 @@ pub fn org_key(a: &Account) -> Option<&str> {
 ///   an org key, a *different* org is correctly seen as a distinct account.
 /// - Otherwise (API-key accounts, or no UUID yet): fall back to matching by name.
 pub fn same_identity(a: &Account, b: &Account) -> bool {
-    match (
-        a.account_uuid.as_deref().filter(|s| !s.is_empty()),
-        b.account_uuid.as_deref().filter(|s| !s.is_empty()),
-    ) {
+    match (uuid_key(a), uuid_key(b)) {
         (Some(ua), Some(ub)) => {
             if ua != ub {
                 return false;
@@ -50,6 +53,77 @@ pub fn same_identity(a: &Account, b: &Account) -> bool {
             }
         }
         _ => a.name == b.name,
+    }
+}
+
+/// Whether two records match on FULLY KNOWN identity: both carry an account UUID,
+/// both carry an org key, and both agree on each.
+///
+/// This is [`same_identity`] with its tolerance removed, and it exists only to
+/// break ties. `same_identity` treats an unknown org as a match so a
+/// freshly-profiled login can backfill a legacy entry written before org UUIDs
+/// were stored — which necessarily means that one legacy entry also matches
+/// EVERY other org of the same person. A record that matches with nothing left
+/// unknown matches on evidence; the others match only on absence. See [`resolve`].
+///
+/// Records with no UUID on either side are never exact: `same_identity` falls back
+/// to name equality there, and two entries sharing a name are genuinely
+/// indistinguishable — there is no stricter fact to prefer one by.
+pub fn same_identity_exact(a: &Account, b: &Account) -> bool {
+    match (uuid_key(a), uuid_key(b)) {
+        (Some(ua), Some(ub)) if ua == ub => {
+            matches!((org_key(a), org_key(b)), (Some(ka), Some(kb)) if ka == kb)
+        }
+        _ => false,
+    }
+}
+
+/// Which of a set of candidate records an identity resolves to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Resolved {
+    /// Exactly one candidate is the answer, at this index.
+    One(usize),
+    /// No candidate carries that identity.
+    None,
+    /// Two or more candidates match and the tie cannot be broken on the stored
+    /// identity alone.
+    Many,
+}
+
+/// Resolve `target` to at most ONE of `candidates` — the single record a rotated
+/// credential or a `disabled` flag may be written to.
+///
+/// One loose match is the answer. Several loose matches are the legacy two-org
+/// shape far more often than a real ambiguity: an entry stored before org UUIDs
+/// existed carries a UUID and no org, so `same_identity` matches it against every
+/// org of that person. When exactly one of the tied candidates matches on fully
+/// known identity ([`same_identity_exact`]) the rest matched only because
+/// something was missing, so the exact one is the answer.
+///
+/// An unbreakable tie is [`Resolved::Many`] and every caller REFUSES rather than
+/// guesses. Guessing is not a cosmetic error here: stamping account A's rotated
+/// credential onto account B's record overwrites B's own single-use refresh token,
+/// which then 400s (`invalid_grant`) on its next use and leaves B dead until it is
+/// re-authed by hand.
+pub fn resolve<'a, I>(candidates: I, target: &Account) -> Resolved
+where
+    I: IntoIterator<Item = (usize, &'a Account)>,
+{
+    let mut loose: Vec<usize> = Vec::new();
+    let mut exact: Vec<usize> = Vec::new();
+    for (index, candidate) in candidates {
+        if same_identity(target, candidate) {
+            loose.push(index);
+            if same_identity_exact(target, candidate) {
+                exact.push(index);
+            }
+        }
+    }
+    match (loose.as_slice(), exact.as_slice()) {
+        ([], _) => Resolved::None,
+        ([only], _) => Resolved::One(*only),
+        (_, [only]) => Resolved::One(*only),
+        _ => Resolved::Many,
     }
 }
 
@@ -231,6 +305,104 @@ mod tests {
             "unknown org on one side → same"
         );
         assert!(same_identity(&fresh, &legacy), "symmetric");
+    }
+
+    #[test]
+    fn exact_match_needs_both_sides_fully_known() {
+        let full = acct("me@example.com", Some("u1"), Some("org-a"), Some("Corp"));
+        let legacy = acct("me@example.com", Some("u1"), None, None);
+        let other_org = acct(
+            "me@example.com",
+            Some("u1"),
+            Some("org-b"),
+            Some("Personal"),
+        );
+        let no_uuid = acct("me@example.com", None, None, None);
+
+        assert!(same_identity_exact(&full, &full.clone()));
+        assert!(
+            !same_identity_exact(&full, &legacy),
+            "an unknown org on one side is a LOOSE match, never an exact one"
+        );
+        assert!(
+            same_identity(&full, &legacy),
+            "…but it is still loose-equal"
+        );
+        assert!(!same_identity_exact(&full, &other_org));
+        assert!(
+            !same_identity_exact(&no_uuid, &no_uuid.clone()),
+            "name equality is never exact — two same-named entries are indistinguishable"
+        );
+    }
+
+    /// The legacy two-org shape, which is the whole reason `resolve` prefers the
+    /// exact match: entry `{uuid, org-a}` and entry `{uuid}` (written before org
+    /// UUIDs were stored) are TWO REAL ACCOUNTS, and `same_identity` matches the
+    /// org-carrying target against both.
+    #[test]
+    fn resolve_breaks_the_legacy_tie_on_the_exact_match() {
+        let candidates = [
+            acct("me@example.com", Some("u1"), Some("org-a"), Some("Corp")),
+            acct("me@example.com", Some("u1"), None, None),
+        ];
+        let indexed = || candidates.iter().enumerate();
+
+        let corp = acct("me@example.com", Some("u1"), Some("org-a"), Some("Corp"));
+        assert_eq!(
+            resolve(indexed(), &corp),
+            Resolved::One(0),
+            "both candidates match loosely; only one matches on fully known identity"
+        );
+
+        // The same target with its org still unknown has nothing stricter to
+        // prefer either candidate by — that tie is real.
+        let legacy = acct("me@example.com", Some("u1"), None, None);
+        assert_eq!(resolve(indexed(), &legacy), Resolved::Many);
+    }
+
+    #[test]
+    fn resolve_reports_none_one_and_an_unbreakable_tie() {
+        let one = [acct("me@example.com", None, None, None)];
+        assert_eq!(
+            resolve(
+                one.iter().enumerate(),
+                &acct("me@example.com", None, None, None)
+            ),
+            Resolved::One(0)
+        );
+        assert_eq!(
+            resolve(
+                one.iter().enumerate(),
+                &acct("nobody@example.com", None, None, None)
+            ),
+            Resolved::None
+        );
+
+        // Two same-named entries with no UUID: nothing stored distinguishes them.
+        let twins = [
+            acct("me@example.com", None, None, None),
+            acct("me@example.com", None, None, None),
+        ];
+        assert_eq!(
+            resolve(
+                twins.iter().enumerate(),
+                &acct("me@example.com", None, None, None)
+            ),
+            Resolved::Many
+        );
+
+        // Two candidates that BOTH match exactly are equally unbreakable.
+        let duplicates = [
+            acct("me@example.com", Some("u1"), Some("org-a"), None),
+            acct("me@example.com", Some("u1"), Some("org-a"), None),
+        ];
+        assert_eq!(
+            resolve(
+                duplicates.iter().enumerate(),
+                &acct("me@example.com", Some("u1"), Some("org-a"), None)
+            ),
+            Resolved::Many
+        );
     }
 
     #[test]

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -92,6 +92,26 @@ const ERROR_REPROBE_BASE_MS: i64 = 60_000;
 /// most ~twice an hour, so re-probing can never hammer the OAuth endpoint.
 const ERROR_REPROBE_CAP_MS: i64 = 30 * 60_000;
 
+/// How many probe sweeps in a row may fail to read an account's quota before
+/// keep-warm stops waiting for evidence and proceeds without it — the escape valve
+/// on [`Manager::warm_targets`]'s boot gate.
+///
+/// The gate waits because a blank quota is *unknown*, not *known-cold*, and
+/// warming an account whose 5h window is already live is wasted spend. But absence
+/// of evidence is not evidence of a live window, and if the probe fails
+/// persistently the wait never ends: keep-warm goes silently dark while config and
+/// TUI both read as enabled. That is the worse failure — an unbounded wait is a
+/// kill switch, a bounded one costs a few minutes.
+///
+/// Three, from the probe cadence. One failed sweep proves nothing: the fleet-wide
+/// false error `probing.rs` documents (a bursted sweep 429ing itself) is exactly a
+/// one-sweep event, and lifting on it would hand the boot burst straight back.
+/// Three failures are three separate sweeps a full cadence apart, which at the
+/// default [`crate::probe::DEFAULT_PROBE_SECONDS`] (75s) is ~2.5 minutes — a
+/// persistent condition, and a small fraction of any sane `warmupSeconds`. The
+/// wait is bounded by three probe cadences no matter how long the warm interval is.
+const PROBE_FAILURES_BEFORE_WARMING_UNPROBED: u32 = 3;
+
 /// Hard state of an account.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum AccountStatus {
@@ -136,15 +156,27 @@ pub struct AccountRuntime {
     pub expires_at_ms: Option<i64>,
     pub status: AccountStatus,
     pub quota: Quota,
-    /// Latched `true` the first time this account's quota was actually READ from
-    /// the usage endpoint (in [`Manager::apply_usage`], which runs only on a
-    /// successful probe). Never cleared — once we have read an account's quota we
-    /// have read it, and a later probe FAILURE deliberately leaves the
-    /// last-learned windows in place rather than blanking them.
+    /// Latched `true` the first time this account's 5h window was actually READ —
+    /// "we have evidence about this account's window", which is the question
+    /// [`Manager::warm_targets`]' boot gate is really asking. Never cleared: once
+    /// we have read it we have read it, and a later probe FAILURE deliberately
+    /// leaves the last-learned windows in place rather than blanking them.
     ///
-    /// This, and NOT `probe_status`, is [`Manager::warm_targets`]' boot gate.
-    /// `record_probe` stamps `Error`/`Timeout`/`RateLimited` on a FAILED probe too,
-    /// so `probe_status != Never` while `quota` is still `Quota::default()` — and a
+    /// TWO sources latch it, because the evidence genuinely has two sources:
+    ///  - [`Manager::apply_usage`], on a SUCCESSFUL probe of the usage endpoint —
+    ///    including one that reports no 5h bucket at all, which is itself the
+    ///    positive fact "this account has no live window";
+    ///  - [`Manager::update_quota`], when a served response's rate-limit headers
+    ///    carry the unified 5h window. Those headers are first-hand evidence about
+    ///    that account, so an account carrying live traffic must not read as
+    ///    "quota unknown" — it plainly is not.
+    ///
+    /// A response with NO 5h header latches nothing: that is silence, not the
+    /// endpoint telling us there is no window.
+    ///
+    /// This, and NOT `probe_status`, is the gate. `record_probe` stamps
+    /// `Error`/`Timeout`/`RateLimited` on a FAILED probe too, so
+    /// `probe_status != Never` while `quota` is still `Quota::default()` — and a
     /// gate keyed on that lifts on blank quota, which is the boot burst coming
     /// straight back (a real fleet-wide false-error sweep is documented in
     /// `probing.rs`). It is equally NOT `quota.five_hour.is_some()`: `apply_bucket`
@@ -152,6 +184,14 @@ pub struct AccountRuntime {
     /// responses never carry a 5h bucket would become permanently warm-INELIGIBLE —
     /// a dark feature that reads as enabled.
     pub quota_known: bool,
+    /// Probe sweeps that have failed CONSECUTIVELY without reading this account's
+    /// quota. Bumped by [`Manager::record_probe`] on every terminal failure and
+    /// reset to `0` by a success.
+    ///
+    /// It exists to bound the wait: `quota_known` alone can never latch when the
+    /// probe fails forever, so gating on it unconditionally makes keep-warm
+    /// structurally dark. See [`PROBE_FAILURES_BEFORE_WARMING_UNPROBED`].
+    pub consecutive_probe_failures: u32,
     pub input_tokens: u64,
     pub output_tokens: u64,
     /// Cache-read input tokens (a SUBSET of `input_tokens`, not additional quota).
@@ -220,6 +260,7 @@ impl AccountRuntime {
             // Nothing restores the last known windows across a restart, so at boot
             // every account's quota is genuinely unread.
             quota_known: false,
+            consecutive_probe_failures: 0,
             input_tokens: 0,
             output_tokens: 0,
             cache_read_tokens: 0,
@@ -1495,9 +1536,14 @@ mod tests {
     /// enabled (blank quota is unknown, not known-cold), and `config_with` leaves
     /// `quotaProbeSeconds` at its default 75 — so without this, every keep-warm test
     /// below would be measuring the boot gate instead of the predicate it is
-    /// actually about. `update_quota` (which `set_5h`/`set_7d` drive) is the
-    /// response-header path and deliberately touches neither `quota_known` nor
-    /// `probe_status`; only a successful probe does.
+    /// actually about.
+    ///
+    /// `set_5h` now latches `quota_known` by itself (a response's 5h header is
+    /// evidence about the window, and `update_quota` treats it as such), so calling
+    /// this stays necessary only for the accounts a test does NOT drive with
+    /// `set_5h` — including every account driven by `set_7d`, which reports no 5h
+    /// window and so latches nothing. `probe_status` is still only ever set by a
+    /// probe.
     fn mark_all_probed(manager: &Manager) {
         let mut accounts = manager.accounts.write().expect("accounts lock poisoned");
         for account in accounts.iter_mut() {
@@ -5212,6 +5258,157 @@ mod tests {
                 .await
                 .is_err(),
             "quota_known is already latched, so a repeat probe must not re-wake the loop"
+        );
+    }
+
+    /// **State 1 — evidence from the OTHER source.** A served response's
+    /// rate-limit headers are a first-hand read of that account's 5h window, so
+    /// they open the gate exactly as a probe does. Without this an account carrying
+    /// live traffic read as "quota unknown", which is false on its face: we have
+    /// its window, we just did not get it from the probe.
+    ///
+    /// The header path must also WAKE the loop, for the same reason the probe path
+    /// does — an eligible account may not sit out a whole `warmupSeconds`.
+    #[tokio::test]
+    async fn a_served_response_header_is_quota_evidence_and_opens_the_gate() {
+        let refresher = Arc::new(CountingRefresher {
+            calls: Arc::new(AtomicUsize::new(0)),
+        });
+        let manager = build_manager(config_with(vec![account("a", 0)]), refresher);
+        let wake_window = std::time::Duration::from_millis(50);
+        assert!(manager.probe_interval_seconds() > 0);
+        assert!(manager.warm_targets().is_empty(), "boot: nothing read yet");
+
+        // A response carrying the unified 5h window, with a reset already past —
+        // so the window it reports is EXPIRED and the account is genuinely cold.
+        set_5h(&manager, 0, "0.10", -1);
+
+        assert!(
+            manager.accounts.read().unwrap()[0].quota_known,
+            "a response that reported the 5h window is evidence about that window"
+        );
+        assert_eq!(
+            manager.warm_targets(),
+            vec![0],
+            "with the window read and not live, the account is a target"
+        );
+        tokio::time::timeout(wake_window, manager.warm_wake().notified())
+            .await
+            .expect("the first read wakes the warm loop whichever source it came from");
+    }
+
+    /// …but only a response that actually SAID something about the 5h window. A
+    /// response without the header — an error page, a non-Anthropic upstream — is
+    /// silence, and silence is not evidence. `set_7d` reports the weekly window and
+    /// no 5h window, which is exactly that shape.
+    #[test]
+    fn a_response_without_the_five_hour_header_latches_nothing() {
+        let refresher = Arc::new(CountingRefresher {
+            calls: Arc::new(AtomicUsize::new(0)),
+        });
+        let manager = build_manager(config_with(vec![account("a", 0)]), refresher);
+
+        set_7d(&manager, 0, "0.10");
+
+        assert!(
+            !manager.accounts.read().unwrap()[0].quota_known,
+            "a weekly-only response says nothing about the 5h window"
+        );
+        assert!(
+            manager.warm_targets().is_empty(),
+            "so the gate must still be waiting"
+        );
+    }
+
+    /// **State 3 — the bounded wait.** `quota_known` can never latch while the
+    /// probe fails, so gating on it *unconditionally* makes keep-warm structurally
+    /// dark: silently doing nothing while config and TUI both read as enabled.
+    /// After `PROBE_FAILURES_BEFORE_WARMING_UNPROBED` consecutive failed sweeps the
+    /// gate stops waiting — absence of evidence is not evidence of a live window —
+    /// and wakes the loop it kept parked.
+    ///
+    /// One failure must NOT be enough: the fleet-wide false error `probing.rs`
+    /// documents is a one-sweep event, and lifting on it hands the boot burst back.
+    #[tokio::test]
+    async fn a_persistently_failing_probe_stops_blocking_keep_warm() {
+        let refresher = Arc::new(CountingRefresher {
+            calls: Arc::new(AtomicUsize::new(0)),
+        });
+        // No account carries `ok_token`, so every sweep fails on every row.
+        let manager = build_manager_with_prober(
+            config_with(vec![account("a", 0)]),
+            refresher,
+            Arc::new(ScriptedProber {
+                ok_token: "at-nobody".to_string(),
+            }),
+        );
+        let wake_window = std::time::Duration::from_millis(50);
+        assert!(manager.probe_interval_seconds() > 0);
+
+        for sweep in 1..PROBE_FAILURES_BEFORE_WARMING_UNPROBED {
+            manager.probe_all().await;
+            assert!(
+                manager.warm_targets().is_empty(),
+                "sweep {sweep} of {PROBE_FAILURES_BEFORE_WARMING_UNPROBED}: one or two failures are a hiccup, not a verdict"
+            );
+            assert!(
+                tokio::time::timeout(wake_window, manager.warm_wake().notified())
+                    .await
+                    .is_err(),
+                "sweep {sweep}: nothing may wake the loop while the gate is still waiting"
+            );
+        }
+
+        manager.probe_all().await;
+
+        {
+            let accounts = manager.accounts.read().unwrap();
+            assert!(
+                !accounts[0].quota_known,
+                "the escape valve must NOT fake evidence — nothing was ever read"
+            );
+            assert_eq!(
+                accounts[0].consecutive_probe_failures,
+                PROBE_FAILURES_BEFORE_WARMING_UNPROBED
+            );
+        }
+        assert_eq!(
+            manager.warm_targets(),
+            vec![0],
+            "a probe that has failed every sweep is not going to answer; waiting forever is a kill switch"
+        );
+        tokio::time::timeout(wake_window, manager.warm_wake().notified())
+            .await
+            .expect("giving up on the wait must wake the loop, not leave it a full interval away");
+    }
+
+    /// The escape valve is armed by a RUN of failures, not a total: one success in
+    /// between resets it. Otherwise an account that fails, recovers, and fails
+    /// again drifts into "stop waiting" on evidence it actually has.
+    #[tokio::test]
+    async fn a_successful_probe_resets_the_failure_run() {
+        let refresher = Arc::new(CountingRefresher {
+            calls: Arc::new(AtomicUsize::new(0)),
+        });
+        let manager = build_manager_with_prober(
+            config_with(vec![account("a", 0)]),
+            refresher,
+            Arc::new(ScriptedProber {
+                ok_token: "at-nobody".to_string(),
+            }),
+        );
+        manager.probe_all().await;
+        assert_eq!(
+            manager.accounts.read().unwrap()[0].consecutive_probe_failures,
+            1
+        );
+
+        manager.record_probe(0, ProbeStatus::Ok, None);
+
+        assert_eq!(
+            manager.accounts.read().unwrap()[0].consecutive_probe_failures,
+            0,
+            "a successful read ends the run"
         );
     }
 

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -778,19 +778,36 @@ impl Manager {
         // buffer for a single-use token. If this save fails, the freshly rotated
         // token still sits in the snapshot for `persist_now` to flush at shutdown;
         // rolling memory back on failure would lose it for good.
-        let snapshot = {
+        let (snapshot, placement) = {
             let mut config = self.config.lock().expect("config lock poisoned");
-            if let Some(account) = config
-                .accounts
-                .iter_mut()
-                .find(|a| crate::identity::same_identity(a, &probe))
-            {
-                account.access_token = tokens.access_token.clone();
-                account.refresh_token = Some(tokens.refresh_token.clone());
-                account.expires_at = Some(tokens.expires_at_ms);
+            // Resolved, never first-match: `same_identity` treats an unknown org as
+            // a match, so with the legacy two-org shape in the file a first-match
+            // search lands THIS account's rotated credential on the OTHER account's
+            // record — overwriting a single-use refresh token that is then dead.
+            // An unbreakable tie writes nothing and says so.
+            let placement = crate::identity::resolve(config.accounts.iter().enumerate(), &probe);
+            if let crate::identity::Resolved::One(position) = placement {
+                if let Some(account) = config.accounts.get_mut(position) {
+                    account.access_token = tokens.access_token.clone();
+                    account.refresh_token = Some(tokens.refresh_token.clone());
+                    account.expires_at = Some(tokens.expires_at_ms);
+                }
             }
-            config.clone()
+            (config.clone(), placement)
         };
+        // Logged with the config lock released (INV2) — a `warn!` is cheap but the
+        // critical section above is on the per-connection path's lock.
+        match placement {
+            crate::identity::Resolved::One(_) => {}
+            crate::identity::Resolved::None => tracing::warn!(
+                account = %name,
+                "no loaded config account carries this identity; the rotated token is not in the snapshot and will not reach disk"
+            ),
+            crate::identity::Resolved::Many => tracing::warn!(
+                account = %name,
+                "more than one loaded config account carries this identity; refusing to guess which one just rotated, so the rotated token will not reach disk and this account may need `tcr login`"
+            ),
+        }
         // Tokens only: the in-memory config is a boot-time snapshot, so writing
         // it whole would stamp stale settings over the user's live file.
         if let Err(err) = config::save_tokens(path, &snapshot) {
@@ -850,14 +867,16 @@ impl Manager {
             Ok(config::DisabledWrite::Updated) | Ok(config::DisabledWrite::Unchanged)
         ) {
             let mut config = self.config.lock().expect("config lock poisoned");
-            // Matched by identity, exactly as persist_tokens matches, so both land
-            // on the same entry as the write above did.
-            if let Some(account) = config
-                .accounts
-                .iter_mut()
-                .find(|a| crate::identity::same_identity(a, target))
+            // Resolved by identity, exactly as `persist_tokens` and `save_disabled`
+            // resolve, so all three land on the same record. An unbreakable tie
+            // writes nothing: `save_disabled` refuses one too, and memory must not
+            // drift onto a record the file was not allowed to touch.
+            if let crate::identity::Resolved::One(position) =
+                crate::identity::resolve(config.accounts.iter().enumerate(), target)
             {
-                account.disabled = if disabled { Some(true) } else { None };
+                if let Some(account) = config.accounts.get_mut(position) {
+                    account.disabled = if disabled { Some(true) } else { None };
+                }
             }
         }
         match outcome {

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -271,21 +271,35 @@ impl DisablePersist {
     /// The one line to put in front of the user, or `None` when the outcome needs
     /// no explanation. Short enough for a single terminal row and phrased so the
     /// headline (`NOT SAVED`) survives truncation on a narrow pane.
-    pub fn warning(self) -> Option<&'static str> {
+    ///
+    /// `disabled` is the DIRECTION the keypress asked for, and it is required
+    /// because the consequence of a failed write is its exact opposite in the two
+    /// directions. Nothing was written either way, so the file still says whatever
+    /// it said: after a failed **disable** the account comes back IN ROTATION,
+    /// after a failed **enable** it comes back BENCHED. A single direction-blind
+    /// line told the user "it returns to rotation on restart" for both — so on a
+    /// failed enable they restarted on that advice and got the opposite.
+    pub fn warning(self, disabled: bool) -> Option<&'static str> {
         match self {
             // The flag is durable, or was never meant to be (demo/status have no
             // config file at all) — nothing to say.
             Self::Persisted | Self::NoConfigFile => None,
             Self::NoSuchAccount => Some("NOT SAVED: that account row no longer exists"),
-            Self::NoEntry => Some(
-                "NOT SAVED: no config entry matches this account — it returns to rotation on restart",
-            ),
+            Self::NoEntry => Some(if disabled {
+                "NOT SAVED: no config entry matches this account — it returns to rotation on restart"
+            } else {
+                "NOT SAVED: no config entry matches this account — it stays benched after a restart"
+            }),
+            // Says nothing about a restart, so it needs no direction — only an
+            // action that actually helps.
             Self::Ambiguous => Some(
-                "NOT SAVED: two config entries share this account's identity — rename one to fix",
+                "NOT SAVED: two config entries share this account's identity — give each its own orgUuid",
             ),
-            Self::WriteFailed => {
-                Some("NOT SAVED: writing the config failed — it returns to rotation on restart")
-            }
+            Self::WriteFailed => Some(if disabled {
+                "NOT SAVED: writing the config failed — it returns to rotation on restart"
+            } else {
+                "NOT SAVED: writing the config failed — it stays benched after a restart"
+            }),
         }
     }
 }
@@ -4652,27 +4666,75 @@ mod tests {
     /// silent failure arm here is a lie on screen.
     #[test]
     fn every_non_durable_persist_outcome_warns() {
-        for outcome in [DisablePersist::Persisted, DisablePersist::NoConfigFile] {
-            assert_eq!(
-                outcome.warning(),
-                None,
-                "{outcome:?} is not a failure — warning about it would be noise"
-            );
+        for disabled in [true, false] {
+            for outcome in [DisablePersist::Persisted, DisablePersist::NoConfigFile] {
+                assert_eq!(
+                    outcome.warning(disabled),
+                    None,
+                    "{outcome:?} is not a failure — warning about it would be noise"
+                );
+            }
+            for outcome in [
+                DisablePersist::NoSuchAccount,
+                DisablePersist::NoEntry,
+                DisablePersist::Ambiguous,
+                DisablePersist::WriteFailed,
+            ] {
+                let warning = outcome
+                    .warning(disabled)
+                    .unwrap_or_else(|| panic!("{outcome:?} must warn — it did not persist"));
+                assert!(
+                    warning.starts_with("NOT SAVED"),
+                    "{outcome:?} must lead with the headline so it survives truncation: {warning}"
+                );
+            }
         }
-        for outcome in [
-            DisablePersist::NoSuchAccount,
-            DisablePersist::NoEntry,
-            DisablePersist::Ambiguous,
-            DisablePersist::WriteFailed,
-        ] {
-            let warning = outcome
-                .warning()
-                .unwrap_or_else(|| panic!("{outcome:?} must warn — it did not persist"));
+    }
+
+    /// **THE direction guard.** Nothing was written, so the file still says what it
+    /// said — and that means the consequence of a failed write is the OPPOSITE in
+    /// the two directions. A failed `d` (disable) leaves the account in rotation; a
+    /// failed `e` (enable) leaves it BENCHED. One direction-blind line used to
+    /// claim "it returns to rotation on restart" for both, so a user whose enable
+    /// failed restarted on that advice and got the account benched anyway.
+    #[test]
+    fn a_failed_persist_states_the_consequence_of_its_own_direction() {
+        for outcome in [DisablePersist::NoEntry, DisablePersist::WriteFailed] {
+            let disabling = outcome.warning(true).expect("a failed disable must warn");
             assert!(
-                warning.starts_with("NOT SAVED"),
-                "{outcome:?} must lead with the headline so it survives truncation: {warning}"
+                disabling.ends_with("it returns to rotation on restart"),
+                "a failed DISABLE leaves the account in rotation: {disabling}"
+            );
+
+            let enabling = outcome.warning(false).expect("a failed enable must warn");
+            assert!(
+                enabling.ends_with("it stays benched after a restart"),
+                "a failed ENABLE leaves the account benched: {enabling}"
+            );
+            assert!(
+                !enabling.contains("returns to rotation"),
+                "a failed enable must never promise the opposite of what happens: {enabling}"
             );
         }
+    }
+
+    /// The ambiguity refusal must name an action that actually works. It used to
+    /// say "rename one to fix", which is provably wrong whenever both entries carry
+    /// an `accountUuid`: the match never consults names on that path, so renaming
+    /// changes nothing and the next `d` fails identically.
+    #[test]
+    fn the_ambiguity_warning_names_a_remedy_that_works() {
+        let warning = DisablePersist::Ambiguous
+            .warning(true)
+            .expect("an ambiguous refusal must warn");
+        assert!(
+            warning.contains("orgUuid"),
+            "the remedy is giving the entries distinct org keys: {warning}"
+        );
+        assert!(
+            !warning.contains("rename"),
+            "renaming does not break a UUID-matched tie: {warning}"
+        );
     }
 
     /// A manager with no config file behind it reports that distinctly and does NOT

--- a/src/manager/probing.rs
+++ b/src/manager/probing.rs
@@ -6,9 +6,17 @@ impl Manager {
     /// Record the health of account `idx`'s most recent probe. A failing probe
     /// stamps a visible status + message (never a silently-frozen bar), while an
     /// `Ok` probe clears any prior error.
+    ///
+    /// Also keeps the run of consecutive failures that bounds keep-warm's wait for
+    /// quota evidence, and — on the sweep that crosses
+    /// [`PROBE_FAILURES_BEFORE_WARMING_UNPROBED`] — says once, greppably, that
+    /// keep-warm is giving up on waiting for this account.
     pub fn record_probe(&self, idx: usize, status: ProbeStatus, error: Option<String>) {
-        let mut accounts = self.accounts.write().expect("accounts lock poisoned");
-        if let Some(account) = accounts.get_mut(idx) {
+        let gave_up_waiting = {
+            let mut accounts = self.accounts.write().expect("accounts lock poisoned");
+            let Some(account) = accounts.get_mut(idx) else {
+                return;
+            };
             account.probe_status = status;
             account.probe_error = error;
             // "Running" is a transient in-flight marker; only a terminal outcome
@@ -16,6 +24,39 @@ impl Manager {
             if status != ProbeStatus::Never {
                 account.last_probe_ms = Some(crate::now_ms());
             }
+            match status {
+                // A read succeeded — `apply_usage` has already latched
+                // `quota_known` on this path, and the run of failures is over.
+                ProbeStatus::Ok => {
+                    account.consecutive_probe_failures = 0;
+                    false
+                }
+                // Not a terminal outcome; it says nothing either way.
+                ProbeStatus::Never => false,
+                ProbeStatus::Error | ProbeStatus::Timeout | ProbeStatus::RateLimited => {
+                    account.consecutive_probe_failures =
+                        account.consecutive_probe_failures.saturating_add(1);
+                    // The CROSSING sweep only, so a probe that stays broken logs
+                    // once rather than every cadence. An account whose quota we did
+                    // read has nothing to give up on.
+                    !account.quota_known
+                        && account.consecutive_probe_failures
+                            == PROBE_FAILURES_BEFORE_WARMING_UNPROBED
+                }
+            }
+        };
+        if gave_up_waiting {
+            let name = self.account_name(idx).unwrap_or_default();
+            tracing::warn!(
+                account = %name,
+                index = idx,
+                failed_sweeps = PROBE_FAILURES_BEFORE_WARMING_UNPROBED,
+                "keep-warm: proceeding without quota evidence — the probe has failed every sweep and absence of evidence is not evidence of a live 5h window"
+            );
+            // Same edge-triggered wake `apply_usage` fires when the gate opens the
+            // other way: without it the account waits out a whole `warmupSeconds`
+            // after becoming eligible.
+            self.warm_wake.notify_one();
         }
     }
 

--- a/src/manager/usage.rs
+++ b/src/manager/usage.rs
@@ -8,10 +8,36 @@ impl Manager {
     /// it deliberately does NOT touch the request counter — that would double-count
     /// a client request that was retried across accounts (bug #4). Request counting
     /// happens once, in [`Manager::record_served`].
+    ///
+    /// A response that CARRIED the unified 5h header also latches
+    /// [`AccountRuntime::quota_known`], on the same terms and for the same reason
+    /// [`Self::apply_usage`] does: those headers are a first-hand read of this
+    /// account's session window, so an account serving live traffic must not go on
+    /// reading as "we have never seen this account's quota" — it plainly is not
+    /// true, and keep-warm's gate is asking exactly that question. A response
+    /// WITHOUT the header latches nothing: an error page or a non-Anthropic
+    /// upstream tells us nothing about the window, and silence must never be
+    /// mistaken for evidence.
+    ///
+    /// `probe_status` is deliberately still untouched here — that field is about
+    /// probe HEALTH, which a served response says nothing about.
     pub fn update_quota(&self, idx: usize, headers: &reqwest::header::HeaderMap) {
-        let mut accounts = self.accounts.write().expect("accounts lock poisoned");
-        if let Some(account) = accounts.get_mut(idx) {
-            account.quota.update_from_headers(headers);
+        let newly_known = {
+            let mut accounts = self.accounts.write().expect("accounts lock poisoned");
+            match accounts.get_mut(idx) {
+                Some(account) => {
+                    let read_five_hour = account.quota.update_from_headers(headers);
+                    let flipped = read_five_hour && !account.quota_known;
+                    account.quota_known |= read_five_hour;
+                    flipped
+                }
+                None => false,
+            }
+        };
+        // Edge-triggered, with the accounts lock RELEASED — identical to
+        // `apply_usage`, whose comment explains both halves.
+        if newly_known {
+            self.warm_wake.notify_one();
         }
     }
 

--- a/src/manager/warm.rs
+++ b/src/manager/warm.rs
@@ -20,28 +20,47 @@ impl Manager {
     /// blank. Blank is *unknown*, not *known-cold* — and the warm loop's ticker
     /// fires its first tick immediately, so without a gate the first sweep spends a
     /// real upstream request on every probeable account, including ones whose 5h
-    /// window is genuinely live and ones sitting at 100% weekly. An account whose
-    /// quota we have never READ is therefore not a target: we do not warm on quota
-    /// we have not read.
+    /// window is genuinely live and ones sitting at 100% weekly.
     ///
-    /// The predicate is [`AccountRuntime::quota_known`] — "a probe successfully read
-    /// this account's quota" — and NOT `probe_status`. `probe_status` is the wrong
-    /// question: `record_probe` stamps `Error`/`Timeout`/`RateLimited` on a FAILED
-    /// probe, which leaves `probe_status != Never` while the quota is still
-    /// `Quota::default()`, so a gate keyed on it lifts on blank quota and hands the
-    /// boot burst straight back. `probing.rs` documents a real sweep that painted a
-    /// false error on every row — exactly that shape.
+    /// # The gate is about EVIDENCE, and has three states, not two
     ///
-    /// The gate applies ONLY while probing is actually enabled. With
-    /// `quotaProbeSeconds == 0` no probe task is ever spawned, so `quota_known`
-    /// would stay `false` forever and gating on it unconditionally would make
-    /// keep-warm structurally unable to fire — a dark feature that looks enabled.
-    /// With the probe off there is nothing to wait for, so today's behaviour stands.
+    /// "Safe to warm" means: we have evidence about this account's 5h window, and
+    /// that evidence says no window is currently live. So:
     ///
-    /// With probing ON, the deferral costs one probe cycle, not one warm interval:
-    /// [`Manager::apply_usage`] signals [`Manager::warm_wake`] on the flip and the
-    /// warm loop `select!`s on it, so the gate can never strand keep-warm for a
-    /// whole `warmupSeconds`.
+    /// 1. **Evidence present** → open. [`AccountRuntime::quota_known`] is that
+    ///    evidence, and it has TWO sources: a successful probe
+    ///    ([`Manager::apply_usage`]) and a served response whose rate-limit headers
+    ///    carried the unified 5h window ([`Manager::update_quota`]). Both are
+    ///    first-hand reads of this account's window. Leaving the second one out is
+    ///    why an account carrying live traffic used to read as "quota unknown",
+    ///    which was simply false.
+    /// 2. **No evidence yet, still expected** → wait. This is the boot case the
+    ///    gate exists for, and it costs one probe cycle rather than one warm
+    ///    interval: both latch sites signal [`Manager::warm_wake`] on the flip and
+    ///    the warm loop `select!`s on it.
+    /// 3. **Evidence unavailable** → proceed anyway, and say so once.
+    ///    [`PROBE_FAILURES_BEFORE_WARMING_UNPROBED`] consecutive failed sweeps mean
+    ///    the probe is not going to answer. Absence of evidence is not evidence of
+    ///    a live window, and a permanently dark feature is worse than a bounded
+    ///    warm on stale information — the wait must be BOUNDED, or gating on
+    ///    `quota_known` is a silent kill switch whenever the probe stays broken.
+    ///
+    /// State 3 is self-limiting, which is what makes it safe: `warm_account` folds
+    /// the warm response's own rate-limit headers back in, so one warm request per
+    /// account produces the evidence the gate wanted and states 1/2 take over
+    /// again. It cannot become a repeating burst.
+    ///
+    /// The predicate is NOT `probe_status`: `record_probe` stamps
+    /// `Error`/`Timeout`/`RateLimited` on a FAILED probe, which leaves
+    /// `probe_status != Never` while the quota is still `Quota::default()`, so a
+    /// gate keyed on it lifts on blank quota after ONE failure and hands the boot
+    /// burst straight back. `probing.rs` documents a real fleet-wide false-error
+    /// sweep — exactly that shape, and exactly why state 3 needs several failures
+    /// rather than one.
+    ///
+    /// The whole gate applies only while probing is actually enabled. With
+    /// `quotaProbeSeconds == 0` no probe task is ever spawned, so there is nothing
+    /// to wait for and no failure count to accrue either.
     pub fn warm_targets(&self) -> Vec<usize> {
         let now = OffsetDateTime::now_utc();
         // Read the probe cadence BEFORE taking the accounts lock: this touches the
@@ -58,10 +77,13 @@ impl Manager {
                     && !a.disabled
                     && a.status != AccountStatus::Error
                     && a.status != AccountStatus::Throttled
-                    // Quota never READ while the probe is running: it is unknown,
-                    // not known-cold. Wait for a probe to actually read it — a
-                    // probe that merely FAILED has read nothing.
-                    && (!awaiting_first_probe || a.quota_known)
+                    // Evidence about the 5h window, or a bounded wait for it. A
+                    // probe that merely FAILED has read nothing — but once it has
+                    // failed enough times in a row it is not going to read
+                    // anything, and waiting forever is a kill switch, not caution.
+                    && (!awaiting_first_probe
+                        || a.quota_known
+                        || a.consecutive_probe_failures >= PROBE_FAILURES_BEFORE_WARMING_UNPROBED)
                     // A live future 5h reset means the session window is already running.
                     && a.quota.five_hour.and_then(|w| w.live_reset(now)).is_none()
                     // Warming an at/over-threshold account is wasted spend.

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -107,8 +107,17 @@ impl HeaderView for reqwest::header::HeaderMap {
 impl Quota {
     /// Merge in whatever rate-limit headers are present on a response, leaving
     /// windows that were not reported this time untouched.
-    pub fn update_from_headers(&mut self, headers: &impl HeaderView) {
+    ///
+    /// Returns whether this response actually reported the **5-hour** window. That
+    /// is the one dimension a caller needs to distinguish from silence: a response
+    /// carrying the header is first-hand evidence about the account's session
+    /// window, while a response without it (an error page, a non-Anthropic
+    /// upstream) says nothing at all — and the two must never be confused for the
+    /// keep-warm gate. See [`crate::manager::AccountRuntime::quota_known`].
+    #[must_use]
+    pub fn update_from_headers(&mut self, headers: &impl HeaderView) -> bool {
         let now = OffsetDateTime::now_utc();
+        let mut read_five_hour = false;
         if let Some(util) = get_parsed::<f64>(headers, "anthropic-ratelimit-unified-5h-utilization")
             .filter(|v| v.is_finite())
         {
@@ -123,6 +132,7 @@ impl Quota {
                 utilization: util,
                 reset,
             });
+            read_five_hour = true;
         }
         if let Some(util) = get_parsed::<f64>(headers, "anthropic-ratelimit-unified-7d-utilization")
             .filter(|v| v.is_finite())
@@ -177,6 +187,7 @@ impl Quota {
         {
             self.standard_reset = Some(reset);
         }
+        read_five_hour
     }
 
     /// Is this account at/over `threshold` on any gating dimension, evaluated
@@ -367,7 +378,10 @@ mod tests {
             ("anthropic-ratelimit-unified-status", "allowed_warning"),
         ]);
         let mut quota = Quota::default();
-        quota.update_from_headers(&headers);
+        assert!(
+            quota.update_from_headers(&headers),
+            "a response carrying the unified 5h header reports the window"
+        );
 
         let five = quota.five_hour.unwrap();
         assert_eq!(five.utilization, 0.42);
@@ -394,7 +408,10 @@ mod tests {
                 "{bad:?} must parse to None"
             );
             let mut quota = Quota::default();
-            quota.update_from_headers(&headers);
+            assert!(
+                !quota.update_from_headers(&headers),
+                "{bad:?} is not a readable window, so it must not report one either"
+            );
             assert!(
                 quota.five_hour.is_none(),
                 "{bad:?} utilization must not create a window"
@@ -471,7 +488,7 @@ mod tests {
         let mut quota = Quota::default();
         // Utilization with NO reset header.
         let headers = TestHeaders::new(&[("anthropic-ratelimit-unified-5h-utilization", "0.95")]);
-        quota.update_from_headers(&headers);
+        assert!(quota.update_from_headers(&headers));
 
         let now = OffsetDateTime::now_utc();
         // A reset was synthesized in the future, so it gates right now …

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -154,10 +154,10 @@ pub async fn run(manager: Arc<Manager>) -> io::Result<()> {
                         // screen — otherwise the row renders benched and the user
                         // finds out at the next restart.
                         Action::Disable => {
-                            notice = manager.set_disabled(selected, true).warning().map(Notice::new);
+                            notice = manager.set_disabled(selected, true).warning(true).map(Notice::new);
                         }
                         Action::Enable => {
-                            notice = manager.set_disabled(selected, false).warning().map(Notice::new);
+                            notice = manager.set_disabled(selected, false).warning(false).map(Notice::new);
                         }
                         Action::None => {}
                     },
@@ -1583,7 +1583,7 @@ mod tests {
     fn render_shows_a_failed_persist_notice_without_hiding_the_fleet_banner() {
         let snapshot = util_snapshot(QuotaState::Normal);
         let warning = crate::manager::DisablePersist::NoEntry
-            .warning()
+            .warning(true)
             .expect("a NoEntry persist must warn");
 
         let with = {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -73,6 +73,7 @@ fn install_panic_hook() {
 }
 
 /// What a key event asks the loop to do.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum Action {
     None,
     Quit,
@@ -95,24 +96,65 @@ const NOTICE_SECONDS: u64 = 6;
 struct Notice {
     text: &'static str,
     expires_at: std::time::Instant,
+    /// The account the notice is ABOUT, by name — `None` when the keypress named
+    /// no account at all. Every notice describes one row, so it must not be read
+    /// against another: a warning raised for `alice` still on screen while `bob` is
+    /// selected reads as a warning about `bob`.
+    account: Option<String>,
 }
 
 impl Notice {
-    fn new(text: &'static str) -> Self {
+    fn new(text: &'static str, account: Option<String>) -> Self {
         Self {
             text,
             expires_at: std::time::Instant::now() + Duration::from_secs(NOTICE_SECONDS),
+            account,
         }
     }
 }
 
-/// The notice to paint this frame: the current one until it expires, then nothing.
-/// Pure so the expiry rule is testable without a terminal or a real clock.
-fn live_notice(notice: &Option<Notice>, now: std::time::Instant) -> Option<&str> {
+/// The notice to paint this frame: the current one while it is unexpired AND still
+/// about the row on screen, then nothing. Pure so both rules are testable without a
+/// terminal or a real clock.
+///
+/// `selected_account` is the name of the currently selected row (`None` when there
+/// is no such row, which is also what a `NoSuchAccount` notice carries — so those
+/// two agree rather than falling through).
+fn live_notice<'a>(
+    notice: &'a Option<Notice>,
+    now: std::time::Instant,
+    selected_account: Option<&str>,
+) -> Option<&'a str> {
     notice
         .as_ref()
         .filter(|n| now < n.expires_at)
+        .filter(|n| n.account.as_deref() == selected_account)
         .map(|n| n.text)
+}
+
+/// The selected row forced back inside a table of `count` rows — `0` when the table
+/// is empty.
+fn clamp_selected(selected: usize, count: usize) -> usize {
+    selected.min(count.saturating_sub(1))
+}
+
+/// The selection a key event leaves behind: clamped into the table FIRST, then
+/// moved. Every key event goes through this, which is the whole point — the
+/// ordering is the fix, so it lives in one pure function rather than in the shape
+/// of the event loop.
+///
+/// `Down` advances with a `saturating_add` and deliberately may overshoot; the next
+/// event pulls it back. Before, the 500ms repaint was the ONLY thing that clamped,
+/// so a `Down` immediately followed by `d`/`e` reached `set_disabled` with an index
+/// past the end of the table: nothing was benched, and the user got a "that account
+/// row no longer exists" banner about a row plainly on screen.
+fn next_selection(selected: usize, count: usize, action: Action) -> usize {
+    let selected = clamp_selected(selected, count);
+    match action {
+        Action::Up => selected.saturating_sub(1),
+        Action::Down => selected.saturating_add(1),
+        Action::None | Action::Quit | Action::Disable | Action::Enable => selected,
+    }
 }
 
 /// Run the dashboard until the user quits (`q` or `Ctrl-C`). Returns once the
@@ -131,13 +173,12 @@ pub async fn run(manager: Arc<Manager>) -> io::Result<()> {
         tokio::select! {
             _ = ticker.tick() => {
                 let snapshot = manager.snapshot(OffsetDateTime::now_utc());
-                let count = snapshot.accounts.len();
-                if count == 0 {
-                    selected = 0;
-                } else if selected >= count {
-                    selected = count - 1;
-                }
-                let live = live_notice(&notice, std::time::Instant::now());
+                selected = clamp_selected(selected, snapshot.accounts.len());
+                let live = live_notice(
+                    &notice,
+                    std::time::Instant::now(),
+                    snapshot.accounts.get(selected).map(|a| a.name.as_str()),
+                );
                 // A single failed repaint must not crash the process.
                 if let Err(err) = terminal.draw(|frame| render(frame, &snapshot, selected, live)) {
                     tracing::warn!(error = %err, "tui repaint failed");
@@ -145,22 +186,34 @@ pub async fn run(manager: Arc<Manager>) -> io::Result<()> {
             }
             maybe_event = events.next() => {
                 match maybe_event {
-                    Some(Ok(Event::Key(key))) => match key_action(&key) {
-                        Action::Quit => break,
-                        Action::Up => selected = selected.saturating_sub(1),
-                        Action::Down => selected = selected.saturating_add(1),
-                        // A persist that did not reach disk is surfaced HERE, not
-                        // only in the log the TUI has redirected away from the
-                        // screen — otherwise the row renders benched and the user
-                        // finds out at the next restart.
-                        Action::Disable => {
-                            notice = manager.set_disabled(selected, true).warning(true).map(Notice::new);
+                    Some(Ok(Event::Key(key))) => {
+                        let action = key_action(&key);
+                        // Clamp FIRST, move second — and both here, BEFORE the
+                        // arms below read `selected`. The 500ms repaint used to be
+                        // the only clamp, so a key acting on the selection could
+                        // read an index `Down` had already pushed past the end.
+                        selected = next_selection(selected, manager.account_count(), action);
+                        match action {
+                            Action::Quit => break,
+                            // Moving off a row abandons whatever was said about it.
+                            Action::Up | Action::Down => notice = None,
+                            // A persist that did not reach disk is surfaced HERE,
+                            // not only in the log the TUI has redirected away from
+                            // the screen — otherwise the row renders benched and
+                            // the user finds out at the next restart. The notice
+                            // carries the name of the row it is about, so it cannot
+                            // be read against a different one.
+                            Action::Disable | Action::Enable => {
+                                let disabled = action == Action::Disable;
+                                let account = manager.account_name(selected);
+                                notice = manager
+                                    .set_disabled(selected, disabled)
+                                    .warning(disabled)
+                                    .map(|text| Notice::new(text, account));
+                            }
+                            Action::None => {}
                         }
-                        Action::Enable => {
-                            notice = manager.set_disabled(selected, false).warning(false).map(Notice::new);
-                        }
-                        Action::None => {}
-                    },
+                    }
                     // Paste / resize / focus / mouse are non-fatal; a multi-char
                     // paste can never crash the loop.
                     Some(Ok(_)) => {}
@@ -333,9 +386,9 @@ fn render_fleet_banner(
             None => text.push_str(" · next free unknown"),
         }
     }
-    // Red + bold when the fleet is down (0 eligible); a calm green otherwise.
+    // The alarm style when the fleet is down (0 eligible); a calm green otherwise.
     let style = if status.eligible == 0 {
-        Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
+        alarm_style()
     } else {
         Style::default()
             .fg(Color::Green)
@@ -344,13 +397,19 @@ fn render_fleet_banner(
     frame.render_widget(Paragraph::new(Line::from(Span::styled(text, style))), area);
 }
 
-/// The transient notice row. Red + bold, same alarm styling the fleet banner uses
-/// when the fleet is down: every notice we raise means an action the user believes
-/// happened did not.
+/// The one style for "this needs you NOW", shared by the two rows that raise an
+/// alarm: the fleet banner with nothing in rotation, and any notice. Shared so the
+/// two cannot drift apart — a notice that stopped looking like the banner would
+/// read as ordinary chrome, which is exactly what it is not.
+fn alarm_style() -> Style {
+    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
+}
+
+/// The transient notice row. Painted in the alarm style, because every notice we
+/// raise means an action the user believes happened did not.
 fn render_notice(frame: &mut Frame, area: Rect, text: &str) {
-    let style = Style::default().fg(Color::Red).add_modifier(Modifier::BOLD);
     frame.render_widget(
-        Paragraph::new(Line::from(Span::styled(text.to_string(), style))),
+        Paragraph::new(Line::from(Span::styled(text.to_string(), alarm_style()))),
         area,
     );
 }
@@ -1629,21 +1688,116 @@ mod tests {
     /// warning can never outlive the state it describes.
     #[test]
     fn a_notice_expires_and_stops_rendering() {
-        let notice = Some(Notice::new("NOT SAVED: test"));
+        let notice = Some(Notice::new("NOT SAVED: test", Some("alice".to_string())));
         let start = std::time::Instant::now();
 
-        assert_eq!(live_notice(&notice, start), Some("NOT SAVED: test"));
         assert_eq!(
-            live_notice(&notice, start + Duration::from_secs(NOTICE_SECONDS - 1)),
+            live_notice(&notice, start, Some("alice")),
+            Some("NOT SAVED: test")
+        );
+        assert_eq!(
+            live_notice(
+                &notice,
+                start + Duration::from_secs(NOTICE_SECONDS - 1),
+                Some("alice")
+            ),
             Some("NOT SAVED: test"),
             "the notice must survive long enough to be read"
         );
         assert_eq!(
-            live_notice(&notice, start + Duration::from_secs(NOTICE_SECONDS + 1)),
+            live_notice(
+                &notice,
+                start + Duration::from_secs(NOTICE_SECONDS + 1),
+                Some("alice")
+            ),
             None,
             "the notice must clear itself once it expires"
         );
-        assert_eq!(live_notice(&None, start), None);
+        assert_eq!(live_notice(&None, start, Some("alice")), None);
+    }
+
+    /// A notice describes ONE row, so it may only be painted while that row is the
+    /// one on screen. Unscoped, a warning raised for `alice` kept rendering after
+    /// the selection moved to `bob` — where it reads as a warning about `bob`, an
+    /// account nothing was ever attempted on.
+    #[test]
+    fn a_notice_is_scoped_to_the_account_it_was_raised_for() {
+        let notice = Some(Notice::new("NOT SAVED: test", Some("alice".to_string())));
+        let now = std::time::Instant::now();
+
+        assert_eq!(
+            live_notice(&notice, now, Some("alice")),
+            Some("NOT SAVED: test"),
+            "unexpired and about the selected row → painted"
+        );
+        assert_eq!(
+            live_notice(&notice, now, Some("bob")),
+            None,
+            "a warning about alice must never be shown over bob's row"
+        );
+        assert_eq!(
+            live_notice(&notice, now, None),
+            None,
+            "…nor when no row is selected at all"
+        );
+
+        // The one notice that names no account — `NoSuchAccount`, raised when the
+        // selection pointed at nothing — pairs with the empty selection.
+        let rowless = Some(Notice::new("NOT SAVED: no row", None));
+        assert_eq!(live_notice(&rowless, now, None), Some("NOT SAVED: no row"));
+        assert_eq!(live_notice(&rowless, now, Some("alice")), None);
+    }
+
+    /// **THE off-by-one guard.** `Down` advances with a `saturating_add` and the
+    /// 500ms repaint was the ONLY thing that pulled it back in range, so a `Down`
+    /// immediately followed by `d` handed `set_disabled` an index past the end of
+    /// the table: nothing was benched, and the user was told "that account row no
+    /// longer exists" about a row plainly on screen.
+    ///
+    /// Asserted on `next_selection` rather than on `clamp_selected`, because the
+    /// bug was never in the clamp — it was in WHEN the clamp ran. A test of the
+    /// clamp alone passes with the fix reverted, which makes it no gate at all.
+    #[test]
+    fn a_key_acts_on_a_clamped_selection_not_on_an_overshot_one() {
+        // The `Down` that overshoots: last row of a 3-row table → 3, out of range.
+        assert_eq!(next_selection(2, 3, Action::Down), 3);
+
+        // Whatever key comes NEXT must act on row 2, not on row 3.
+        for action in [Action::Disable, Action::Enable, Action::None] {
+            assert_eq!(
+                next_selection(3, 3, action),
+                2,
+                "{action:?} must act on the last row, not on an index past the end"
+            );
+        }
+        assert_eq!(
+            next_selection(3, 3, Action::Up),
+            1,
+            "`Up` starts from the clamped row too, or it takes two presses to move one"
+        );
+
+        // Ordinary movement is untouched.
+        assert_eq!(next_selection(1, 3, Action::Up), 0);
+        assert_eq!(
+            next_selection(0, 3, Action::Up),
+            0,
+            "no underflow at the top"
+        );
+        assert_eq!(next_selection(1, 3, Action::Down), 2);
+
+        // An empty table has no row to select and must not underflow.
+        assert_eq!(next_selection(4, 0, Action::Disable), 0);
+        assert_eq!(next_selection(0, 0, Action::Up), 0);
+    }
+
+    /// The alarm styling is defined once. Two literals would drift, and a notice
+    /// that stopped looking like the fleet-down banner would read as ordinary
+    /// chrome — which is exactly what it is not.
+    #[test]
+    fn the_notice_and_the_downed_fleet_banner_share_one_alarm_style() {
+        let style = alarm_style();
+        assert_eq!(style.fg, Some(Color::Red));
+        assert!(style.add_modifier.contains(Modifier::BOLD));
     }
 
     #[test]


### PR DESCRIPTION
All four confirmed findings from the adversarial review of #17, plus the small ones it flagged. The review bots found nothing on #15 or #17; this is the second round of self-review catching real defects in merged code.

## Token clobber on a duplicate-identity config — the only data-loss bug

`merge_tokens` resolved the memory account by first-identity-match with no ambiguity check. The `EntryMatch` machinery that made `save_disabled` safe in #17 was never applied here. With two entries whose identities both match, a token rotation for account A stamped A's freshly rotated credentials onto **both** — destroying the second account's single-use refresh token. Its next refresh returns 400 `invalid_grant` and the account is dead until re-authed by hand: the exact unrecoverable outcome the INV1 write lock in that same file exists to prevent.

Resolution now runs as a **mutual-uniqueness fixed point**. An entry is written only when it resolves to exactly one unclaimed account *and* that account resolves back to that entry alone; rounds repeat until nothing settles. Ambiguous entries are planned as `Skip` before any mutation, so they cannot reach the write at all, and are reported by name.

## The ambiguity refusal no longer locks out the legacy two-org shape

`same_identity`'s org comparison returns true when either side's org key is absent, so `entry[0] = {uuid U, orgUuid A}` beside a pre-org `entry[1] = {uuid U}` — the documented backfill shape — was refused as ambiguous. Those are two real accounts, and neither could be durably benched. The old first-match code handled them; #17's refusal broke them.

`identity::resolve` now prefers the strict match: when the loose match is ambiguous but exactly one candidate matches on full identity, that is the answer. `Many` is returned only for a genuinely unbreakable tie. Combined with the mutual pass above, the org-carrying entry settles first and the pre-org sibling becomes unambiguous against what remains.

The remediation text also lied: it said "rename one to fix" when matching never consults names once both entries carry a uuid. Following it changed nothing. Now it names an action that works.

## A failed persist states its own direction

`DisablePersist::warning()` had no access to the direction, so a failed **enable** reported "it returns to rotation on restart" — the opposite of the truth. The file still said `"disabled": true`, so the user restarted expecting a fix and got a still-benched account. Now parameterised on the direction.

## The keep-warm gate, derived rather than patched

This predicate has been wrong three times: no gate (boot burst on blank quota), then `probe_status != Never` (opened on a *failed* probe, never reopened), then `quota_known` latched only by a successful probe (never opened at all when the probe failed persistently — a silent kill switch).

Stated once, from what "safe to warm" means — we have evidence about the 5h window, and it says no window is live:

1. **Evidence present** → open. `quota_known` now has **two** sources: a successful probe, and a served response's rate-limit headers. The header path previously and deliberately did not latch it, so an account carrying live traffic read as "quota unknown", which was false.
2. **No evidence yet, still expected** → wait. The boot case the gate exists for.
3. **Evidence unavailable** — N consecutive failed sweeps mean the probe is not going to answer → proceed, logged once. Absence of evidence is not evidence of a live window, and a permanently dark feature is worse than a bounded warm on stale information.

The existing assertion that a failed probe never latches `quota_known` still holds; state 3 is a separate condition, not a change to that latch.

## Smaller fixes

`selected` is clamped on every key event rather than only the 500ms tick, so a Down+`d`/`e` pair cannot act on an out-of-range row; `notice` is scoped to the account it was raised for and cleared on selection change; the duplicated Red+Bold style literal is shared.

## Verification

- `cargo test --lib` — **423 passed, 0 failed** (up from 405). Clippy and `fmt --check` clean.
- Gates proven to fail before being trusted: reverting `identity::resolve` to first-match-wins failed **seven** tests, including `persist_refuses_to_write_a_credential_into_an_ambiguous_entry` — the token-clobber gate — and restoring it returned the suite to 423 green.

Built with Henry and Gil <1435669+dhkts1@users.noreply.github.com>
