### PR TITLE
feat: show when a throttled or quota-gated account actually comes back

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1047,7 +1047,11 @@ mod tests {
             true,
         )
         .await;
-        let text = render_accounts(&snapshot, &thresholds, StatusSource::Live);
+        // Offline is the honest source for a snapshot built by `snapshot_offline`,
+        // and it is the exact line shape `tcr accounts` emits — that verb is
+        // offline by construction, so this is the greppable line a human reads
+        // most often.
+        let text = render_accounts(&snapshot, &thresholds, StatusSource::Offline);
         let lines: Vec<&str> = text.lines().collect();
         assert_eq!(lines.len(), 2, "one line per account");
         // Each line is greppable: name + priority + per-window utilization.
@@ -1072,6 +1076,15 @@ mod tests {
             !text.contains("held=") && !text.contains("quota="),
             "legacy quota/held fields are gone: {text}"
         );
+        // Every token stays `key=value`, so the new stream-error token is greppable
+        // wherever it sits in the line and does not displace its neighbours.
+        for line in &lines {
+            assert!(
+                line.contains("probe=") && line.contains("stream_errors=n/a"),
+                "the offline line keeps probe= and carries an unmeasured \
+                 stream-error token: {line}"
+            );
+        }
     }
 
     /// THE HONESTY TEST. An offline snapshot's serving counters live in the

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -390,7 +390,15 @@ fn render_window(
 /// output is greppable (`account NAME priority=P quota=Q% status=S ...`). The
 /// ratatui TUI renderer is unusable for stdout, and per Gil's greppable-output
 /// rule a naive grep must be able to match any single field.
-pub fn render_accounts(snapshot: &StatsSnapshot, thresholds: &[f64]) -> String {
+///
+/// `source` is taken rather than inferred because one token depends on it:
+/// `stream_errors` is a SERVING counter, so an offline snapshot's zero is
+/// structurally unmeasured (see [`StatusSource`]) and renders `n/a`, never `0`.
+pub fn render_accounts(
+    snapshot: &StatsSnapshot,
+    thresholds: &[f64],
+    source: StatusSource,
+) -> String {
     if snapshot.accounts.is_empty() {
         return "no accounts configured\n".to_string();
     }
@@ -422,8 +430,29 @@ pub fn render_accounts(snapshot: &StatsSnapshot, thresholds: &[f64]) -> String {
                 a.cache_read_tokens as f64 / a.input_tokens as f64 * 100.0
             )
         };
+        // In-band SSE `error` events this account's streams carried (decayed
+        // window). A truncated 200 books as a clean serve, so this is the only
+        // place that class of failure is visible at all.
+        //
+        // `n/a` — never `0` — on an OFFLINE snapshot, for the same reason
+        // `cache=n/a` exists: the counter lives in the serving process, so a fresh
+        // one reads structurally zero, and "0 stream errors" is an affirmative
+        // all-clear in a way "0 requests" is not. Publishing an unmeasured
+        // all-clear on an error counter is precisely the failure this field was
+        // added to end.
+        let stream_errors = match source {
+            StatusSource::Offline => " stream_errors=n/a".to_string(),
+            StatusSource::Live => format!(" stream_errors={}", a.stream_error_count),
+        };
+        // The latest error's `error.type`, alongside the count. Omitted entirely
+        // when none has been seen, matching the `fable=` idiom — the count above
+        // already distinguishes "none" from "not measured".
+        let last_stream_error = match (source, a.last_stream_error.as_deref()) {
+            (StatusSource::Live, Some(kind)) => format!(" last_stream_error={kind}"),
+            _ => String::new(),
+        };
         out.push_str(&format!(
-            "account {} priority={} {} {}{}{} state={} status={} probe={}{}\n",
+            "account {} priority={} {} {}{}{} state={} status={} probe={}{}{}{}\n",
             a.name,
             a.priority,
             five_hour,
@@ -433,6 +462,8 @@ pub fn render_accounts(snapshot: &StatsSnapshot, thresholds: &[f64]) -> String {
             quota_state_token(a.quota_state),
             a.status,
             a.probe_status.as_str(),
+            stream_errors,
+            last_stream_error,
             if a.disabled { " disabled" } else { "" },
         ));
     }
@@ -539,6 +570,23 @@ fn render_accounts_json(
                 },
                 "probeStatus": a.probe_status.as_str(),
                 "probeError": a.probe_error,
+                // Decayed count of in-band SSE `error` events — a truncated 200
+                // that books as a clean serve. `null`, NEVER 0, on the offline
+                // path: the counter lives in the serving process, so a fresh one
+                // is structurally zero, and an unmeasured `0` on an ERROR counter
+                // publishes an all-clear nobody measured. Same "not measured"
+                // idiom as `cacheHitRatio`; `source` says which process would
+                // have measured it.
+                "streamErrorCount": match source {
+                    StatusSource::Offline => serde_json::Value::Null,
+                    StatusSource::Live => serde_json::json!(a.stream_error_count),
+                },
+                // The latest error's `error.type` (e.g. "overloaded_error"), or
+                // null when none has been observed / nothing measured.
+                "lastStreamError": match source {
+                    StatusSource::Offline => None,
+                    StatusSource::Live => a.last_stream_error.clone(),
+                },
                 "held": held,
             })
         })
@@ -560,7 +608,13 @@ pub async fn list_accounts(config_path: &Path, probe: bool) -> anyhow::Result<()
         probe,
     )
     .await;
-    print!("{}", render_accounts(&snapshot, &thresholds));
+    // `tcr accounts` is the offline verb by construction — it builds its own
+    // Manager and never asks the server — so its serving counters are structurally
+    // zero and must render as unmeasured, not as a measurement.
+    print!(
+        "{}",
+        render_accounts(&snapshot, &thresholds, StatusSource::Offline)
+    );
     Ok(())
 }
 
@@ -714,7 +768,7 @@ pub async fn status(config_path: &Path, json: bool) -> anyhow::Result<()> {
             },
             build_fields(server_build.as_ref()),
         );
-        print!("{}", render_accounts(&snapshot, &thresholds));
+        print!("{}", render_accounts(&snapshot, &thresholds, source));
     }
     Ok(())
 }
@@ -993,7 +1047,7 @@ mod tests {
             true,
         )
         .await;
-        let text = render_accounts(&snapshot, &thresholds);
+        let text = render_accounts(&snapshot, &thresholds, StatusSource::Live);
         let lines: Vec<&str> = text.lines().collect();
         assert_eq!(lines.len(), 2, "one line per account");
         // Each line is greppable: name + priority + per-window utilization.
@@ -1082,7 +1136,7 @@ mod tests {
         );
 
         // The human view uses the same `n/a` idiom the unknown quota windows use.
-        let text = render_accounts(&snapshot, &thresholds);
+        let text = render_accounts(&snapshot, &thresholds, StatusSource::Offline);
         for line in text.lines() {
             assert!(
                 line.contains("cache=n/a"),
@@ -1091,8 +1145,87 @@ mod tests {
             assert!(!line.contains("cache=0%"), "no false measured zero: {line}");
         }
         assert!(
-            render_accounts(&counted, &thresholds).contains("cache=75%"),
+            render_accounts(&counted, &thresholds, StatusSource::Live).contains("cache=75%"),
             "a measured ratio still renders as a percentage"
+        );
+    }
+
+    /// The stream-error counter obeys the same rule as the cache ratio above, and
+    /// for a sharper reason: `0` on an ERROR counter is an affirmative all-clear.
+    /// Offline it is structurally zero — the count lives in the serving process —
+    /// so publishing it as `0` would claim "no truncated streams" about a process
+    /// this one never spoke to.
+    #[tokio::test]
+    async fn offline_status_reports_null_not_zero_stream_errors() {
+        let config = load_from(TWO_ACCOUNTS);
+        let thresholds = resolve_thresholds(&config);
+        let snapshot = snapshot_offline(
+            config,
+            Arc::new(NoRefresh),
+            Arc::new(FixedProber { util: 0.25 }),
+            true,
+        )
+        .await;
+
+        let offline = render_accounts_json(&snapshot, &thresholds, StatusSource::Offline, None);
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&offline).expect("valid json");
+        for row in &rows {
+            // `get`, not `row[...]`: indexing a MISSING key also yields Null, so
+            // `row["streamErrorCount"].is_null()` would pass against the very bug
+            // this test exists for — the field never being rendered at all.
+            assert_eq!(
+                row.get("streamErrorCount"),
+                Some(&serde_json::Value::Null),
+                "the key is present AND null — unmeasured, never a 0 all-clear: {row}"
+            );
+            assert_eq!(
+                row.get("lastStreamError"),
+                Some(&serde_json::Value::Null),
+                "nothing measured: {row}"
+            );
+        }
+
+        // Measured and genuinely clean is a DIFFERENT state, and renders as 0.
+        let live = render_accounts_json(&snapshot, &thresholds, StatusSource::Live, None);
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&live).expect("valid json");
+        assert_eq!(rows[0]["streamErrorCount"], serde_json::json!(0));
+
+        // Measured and dirty carries both the count and the latest error type.
+        let mut errored = snapshot.clone();
+        errored.accounts[0].stream_error_count = 3;
+        errored.accounts[0].last_stream_error = Some("overloaded_error".to_string());
+        let live = render_accounts_json(&errored, &thresholds, StatusSource::Live, None);
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&live).expect("valid json");
+        assert_eq!(rows[0]["streamErrorCount"], serde_json::json!(3));
+        assert_eq!(
+            rows[0]["lastStreamError"],
+            serde_json::json!("overloaded_error")
+        );
+
+        // The text view carries the same three states as greppable tokens.
+        let text = render_accounts(&snapshot, &thresholds, StatusSource::Offline);
+        for line in text.lines() {
+            assert!(
+                line.contains("stream_errors=n/a"),
+                "unmeasured reads n/a, never 0: {line}"
+            );
+            assert!(
+                !line.contains("stream_errors=0"),
+                "no false all-clear: {line}"
+            );
+        }
+        assert!(
+            render_accounts(&snapshot, &thresholds, StatusSource::Live).contains("stream_errors=0"),
+            "a measured clean fleet still renders a real 0"
+        );
+        let text = render_accounts(&errored, &thresholds, StatusSource::Live);
+        assert!(
+            text.contains("stream_errors=3"),
+            "the count is greppable: {text}"
+        );
+        assert!(
+            text.contains("last_stream_error=overloaded_error"),
+            "the latest error type is greppable: {text}"
         );
     }
 
@@ -1335,7 +1468,7 @@ mod tests {
             calls: calls.clone(),
         });
         let snapshot = snapshot_offline(config, refresher, Arc::new(RejectingProber), true).await;
-        let text = render_accounts(&snapshot, &thresholds);
+        let text = render_accounts(&snapshot, &thresholds, StatusSource::Offline);
         assert!(
             text.contains("stale@example.com"),
             "renders the account: {text}"
@@ -1433,7 +1566,7 @@ mod tests {
         let thresholds = resolve_thresholds(&config);
         let snapshot =
             snapshot_offline(config, Arc::new(NoRefresh), Arc::new(WindowProber), true).await;
-        let text = render_accounts(&snapshot, &thresholds);
+        let text = render_accounts(&snapshot, &thresholds, StatusSource::Live);
         let alice = text
             .lines()
             .find(|l| l.contains("alice@example.com"))
@@ -1505,7 +1638,7 @@ mod tests {
         let thresholds = resolve_thresholds(&config);
         let snapshot =
             snapshot_offline(config, Arc::new(NoRefresh), Arc::new(ExhaustedProber), true).await;
-        let text = render_accounts(&snapshot, &thresholds);
+        let text = render_accounts(&snapshot, &thresholds, StatusSource::Live);
         let line = text
             .lines()
             .find(|l| l.contains("alice@example.com"))

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -73,6 +73,8 @@ fn base(name: &str, priority: i64) -> AccountRuntime {
         probe_status: ProbeStatus::Ok,
         last_probe_ms: Some(now - 12_000),
         probe_error: None,
+        stream_error_times_ms: std::collections::VecDeque::new(),
+        last_stream_error: None,
     }
 }
 

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -112,6 +112,17 @@ const ERROR_REPROBE_CAP_MS: i64 = 30 * 60_000;
 /// wait is bounded by three probe cadences no matter how long the warm interval is.
 const PROBE_FAILURES_BEFORE_WARMING_UNPROBED: u32 = 3;
 
+/// Decay window for [`AccountRuntime::stream_error_times_ms`] — how far back a
+/// stream error still counts toward the operator-facing decayed count. An hour:
+/// long enough to show a persistent pattern, short enough that a stale blip from
+/// hours ago does not linger in the TUI forever.
+const STREAM_ERROR_WINDOW_MS: i64 = 3_600_000;
+
+/// Hard cap on [`AccountRuntime::stream_error_times_ms`] so a pathological
+/// account (erroring on every request, indefinitely) cannot grow the queue
+/// without bound even inside the decay window.
+const STREAM_ERROR_CAP: usize = 64;
+
 /// Hard state of an account.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum AccountStatus {
@@ -238,6 +249,15 @@ pub struct AccountRuntime {
     pub probe_status: ProbeStatus,
     pub last_probe_ms: Option<i64>,
     pub probe_error: Option<String>,
+    /// Wall-clock ms of each in-band SSE `error` event observed on a stream this
+    /// account served (see [`Manager::record_stream_error`]), pruned to
+    /// [`STREAM_ERROR_WINDOW_MS`] and hard-capped at [`STREAM_ERROR_CAP`] entries
+    /// on BOTH insert and read, so it cannot grow unbounded. OBSERVABILITY ONLY —
+    /// nothing in `select.rs` reads this field; see that module's gates for why.
+    pub stream_error_times_ms: VecDeque<i64>,
+    /// The most recent stream error's `error.type` (e.g. `"overloaded_error"`),
+    /// alongside the decayed count above.
+    pub last_stream_error: Option<String>,
 }
 
 impl AccountRuntime {
@@ -277,6 +297,8 @@ impl AccountRuntime {
             probe_status: ProbeStatus::Never,
             last_probe_ms: None,
             probe_error: None,
+            stream_error_times_ms: VecDeque::new(),
+            last_stream_error: None,
         }
     }
 }

--- a/src/manager/select.rs
+++ b/src/manager/select.rs
@@ -1003,18 +1003,25 @@ impl Manager {
     /// reset (a window over threshold whose reset is unknown) is the
     /// longest-possible constraint, so it sorts as "latest": it becomes the reason
     /// and `free_at` is `None` (we cannot promise a time). No active gate → `Ok`.
-    pub(super) fn account_gate(
+    /// Every ACTIVE hard gate on `account`, paired with the instant it clears
+    /// (`None` = active but no known reset).
+    ///
+    /// Extracted so [`Self::account_gate`] and [`Self::account_gate_known_floor`]
+    /// fold the SAME collection two different ways and cannot drift apart. `Err`
+    /// carries a terminal state (never self-frees), which both callers must treat
+    /// as "no clear-instant at all" rather than as an empty gate list.
+    fn active_gates(
         account: &AccountRuntime,
         threshold: f64,
         now: OffsetDateTime,
         now_ms: i64,
         is_fable: bool,
-    ) -> (GateReason, Option<OffsetDateTime>) {
+    ) -> Result<Vec<(GateReason, Option<OffsetDateTime>)>, GateReason> {
         // Terminal states that never self-free — reported with no clear-instant.
         // Shared with `account_hard_ok` so the two can no longer disagree about
         // which blocks are account-level (see `account_terminal_gate`).
         if let Some(reason) = Self::account_terminal_gate(account) {
-            return (reason, None);
+            return Err(reason);
         }
 
         // Every ACTIVE hard gate paired with the instant it clears (`None` = active
@@ -1074,10 +1081,50 @@ impl Manager {
         // wins here and carries its `None` out as `free_at` — exactly the
         // "cannot promise a time" case. `max_by_key` breaks ties toward the
         // last-collected gate, a deterministic order.
-        gates
+        Ok(gates)
+    }
+
+    pub(super) fn account_gate(
+        account: &AccountRuntime,
+        threshold: f64,
+        now: OffsetDateTime,
+        now_ms: i64,
+        is_fable: bool,
+    ) -> (GateReason, Option<OffsetDateTime>) {
+        match Self::active_gates(account, threshold, now, now_ms, is_fable) {
+            Err(reason) => (reason, None),
+            Ok(gates) => gates
+                .into_iter()
+                .max_by_key(|&(_, at)| gate_clear_key(at))
+                .unwrap_or((GateReason::Ok, None)),
+        }
+    }
+
+    /// DISPLAY ONLY: the LATEST clear-instant among the gates that have one, or
+    /// `None` when no active gate has a known reset.
+    ///
+    /// This is a FLOOR ("will not free before this, possibly later"), not a
+    /// promise. It exists because [`Self::account_gate`] reports `free_at = None`
+    /// whenever ANY active gate's reset is unknown — that unknown sorts last in
+    /// `gate_clear_key` and wins — so an account gated on both a known 7-day reset
+    /// and an unknown one renders with no time at all, hiding a bound we do know.
+    ///
+    /// It must NEVER feed [`super::Manager::retry_after_hint`]. That path is
+    /// deliberately honest-by-construction: its doc records that minimising over
+    /// raw window resets "promised a recovery that would not happen", and a floor
+    /// is exactly such a too-early promise. Renderers only.
+    pub(super) fn account_gate_known_floor(
+        account: &AccountRuntime,
+        threshold: f64,
+        now: OffsetDateTime,
+        now_ms: i64,
+        is_fable: bool,
+    ) -> Option<OffsetDateTime> {
+        Self::active_gates(account, threshold, now, now_ms, is_fable)
+            .ok()?
             .into_iter()
-            .max_by_key(|&(_, at)| gate_clear_key(at))
-            .unwrap_or((GateReason::Ok, None))
+            .filter_map(|(_, at)| at)
+            .max()
     }
 
     /// The best pacing-respecting eligible account not in `tried`, by ascending

--- a/src/manager/snapshot.rs
+++ b/src/manager/snapshot.rs
@@ -173,6 +173,11 @@ impl Manager {
                     quota_state,
                     gate,
                     free_at,
+                    stream_error_count: super::usage::stream_error_count(
+                        &a.stream_error_times_ms,
+                        now_ms,
+                    ),
+                    last_stream_error: a.last_stream_error.clone(),
                 }
             })
             .collect();

--- a/src/manager/snapshot.rs
+++ b/src/manager/snapshot.rs
@@ -130,6 +130,12 @@ impl Manager {
                 // never gates a general fleet row (an account spent only on its
                 // Fable bucket still serves every other model, so it reads `Ok`).
                 let (gate, free_at) = Self::account_gate(a, threshold, now, now_ms, false);
+                // Display-only floor for the Gate cell when `free_at` is None
+                // because an active gate's reset is unknown. Same `is_fable=false`
+                // view as the line above, so the two always describe one account
+                // state rather than two.
+                let free_at_floor =
+                    Self::account_gate_known_floor(a, threshold, now, now_ms, false);
                 AccountSnapshot {
                     name: a.name.clone(),
                     priority: a.priority,
@@ -173,6 +179,7 @@ impl Manager {
                     quota_state,
                     gate,
                     free_at,
+                    free_at_floor,
                     stream_error_count: super::usage::stream_error_count(
                         &a.stream_error_times_ms,
                         now_ms,

--- a/src/manager/usage.rs
+++ b/src/manager/usage.rs
@@ -124,4 +124,58 @@ impl Manager {
             }
         }
     }
+
+    /// Record that account `idx` served a stream that carried an in-band SSE
+    /// `error` event (`kind` is `error.error.type`, e.g. `"overloaded_error"`) —
+    /// a truncated turn the client saw as a 200 that must not read as a clean
+    /// serve. OBSERVABILITY ONLY: this warns and updates a decayed counter and
+    /// the account's last-error label; it deliberately does NOT call
+    /// `mark_error` (that condemns terminally — see its doc comment on the 2026-07-17
+    /// incident) or `mark_rate_limited` (an overloaded account is not over quota —
+    /// see [`Self::mark_rate_limited`]'s doc comment), and nothing in
+    /// `select.rs`'s `eligible`/`hard_ok`/`account_terminal_gate` reads the
+    /// counter this writes — wiring it into routing is a separate, later,
+    /// premortem'd change.
+    pub fn record_stream_error(&self, idx: usize, kind: &str) {
+        let now_ms = crate::now_ms();
+        let mut accounts = self.accounts.write().expect("accounts lock poisoned");
+        if let Some(account) = accounts.get_mut(idx) {
+            tracing::warn!(
+                account = %account.name,
+                index = idx,
+                error_type = kind,
+                "SSE stream carried an in-band error event — truncated turn, not a clean serve"
+            );
+            account.stream_error_times_ms.push_back(now_ms);
+            prune_stream_errors(&mut account.stream_error_times_ms, now_ms);
+            account.last_stream_error = Some(kind.to_string());
+        }
+    }
+}
+
+/// Prune `times` to [`STREAM_ERROR_WINDOW_MS`] and hard-cap at
+/// [`STREAM_ERROR_CAP`] entries, oldest first. The mutating half of pruning —
+/// called on INSERT, where the caller already holds the accounts write lock.
+fn prune_stream_errors(times: &mut VecDeque<i64>, now_ms: i64) {
+    while times
+        .front()
+        .is_some_and(|&t| now_ms - t > STREAM_ERROR_WINDOW_MS)
+    {
+        times.pop_front();
+    }
+    while times.len() > STREAM_ERROR_CAP {
+        times.pop_front();
+    }
+}
+
+/// The account's DECAYED stream-error count as of `now_ms`: entries within
+/// [`STREAM_ERROR_WINDOW_MS`]. The read-side half of pruning — [`Manager::snapshot`]
+/// holds only the accounts READ lock, so it cannot pop stale entries the way
+/// [`prune_stream_errors`] does on insert; this counts without mutating instead,
+/// which is equivalent for display purposes (the next insert physically prunes).
+pub(super) fn stream_error_count(times: &VecDeque<i64>, now_ms: i64) -> usize {
+    times
+        .iter()
+        .filter(|&&t| now_ms - t <= STREAM_ERROR_WINDOW_MS)
+        .count()
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1274,7 +1274,7 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
                         .await
                         .map(|bytes| (Ok::<Bytes, Infallible>(bytes), rx))
                 });
-                let parsed = parse_sse_usage(byte_stream).await;
+                let (parsed, stream_error) = parse_sse_usage(byte_stream).await;
                 if parsed.input_total > 0 || parsed.output > 0 {
                     manager_side.update_usage(
                         idx,
@@ -1283,6 +1283,15 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
                         parsed.cache_read,
                         parsed.cache_creation,
                     );
+                }
+                // Sibling of the usage guard above, not nested in it: an error
+                // event with NO message_start leaves input_total == output == 0,
+                // and this must still be recorded — that is precisely the bug
+                // (a truncated stream booked as a clean serve). Called ONCE per
+                // stream, after the parse loop ends, never per event — a
+                // per-event call on a long erroring stream is a log-flood vector.
+                if let Some(kind) = stream_error {
+                    manager_side.record_stream_error(idx, &kind);
                 }
             });
             let passthrough = resp.bytes_stream().map(move |chunk| {
@@ -1819,7 +1828,9 @@ fn usage_from_json(bytes: &[u8]) -> ParsedUsage {
     }
 }
 
-/// Parse the total usage breakdown from an SSE messages stream.
+/// Parse the total usage breakdown from an SSE messages stream, plus — out of
+/// band, so [`ParsedUsage`] can stay `Copy` — the FIRST in-band `error` event's
+/// `error.type`, if any arrived.
 ///
 /// `input_total` is taken from `message_start` (base + cache tokens); `output`
 /// is the latest cumulative count from `message_delta` (or `message_start` if
@@ -1829,7 +1840,13 @@ fn usage_from_json(bytes: &[u8]) -> ParsedUsage {
 /// boundary-split `message_start` is still parsed whole (bug #1 designed out).
 /// The cache components come from the same `message_start` usage via the shared
 /// [`cache_breakdown`] (R2: identical extraction to the JSON path).
-async fn parse_sse_usage<S, B, E>(stream: S) -> ParsedUsage
+///
+/// An Anthropic error envelope can arrive INSIDE a 200 `text/event-stream` body
+/// (the same shape this proxy itself synthesizes — see [`error_response`] used
+/// as a template, and the `event: error` fixture below) — that is a truncated,
+/// failed turn, not usage to add to the quota. First `error` event wins; a
+/// second is ignored, so multi-event streams still name their root cause.
+async fn parse_sse_usage<S, B, E>(stream: S) -> (ParsedUsage, Option<String>)
 where
     S: futures::Stream<Item = Result<B, E>>,
     B: AsRef<[u8]>,
@@ -1838,6 +1855,7 @@ where
     futures::pin_mut!(events);
 
     let mut parsed = ParsedUsage::default();
+    let mut stream_error: Option<String> = None;
     while let Some(item) = events.next().await {
         let Ok(event) = item else {
             break; // malformed/utf8/transport error — stop parsing, keep totals
@@ -1867,10 +1885,21 @@ where
                     parsed.output = out;
                 }
             }
+            // First `error` event wins — a later one is ignored (guard skips the
+            // arm rather than nesting an `if` inside it, per clippy).
+            Some("error") if stream_error.is_none() => {
+                let kind = value
+                    .get("error")
+                    .and_then(|e| e.get("type"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown")
+                    .to_string();
+                stream_error = Some(kind);
+            }
             _ => {}
         }
     }
-    parsed
+    (parsed, stream_error)
 }
 
 /// A JSON error response in Anthropic's error envelope.
@@ -2308,7 +2337,8 @@ mod tests {
             Ok::<Bytes, Infallible>(Bytes::copy_from_slice(&full.as_bytes()[..split])),
             Ok::<Bytes, Infallible>(Bytes::copy_from_slice(&full.as_bytes()[split..])),
         ];
-        let parsed = parse_sse_usage(futures::stream::iter(chunks)).await;
+        let (parsed, stream_error) = parse_sse_usage(futures::stream::iter(chunks)).await;
+        assert_eq!(stream_error, None, "a clean stream has no error event");
         // R1: the quota sum is byte-identical to before.
         assert_eq!(
             parsed.input_total, 1110,
@@ -2334,7 +2364,8 @@ mod tests {
             "event: message_delta\ndata: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":37}}\n\n",
         );
         let stream = futures::stream::iter(vec![Ok::<Bytes, Infallible>(Bytes::from(full))]);
-        let parsed = parse_sse_usage(stream).await;
+        let (parsed, stream_error) = parse_sse_usage(stream).await;
+        assert_eq!(stream_error, None, "a clean stream has no error event");
         assert_eq!(parsed.input_total, 5);
         assert_eq!(parsed.output, 37, "final cumulative output, not 20 + 37");
         // No cache tokens in this fixture → both stay zero.
@@ -3754,6 +3785,170 @@ mod tests {
             "a 2nd 401 is rotation churn, not a dead credential — it must leave the \
              account Active; `Error` is terminal and would sideline a healthy account \
              forever (nothing re-probes or re-selects an errored row)"
+        );
+    }
+
+    /// Bounded-poll the manager's decayed stream-error count for account 0 until
+    /// it matches `want`, or give up after ~2s. The tee task that records it runs
+    /// in a DETACHED `tokio::spawn`, so the client can observe body EOF before
+    /// that task has drained its channel and finished the parse loop — reading to
+    /// EOF then asserting immediately is racy. Returns the last-observed count and
+    /// how many times it polled, so a caller's failure message states what it saw
+    /// rather than reading as a hang or a bare timing artifact.
+    async fn poll_stream_error_count(manager: &Manager, want: usize) -> (usize, u32) {
+        let mut polls = 0u32;
+        let mut seen = manager.snapshot(OffsetDateTime::now_utc()).accounts[0].stream_error_count;
+        while seen != want && polls < 200 {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            seen = manager.snapshot(OffsetDateTime::now_utc()).accounts[0].stream_error_count;
+            polls += 1;
+        }
+        (seen, polls)
+    }
+
+    /// THE BUG: an Anthropic error envelope delivered inside a 200
+    /// `text/event-stream` body — the same shape this proxy itself synthesizes,
+    /// and the shape Anthropic's real upstream uses for a mid-stream failure —
+    /// must be OBSERVED, not silently booked as a clean serve. Before the fix,
+    /// `parse_sse_usage`'s match had no `error` arm, so the event fell into
+    /// `_ => {}` and nothing was recorded.
+    #[tokio::test]
+    async fn sse_error_event_is_observed_not_counted_as_clean_serve() {
+        let upstream = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let up_addr = upstream.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = upstream.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut buf = [0u8; 1024];
+                    let _ = sock.read(&mut buf).await;
+                    let body = concat!(
+                        "event: error\n",
+                        "data: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}}\n\n",
+                    );
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = sock.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+
+        let manager =
+            Manager::with_live_refresher(dummy_config(None, &format!("http://{up_addr}")), None);
+
+        let proxy = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = proxy.local_addr().unwrap();
+        let served = Arc::clone(&manager);
+        tokio::spawn(async move {
+            let _ = axum::serve(proxy, app(served)).await;
+        });
+
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let resp = client
+            .post(format!("http://{proxy_addr}/v1/messages"))
+            .body("{}")
+            .send()
+            .await
+            .unwrap();
+        // Read the body to completion FIRST — the client can see EOF before the
+        // detached tee task has finished parsing (see `poll_stream_error_count`).
+        let _ = resp.bytes().await.unwrap();
+
+        let (seen, polls) = poll_stream_error_count(&manager, 1).await;
+        assert_eq!(
+            seen, 1,
+            "polled {polls} times, stream-error count stayed {seen} — an in-band \
+             SSE error event must be observed, not silently dropped as a clean serve"
+        );
+
+        // The terminal-outcome counter (`record_served`) is UNCHANGED by this —
+        // it fires on the upstream's 200 status same as any clean serve, and this
+        // fix is deliberately observability-only: it adds a SECOND signal, it
+        // does not replace or gate the first.
+        assert_eq!(
+            manager.snapshot(OffsetDateTime::now_utc()).accounts[0].requests,
+            1,
+            "the request-served counter is untouched by this fix"
+        );
+    }
+
+    /// NEGATIVE CONTROL: a clean 200 SSE stream (normal `message_start` /
+    /// `message_delta`, no `error` event) must record NO stream error. Uses the
+    /// same bounded-poll discipline as the positive case — asserting absence
+    /// after a trivially-passing zero-wait would be vacuous.
+    #[tokio::test]
+    async fn sse_clean_stream_records_no_stream_error() {
+        let upstream = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let up_addr = upstream.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = upstream.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut buf = [0u8; 1024];
+                    let _ = sock.read(&mut buf).await;
+                    let body = concat!(
+                        "event: message_start\n",
+                        "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}}\n\n",
+                        "event: message_delta\n",
+                        "data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":9}}\n\n",
+                    );
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = sock.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+
+        let manager =
+            Manager::with_live_refresher(dummy_config(None, &format!("http://{up_addr}")), None);
+
+        let proxy = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = proxy.local_addr().unwrap();
+        let served = Arc::clone(&manager);
+        tokio::spawn(async move {
+            let _ = axum::serve(proxy, app(served)).await;
+        });
+
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let resp = client
+            .post(format!("http://{proxy_addr}/v1/messages"))
+            .body("{}")
+            .send()
+            .await
+            .unwrap();
+        let _ = resp.bytes().await.unwrap();
+
+        // Poll for the USAGE to land (a positive, waitable signal that the tee
+        // task has finished), then assert the error count is absent — never a
+        // zero-wait check, which would pass vacuously before the tee even runs.
+        let mut polls = 0u32;
+        let mut input_tokens = manager.snapshot(OffsetDateTime::now_utc()).accounts[0].input_tokens;
+        while input_tokens == 0 && polls < 200 {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            input_tokens = manager.snapshot(OffsetDateTime::now_utc()).accounts[0].input_tokens;
+            polls += 1;
+        }
+        assert_eq!(
+            input_tokens, 5,
+            "polled {polls} times waiting for usage to land"
+        );
+
+        assert_eq!(
+            manager.snapshot(OffsetDateTime::now_utc()).accounts[0].stream_error_count,
+            0,
+            "a clean SSE stream must record no stream error"
         );
     }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -124,6 +124,12 @@ pub struct AccountSnapshot {
     /// (`Login`/`Disabled`), or when a gating window has no known reset (unknown —
     /// we cannot promise a time).
     pub free_at: Option<OffsetDateTime>,
+    /// DISPLAY ONLY floor: the latest clear-instant among the gates that HAVE one,
+    /// when [`Self::free_at`] is `None` because some other active gate's reset is
+    /// unknown. Read as "not before this, possibly later" — never as a promise,
+    /// and never fed to `retry_after_hint` (see
+    /// [`crate::manager::Manager::account_gate_known_floor`]).
+    pub free_at_floor: Option<OffsetDateTime>,
     /// Count of in-band SSE `error` events this account's streams carried within
     /// the decay window (see `STREAM_ERROR_WINDOW_MS` in `manager/mod.rs`) — a
     /// truncated 200 that got booked as a clean serve before this field existed.

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -124,6 +124,17 @@ pub struct AccountSnapshot {
     /// (`Login`/`Disabled`), or when a gating window has no known reset (unknown —
     /// we cannot promise a time).
     pub free_at: Option<OffsetDateTime>,
+    /// Count of in-band SSE `error` events this account's streams carried within
+    /// the decay window (see `STREAM_ERROR_WINDOW_MS` in `manager/mod.rs`) — a
+    /// truncated 200 that got booked as a clean serve before this field existed.
+    /// OBSERVABILITY ONLY: nothing in `select.rs` reads it, so it never gates
+    /// rotation. On the wire deliberately (see `status.rs`'s module doc): it
+    /// carries no credential material, and `tcr status --json` is how an
+    /// operator sees the fleet.
+    pub stream_error_count: usize,
+    /// The most recent stream error's `error.type` (e.g. `"overloaded_error"`),
+    /// alongside the count above. Same on-the-wire decision as `stream_error_count`.
+    pub last_stream_error: Option<String>,
 }
 
 /// Whether a live session was keyed on a stable client identity (x-api-key /

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -130,10 +130,20 @@ pub struct AccountSnapshot {
     /// OBSERVABILITY ONLY: nothing in `select.rs` reads it, so it never gates
     /// rotation. On the wire deliberately (see `status.rs`'s module doc): it
     /// carries no credential material, and `tcr status --json` is how an
-    /// operator sees the fleet.
+    /// operator sees the fleet — `tcr status --json | jq '.[].streamErrorCount'`,
+    /// rendered by `cli::render_accounts_json`, with the plain-text `tcr status`
+    /// carrying the same number as a `stream_errors=` token.
+    ///
+    /// That last sentence was FALSE when this field was introduced: the renderers
+    /// did not exist, so the value reached the wire and stopped there. Both were
+    /// added afterwards, which is what makes the claim true now. It is load-bearing
+    /// — if a future change drops either renderer, delete the claim with it rather
+    /// than leaving a rationale the code no longer earns.
     pub stream_error_count: usize,
     /// The most recent stream error's `error.type` (e.g. `"overloaded_error"`),
-    /// alongside the count above. Same on-the-wire decision as `stream_error_count`.
+    /// alongside the count above. Same on-the-wire decision as `stream_error_count`,
+    /// and surfaced by the same two renderers (`lastStreamError` in JSON, the
+    /// `last_stream_error=` token in text).
     pub last_stream_error: Option<String>,
 }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -122,6 +122,8 @@ pub struct AccountStatus {
     pub quota_state: QuotaState,
     pub gate: GateReason,
     pub free_at_ms: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub free_at_floor_ms: Option<i64>,
     /// The account's effective switch threshold on the SERVER (its own
     /// `switchThreshold`, else the global one).
     pub threshold: f64,
@@ -180,6 +182,7 @@ impl StatusPayload {
                 quota_state: a.quota_state,
                 gate: a.gate,
                 free_at_ms: a.free_at.map(to_ms),
+                free_at_floor_ms: a.free_at_floor.map(to_ms),
                 threshold: thresholds.get(i).copied().unwrap_or(1.0),
                 stream_error_count: a.stream_error_count,
                 last_stream_error: a.last_stream_error.clone(),
@@ -231,6 +234,7 @@ impl StatusPayload {
                     quota_state: a.quota_state,
                     gate: a.gate,
                     free_at: a.free_at_ms.and_then(from_ms),
+                    free_at_floor: a.free_at_floor_ms.and_then(from_ms),
                     stream_error_count: a.stream_error_count,
                     last_stream_error: a.last_stream_error,
                 }
@@ -277,6 +281,7 @@ mod tests {
                 quota_state: QuotaState::Normal,
                 gate: GateReason::Ok,
                 free_at: None,
+                free_at_floor: None,
                 stream_error_count: 0,
                 last_stream_error: None,
             }],

--- a/src/status.rs
+++ b/src/status.rs
@@ -125,6 +125,15 @@ pub struct AccountStatus {
     /// The account's effective switch threshold on the SERVER (its own
     /// `switchThreshold`, else the global one).
     pub threshold: f64,
+    /// Decayed count of in-band SSE `error` events (see
+    /// [`AccountSnapshot::stream_error_count`]). Put ON the wire deliberately —
+    /// it carries no credential material and `tcr status --json` is how an
+    /// operator sees the fleet; see this module's doc comment on the
+    /// no-secret invariant.
+    pub stream_error_count: usize,
+    /// The most recent stream error's type, alongside the count above. Same
+    /// on-the-wire decision as `stream_error_count`.
+    pub last_stream_error: Option<String>,
 }
 
 /// Unix milliseconds for an instant, matching [`crate::now_ms`]'s unit.
@@ -172,6 +181,8 @@ impl StatusPayload {
                 gate: a.gate,
                 free_at_ms: a.free_at.map(to_ms),
                 threshold: thresholds.get(i).copied().unwrap_or(1.0),
+                stream_error_count: a.stream_error_count,
+                last_stream_error: a.last_stream_error.clone(),
             })
             .collect();
         Self {
@@ -220,6 +231,8 @@ impl StatusPayload {
                     quota_state: a.quota_state,
                     gate: a.gate,
                     free_at: a.free_at_ms.and_then(from_ms),
+                    stream_error_count: a.stream_error_count,
+                    last_stream_error: a.last_stream_error,
                 }
             })
             .collect();
@@ -264,6 +277,8 @@ mod tests {
                 quota_state: QuotaState::Normal,
                 gate: GateReason::Ok,
                 free_at: None,
+                stream_error_count: 0,
+                last_stream_error: None,
             }],
             current: Some(0),
             recent: Vec::new(),

--- a/src/status.rs
+++ b/src/status.rs
@@ -128,11 +128,11 @@ pub struct AccountStatus {
     /// Decayed count of in-band SSE `error` events (see
     /// [`AccountSnapshot::stream_error_count`]). Put ON the wire deliberately —
     /// it carries no credential material and `tcr status --json` is how an
-    /// operator sees the fleet; see this module's doc comment on the
-    /// no-secret invariant.
+    /// operator sees the fleet (`tcr status --json | jq '.[].streamErrorCount'`);
+    /// see this module's doc comment on the no-secret invariant.
     pub stream_error_count: usize,
     /// The most recent stream error's type, alongside the count above. Same
-    /// on-the-wire decision as `stream_error_count`.
+    /// on-the-wire decision as `stream_error_count`; rendered as `lastStreamError`.
     pub last_stream_error: Option<String>,
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -974,9 +974,16 @@ fn gate_chip(account: &AccountSnapshot, now: OffsetDateTime) -> (String, Style) 
         .add_modifier(Modifier::DIM);
     // A quota/Fable gate's back-when: the compact `rel`, or just the prefix when
     // the reset is unknown.
+    // Exact instant when we have one; otherwise the known FLOOR (">=3d") when some
+    // other active gate's unknown reset suppressed `free_at`. Showing the floor
+    // beats showing nothing: the badge alone hides a bound we actually know. The
+    // ">=" is load-bearing punctuation — this is "not before", never "at".
     let back = |prefix: &str| match account.free_at {
         Some(f) if f > now => format!("{prefix} {}", rel(f - now)),
-        _ => prefix.to_string(),
+        _ => match account.free_at_floor {
+            Some(fl) if fl > now => format!("{prefix} \u{2265}{}", rel(fl - now)),
+            _ => prefix.to_string(),
+        },
     };
     match account.gate {
         GateReason::Ok => ("OK".to_string(), dim),
@@ -1454,6 +1461,7 @@ mod tests {
             quota_state: QuotaState::Normal,
             gate,
             free_at,
+            free_at_floor: None,
             stream_error_count: 0,
             last_stream_error: None,
         }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -544,7 +544,8 @@ fn render_accounts(
             // Columns shared by both layouts, in their shared order.
             let name = Cell::from(format!("{marker}{}", account.name));
             let priority = Cell::from(account.priority.to_string());
-            let status = Cell::from(account.status.clone()).style(status_style(&account.status));
+            let status =
+                Cell::from(status_label(account, now)).style(status_style(&account.status));
             let gate = Cell::from(gate_label).style(gate_style);
             let reqs = Cell::from(account.requests.to_string());
             let input = Cell::from(fmt_tokens(account.input_tokens));
@@ -1005,6 +1006,32 @@ fn gate_chip(account: &AccountSnapshot, now: OffsetDateTime) -> (String, Style) 
     }
 }
 
+/// The Status cell's text: the raw status word, plus the clear-instant when the
+/// account is on a live 429 hold ("throttled 12s").
+///
+/// "When does it come back" is the only actionable thing about a hold, and the
+/// bare word forces the operator over to the Gate column — which shows `HOLD`
+/// only when no later-clearing gate outranks it, so a throttled-AND-quota-gated
+/// account shows the hold nowhere at all.
+///
+/// DISPLAY ONLY, and deliberately so. [`crate::manager::Manager::account_gate`]
+/// reports `free_at = None` whenever any active gate's reset is unknown, and
+/// [`crate::manager::Manager::retry_after_hint`] turns that into the client-facing
+/// `retry-after` — its doc records that promising a recovery which will not happen
+/// was a real bug. This cell must never become a source of truth for that path.
+///
+/// `rate_limited_until` is already live-filtered by the snapshot (an expired hold
+/// arrives as `None`); the `until > now` guard is belt-and-braces for a snapshot
+/// rendered slightly after it was taken.
+fn status_label(account: &AccountSnapshot, now: OffsetDateTime) -> String {
+    match account.rate_limited_until {
+        Some(until) if account.status == "throttled" && until > now => {
+            format!("{} {}", account.status, rel(until - now))
+        }
+        _ => account.status.clone(),
+    }
+}
+
 fn status_style(status: &str) -> Style {
     match status {
         "active" => Style::default().fg(Color::Green),
@@ -1435,6 +1462,35 @@ mod tests {
     /// A stable, far-from-epoch anchor so `now + delta` never underflows.
     fn anchor() -> OffsetDateTime {
         OffsetDateTime::UNIX_EPOCH + TimeDuration::days(3650)
+    }
+
+    #[test]
+    fn status_label_shows_a_live_hold_and_nothing_else() {
+        let now = anchor();
+        let mut a = snap_gate("acct", GateReason::Ok, None);
+
+        // A live hold renders its clear-instant beside the word.
+        a.status = "throttled".to_string();
+        a.rate_limited_until = Some(now + TimeDuration::seconds(12));
+        assert_eq!(status_label(&a, now), "throttled 12s");
+
+        // No deadline (or one that has already passed — the snapshot normally
+        // filters those to None, this is the belt-and-braces arm) falls back to the
+        // bare word rather than inventing or negating a time.
+        a.rate_limited_until = None;
+        assert_eq!(status_label(&a, now), "throttled");
+        a.rate_limited_until = Some(now - TimeDuration::seconds(1));
+        assert_eq!(status_label(&a, now), "throttled");
+
+        // THE LEAK GUARD: a deadline must never decorate a row that is not on a
+        // hold. `clear_rate_limited` nulls the field when it flips the status back,
+        // but the two are separate writes and this cell must not depend on that
+        // ordering — an `active` row showing a countdown would read as gated.
+        a.status = "active".to_string();
+        a.rate_limited_until = Some(now + TimeDuration::seconds(12));
+        assert_eq!(status_label(&a, now), "active");
+        a.status = "error".to_string();
+        assert_eq!(status_label(&a, now), "error");
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -493,7 +493,7 @@ fn render_accounts(
     let header = match layout {
         AccountsLayout::Full => Row::new(vec![
             "Account", "Pri", "Status", "Gate", "Probe", "5h", "7d", "Fable", "Reqs", "In",
-            "Cache", "Out", "Last",
+            "Cache", "Out", "Last", "Err",
         ]),
         AccountsLayout::Compact => Row::new(vec![
             "Account", "Pri", "Status", "Gate", "5h", "7d", "Fable", "Reqs", "In", "Out", "Last",
@@ -555,6 +555,13 @@ fn render_accounts(
                         )),
                         output,
                         last,
+                        // In-band SSE `error` events (decayed count), observability
+                        // only — never a routing input. `-` when none observed.
+                        Cell::from(if account.stream_error_count > 0 {
+                            account.stream_error_count.to_string()
+                        } else {
+                            "-".to_string()
+                        }),
                     ]
                 }
                 // Compact mode: Probe and Cache dropped; each quota bucket becomes a
@@ -613,9 +620,12 @@ fn render_accounts(
             Constraint::Length(7),
             Constraint::Length(8),
             Constraint::Length(6),
+            // Decayed in-band SSE error count, or "-".
+            Constraint::Length(4),
         ],
         // 91 widths + 10 spacing + 2 borders ≈ 103 cols. The three bar columns
-        // collapse to bare percentages and Probe/Cache are gone.
+        // collapse to bare percentages and Probe/Cache are gone. The stream-error
+        // column stays Full-only — Compact is already the narrow-terminal squeeze.
         AccountsLayout::Compact => vec![
             Constraint::Length(18),
             Constraint::Length(3),
@@ -1411,6 +1421,8 @@ mod tests {
             quota_state: QuotaState::Normal,
             gate,
             free_at,
+            stream_error_count: 0,
+            last_stream_error: None,
         }
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1594,15 +1594,50 @@ mod tests {
         }
     }
 
+    /// The Full layout's minimum width, DERIVED from the columns themselves:
+    /// every declared width, one cell of `column_spacing` between each adjacent
+    /// pair, and the block's two borders.
+    ///
+    /// Computed, never transcribed. A test that copies the constant it is meant
+    /// to check agrees with a stale value by construction.
+    fn derived_full_layout_min_width() -> u16 {
+        let columns: u16 = FULL_COLUMN_WIDTHS.iter().sum();
+        let gaps = FULL_COLUMN_WIDTHS.len() as u16 - 1;
+        let borders = 2;
+        columns + gaps + borders
+    }
+
+    /// The constant must EQUAL its own columns' derived total, so it cannot drift
+    /// from the table it measures.
+    ///
+    /// This is the assertion that executes the arithmetic the constant's doc
+    /// comment merely states. Without it the number is commentary: a fifteenth
+    /// column moves the true minimum without moving the constant, and a gate that
+    /// only *mentions* the number stays green while the layout clips.
+    #[test]
+    fn full_layout_min_width_equals_the_derived_total() {
+        assert_eq!(
+            FULL_LAYOUT_MIN_WIDTH,
+            derived_full_layout_min_width(),
+            "FULL_LAYOUT_MIN_WIDTH must equal Σ FULL_COLUMN_WIDTHS ({}) + {} inter-column gaps \
+             + 2 borders; a column was added or resized without updating it",
+            FULL_COLUMN_WIDTHS.iter().sum::<u16>(),
+            FULL_COLUMN_WIDTHS.len() - 1,
+        );
+    }
+
     #[test]
     fn accounts_layout_picks_mode_at_threshold() {
-        // The breakpoint is exact: FULL_LAYOUT_MIN_WIDTH still fits the full
-        // table; one column narrower drops to compact.
-        assert_eq!(accounts_layout(FULL_LAYOUT_MIN_WIDTH), AccountsLayout::Full);
-        assert_eq!(
-            accounts_layout(FULL_LAYOUT_MIN_WIDTH - 1),
-            AccountsLayout::Compact
-        );
+        // The breakpoint is exact: the derived minimum still fits the full table;
+        // one column narrower drops to compact.
+        //
+        // Fed the DERIVED width, never FULL_LAYOUT_MIN_WIDTH. `accounts_layout` is
+        // `width >= FULL_LAYOUT_MIN_WIDTH`, so passing it the constant returns Full
+        // for every value that constant could possibly hold — it asserts the
+        // comparison operator and learns nothing about the width.
+        let derived = derived_full_layout_min_width();
+        assert_eq!(accounts_layout(derived), AccountsLayout::Full);
+        assert_eq!(accounts_layout(derived - 1), AccountsLayout::Compact);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -443,7 +443,7 @@ fn render_table<'a>(
 /// of bare percentages) rather than letting the solver clip a number silently.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AccountsLayout {
-    /// The full 13-column table, unchanged. Chosen at or above
+    /// The full 14-column table, unchanged. Chosen at or above
     /// [`FULL_LAYOUT_MIN_WIDTH`].
     Full,
     /// The reduced 11-column table: Probe/Cache dropped, the three quota buckets
@@ -452,18 +452,44 @@ enum AccountsLayout {
     Compact,
 }
 
-/// The narrowest terminal width that still fits the full 13-column table without
+/// The Full layout's column headers, in render order. Paired BY INDEX with
+/// [`FULL_COLUMN_WIDTHS`]; `full_layout_header_and_widths_are_paired` holds the
+/// two lengths equal, because a header added without its width is the same class
+/// of drift as a width added without its constant.
+const FULL_COLUMNS: [&str; 14] = [
+    "Account", "Pri", "Status", "Gate", "Probe", "5h", "7d", "Fable", "Reqs", "In", "Cache", "Out",
+    "Last", "Err",
+];
+
+/// The Full layout's declared column widths, paired by index with
+/// [`FULL_COLUMNS`]. Sized to their widest legitimate content — the reason each
+/// non-obvious one is what it is:
+///
+/// * `Gate` (15) — the widest gate chip, `FABLE-7D 47h30m`.
+/// * `5h`/`Fable` (15) — a learned bar is `[########] 100%`; 14 clipped the `%`.
+/// * `7d` (20) — the same bar plus a `near`/`full` quota label.
+/// * `Cache` (7) — the hit ratio as a percentage, or `-` before any input.
+/// * `Err` (4) — the decayed in-band SSE error count, or `-`.
+const FULL_COLUMN_WIDTHS: [u16; 14] = [18, 3, 9, 15, 11, 15, 20, 15, 6, 8, 7, 8, 6, 4];
+
+/// The narrowest terminal width that still fits the full 14-column table without
 /// the constraint solver clipping a column. Kept a literal with the arithmetic
 /// shown so a future column edit must update it *consciously* rather than
 /// silently re-introducing the squeeze it exists to prevent:
 ///
 /// ```text
-///   141  Σ the 13 column widths: 18+3+9+15+11+15+20+15+6+8+7+8+6
-/// +  12  column_spacing (1 cell × 12 inter-column gaps)
+///   145  Σ FULL_COLUMN_WIDTHS: 18+3+9+15+11+15+20+15+6+8+7+8+6+4
+/// +  13  column_spacing (1 cell × 13 inter-column gaps)
 /// +   2  the block's left + right borders
-/// = 155
+/// = 160
 /// ```
-const FULL_LAYOUT_MIN_WIDTH: u16 = 155;
+///
+/// The arithmetic is not taken on faith: `full_layout_min_width_fits_every_column`
+/// RENDERS the table at this width and reads back each column's realised width
+/// from the buffer. It was 155 while the table had 13 columns; the `Err` column
+/// landed without it, and at 155 the solver silently took `Gate` down to 11 —
+/// truncating exactly the `FABLE-7D 47h30m` label that column exists to show.
+const FULL_LAYOUT_MIN_WIDTH: u16 = 160;
 
 /// Pick the accounts-table layout for a pane `width` — the pure, rendering-free
 /// core of the responsive table, so the breakpoint is unit-testable without a
@@ -476,7 +502,7 @@ fn accounts_layout(width: u16) -> AccountsLayout {
     }
 }
 
-/// The accounts table. Responsive: [`AccountsLayout::Full`] renders all 13
+/// The accounts table. Responsive: [`AccountsLayout::Full`] renders all 14
 /// columns; [`AccountsLayout::Compact`] (below [`FULL_LAYOUT_MIN_WIDTH`]) drops
 /// Probe/Cache and renders the quota buckets as bar-less percentages so the
 /// utilization numbers stay visible on a narrow pane instead of being silently
@@ -491,10 +517,7 @@ fn render_accounts(
     let layout = accounts_layout(area.width);
 
     let header = match layout {
-        AccountsLayout::Full => Row::new(vec![
-            "Account", "Pri", "Status", "Gate", "Probe", "5h", "7d", "Fable", "Reqs", "In",
-            "Cache", "Out", "Last", "Err",
-        ]),
+        AccountsLayout::Full => Row::new(FULL_COLUMNS.to_vec()),
         AccountsLayout::Compact => Row::new(vec![
             "Account", "Pri", "Status", "Gate", "5h", "7d", "Fable", "Reqs", "In", "Out", "Last",
         ]),
@@ -600,29 +623,12 @@ fn render_accounts(
         .collect();
 
     let widths = match layout {
-        AccountsLayout::Full => vec![
-            Constraint::Length(18),
-            Constraint::Length(3),
-            Constraint::Length(9),
-            // Gate chip: fits the widest label + back-when (`FABLE-7D 47h30m`).
-            Constraint::Length(15),
-            Constraint::Length(11),
-            // A learned bar is 15 chars (`[########] 100%`) — 14 clipped the `%`.
-            Constraint::Length(15),
-            // 7d bar + a "near"/"full" quota label — wider than the 5h column.
-            Constraint::Length(20),
-            // Fable weekly bar, same shape as 5h (no quota label).
-            Constraint::Length(15),
-            Constraint::Length(6),
-            Constraint::Length(8),
-            // Cache hit ratio (`cache_read / input`) as a percentage, or "-" when
-            // no input has been counted yet.
-            Constraint::Length(7),
-            Constraint::Length(8),
-            Constraint::Length(6),
-            // Decayed in-band SSE error count, or "-".
-            Constraint::Length(4),
-        ],
+        // Straight from the declared widths, so the table ratatui lays out and the
+        // number `FULL_LAYOUT_MIN_WIDTH` is computed from can never be two things.
+        AccountsLayout::Full => FULL_COLUMN_WIDTHS
+            .iter()
+            .map(|w| Constraint::Length(*w))
+            .collect(),
         // 91 widths + 10 spacing + 2 borders ≈ 103 cols. The three bar columns
         // collapse to bare percentages and Probe/Cache are gone. The stream-error
         // column stays Full-only — Compact is already the narrow-terminal squeeze.
@@ -1596,6 +1602,75 @@ mod tests {
         assert_eq!(
             accounts_layout(FULL_LAYOUT_MIN_WIDTH - 1),
             AccountsLayout::Compact
+        );
+    }
+
+    #[test]
+    fn full_layout_header_and_widths_are_paired() {
+        // Two parallel lists indexed against each other. A header added without
+        // its width (or the reverse) shifts every column right of the seam.
+        assert_eq!(FULL_COLUMNS.len(), FULL_COLUMN_WIDTHS.len());
+    }
+
+    /// Read back each Full column's REALISED width from a render at exactly
+    /// [`FULL_LAYOUT_MIN_WIDTH`] and hold it to the width that was declared.
+    ///
+    /// This is the assertion the old one only gestured at. Asserting
+    /// `accounts_layout(FULL_LAYOUT_MIN_WIDTH) == Full` compares the constant
+    /// against itself and passes for every value it could possibly hold; this one
+    /// puts the table through ratatui's constraint solver — the thing that does the
+    /// silent squeezing — and fails when the constant is too small for the columns
+    /// actually in the table. At the shipped 155 it reports `Gate` realised 11 of
+    /// its declared 15.
+    #[test]
+    fn full_layout_min_width_fits_every_column() {
+        let snapshot = util_snapshot(QuotaState::Normal);
+        let backend = TestBackend::new(FULL_LAYOUT_MIN_WIDTH, 6);
+        let mut terminal = Terminal::new(backend).expect("test backend builds a terminal");
+        terminal
+            .draw(|frame| render_accounts(frame, frame.area(), &snapshot, 0, anchor()))
+            .expect("render succeeds");
+        let rows = buffer_rows(terminal.backend().buffer());
+        // Row 0 is the block's top border; row 1 is the header. Indexed in CHARS,
+        // never bytes: the block's `│` borders are 3 bytes each, so a byte offset
+        // reads 2 cells to the right of the cell it names.
+        let header: Vec<char> = rows[1].chars().collect();
+
+        // Walk the header left to right, taking each label's offset in turn, so a
+        // repeated substring cannot match an earlier column's cell.
+        let mut starts = Vec::with_capacity(FULL_COLUMNS.len());
+        let mut from = 0usize;
+        for label in FULL_COLUMNS {
+            let needle: Vec<char> = label.chars().collect();
+            let at = (from..=header.len().saturating_sub(needle.len()))
+                .find(|i| header[*i..*i + needle.len()] == needle[..])
+                .unwrap_or_else(|| {
+                    panic!(
+                        "header column {label:?} is missing from {:?}",
+                        rows[1].as_str()
+                    )
+                });
+            starts.push(at);
+            from = at + needle.len();
+        }
+
+        // Each column runs to the next column's start, less the 1-cell spacing;
+        // the last runs to the block's right border.
+        let right_border = usize::from(FULL_LAYOUT_MIN_WIDTH) - 1;
+        let realised: Vec<u16> = starts
+            .iter()
+            .enumerate()
+            .map(|(i, start)| {
+                let end = starts.get(i + 1).map_or(right_border, |next| next - 1);
+                (end - start) as u16
+            })
+            .collect();
+
+        assert_eq!(
+            realised,
+            FULL_COLUMN_WIDTHS.to_vec(),
+            "at FULL_LAYOUT_MIN_WIDTH ({FULL_LAYOUT_MIN_WIDTH}) every column must realise its \
+             declared width; a shortfall means the constant has not followed the columns"
         );
     }
 


### PR DESCRIPTION
## What

Two display fixes to the accounts table, plus the SSE stream-error observation work already on this branch.

**`throttled` now shows when it clears.** The deadline was already in the struct the renderer reads (`AccountSnapshot::rate_limited_until`, live-filtered so an expired hold arrives as `None`) — `tui.rs` referenced it exactly once, in a test fixture set to `None`. Never read by any render path.

**Quota badges no longer hide a reset we know.** A row rendered as a bare `5H`/`7D` whenever *any* active gate's reset was unknown: that `None` sorts last in `gate_clear_key`, wins the `max_by_key`, and carries out as `free_at = None`. Now renders `7D ≥3d` — a floor, not a promise.

## Why it is display-only, deliberately

`account_gate` is untouched and its 9 existing tests pass unchanged. Its `None` is load-bearing: it feeds `retry_after_hint` → the client-facing `retry-after` on a synthesized 429 (`proxy.rs:1938`) and the soft-wait (`:827`). That doc records that minimising over raw window resets *"promised a recovery that would not happen"* — a bug already fixed once. A floor is exactly such a too-early promise, so it must never reach that path.

Instead the gate collection is extracted to `active_gates()` and folded two ways, so the two derivations cannot drift: `account_gate` takes the latest-clearing gate; the new display-only `account_gate_known_floor` takes the max over gates that *have* a reset. Terminal states (`Rejected`/`Login`/`Disabled`) return `Err` and get no floor — telling an operator to wait for a recovery only a human can cause is the same lie in a different cell.

## Verification

`cargo check` 0 · `cargo clippy --all-targets -- -D warnings` 0 · **443 tests pass** · gitleaks clean.

Both new tests were watched failing before being trusted, per this repo's rule:

- status label: dropping the formatting yields `"throttled"` vs `"throttled 12s"`; dropping the status guard yields `"active 12s"` vs `"active"` (the leak guard — `clear_rate_limited` nulls the deadline and flips the status in two separate writes, so the cell must not depend on that ordering).
- known floor: `.max()`→`.min()` yields the earlier bound instead of the later; removing the terminal guard hands a disabled account a floor.

## Note

`cargo build --release` was never run — it would replace the binary the live proxy is serving from. The TUI runs in the server process, so neither change is visible until a rebuild and restart.

https://claude.ai/code/session_01XmVrUGTQvfy9FZ58cN9Lqk
