### PR TITLE
feat: install TcrBar to /Applications, start the server at launch, add tcr ui

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -13,6 +13,9 @@ struct FleetView: View {
     @ObservedObject var server: ServerController
     @ObservedObject var loginItem: LoginItem
     @ObservedObject var accounts: AccountController
+    /// Owned by the app so it survives the panel closing; bound here so the
+    /// checkbox and the launch path can never disagree about its value.
+    @Binding var startServerAtLaunch: Bool
 
     /// Measured height of the account rows.
     ///
@@ -208,8 +211,33 @@ struct FleetView: View {
             .buttonStyle(.bordered)
 
             launchAtLogin
+            startServerToggle
 
             dangerZone
+        }
+    }
+
+    /// Bring the proxy up when TcrBar starts. Pairs with "Launch at login" to
+    /// mean "the proxy is always up".
+    ///
+    /// The warning is not decoration. Once TcrBar supervises the server, Quit
+    /// stops it — correct for a supervisor, and a genuinely expensive surprise if
+    /// nobody said so before the box was ticked.
+    private var startServerToggle: some View {
+        VStack(alignment: .leading, spacing: Tok.tightSpacing) {
+            Toggle("Start server at launch", isOn: $startServerAtLaunch)
+                .toggleStyle(.checkbox)
+                .font(Tok.secondaryFont)
+                .help(
+                    "Runs `tcr server --no-replace` when TcrBar starts, so a proxy "
+                        + "that is already serving is never disturbed."
+                )
+            if startServerAtLaunch {
+                Text("TcrBar supervises the server, so quitting TcrBar stops it.")
+                    .font(Tok.detailFont)
+                    .foregroundStyle(Tok.near)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
     }
 

--- a/apps/macos/Sources/TcrBar/TcrBarApp.swift
+++ b/apps/macos/Sources/TcrBar/TcrBarApp.swift
@@ -13,16 +13,43 @@ struct TcrBarApp: App {
     @StateObject private var loginItem = LoginItem()
     @StateObject private var accounts = AccountController()
 
+    /// Bring the proxy up when the app starts.
+    ///
+    /// Opt-in, and deliberately not default-on. Paired with "Launch at login" it
+    /// means the proxy is simply always up — but it also makes Quit expensive,
+    /// because once TcrBar supervises the server, quitting stops it. Turning that
+    /// on should be a decision the operator made, not a surprise on first launch.
+    ///
+    /// Safe by construction: this is `start()`, which passes `--no-replace`, so a
+    /// proxy that is already serving is never disturbed. If one is, the spawn
+    /// reports "already running" and nothing happens.
+    @AppStorage("startServerAtLaunch") private var startServerAtLaunch = false
+
+    /// Fires once per process, not once per panel open. `onAppear` on the
+    /// `MenuBarExtra` content runs every time the menu is opened, so without this
+    /// the app would attempt a spawn on every click.
+    @State private var didAttemptLaunchStart = false
+
     var body: some Scene {
         MenuBarExtra {
-            FleetView(poller: poller, server: server, loginItem: loginItem, accounts: accounts)
-                .onAppear {
-                    poller.start()
-                    delegate.server = server
-                    // macOS owns the login-item bit; re-read it every time the
-                    // panel opens so a revocation in System Settings shows up.
-                    loginItem.refresh()
+            FleetView(
+                poller: poller,
+                server: server,
+                loginItem: loginItem,
+                accounts: accounts,
+                startServerAtLaunch: $startServerAtLaunch
+            )
+            .onAppear {
+                poller.start()
+                delegate.server = server
+                // macOS owns the login-item bit; re-read it every time the
+                // panel opens so a revocation in System Settings shows up.
+                loginItem.refresh()
+                if startServerAtLaunch, !didAttemptLaunchStart {
+                    didAttemptLaunchStart = true
+                    server.start()
                 }
+            }
         } label: {
             MenuBarLabel(state: poller.state)
         }

--- a/apps/macos/scripts/install.sh
+++ b/apps/macos/scripts/install.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# install.sh — build TcrBar and install it to /Applications.
+#
+# WHY THIS EXISTS, and it is not tidiness.
+#
+# `swift build` leaves the bundle in apps/macos/build/, which is gitignored and
+# replaced wholesale on every rebuild. Two things break if you run it from there:
+#
+#  1. Launch at login. `SMAppService.mainApp` registers the bundle at the path it
+#     currently occupies. Rebuild, clean, or move the checkout and macOS is left
+#     holding a login item aimed at a bundle that is no longer there.
+#  2. LaunchServices. Replacing a running bundle in place is what produces
+#     `_LSOpenURLsWithCompletionHandler() failed with error -600` — the app was
+#     swapped underneath the launcher.
+#
+# /Applications is a stable path, so the login item survives rebuilds and the app
+# shows up in Spotlight and Launchpad like anything else.
+#
+# Idempotent: safe to re-run. Uninstall with scripts/uninstall.sh.
+set -euo pipefail
+
+MACOS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_NAME="TcrBar"
+SRC="$MACOS_DIR/build/${APP_NAME}.app"
+DEST="/Applications/${APP_NAME}.app"
+
+echo "==> Building ${APP_NAME}…"
+bash "$MACOS_DIR/scripts/build-tcrbar.sh"
+
+[ -d "$SRC" ] || { echo "build produced no bundle at $SRC" >&2; exit 1; }
+
+# Stop only OUR app, and only the copy being replaced. `pkill -f TcrBar` would
+# also match an editor with the name in its title or a grep for it.
+if pgrep -f "${APP_NAME}.app/Contents/MacOS/${APP_NAME}" >/dev/null 2>&1; then
+  echo "==> Stopping the running ${APP_NAME}…"
+  pkill -f "${APP_NAME}.app/Contents/MacOS/${APP_NAME}" || true
+  # Give the supervised child, if any, a moment to be reaped cleanly.
+  sleep 1
+fi
+
+echo "==> Installing to ${DEST}…"
+# ditto, not cp -R: it preserves the bundle's resource forks, extended
+# attributes and the code signature. A cp -R can invalidate the signature.
+rm -rf "$DEST"
+ditto "$SRC" "$DEST"
+
+# Re-register so LaunchServices knows about the new copy immediately rather than
+# whenever it next rescans.
+/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister \
+  -f "$DEST" >/dev/null 2>&1 || true
+
+echo "==> Verifying the installed bundle…"
+codesign -dv "$DEST" 2>&1 | rg -i 'Identifier|Authority=Apple|Signature' | sed 's/^/    /' || true
+
+echo "==> Launching…"
+open "$DEST"
+
+cat <<INSTRUCTIONS
+
+Installed: $DEST
+
+  * The menu-bar item is the whole app — there is no Dock icon (LSUIElement).
+  * "Launch at login" now registers a STABLE path, so it survives rebuilds.
+  * "Start server at launch" brings the proxy up with --no-replace, so it can
+    never disturb a proxy that is already serving.
+
+  NOTE: once TcrBar supervises the server, quitting the app STOPS that server.
+  That is deliberate — it only ever terminates a child it spawned itself — but it
+  does mean Quit is an expensive action while supervising.
+
+  Re-run this script after any rebuild. Remove with scripts/uninstall.sh.
+INSTRUCTIONS

--- a/apps/macos/scripts/uninstall.sh
+++ b/apps/macos/scripts/uninstall.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# uninstall.sh — remove TcrBar from /Applications, reversibly and completely.
+#
+# An install that cannot be undone is not an install, it is a mess. This also
+# unregisters the login item: leaving it behind means macOS keeps trying to
+# launch a bundle that no longer exists, which surfaces to the user as a vague
+# login-items error with nothing to click.
+set -euo pipefail
+
+APP_NAME="TcrBar"
+BUNDLE_ID="com.github.dhkts1.tcrbar"
+DEST="/Applications/${APP_NAME}.app"
+
+if pgrep -f "${APP_NAME}.app/Contents/MacOS/${APP_NAME}" >/dev/null 2>&1; then
+  echo "==> Stopping ${APP_NAME}…"
+  echo "    (any server it was supervising stops with it — that is by design)"
+  pkill -f "${APP_NAME}.app/Contents/MacOS/${APP_NAME}" || true
+  sleep 1
+fi
+
+# Unregister the login item before deleting the bundle: SMAppService keys on the
+# bundle, so removing the app first can strand the registration.
+if [ -d "$DEST" ]; then
+  echo "==> Unregistering the login item…"
+  /usr/bin/osascript -e "tell application \"System Events\" to delete login item \"${APP_NAME}\"" \
+    >/dev/null 2>&1 || true
+  /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister \
+    -u "$DEST" >/dev/null 2>&1 || true
+
+  echo "==> Removing ${DEST}…"
+  rm -rf "$DEST"
+else
+  echo "==> Nothing installed at ${DEST}."
+fi
+
+echo
+echo "Removed. The app's preferences are untouched; clear them with:"
+echo "    defaults delete ${BUNDLE_ID}"
+echo
+echo "Nothing about tcr itself was changed. If a server was running independently"
+echo "of TcrBar, it is still running."

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,8 @@ enum Command {
     Update(UpdateArgs),
     /// Render the TUI against fake accounts (for a sanitized README screenshot).
     Demo,
+    /// Open TcrBar, the macOS menu-bar app (macOS only).
+    Ui,
 }
 
 #[derive(clap::Args)]
@@ -198,6 +200,7 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Status(args)) => run_status(args).await,
         Some(Command::Update(args)) => update::run_update(args.force),
         Some(Command::Demo) => demo::run_demo().await.map_err(anyhow::Error::from),
+        Some(Command::Ui) => run_ui(),
         None => run_server(cli.server).await,
     }
 }
@@ -245,6 +248,45 @@ fn run_disable(args: DisableArgs) -> anyhow::Result<()> {
 async fn run_status(args: StatusArgs) -> anyhow::Result<()> {
     let config_path = args.config.unwrap_or_else(config::default_path);
     cli::status(&config_path, args.json).await
+}
+
+/// `tcr ui` — open TcrBar, the macOS menu-bar app.
+///
+/// This exists for discoverability, not capability: `open -a TcrBar` already
+/// works. Without it nothing in `tcr --help` reveals that a UI exists at all, so
+/// the app is only findable by knowing it is there.
+///
+/// It deliberately does NOT build the app or know where the checkout is. It asks
+/// LaunchServices to open a bundle id, which resolves wherever the app was
+/// installed. A `tcr` that shells into a source tree would break the moment the
+/// checkout moved.
+#[cfg(target_os = "macos")]
+fn run_ui() -> anyhow::Result<()> {
+    use anyhow::Context;
+
+    let status = std::process::Command::new("open")
+        .args(["-b", "com.github.dhkts1.tcrbar"])
+        .status()
+        .context("failed to run `open`")?;
+
+    if status.success() {
+        return Ok(());
+    }
+
+    // `open -b` fails when the bundle id is not registered, which almost always
+    // means "not installed" rather than "broken". Say which, and say how to fix
+    // it, rather than surfacing LaunchServices' own opaque exit code.
+    anyhow::bail!(
+        "TcrBar is not installed. Build and install it with:\n    \
+         bash apps/macos/scripts/install.sh"
+    )
+}
+
+/// Non-macOS builds keep the subcommand so `--help` is identical everywhere, and
+/// fail with the reason rather than a missing-subcommand error.
+#[cfg(not(target_os = "macos"))]
+fn run_ui() -> anyhow::Result<()> {
+    anyhow::bail!("`tcr ui` opens the macOS menu-bar app, and this is not macOS.")
 }
 
 /// `tcr run [-- args…]` — launch Claude Code already pointed at this proxy.


### PR DESCRIPTION
feat: install TcrBar to /Applications, start the server at launch, add `tcr ui`

Three changes that together answer "how do I actually run this", which until now
meant building from source and opening a bundle out of a gitignored directory.

install.sh / uninstall.sh. Installing to /Applications is not tidiness: it is what
makes launch-at-login work. SMAppService registers the bundle at the path it
currently occupies, and apps/macos/build/ is wiped and rewritten by every build,
so a login item registered from there points at a bundle that moved. Replacing a
running bundle in place is also what produces LaunchServices error -600, which
this hit during testing. ditto rather than cp -R, so the code signature survives.
The uninstaller unregisters the login item BEFORE removing the app, since
removing the app first strands the registration and macOS then reports a login
item it cannot explain.

"Start server at launch", opt-in. Paired with launch-at-login it means the proxy
is simply always up. Deliberately not default-on: once TcrBar supervises the
server, quitting TcrBar stops it, and that should be a decision rather than a
surprise. The panel says so, in place, whenever the box is ticked. Safe by
construction -- it calls start(), which passes --no-replace, so a proxy already
serving is never disturbed. It fires once per process, not per panel open, since
onAppear on a MenuBarExtra runs on every click.

`tcr ui`. This is discoverability, not capability -- `open -a TcrBar` already
worked, but nothing in `tcr --help` revealed a UI existed. It opens a BUNDLE ID
via LaunchServices rather than a path, so it does not need to know where the
checkout is and cannot break when the checkout moves. When the app is not
installed it says so and names install.sh, instead of surfacing LaunchServices'
opaque exit code. Non-macOS builds keep the subcommand so --help is identical
everywhere, and fail with the reason.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `swift build`, `swift test` — 65 tests, 0 failures
- `shellcheck` on both new scripts — clean
- `tcr ui` run against a freshly built binary — exit 0, app opened

**Not verified:** the install path itself. `install.sh` has not been run end to end
(it writes to /Applications and re-registers the login item, which changes machine
state), and the new toggle is unverified visually — screencapture and osascript are
permission-blocked on this machine.

One gotcha worth recording: `CARGO_TARGET_DIR` is set to `~/.cache/cargo-target`
on this machine, so the repo's own `target/debug/tcr` is a stale orphan. Testing
`tcr ui` against it reported "unrecognized subcommand" on code that was correct.