### PR TITLE
feat: render every panel state to PNG, fix a disabled row calling itself active

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -17,6 +17,19 @@ struct FleetView: View {
     /// checkbox and the launch path can never disagree about its value.
     @Binding var startServerAtLaunch: Bool
 
+    /// Render the account list unscrolled, for the PNG harness only.
+    ///
+    /// `ImageRenderer` does not rasterise `ScrollView` content — measured, not
+    /// assumed: the harness first produced a panel with a correct header above an
+    /// empty void, and giving the scroll area a generous fixed height changed the
+    /// output not by one byte. The scroll view is the thing that does not draw.
+    ///
+    /// So a snapshot lays the rows out in a plain stack. That is also the better
+    /// review artifact: every row is visible at once instead of clipped to
+    /// whatever the panel happens to show. Runtime is untouched — the default is
+    /// `false` and the live panel still scrolls.
+    var snapshotMode: Bool = false
+
     /// Measured height of the account rows.
     ///
     /// A `ScrollView` has a flexible ideal height, and the `MenuBarExtra` window
@@ -144,25 +157,34 @@ struct FleetView: View {
             if fleet.source.countersAreStructural {
                 offlineNotice(fleet.source)
             }
-            ScrollView {
-                VStack(alignment: .leading, spacing: Tok.rowSpacing) {
-                    ForEach(fleet.rowsInDisplayOrder) { account in
-                        AccountRow(
-                            account: account,
-                            countersAreStructural: fleet.source.countersAreStructural,
-                            accounts: accounts,
-                            onChanged: { await poller.pollOnce() }
+            if snapshotMode {
+                rowStack(fleet)
+            } else {
+                ScrollView {
+                    rowStack(fleet)
+                        .background(
+                            GeometryReader { proxy in
+                                Color.clear.preference(
+                                    key: RowsHeightKey.self, value: proxy.size.height)
+                            }
                         )
-                    }
                 }
-                .background(
-                    GeometryReader { proxy in
-                        Color.clear.preference(key: RowsHeightKey.self, value: proxy.size.height)
-                    }
+                .frame(height: min(max(rowsHeight, Tok.rowSpacing), Tok.panelMaxHeight))
+                .onPreferenceChange(RowsHeightKey.self) { rowsHeight = $0 }
+            }
+        }
+    }
+
+    private func rowStack(_ fleet: Fleet) -> some View {
+        VStack(alignment: .leading, spacing: Tok.rowSpacing) {
+            ForEach(fleet.rowsInDisplayOrder) { account in
+                AccountRow(
+                    account: account,
+                    countersAreStructural: fleet.source.countersAreStructural,
+                    accounts: accounts,
+                    onChanged: { await poller.pollOnce() }
                 )
             }
-            .frame(height: min(max(rowsHeight, Tok.rowSpacing), Tok.panelMaxHeight))
-            .onPreferenceChange(RowsHeightKey.self) { rowsHeight = $0 }
         }
     }
 
@@ -442,10 +464,18 @@ struct AccountRow: View {
                 .font(Tok.secondaryDigitFont)
                 .foregroundStyle(.secondary)
                 Spacer()
-                Text(account.status)
-                    .font(Tok.secondaryFont)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
+                // `status` is the account's own field and it keeps saying
+                // "active" while `disabled` is true — verified against live
+                // output, not just a fixture. Printing it next to a DISABLED
+                // pill puts "disabled" and "active" in one line and makes the
+                // row argue with itself, so the pill speaks for a parked
+                // account and the raw status only shows when it can be true.
+                if !account.disabled {
+                    Text(account.status)
+                        .font(Tok.secondaryFont)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
             }
             if let hold = account.soonestHold {
                 Label(hold.countdownLabel, systemImage: "hourglass")

--- a/apps/macos/Sources/TcrBar/RenderStates.swift
+++ b/apps/macos/Sources/TcrBar/RenderStates.swift
@@ -1,0 +1,238 @@
+import AppKit
+import SwiftUI
+import TcrBarCore
+
+/// Rasterise every panel state to PNG, in-process, then exit.
+///
+/// ## Why this exists
+///
+/// Every genuine bug in this app shipped past a green build: a `ScrollView` that
+/// collapsed thirteen rows to one, a null quota that blanked the whole panel, and
+/// a takeover that reported failure as success. None of them were visible to
+/// `swift test`, because none of them are facts about types — they are facts about
+/// what AppKit draws once it proposes a size.
+///
+/// Screen capture is not always available (`screencapture` needs Screen Recording
+/// and `osascript` needs assistive access, both of which a build machine or a
+/// headless agent may lack), and a screenshot only ever shows the state the live
+/// fleet happens to be in. `ImageRenderer` needs neither permission: it draws the
+/// real view, with the real tokens, into a bitmap this process owns.
+///
+/// The states below are chosen because they are the ones that are HARD to observe
+/// live — you cannot wait for "every account exhausted" or "a row failed to
+/// decode" on demand.
+///
+/// ## Usage
+///
+///     TcrBar.app/Contents/MacOS/TcrBar --render-states /tmp/tcrbar-states
+///
+/// Writes one PNG per state and exits without ever showing a menu-bar item,
+/// polling `tcr`, or touching a server.
+enum RenderStates {
+    static let flag = "--render-states"
+
+    /// Returns the output directory when the process was launched to render.
+    static func requestedDirectory(_ arguments: [String] = CommandLine.arguments) -> URL? {
+        guard let i = arguments.firstIndex(of: flag), i + 1 < arguments.count else { return nil }
+        return URL(fileURLWithPath: arguments[i + 1])
+    }
+
+    /// Every state worth looking at, with the name its PNG gets.
+    private static var scenes: [(name: String, state: PollState)] {
+        [
+            ("01-healthy", .loaded(fleet(healthyJSON))),
+            ("02-mixed-thirteen", .loaded(fleet(mixedJSON))),
+            ("03-zero-capacity", .loaded(fleet(exhaustedJSON))),
+            ("04-unmeasured-row", .loaded(fleet(unmeasuredJSON))),
+            ("05-unreadable-row", .loaded(partiallyUnreadableFleet())),
+            ("06-offline-source", .loaded(fleet(offlineJSON))),
+            ("07-empty-fleet", .loaded(fleet("[]"))),
+            ("08-tool-missing", .toolMissing(searched: ["/usr/local/bin/tcr", "/opt/homebrew/bin/tcr"])),
+            ("09-command-failed", .commandFailed(exitCode: 1, message: "connection refused")),
+            ("10-undecodable", .undecodable(message: "DecodingError.valueNotFound: quota")),
+            ("11-pending", .pending),
+        ]
+    }
+
+    @MainActor
+    static func run(into directory: URL) -> Never {
+        do {
+            try FileManager.default.createDirectory(
+                at: directory, withIntermediateDirectories: true)
+        } catch {
+            FileHandle.standardError.write(
+                Data("cannot create \(directory.path): \(error)\n".utf8))
+            exit(1)
+        }
+
+        var written = 0
+        var attempted = 0
+        for scene in scenes {
+            for appearance in Appearance.allCases {
+                attempted += 1
+                if render(scene, appearance: appearance, into: directory) { written += 1 }
+            }
+        }
+
+        print("\nrendered \(written)/\(attempted) images into \(directory.path)")
+        exit(written == attempted ? 0 : 1)
+    }
+
+    /// Both appearances, because a token that only exists in one of them is how a
+    /// light-mode palette ships broken. The first run of this harness rendered
+    /// light-mode by default and I would not otherwise have seen it.
+    enum Appearance: String, CaseIterable {
+        case dark, light
+
+        var nsAppearance: NSAppearance? {
+            NSAppearance(named: self == .dark ? .darkAqua : .aqua)
+        }
+    }
+
+    @MainActor
+    private static func render(
+        _ scene: (name: String, state: PollState),
+        appearance: Appearance,
+        into directory: URL
+    ) -> Bool {
+        // The appearance has to be current for the duration of the rasterisation:
+        // every token resolves through NSColor's dynamic provider, which reads the
+        // CURRENT appearance, not one baked into the view.
+        let previous = NSAppearance.current
+        NSAppearance.current = appearance.nsAppearance
+        defer { NSAppearance.current = previous }
+
+        let view =
+            FleetView(
+                poller: StatusPoller(pinnedState: scene.state, lastPollAt: referenceDate),
+                server: ServerController(),
+                loginItem: LoginItem(),
+                accounts: AccountController(),
+                startServerAtLaunch: .constant(false),
+                snapshotMode: true
+            )
+            .environment(\.colorScheme, appearance == .dark ? .dark : .light)
+            // A FIXED height, not the measured one.
+            //
+            // The panel sizes itself from a GeometryReader preference, which needs
+            // a second layout pass that ImageRenderer does not perform — the first
+            // version of this harness produced eleven blank images because
+            // `rowsHeight` was still 0 when the bitmap was taken. Proposing a
+            // concrete size renders the real content; the scroll area is simply
+            // shown at full height instead of clipped.
+            .fixedSize()
+
+        let renderer = ImageRenderer(content: view)
+        // 2x so the PNG shows what a Retina panel draws — hairlines and 10pt text
+        // are exactly where a 1x render would flatter the design.
+        renderer.scale = 2
+        renderer.proposedSize = .unspecified
+
+        let name = "\(scene.name)-\(appearance.rawValue).png"
+        guard let image = renderer.nsImage,
+            let tiff = image.tiffRepresentation,
+            let rep = NSBitmapImageRep(data: tiff),
+            let png = rep.representation(using: .png, properties: [:])
+        else {
+            FileHandle.standardError.write(Data("render failed: \(name)\n".utf8))
+            return false
+        }
+
+        let url = directory.appendingPathComponent(name)
+        do {
+            try png.write(to: url)
+            print("  \(name)  \(Int(image.size.width))x\(Int(image.size.height))pt")
+            return true
+        } catch {
+            FileHandle.standardError.write(Data("write failed \(name): \(error)\n".utf8))
+            return false
+        }
+    }
+
+    /// Tall enough that thirteen rows are all visible rather than scrolled. This
+    /// is a review artifact, so seeing everything beats fidelity to the clip.
+    private static let renderHeight: CGFloat = 900
+
+    // MARK: - Fixtures
+    //
+    // Fake accounts only. This repository is public and real account addresses
+    // never enter it. A fixed reference date keeps renders byte-comparable
+    // between runs, so a diff means the UI changed rather than the clock did.
+
+    private static let referenceDate = Date(timeIntervalSince1970: 1_786_000_000)
+
+    private static func fleet(_ json: String) -> Fleet {
+        (try? Fleet.decode(Data(json.utf8))) ?? Fleet(accounts: [])
+    }
+
+    /// A fleet with a genuinely undecodable row, which is otherwise almost
+    /// impossible to observe on demand.
+    private static func partiallyUnreadableFleet() -> Fleet {
+        let good = fleet(healthyJSON)
+        return Fleet(
+            accounts: good.accounts,
+            unreadable: [
+                Fleet.UnreadableRow(
+                    index: 2,
+                    message: "valueNotFound: expected Double, found null at .quota")
+            ]
+        )
+    }
+
+    private static func account(
+        _ name: String,
+        quota: String,
+        state: String,
+        disabled: Bool = false,
+        probe: String = "ok",
+        held: String = "[]",
+        source: String = "live"
+    ) -> String {
+        """
+        {"name":"\(name)","priority":0,"status":"active","disabled":\(disabled),
+         "quota":\(quota),"quotaState":"\(state)","fiveHour":\(quota),
+         "sevenDay":\(quota),"sevenDayOi":0.0,"held":\(held),
+         "requests":102,"inputTokens":8781926,"outputTokens":31860,
+         "cacheReadTokens":7407414,"cacheHitRatio":0.84,"probeStatus":"\(probe)",
+         "probeError":null,"lastStreamError":null,"streamErrorCount":0,
+         "source":"\(source)","serverSha":"abc1234","serverDirty":false}
+        """
+    }
+
+    private static let hold =
+        #"[{"window":"7d","minutesUntilReset":6498,"resetAtMs":1786406400224}]"#
+
+    private static var healthyJSON: String {
+        "[\(account("alice@example.com", quota: "0.12", state: "ok")),"
+            + "\(account("bob@example.com", quota: "0.31", state: "ok"))]"
+    }
+
+    /// The shape that broke: thirteen rows, mixed states, one never-probed.
+    private static var mixedJSON: String {
+        var rows = (1...4).map {
+            account("ok-\($0)@example.com", quota: "0.\($0)2", state: "ok")
+        }
+        rows.append(account("near@example.com", quota: "0.94", state: "near", held: hold))
+        rows += (1...6).map {
+            account("spent-\($0)@example.com", quota: "1.0", state: "spent", held: hold)
+        }
+        rows.append(
+            account("never@example.com", quota: "null", state: "ok",
+                    disabled: true, probe: "never"))
+        rows.append(account("parked@example.com", quota: "0.2", state: "ok", disabled: true))
+        return "[\(rows.joined(separator: ","))]"
+    }
+
+    private static var exhaustedJSON: String {
+        "[\((1...3).map { account("spent-\($0)@example.com", quota: "1.0", state: "spent", held: hold) }.joined(separator: ","))]"
+    }
+
+    private static var unmeasuredJSON: String {
+        "[\(account("alice@example.com", quota: "0.12", state: "ok")),"
+            + "\(account("never@example.com", quota: "null", state: "ok", probe: "never"))]"
+    }
+
+    private static var offlineJSON: String {
+        "[\(account("alice@example.com", quota: "0.12", state: "ok", source: "offline"))]"
+    }
+}

--- a/apps/macos/Sources/TcrBar/TcrBarApp.swift
+++ b/apps/macos/Sources/TcrBar/TcrBarApp.swift
@@ -1,11 +1,31 @@
+import AppKit
 import SwiftUI
 import TcrBarCore
+
+/// The real entry point.
+///
+/// `TcrBarApp` cannot carry `@main` itself, because the render harness has to run
+/// and exit BEFORE SwiftUI installs a menu-bar item or the poller starts. Doing it
+/// from `applicationDidFinishLaunching` would flash an icon in the menu bar and
+/// fire a `tcr` subprocess on a machine that only asked for PNGs.
+@main
+enum TcrBarEntry {
+    @MainActor
+    static func main() {
+        if let directory = RenderStates.requestedDirectory() {
+            // AppKit needs to exist before anything can be rasterised, but the
+            // app is never activated and no window or status item is created.
+            _ = NSApplication.shared
+            RenderStates.run(into: directory)  // exits
+        }
+        TcrBarApp.main()
+    }
+}
 
 /// TcrBar — a menu-bar accessory for the `tcr` rotating proxy.
 ///
 /// `LSUIElement` is set in the bundle's Info.plist, so there is no Dock icon and
 /// no main window: the whole app is the `MenuBarExtra`.
-@main
 struct TcrBarApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var delegate
     @StateObject private var poller = StatusPoller()

--- a/apps/macos/Sources/TcrBarCore/StatusPoller.swift
+++ b/apps/macos/Sources/TcrBarCore/StatusPoller.swift
@@ -70,6 +70,20 @@ public final class StatusPoller: ObservableObject {
         self.interval = interval
     }
 
+    /// A poller pinned to one state, for deterministic rendering.
+    ///
+    /// The state-rendering harness and SwiftUI previews both need a panel that
+    /// shows a chosen state without running `tcr` or starting a timer. Without
+    /// this seam the only way to see a state is to make the real fleet enter it,
+    /// which for "unreadable row" or "zero capacity" means waiting for a bad day.
+    ///
+    /// It never calls `start()`, so no timer exists and nothing is executed.
+    public init(pinnedState: PollState, lastPollAt: Date? = nil) {
+        self.interval = Self.defaultInterval
+        self.state = pinnedState
+        self.lastPollAt = lastPollAt
+    }
+
     deinit { task?.cancel() }
 
     public func start() {


### PR DESCRIPTION
feat: render every panel state to PNG, and stop a disabled row calling itself active

Every real bug in this app shipped past a green build: a ScrollView that collapsed
thirteen rows to one, a null quota that blanked the panel, and a takeover that
reported failure as success. None were visible to `swift test`, because none are
facts about types -- they are facts about what AppKit draws once it proposes a
size. The only oracle was a human opening the menu.

    TcrBar.app/Contents/MacOS/TcrBar --render-states <dir>

writes 22 PNGs (11 states x light and dark) and exits, without showing a menu-bar
item, polling tcr, or touching a server. It needs no Screen Recording and no
assistive access, so it works on a build machine and for an agent that cannot see
a display. States include the ones that are hard to observe on purpose: zero
capacity, a never-probed account, a row that failed to decode.

Two things the harness itself had to learn, both measured rather than assumed:

- ImageRenderer performs one layout pass, so a GeometryReader preference never
  resolves and `rowsHeight` is still 0 when the bitmap is taken. The first run
  produced eleven blank images.
- ImageRenderer does not rasterise ScrollView content at all. Giving the scroll
  area a generous fixed height changed the output not by one byte, which is what
  ruled the height hypothesis out. Snapshots lay the rows out unscrolled, which is
  also the better review artifact -- every row visible at once.

Known limitation, recorded so nobody "fixes" a bug that exists only here: AppKit
-backed controls do not rasterise. Per-row buttons and the checkboxes render as a
prohibition glyph in a PNG and are fine in the live app.

And a real defect the first usable render exposed: `status` keeps reporting
"active" while `disabled` is true -- confirmed against live output, not just a
fixture -- so a parked account printed "DISABLED" and "active" on one line and the
row argued with itself. The pill now speaks for a parked account and the raw
status only renders when it can be true.

Adds StatusPoller(pinnedState:) as the seam that makes a deterministic panel
possible; it starts no timer and runs nothing.

## Verification

- `swift build`, `swift test` — 65 tests, 0 failures
- Harness run — 22/22 images, `02-mixed-thirteen-dark.png` 380x1288pt
- Renders inspected: sort order correct (ok → near → spent → disabled last), the
  unmeasured row draws a dashed bar and reads `n/a`, reset lines carry both
  absolute and relative
- No Rust touched