### PR TITLE
feat: add an "Add account…" button that hands tcr login to a Terminal

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -30,6 +30,10 @@ struct FleetView: View {
     /// `false` and the live panel still scrolls.
     var snapshotMode: Bool = false
 
+    /// Surfaced in place rather than swallowed: a button that silently does
+    /// nothing is worse than one that says why.
+    @State private var loginError: String?
+
     /// Measured height of the account rows.
     ///
     /// A `ScrollView` has a flexible ideal height, and the `MenuBarExtra` window
@@ -227,10 +231,23 @@ struct FleetView: View {
                     Button("Start server") { server.start() }
                 }
                 Button("Refresh") { Task { await poller.pollOnce() } }
+                Button("Add account…") { addAccount() }
+                    .help(
+                        "Opens `tcr login` in a Terminal window. It needs one: it "
+                            + "prompts for a name, may ask for a pasted code, and "
+                            + "refuses while a proxy is holding the port."
+                    )
                 Spacer()
                 Button("Quit") { NSApplication.shared.terminate(nil) }
             }
             .buttonStyle(.bordered)
+
+            if let loginError {
+                Text(loginError)
+                    .font(Tok.detailFont)
+                    .foregroundStyle(Tok.spent)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
 
             launchAtLogin
             startServerToggle
@@ -260,6 +277,25 @@ struct FleetView: View {
                     .foregroundStyle(Tok.near)
                     .fixedSize(horizontal: false, vertical: true)
             }
+        }
+    }
+
+    /// Hand `tcr login` to a Terminal window.
+    ///
+    /// Deliberately a hand-off, not an in-app flow. `tcr login` refuses while a
+    /// proxy holds the port and prompts on stdin, so a background spawn would
+    /// usually fail and would hide its own prompts when it did not. The ellipsis
+    /// in the label is doing real work: this opens something.
+    private func addAccount() {
+        if case .failure(let why) = LoginLauncher.launch() {
+            switch why {
+            case .toolMissing(let searched):
+                loginError = "tcr not found (searched \(searched.count) locations)."
+            case .couldNotWriteScript(let message):
+                loginError = "Could not open Terminal: \(message)"
+            }
+        } else {
+            loginError = nil
         }
     }
 

--- a/apps/macos/Sources/TcrBarCore/LoginLauncher.swift
+++ b/apps/macos/Sources/TcrBarCore/LoginLauncher.swift
@@ -1,0 +1,85 @@
+import AppKit
+import Foundation
+
+/// Hands `tcr login` to a real Terminal window.
+///
+/// ## Why not just spawn it
+///
+/// `tcr login` cannot run as a background subprocess of a GUI app, for two
+/// independent reasons, and both are in `tcr`'s own source rather than guesswork:
+///
+///  1. **It refuses while a server holds the port** (`src/oauth.rs:752-757`):
+///     logging in then would be overwritten by the server's next token refresh.
+///     TcrBar exists because a proxy is always running, so that refusal is the
+///     normal case here, not an edge case. Its message names the pid and the
+///     stop-login-restart sequence — which is useful only if a human can read it.
+///  2. **It is interactive.** It prompts for an account name on stdin
+///     (`src/oauth.rs:645`) and can take a pasted authorization code
+///     (`src/oauth.rs:450`). With no TTY those prompts go nowhere and stdin hits
+///     EOF immediately.
+///
+/// So the button hands off rather than pretending. In a Terminal window the
+/// prompts are visible, the browser callback still works, and tcr's refusal — if
+/// it refuses — is read by the person who can act on it.
+///
+/// `--force` is never passed. `tcr` documents it as unsafe, and a GUI silently
+/// forcing past a guard the CLI put up is exactly the wrong use of a button.
+public enum LoginLauncher {
+
+    public enum Failure: Error, Equatable {
+        case toolMissing(searched: [String])
+        case couldNotWriteScript(String)
+    }
+
+    /// Compose the shell script that a Terminal window will run.
+    ///
+    /// Split out and pure so the quoting is testable: an install path containing a
+    /// space or a quote must not become a broken or, worse, an injectable command.
+    public static func script(forExecutableAt path: String) -> String {
+        // Single-quote the path and escape any embedded single quote the POSIX
+        // way ('\'') so the shell receives exactly one argument whatever the path
+        // contains.
+        let quoted = "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        return """
+            #!/bin/sh
+            # Opened by TcrBar. `tcr login` needs a terminal: it prompts for an
+            # account name and may ask you to paste an authorization code, and it
+            # refuses outright while a proxy is holding the port.
+            echo "Running tcr login — follow the prompts below."
+            echo
+            exec \(quoted) login
+            """
+    }
+
+    /// Write the script somewhere Terminal will open, and open it.
+    ///
+    /// A `.command` file opened via LaunchServices starts Terminal directly. The
+    /// alternative — an AppleScript `do script` — needs Automation permission and
+    /// would put a consent dialog between the operator and a login they asked for.
+    @discardableResult
+    public static func launch(
+        resolve: () -> Result<URL, TcrTool.NotFound> = { TcrTool.resolve() },
+        open: (URL) -> Void = { NSWorkspace.shared.open($0) }
+    ) -> Result<URL, Failure> {
+        let executable: URL
+        switch resolve() {
+        case .success(let url): executable = url
+        case .failure(let missing): return .failure(.toolMissing(searched: missing.searched))
+        }
+
+        let script = script(forExecutableAt: executable.path)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tcr-login.command")
+
+        do {
+            try script.write(to: url, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o700], ofItemAtPath: url.path)
+        } catch {
+            return .failure(.couldNotWriteScript(error.localizedDescription))
+        }
+
+        open(url)
+        return .success(url)
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/LoginLauncherTests.swift
+++ b/apps/macos/Tests/TcrBarTests/LoginLauncherTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+
+@testable import TcrBarCore
+
+/// The script handed to Terminal is a composed shell command, which is the one
+/// place in this app where a path becomes executable text. These tests exist for
+/// the quoting.
+final class LoginLauncherTests: XCTestCase {
+
+    func testOrdinaryPathIsQuotedAndRunsLogin() {
+        let script = LoginLauncher.script(forExecutableAt: "/opt/homebrew/bin/tcr")
+        XCTAssertTrue(script.contains("exec '/opt/homebrew/bin/tcr' login"), script)
+    }
+
+    /// An install path with a space must stay ONE argument. Unquoted, the shell
+    /// would try to run `/Applications/My` with `Tools/tcr` as an argument.
+    func testPathWithSpacesStaysASingleArgument() {
+        let script = LoginLauncher.script(forExecutableAt: "/Users/x/My Tools/tcr")
+        XCTAssertTrue(script.contains("exec '/Users/x/My Tools/tcr' login"), script)
+    }
+
+    /// The injection case. A single quote inside the path would otherwise close
+    /// the quoting and let everything after it run as its own command.
+    func testSingleQuoteInPathCannotEscapeTheQuoting() {
+        let script = LoginLauncher.script(forExecutableAt: "/tmp/ev'il/tcr")
+
+        XCTAssertTrue(
+            script.contains(#"exec '/tmp/ev'\''il/tcr' login"#),
+            "a quote must be escaped POSIX-style, got: \(script)"
+        )
+        // Nothing may follow the quoted path except the subcommand.
+        let execLine = script.split(separator: "\n").first { $0.hasPrefix("exec ") }
+        XCTAssertEqual(execLine?.hasSuffix("' login"), true, "trailing text after the path")
+    }
+
+    /// `--force` exists in `tcr login` and is documented there as unsafe: it logs
+    /// in past the running-server guard, and the server's next token refresh then
+    /// overwrites the login. A GUI must never pass it silently.
+    func testNeverPassesForce() {
+        for path in ["/usr/local/bin/tcr", "/Users/x/My Tools/tcr", "/tmp/ev'il/tcr"] {
+            XCTAssertFalse(
+                LoginLauncher.script(forExecutableAt: path).contains("--force"),
+                "script for \(path) must not force past the login guard"
+            )
+        }
+    }
+
+    /// A missing tool is reported, not silently swallowed into a button that does
+    /// nothing when clicked.
+    func testMissingToolIsReportedWithWhatWasSearched() {
+        var opened: URL?
+        let result = LoginLauncher.launch(
+            resolve: { .failure(TcrTool.NotFound(searched: ["/a/tcr", "/b/tcr"])) },
+            open: { opened = $0 }
+        )
+
+        guard case .failure(.toolMissing(let searched)) = result else {
+            return XCTFail("expected a toolMissing failure, got \(result)")
+        }
+        XCTAssertEqual(searched, ["/a/tcr", "/b/tcr"])
+        XCTAssertNil(opened, "nothing should be opened when tcr was never found")
+    }
+
+    func testSuccessWritesAnExecutableScriptAndOpensIt() throws {
+        var opened: URL?
+        let result = LoginLauncher.launch(
+            resolve: { .success(URL(fileURLWithPath: "/usr/local/bin/tcr")) },
+            open: { opened = $0 }
+        )
+
+        guard case .success(let url) = result else {
+            return XCTFail("expected success, got \(result)")
+        }
+        XCTAssertEqual(opened, url)
+        XCTAssertEqual(url.pathExtension, "command", "Terminal opens .command files")
+
+        let written = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertTrue(written.contains("exec '/usr/local/bin/tcr' login"), written)
+
+        let mode = try FileManager.default.attributesOfItem(atPath: url.path)[.posixPermissions]
+        XCTAssertEqual(mode as? NSNumber, 0o700, "must be executable, and only by its owner")
+    }
+}


### PR DESCRIPTION
feat: add an "Add account…" button that hands tcr login to a Terminal

The panel could enable and disable accounts but not add one, so the only missing
verb was the one you need on a fresh machine.

It is a HAND-OFF, not an in-app flow, and that is the whole design. `tcr login`
cannot run as a background subprocess of a GUI app for two independent reasons,
both read out of tcr's own source rather than assumed:

- It refuses while a server holds the port (src/oauth.rs:752-757): logging in then
  would be overwritten by the server's next token refresh. TcrBar exists because a
  proxy is always running, so that refusal is the NORMAL case here. Its message
  names the pid and the stop-login-restart sequence, which is only useful if a
  human can read it.
- It is interactive: it prompts for an account name on stdin (src/oauth.rs:645)
  and can take a pasted authorization code (src/oauth.rs:450). With no TTY those
  prompts go nowhere and stdin hits EOF immediately.

So the button writes a .command file and opens it, which starts Terminal directly.
The AppleScript `do script` alternative needs Automation permission and would put
a consent dialog between the operator and a login they just asked for.

`--force` is never passed. tcr documents it as unsafe, and a GUI silently forcing
past a guard the CLI raised is the wrong use of a button.

The script is composed shell text, which is the one place in this app where a path
becomes executable, so the quoting is a pure function with tests: a path with a
space stays one argument, and a path containing a single quote is escaped POSIX
-style so it cannot close the quoting and run the remainder as its own command.
That last test was verified by breaking the escaping and watching it fail.

A missing tcr is reported in place rather than swallowed — a button that silently
does nothing is worse than one that says why.

## Verification

- `swift build`, `swift test` — **71 tests**, 0 failures (6 new)
- Fail-first: broke the POSIX quote escaping, watched `testSingleQuoteInPathCannotEscapeTheQuoting` fail, restored byte-identical
- `scripts/tcrbar-palette.py` — exit 0
- Render harness — 22/22, button visible in the footer
- Installed to /Applications and running
- No Rust touched

**Not verified:** the login flow end to end. Running it would open a browser OAuth
against a real account, and with a proxy holding the port `tcr` would refuse — which
is the correct behaviour but means the happy path is untested from here.