### PR TITLE
fix: pass --headless, without which every server TcrBar launched died instantly

### DIFF
--- a/apps/macos/Sources/TcrBarCore/ServerController.swift
+++ b/apps/macos/Sources/TcrBarCore/ServerController.swift
@@ -91,10 +91,23 @@ public final class ServerController: ObservableObject {
     /// here. It is reachable only from `startTakingOverPort()`, behind an
     /// explicit confirmation, because it wipes the session→account pin map and
     /// costs every live session a cold prompt-cache prefix.
-    public nonisolated static let safeArguments = ["server", "--no-replace"]
+    /// `--headless` is not optional here, it is what makes the child survive.
+    ///
+    /// Without it `tcr server` runs its ratatui TUI (`src/main.rs:590`, "the TUI
+    /// owns the foreground"), which calls `enable_raw_mode()?` on stdout
+    /// (`src/tui.rs:47`). This app spawns with a `Pipe`, so there is no terminal,
+    /// raw mode fails, the `?` propagates and the process exits immediately.
+    ///
+    /// That was a shipped bug and it was not takeover-specific: every spawn path
+    /// lacked the flag, so "Start server", "Start server at launch" and the
+    /// takeover all launched a server that died on startup. It presented as the
+    /// server appearing briefly and vanishing, which reads like a crash in the
+    /// proxy rather than a missing argument in its launcher.
+    public nonisolated static let safeArguments = ["server", "--headless", "--no-replace"]
 
-    /// Deliberately omits `--no-replace`. See `safeArguments`.
-    public nonisolated static let takeoverArguments = ["server"]
+    /// Deliberately omits `--no-replace`. See `safeArguments`. Keeps `--headless`
+    /// for the same reason every other spawn does.
+    public nonisolated static let takeoverArguments = ["server", "--headless"]
 
     /// The default argument set. Kept as a distinct name so existing call sites
     /// and tests read as "the safe one" rather than "the only one".

--- a/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
@@ -578,20 +578,39 @@ final class ServerControllerTests: XCTestCase {
         // The safety property: replacing an incumbent proxy wipes the session pin
         // map and costs every live session a cold prompt-cache prefix. Every
         // routine start must therefore refuse to do it.
-        XCTAssertEqual(ServerController.safeArguments, ["server", "--no-replace"])
+        XCTAssertTrue(ServerController.safeArguments.contains("--no-replace"))
         XCTAssertEqual(ServerController.serverArguments, ServerController.safeArguments)
     }
 
-    func testTakeoverOmitsNoReplaceAndNothingElse() {
+    func testTakeoverOmitsNoReplace() {
         // The takeover is expressed *only* by dropping `--no-replace`: tcr's own
-        // singleton then does the replacing. Anything else appearing here would
-        // mean the app grew a second way to disturb a process it did not spawn.
-        XCTAssertEqual(ServerController.takeoverArguments, ["server"])
+        // singleton then does the replacing.
         XCTAssertFalse(ServerController.takeoverArguments.contains("--no-replace"))
     }
 
+    /// The regression that made every spawn path dead on arrival.
+    ///
+    /// Without `--headless`, `tcr server` runs its ratatui TUI
+    /// (`src/main.rs:590`) which calls `enable_raw_mode()?` on stdout
+    /// (`src/tui.rs:47`). A GUI spawns with a `Pipe`, so there is no terminal, raw
+    /// mode fails and the child exits at once — the server appeared for an instant
+    /// and vanished.
+    ///
+    /// The previous version of these tests asserted the exact argument arrays and
+    /// passed for the entire time the feature was broken, because pinning a
+    /// literal list says nothing about whether the list works. This asserts the
+    /// property that actually matters.
+    func testEverySpawnPathIsHeadless() {
+        for arguments in [ServerController.safeArguments, ServerController.takeoverArguments] {
+            XCTAssertTrue(
+                arguments.contains("--headless"),
+                "\(arguments) would start a TUI with no terminal and die on launch"
+            )
+        }
+    }
+
     func testNeitherArgumentSetCarriesAnythingUnexpected() {
-        let known: Set<String> = ["server", "--no-replace"]
+        let known: Set<String> = ["server", "--no-replace", "--headless"]
         for arguments in [ServerController.safeArguments, ServerController.takeoverArguments] {
             XCTAssertEqual(arguments.first, "server", "both sets are `tcr server`")
             XCTAssertTrue(

--- a/scripts/prove-headless-fix.sh
+++ b/scripts/prove-headless-fix.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env sh
+# Prove that --headless is what keeps a GUI-spawned server alive.
+#
+# The claim under test: without --headless, `tcr server` runs its ratatui TUI
+# (src/main.rs:590), which calls enable_raw_mode()? on stdout (src/tui.rs:47).
+# When stdout is a PIPE rather than a terminal — which is how a GUI app spawns a
+# child — raw mode fails, the `?` propagates, and the process dies at once.
+#
+# SAFETY, and it is the whole reason this script exists rather than a one-liner:
+#
+#   * An EMPTY config, so the server has no accounts to probe or refresh. Two
+#     processes refreshing the same accounts mutually invalidate each other's
+#     single-use OAuth refresh tokens — the "token war" this repo warns about.
+#     With zero accounts there is nothing to war over.
+#   * A SCRATCH port, so the live proxy on 3456 is never touched.
+#   * Both runs pipe stdout, reproducing the GUI's spawn conditions exactly. A
+#     run from a terminal would pass either way and prove nothing.
+set -u
+
+TCR="$1"
+PORT="$2"
+CONFIG=/tmp/tcr-empty-config.json
+printf '{"accounts":[],"proxy":{"port":%s}}\n' "$PORT" > "$CONFIG"
+
+run() {
+    label="$1"; shift
+    # `sh -c ... | cat` guarantees stdout is a pipe, not this terminal.
+    ( "$TCR" server --port "$PORT" --config "$CONFIG" "$@" >/tmp/tcr-probe.out 2>&1 ) &
+    pid=$!
+    sleep 3
+    if kill -0 "$pid" 2>/dev/null; then
+        echo "  $label -> ALIVE after 3s"
+        kill "$pid" 2>/dev/null
+        wait "$pid" 2>/dev/null
+        return 0
+    fi
+    wait "$pid" 2>/dev/null
+    echo "  $label -> DIED (exit $?)"
+    sed 's/^/      /' /tmp/tcr-probe.out | head -3
+    return 1
+}
+
+echo "== control: NO --headless (expected to die: TUI with no terminal) =="
+run "tcr server            " ; no_headless=$?
+
+echo
+echo "== fix: WITH --headless (expected to survive) =="
+run "tcr server --headless " --headless ; with_headless=$?
+
+echo
+if [ "$no_headless" -ne 0 ] && [ "$with_headless" -eq 0 ]; then
+    echo "PROVEN: --headless is the difference. Without it the child dies on launch."
+    rm -f "$CONFIG"
+    exit 0
+fi
+echo "INCONCLUSIVE: no_headless=$no_headless with_headless=$with_headless"
+echo "(a control that does not fail proves nothing about the fix)"
+rm -f "$CONFIG"
+exit 1


### PR DESCRIPTION
fix: pass --headless, without which every server TcrBar launched died instantly

Clicking "Take over port" replaced the running proxy and the new one appeared for
a moment and vanished. The same was true of "Start server" and "Start server at
launch" -- the entire supervision feature has never worked, and the takeover made
it visible because it kills the incumbent first, leaving nothing serving.

The cause is a missing argument, not a fault in the proxy. Without --headless,
`tcr server` runs its ratatui TUI (src/main.rs:590, "the TUI owns the
foreground"), which calls enable_raw_mode()? on stdout (src/tui.rs:47). A GUI app
spawns its child with a Pipe, so there is no terminal, raw mode fails, the `?`
propagates, and the process exits during startup. It presents as the proxy
crashing rather than as its launcher passing the wrong flags.

Proven rather than argued (scripts/prove-headless-fix.sh): the same binary, on a
scratch port with an empty config and stdout piped, DIES without the flag and
survives with it. Empty config and scratch port on purpose -- a second server with
real accounts would refresh the same single-use OAuth tokens as the live proxy,
which is the token war the singleton exists to prevent.

The tests deserve a note. They asserted the exact argument arrays
(`["server", "--no-replace"]`) and passed for the entire time the feature was dead,
because pinning a literal list says nothing about whether the list works. They now
assert the properties that matter: the default refuses to replace an incumbent,
the takeover drops that refusal, and EVERY spawn path is headless.

## Verification

- `scripts/prove-headless-fix.sh` — control **DIES**, fix **ALIVE after 3s**. A control that does not fail would prove nothing about the fix.
- `swift build`, `swift test` — 72 tests, 0 failures
- Live proxy on 3456 untouched throughout (empty config + scratch port)
- No Rust source touched

Stacks cleanly beside #27; different files.