### PR TITLE
fix: install the CLI with rename(2), and stop lying about where the binary is

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -58,17 +58,49 @@ echo "post-merge: rebuilding tcr (release) at $sha — this takes a moment." >&2
 
 # Quiet on success, loud on failure: cargo's output is captured and only replayed
 # when the build fails.
+# WHERE the build lands is not `target/` by assumption.
+#
+# `CARGO_TARGET_DIR` (or `build.target-dir` in a config.toml) redirects it
+# elsewhere, and every agent session in this repo sets that variable. Measured
+# 2026-08-06: this hook announced "built 2dc3138" while the binary went to
+# ~/.cache/cargo-target and the repo's own target/release/tcr — the path the
+# operator's `tcr` resolves through — stayed on the PREVIOUS sha. The hook
+# reported success for work that landed somewhere the reader was not looking,
+# which is the exact failure this hook exists to prevent, aimed at itself.
+#
+# `cargo metadata` is authoritative (it honours the env var AND config.toml).
+# The `${CARGO_TARGET_DIR:-...}` fallback covers a machine without `jq` and is
+# cargo's own rule minus the config-file case.
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo .)
+target_dir=""
+if command -v jq >/dev/null 2>&1; then
+  target_dir=$(cargo metadata --no-deps --format-version 1 2>/dev/null | jq -r '.target_directory // empty' || true)
+fi
+[ -n "$target_dir" ] || target_dir="${CARGO_TARGET_DIR:-$repo_root/target}"
+bin="$target_dir/release/tcr"
+
 log=$(mktemp -t tcr-post-merge)
 if cargo build --release >"$log" 2>&1; then
   rm -f "$log"
-  # Replacing target/release/tcr does NOT disturb a running server: on Unix the
+  # Replacing the release binary does NOT disturb a running server: on Unix the
   # live process holds its own open inode, and cargo writes a NEW file over the
   # path. The old process keeps executing the old bytes until someone restarts
   # it — deliberately, per the note above. Do not "fix" this by signalling it.
-  echo "post-merge: built $sha — a RUNNING tcr still serves the old binary; restart it when convenient." >&2
+  #
+  # Verify rather than assert. "built $sha" was previously a claim; build.rs
+  # stamps TCR_BUILD_SHA into the binary, so it costs one grep to make it a fact.
+  if [ -f "$bin" ] && grep -aq "$sha" "$bin" 2>/dev/null; then
+    echo "post-merge: built $sha -> $bin — a RUNNING tcr still serves the old binary; restart it when convenient." >&2
+  else
+    echo "post-merge: built at $sha but $bin does not carry that sha — treat the on-disk binary as UNTRUSTED." >&2
+  fi
+  # Say it plainly when the artifact is not where a reader would look for it.
+  if [ "$target_dir" != "$repo_root/target" ]; then
+    echo "post-merge: NOTE — CARGO_TARGET_DIR is in effect, so $repo_root/target/release/tcr was NOT updated." >&2
+  fi
 else
   echo "" >&2
-  echo "post-merge: BUILD FAILED at $sha — target/release/tcr is now STALE or missing." >&2
+  echo "post-merge: BUILD FAILED at $sha — $bin is now STALE or missing." >&2
   echo "  The merge itself completed; only the rebuild failed. Full output:" >&2
   cat "$log" >&2
   rm -f "$log"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ so it's a drop-in on the same port.
 
 ```sh
 cargo build --release
-ln -sfn "$PWD/target/release/tcr" ~/.local/bin/tcr   # put `tcr` on PATH
+scripts/install-cli.sh          # put `tcr` on PATH (~/.local/bin/tcr by default)
 ```
 
 ## Configure

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -72,11 +72,52 @@ open build/TcrBar.app
 the commit count plus a `TcrGitSHA` key from the short SHA, suffixed `-dirty` on a
 dirty tree. Developer ID signing, notarization and DMG packaging are out of scope.
 
+## The bundled `tcr`
+
+`build-tcrbar.sh` builds the Rust `tcr` binary and copies it into
+`TcrBar.app/Contents/MacOS/tcr`, so the app and the server it drives are one
+artifact and cannot drift. They previously drifted twice in a single day.
+
+Two details are load-bearing:
+
+- The build reads cargo's output directory from
+  `cargo metadata --no-deps --format-version 1`, never assuming `target/release`.
+  `CARGO_TARGET_DIR` redirects it, and a build that lands elsewhere while
+  reporting success is exactly how the drift happened.
+- The copy is then checked for the `TCR_BUILD_SHA` that `build.rs` stamps, and
+  the build fails if it does not match `HEAD`. A bundle holding a stale `tcr` is
+  worse than no bundle, because the app would confidently serve old code.
+
+`Contents/MacOS/tcr` is codesigned **before** the bundle around it. Signing a
+nested Mach-O afterwards mutates a file the outer signature seals, which
+invalidates it — and per the note in the script an invalid signature silently
+breaks "Launch at login" and every permission grant. `codesign -v --deep
+--strict build/TcrBar.app` is the gate that proves the order.
+
+### Optionally pointing the CLI at the bundle
+
+Once the bundle is verified runnable, `~/.local/bin/tcr` can be repointed at
+`/Applications/TcrBar.app/Contents/MacOS/tcr` so the CLI and the app share one
+binary and only one thing needs updating.
+
+Do this by hand, and verify first — `Contents/MacOS/tcr --version` must run from
+the installed bundle. That symlink is what every shell `tcr` invocation resolves
+through, **including live `tcr run` sessions**: aim it at a missing, unsigned or
+quarantined binary and every `tcr` command on the machine breaks at once. The
+build script deliberately does not touch it.
+
 ## Finding the `tcr` binary
 
-An app launched from Finder inherits a minimal `PATH`, so TcrBar probes `PATH`
-first and then the usual install directories (`~/.local/bin`, `~/.cargo/bin`,
-`/opt/homebrew/bin`, `/usr/local/bin`). Override it explicitly with either:
+An app launched from Finder inherits a minimal `PATH`, so TcrBar probes, in
+order: the `TCR_BIN` environment variable, the `TcrExecutablePath` defaults key,
+the `tcr` bundled next to its own executable, then `PATH`, then the usual
+install directories (`~/.local/bin`, `~/.cargo/bin`, `/opt/homebrew/bin`,
+`/usr/local/bin`).
+
+The bundled binary sits between the overrides and `PATH` on purpose: an operator
+who names a path means it, but a `tcr` shipped inside this bundle must beat
+whatever happens to be on `PATH`, or bundling buys nothing. Override explicitly
+with either:
 
 ```sh
 defaults write com.github.dhkts1.tcrbar TcrExecutablePath /path/to/tcr
@@ -84,7 +125,7 @@ TCR_BIN=/path/to/tcr open build/TcrBar.app     # env override, shell launches
 ```
 
 If nothing is found the panel says so and names how many locations it searched —
-it never shows an empty list.
+the bundle path included — it never shows an empty list.
 
 ## Reading the panel honestly
 

--- a/apps/macos/Sources/TcrBarCore/ServerController.swift
+++ b/apps/macos/Sources/TcrBarCore/ServerController.swift
@@ -143,7 +143,24 @@ public final class ServerController: ObservableObject {
         process.arguments = arguments
         let err = Pipe()
         process.standardError = err
-        process.standardOutput = Pipe()
+        // Discard stdout — do NOT hand it a Pipe.
+        //
+        // `--headless` means "log to stdout" (`src/main.rs`), so a spawned server
+        // writes a steady stream there. A `Pipe()` nothing reads fills its 64KiB
+        // kernel buffer and the next write blocks FOREVER: the proxy wedges
+        // mid-serve, still alive, so `terminationHandler` never fires and this app
+        // keeps reporting `.supervising`. A hung server displayed as healthy.
+        //
+        // Only `standardError` gets a Pipe, and it is drained by the
+        // `readabilityHandler` below — that is what makes it safe.
+        //
+        // Nothing is lost: the server's durable log is `$TMPDIR/teamclaude-rs.log`,
+        // which is where `tcr status` and every diagnostic already read from.
+        //
+        // Pairs with ce1cb27 (`--headless`, without which the child died instantly).
+        // That fix let the server SURVIVE startup, which is precisely what let it
+        // live long enough to reach this second wall.
+        process.standardOutput = FileHandle.nullDevice
         stderrBuffer.reset()
         err.fileHandleForReading.readabilityHandler = { [stderrBuffer] handle in
             let data = handle.availableData

--- a/apps/macos/Sources/TcrBarCore/TcrTool.swift
+++ b/apps/macos/Sources/TcrBarCore/TcrTool.swift
@@ -37,6 +37,22 @@ public enum TcrTool {
         ]
     }
 
+    /// The directory holding this app's own executable, which is where
+    /// `build-tcrbar.sh` also puts the `tcr` it bundles (`Contents/MacOS/`).
+    ///
+    /// Derived from `Bundle.main`, never hard-coded: this repository is public
+    /// and no user-absolute path belongs in it. `executableURL` is used rather
+    /// than `bundleURL` because it resolves correctly for BOTH shapes this code
+    /// runs in — inside `TcrBar.app` it is `…/TcrBar.app/Contents/MacOS/TcrBar`,
+    /// and under `swift run`/`swift test` it is the bare tool — while
+    /// `bundleURL` alone would need a different suffix for each.
+    ///
+    /// `nil` when the bundle cannot name its executable; the caller then simply
+    /// has no bundle candidate to probe.
+    public static func bundledDirectory(bundle: Bundle = .main) -> URL? {
+        bundle.executableURL?.deletingLastPathComponent()
+    }
+
     /// Candidate directories, `PATH` first, in probe order.
     public static func searchDirectories(
         environment: [String: String] = ProcessInfo.processInfo.environment,
@@ -50,12 +66,20 @@ public enum TcrTool {
     }
 
     /// Resolve the binary, honouring the env override, then the defaults
-    /// override, then the search path.
+    /// override, then the bundled binary, then the search path.
+    ///
+    /// The bundled binary sits between the two explicit overrides and `PATH` on
+    /// purpose. An operator who names a path in `TCR_BIN` or the defaults key
+    /// means it, so those still win. But a `tcr` that shipped inside this very
+    /// bundle must beat whatever happens to be on `PATH`: the app and the server
+    /// are built and installed as one artifact precisely so they cannot drift,
+    /// and letting an older `PATH` copy win would give that away for nothing.
     public static func resolve(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         defaults: UserDefaults = .standard,
         home: URL = FileManager.default.homeDirectoryForCurrentUser,
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        bundle: URL? = bundledDirectory()
     ) -> Result<URL, NotFound> {
         var searched: [String] = []
         for override in [environment[overrideEnvKey], defaults.string(forKey: overrideDefaultsKey)] {
@@ -63,6 +87,11 @@ public enum TcrTool {
             let url = URL(fileURLWithPath: override)
             searched.append(url.path)
             if fileManager.isExecutableFile(atPath: url.path) { return .success(url) }
+        }
+        if let bundle {
+            let candidate = bundle.appendingPathComponent("tcr")
+            searched.append(candidate.path)
+            if fileManager.isExecutableFile(atPath: candidate.path) { return .success(candidate) }
         }
         for dir in searchDirectories(environment: environment, home: home) {
             let candidate = dir.appendingPathComponent("tcr")

--- a/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
@@ -724,14 +724,97 @@ final class TcrToolTests: XCTestCase {
     }
 
     func testMissingToolReportsWhatItSearched() {
+        let bundle = URL(fileURLWithPath: "/nonexistent-bundle", isDirectory: true)
         let result = TcrTool.resolve(
             environment: ["PATH": "/nonexistent-dir"],
             defaults: UserDefaults(suiteName: "com.github.dhkts1.tcrbar.tests")!,
-            home: URL(fileURLWithPath: "/nonexistent-home", isDirectory: true)
+            home: URL(fileURLWithPath: "/nonexistent-home", isDirectory: true),
+            bundle: bundle
         )
         guard case .failure(let notFound) = result else {
             return XCTFail("no tcr should have been found under a fake PATH")
         }
         XCTAssertFalse(notFound.searched.isEmpty, "the error must name where it looked")
+        // The bundled candidate is a real place this looked, so a truthful
+        // "not found" has to name it too.
+        XCTAssertTrue(
+            notFound.searched.contains("/nonexistent-bundle/tcr"),
+            "the searched list must include the bundle candidate, got \(notFound.searched)"
+        )
+    }
+
+    /// Writes an executable `tcr` into a fresh temp directory and returns it.
+    private func makeToolDirectory() throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("tcrtool-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+        let tool = dir.appendingPathComponent("tcr")
+        try "#!/bin/sh\nexit 0\n".write(to: tool, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: tool.path)
+        return tool
+    }
+
+    private var scratchDefaults: UserDefaults {
+        let defaults = UserDefaults(suiteName: "com.github.dhkts1.tcrbar.tests")!
+        defaults.removeObject(forKey: TcrTool.overrideDefaultsKey)
+        return defaults
+    }
+
+    func testBundledBinaryBeatsPath() throws {
+        let bundled = try makeToolDirectory()
+        let onPath = try makeToolDirectory()
+        let result = TcrTool.resolve(
+            environment: ["PATH": onPath.deletingLastPathComponent().path],
+            defaults: scratchDefaults,
+            home: URL(fileURLWithPath: "/nonexistent-home", isDirectory: true),
+            bundle: bundled.deletingLastPathComponent()
+        )
+        guard case .success(let found) = result else {
+            return XCTFail("a tcr exists in both the bundle and on PATH, got \(result)")
+        }
+        XCTAssertEqual(
+            found.path, bundled.path,
+            "the bundled tcr must win over the one on PATH (\(onPath.path))"
+        )
+    }
+
+    func testEnvironmentOverrideBeatsBundledBinary() throws {
+        let bundled = try makeToolDirectory()
+        let override = try makeToolDirectory()
+        let result = TcrTool.resolve(
+            environment: [TcrTool.overrideEnvKey: override.path, "PATH": "/nonexistent-dir"],
+            defaults: scratchDefaults,
+            home: URL(fileURLWithPath: "/nonexistent-home", isDirectory: true),
+            bundle: bundled.deletingLastPathComponent()
+        )
+        guard case .success(let found) = result else {
+            return XCTFail("TCR_BIN names a real executable, got \(result)")
+        }
+        XCTAssertEqual(
+            found.path, override.path,
+            "an explicit TCR_BIN must still beat the bundled tcr (\(bundled.path))"
+        )
+    }
+
+    func testDefaultsOverrideBeatsBundledBinary() throws {
+        let bundled = try makeToolDirectory()
+        let override = try makeToolDirectory()
+        let defaults = scratchDefaults
+        defaults.set(override.path, forKey: TcrTool.overrideDefaultsKey)
+        defer { defaults.removeObject(forKey: TcrTool.overrideDefaultsKey) }
+        let result = TcrTool.resolve(
+            environment: ["PATH": "/nonexistent-dir"],
+            defaults: defaults,
+            home: URL(fileURLWithPath: "/nonexistent-home", isDirectory: true),
+            bundle: bundled.deletingLastPathComponent()
+        )
+        guard case .success(let found) = result else {
+            return XCTFail("the defaults key names a real executable, got \(result)")
+        }
+        XCTAssertEqual(
+            found.path, override.path,
+            "an explicit defaults override must still beat the bundled tcr (\(bundled.path))"
+        )
     }
 }

--- a/apps/macos/scripts/build-tcrbar.sh
+++ b/apps/macos/scripts/build-tcrbar.sh
@@ -38,6 +38,48 @@ rm -rf "$app_dir"
 mkdir -p "$macos_dir"
 cp "$binary" "$macos_dir/$app_name"
 
+# Bundle the `tcr` server binary alongside the app.
+#
+# The app and the server ship as ONE artifact so they cannot drift: before this,
+# the two were built separately and TcrBar resolved `tcr` from `PATH`, which
+# drifted twice in a single day. `TcrTool.resolve()` probes
+# `Contents/MacOS/tcr` ahead of `PATH` for the same reason.
+#
+# The output path is READ OUT OF CARGO, never assumed to be `$repo_root/target`.
+# `CARGO_TARGET_DIR` redirects it, and assuming otherwise is not a hypothetical:
+# `.githooks/post-merge` announced `built <sha>` for a binary that had landed in
+# `$CARGO_TARGET_DIR` while the `target/release/tcr` a symlink actually resolved
+# to stayed at the old sha. A build that reports success from the wrong path is
+# worse than a failed one.
+echo "==> cargo build --release --bin tcr"
+cargo build --manifest-path "$repo_root/Cargo.toml" --release --bin tcr
+cargo_target_dir="$(cargo metadata --manifest-path "$repo_root/Cargo.toml" --no-deps --format-version 1 | jq -r .target_directory)"
+tcr_binary="$cargo_target_dir/release/tcr"
+if [ ! -x "$tcr_binary" ]; then
+  echo "ERROR: cargo reported target_directory=$cargo_target_dir but $tcr_binary is not executable." >&2
+  exit 1
+fi
+cp "$tcr_binary" "$macos_dir/tcr"
+chmod +x "$macos_dir/tcr"
+
+# Assert the COPY carries the sha we think we built.
+#
+# `build.rs` stamps `TCR_BUILD_SHA` into the binary, so the bundled file can be
+# asked what it is rather than trusted. A bundle holding a stale `tcr` is worse
+# than no bundle at all — the app would then confidently serve old code. The
+# expected value is the bare short sha; `$git_sha` may carry a `-dirty` suffix
+# that is not part of the stamp.
+expected_sha="$(git -C "$repo_root" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+if [ "$expected_sha" = "unknown" ]; then
+  echo "    tcr: bundled (no git sha to verify against)"
+elif grep -aq "$expected_sha" "$macos_dir/tcr"; then
+  echo "    tcr: bundled from $tcr_binary (sha $expected_sha)"
+else
+  echo "ERROR: $macos_dir/tcr does not carry the expected build sha $expected_sha." >&2
+  echo "ERROR: the bundled server would be a DIFFERENT build from this checkout." >&2
+  exit 1
+fi
+
 # The icon is DRAWN BY THE APP, not committed as a binary asset.
 #
 # `AppIcon.swift` renders it from the same `Tok` values the panel uses, so the
@@ -127,12 +169,21 @@ for class in "Developer ID Application" "Apple Development"; do
   fi
 done
 
+# Nested Mach-O binaries are signed BEFORE the bundle that contains them.
+#
+# The outer signature seals the bundle's contents, so signing `Contents/MacOS/tcr`
+# afterwards would mutate a file the app's own seal covers and invalidate it.
+# `codesign -v --deep --strict` on the finished bundle is what proves the order
+# is right, and per the note above an invalid signature is not cosmetic: it
+# silently breaks "Launch at login" and every permission grant.
 if [ -n "$sign_identity" ]; then
   echo "==> codesign ($sign_tier)"
+  codesign -s "$sign_identity" --force "$macos_dir/tcr"
   codesign -s "$sign_identity" --force "$app_dir"
 else
   sign_tier="ad-hoc"
   echo "==> codesign (ad-hoc)"
+  codesign -s - --force "$macos_dir/tcr"
   codesign -s - --force "$app_dir"
   {
     echo

--- a/apps/macos/scripts/build-tcrbar.sh
+++ b/apps/macos/scripts/build-tcrbar.sh
@@ -13,21 +13,49 @@ repo_root="$(cd "$pkg_dir/../.." && pwd)"
 
 app_name="TcrBar"
 bundle_id="com.github.dhkts1.tcrbar"
-short_version="0.1.0"
 build_dir="$pkg_dir/build"
 app_dir="$build_dir/$app_name.app"
 macos_dir="$app_dir/Contents/MacOS"
 
 # Build stamp. A missing or unreadable .git must never fail the build.
+#
+# `--untracked-files=no` matches what `build.rs` uses for TCR_BUILD_DIRTY, and
+# for the same reason: an untracked file cannot reach a build unless some
+# TRACKED file starts referring to it. Counting untracked files made this stamp
+# call a clean tracked tree "dirty" whenever scratch scripts were lying around,
+# which is both wrong and exactly the kind of stamp nobody believes twice.
 git_sha="unknown"
 build_number="0"
 if git -C "$repo_root" rev-parse --git-dir >/dev/null 2>&1; then
   git_sha="$(git -C "$repo_root" rev-parse --short HEAD 2>/dev/null || echo unknown)"
   build_number="$(git -C "$repo_root" rev-list --count HEAD 2>/dev/null || echo 0)"
-  if [ -n "$(git -C "$repo_root" status --porcelain 2>/dev/null)" ]; then
+  if [ -n "$(git -C "$repo_root" status --porcelain --untracked-files=no 2>/dev/null)" ]; then
     git_sha="$git_sha-dirty"
   fi
 fi
+
+# The version is DERIVED, never written down here.
+#
+# It used to be a literal `0.1.0` in this script AND a literal `0.1.0` in
+# Cargo.toml -- two copies of one fact, kept in step by memory alone. And it
+# never moved, so every build of every commit claimed the same version.
+#
+# MAJOR.MINOR is read from Cargo.toml (the one place a human sets it); PATCH is
+# the commit count, which rises with every commit and therefore with every push.
+# That makes "bump the version before pushing" impossible to forget, because
+# there is nothing to bump.
+#
+# Deliberately NOT a pre-push hook: git resolves the refs to push before
+# pre-push runs, so a hook that edits a version file cannot get that edit into
+# the push it is running for. It would either leave the tree dirty with the bump
+# excluded, or commit a bump that ships one push late -- forever publishing N
+# while the tree reads N+1.
+base_version="$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([0-9]\{1,\}\.[0-9]\{1,\}\)\..*"/\1/p' "$repo_root/Cargo.toml" 2>/dev/null | head -1)"
+if [ -z "$base_version" ]; then
+  echo "WARNING: could not read version from Cargo.toml — falling back to 0.0" >&2
+  base_version="0.0"
+fi
+short_version="$base_version.$build_number"
 
 echo "==> swift build -c release --product $app_name"
 swift build --package-path "$pkg_dir" -c release --product "$app_name"

--- a/apps/macos/scripts/install.sh
+++ b/apps/macos/scripts/install.sh
@@ -74,6 +74,11 @@ cleanup() {
   rm -rf "$STAGE_DIR"
 }
 trap cleanup EXIT
+# A shell killed by an UNCAUGHT signal does not run its EXIT trap — verified in
+# the sandbox gate, where a SIGTERM mid-ditto orphaned the staging directory.
+# Catching the signal turns it into an ordinary exit, which does run cleanup.
+trap 'exit 130' INT
+trap 'exit 143' TERM HUP
 
 echo "==> Staging the new bundle…"
 # ditto, not cp -R: it preserves the bundle's resource forks, extended

--- a/apps/macos/scripts/install.sh
+++ b/apps/macos/scripts/install.sh
@@ -16,6 +16,34 @@
 # /Applications is a stable path, so the login item survives rebuilds and the app
 # shows up in Spotlight and Launchpad like anything else.
 #
+# HOW THE INSTALL IS ORDERED, and that ordering is the point.
+#
+# The obvious `rm -rf "$DEST" && ditto "$SRC" "$DEST"` has two faults. For the
+# whole duration of the copy /Applications/TcrBar.app does not exist — Spotlight,
+# Launchpad, the login item and anyone double-clicking see nothing — and if the
+# copy fails you are left with no app at all and no way back. So instead:
+#
+#   stage → verify → stop the app → swap → drop the old copy
+#
+# The staged bundle is ditto'd to a temp directory inside /Applications (same
+# filesystem, which rename(2) requires) and code-signature-checked THERE. Only a
+# bundle that passed the check is ever moved over the good one; a failed build or
+# a broken signature aborts with the existing install untouched and still running.
+# Because the check now happens before the swap it is load-bearing, which the
+# old post-install `codesign -dv` printout never was.
+#
+# The swap is `mv` of directories, not a copy: rename(2) is atomic and the new
+# bundle arrives with fresh inodes. That keeps the property `rm -rf` + `ditto`
+# had and an in-place `cp -R` does not — nothing rewrites an executable another
+# process is exec'ing, which is what SIGKILLed running binaries with
+# `Code Signature Invalid` on 2026-08-06 (see scripts/install-cli.sh, same rule
+# applied to a single file). A directory rename cannot clobber a directory, so
+# the old bundle is moved aside first; if the second rename fails it is moved
+# back. The only gap is between those two renames, and it is recoverable.
+#
+# Everything staged is removed by an EXIT trap on every path, success or failure,
+# so a failed install never leaves an orphan bundle sitting in /Applications.
+#
 # Idempotent: safe to re-run. Uninstall with scripts/uninstall.sh.
 set -euo pipefail
 
@@ -29,8 +57,43 @@ bash "$MACOS_DIR/scripts/build-tcrbar.sh"
 
 [ -d "$SRC" ] || { echo "build produced no bundle at $SRC" >&2; exit 1; }
 
+# Staging directory lives beside the destination: rename(2) is only atomic within
+# one filesystem, and /tmp is frequently a different one.
+STAGE_DIR="$(mktemp -d "$(dirname "$DEST")/.${APP_NAME}.install.XXXXXX")"
+STAGE="$STAGE_DIR/${APP_NAME}.app"
+BACKUP="$STAGE_DIR/${APP_NAME}.previous.app"
+
+# Runs on every exit path. If we died between the two renames the destination is
+# missing and the old bundle is still in the staging directory — put it back
+# before the staging directory is removed, or the cleanup would delete the only
+# copy of the app.
+cleanup() {
+  if [ ! -e "$DEST" ] && [ -d "$BACKUP" ]; then
+    mv "$BACKUP" "$DEST" || true
+  fi
+  rm -rf "$STAGE_DIR"
+}
+trap cleanup EXIT
+
+echo "==> Staging the new bundle…"
+# ditto, not cp -R: it preserves the bundle's resource forks, extended
+# attributes and the code signature. A cp -R can invalidate the signature.
+ditto "$SRC" "$STAGE"
+
+echo "==> Verifying the staged bundle…"
+# --deep --strict, because the inner Contents/MacOS/tcr is signed before the
+# bundle around it and only a deep check proves that order held (apps/macos/README.md).
+# This runs while the currently installed app is still in place: a failure here
+# aborts and leaves it exactly as it was.
+if ! codesign -v --deep --strict "$STAGE"; then
+  echo "staged bundle at $SRC failed code-signature verification — refusing to install" >&2
+  echo "the existing install at $DEST is untouched" >&2
+  exit 1
+fi
+
 # Stop only OUR app, and only the copy being replaced. `pkill -f TcrBar` would
-# also match an editor with the name in its title or a grep for it.
+# also match an editor with the name in its title or a grep for it. This happens
+# after verification so a bad build never costs you the running app.
 if pgrep -f "${APP_NAME}.app/Contents/MacOS/${APP_NAME}" >/dev/null 2>&1; then
   echo "==> Stopping the running ${APP_NAME}…"
   pkill -f "${APP_NAME}.app/Contents/MacOS/${APP_NAME}" || true
@@ -39,17 +102,23 @@ if pgrep -f "${APP_NAME}.app/Contents/MacOS/${APP_NAME}" >/dev/null 2>&1; then
 fi
 
 echo "==> Installing to ${DEST}…"
-# ditto, not cp -R: it preserves the bundle's resource forks, extended
-# attributes and the code signature. A cp -R can invalidate the signature.
-rm -rf "$DEST"
-ditto "$SRC" "$DEST"
+if [ -e "$DEST" ]; then
+  mv "$DEST" "$BACKUP"
+fi
+if ! mv "$STAGE" "$DEST"; then
+  echo "could not move the staged bundle into place — restoring the previous install" >&2
+  exit 1
+fi
+rm -rf "$BACKUP"
 
 # Re-register so LaunchServices knows about the new copy immediately rather than
 # whenever it next rescans.
 /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister \
   -f "$DEST" >/dev/null 2>&1 || true
 
-echo "==> Verifying the installed bundle…"
+# Informational only — the gate that can still save you already ran, above, on
+# the staged copy. This just shows what landed.
+echo "==> Installed signature…"
 codesign -dv "$DEST" 2>&1 | rg -i 'Identifier|Authority=Apple|Signature' | sed 's/^/    /' || true
 
 echo "==> Launching…"

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Install the release `tcr` binary onto PATH.
 #
-# Usage: scripts/install-cli.sh [destination]        (default: ~/.local/bin/tcr)
+# Usage: scripts/install-cli.sh [--force] [destination]    (default: ~/.local/bin/tcr)
 #
 # Two things here are deliberate, and both exist because of a specific incident.
 #
@@ -23,9 +23,28 @@
 #      rather than following it -- `cp` would write through the link and corrupt
 #      whatever it pointed at, which is how the 2026-08-06 burst reached the repo's
 #      own build output.
+#
+#   3. That same rename(2) property has a second, unwanted consequence, so the
+#      script refuses to run when the destination is a symlink. apps/macos/README.md
+#      documents the intended arrangement where ~/.local/bin/tcr is a SYMLINK into
+#      /Applications/TcrBar.app/Contents/MacOS/tcr, so the menu-bar app and the CLI
+#      are one artifact and only one thing ever needs updating. Because `mv -f`
+#      replaces a symlink instead of following it, running this installer over that
+#      link turns it back into an independent regular file -- silently, with no
+#      error -- and binary drift between the app and the CLI is back. Refusing is
+#      the only way that undoing is visible; TCR_INSTALL_FORCE=1 (or --force) is
+#      the deliberate override.
 set -euo pipefail
 
-DEST="${1:-$HOME/.local/bin/tcr}"
+FORCE="${TCR_INSTALL_FORCE:-0}"
+DEST=""
+for arg in "$@"; do
+  case "$arg" in
+    --force) FORCE=1 ;;
+    *)       DEST="$arg" ;;
+  esac
+done
+DEST="${DEST:-$HOME/.local/bin/tcr}"
 
 fail() { printf '!! %s\n' "$1" >&2; exit 1; }
 
@@ -38,6 +57,22 @@ SRC="$TARGET_DIR/release/tcr"
 
 [ -f "$SRC" ] || fail "no release binary at $SRC -- build it first:  cargo build --release"
 [ -x "$SRC" ] || fail "$SRC is not executable"
+
+# See note 3 in the header: `mv -f` replaces a symlink destination rather than
+# following it, so installing over the app-bundle symlink would quietly split the
+# one shared binary back into two that drift apart.
+if [ -L "$DEST" ] && [ "$FORCE" != "1" ]; then
+  fail "$(printf '%s\n' \
+    "symlinked destination -- refusing to install" \
+    "  $DEST -> $(readlink "$DEST")" \
+    "It is a symlink, most likely the shared TcrBar.app binary documented in" \
+    "apps/macos/README.md. Installing here would replace the link with a regular" \
+    "file and reintroduce drift between the app and the CLI." \
+    "Instead:" \
+    "  update the bundle:  apps/macos/scripts/install.sh" \
+    "  or install elsewhere:  scripts/install-cli.sh /some/other/path/tcr" \
+    "  or override on purpose:  scripts/install-cli.sh --force  (TCR_INSTALL_FORCE=1)")"
+fi
 
 DEST_DIR="$(dirname "$DEST")"
 mkdir -p "$DEST_DIR"

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Install the release `tcr` binary onto PATH.
+#
+# Usage: scripts/install-cli.sh [destination]        (default: ~/.local/bin/tcr)
+#
+# Two things here are deliberate, and both exist because of a specific incident.
+#
+#   1. The source is resolved from `cargo metadata`, never from the literal
+#      `target/release`. With CARGO_TARGET_DIR exported -- as it is on this
+#      machine -- cargo writes nowhere near the repo, so `<repo>/target/release/tcr`
+#      is a stale orphan from before the variable was set. Installing it silently
+#      ships old code and every "the fix is live" claim afterwards is false.
+#
+#   2. The binary is copied to a temp file in the DESTINATION'S OWN directory and
+#      then renamed over the destination -- never `cp` straight onto it. A `cp`
+#      onto a live path is an in-place, same-inode rewrite of an executable other
+#      processes are exec'ing; macOS answers by SIGKILLing them with
+#      `Code Signature Invalid` / `Taskgated Invalid Signature`. That is not
+#      hypothetical: 25 such crash reports landed in ~/Library/Logs/DiagnosticReports/
+#      between 19:56:55 and 19:57:22 on 2026-08-06, from exactly this pattern.
+#      rename(2) is atomic and gives the destination a NEW inode, so already-running
+#      execs keep their old inode intact. It also replaces a *symlink* destination
+#      rather than following it -- `cp` would write through the link and corrupt
+#      whatever it pointed at, which is how the 2026-08-06 burst reached the repo's
+#      own build output.
+set -euo pipefail
+
+DEST="${1:-$HOME/.local/bin/tcr}"
+
+fail() { printf '!! %s\n' "$1" >&2; exit 1; }
+
+command -v cargo >/dev/null 2>&1 || fail "cargo not found on PATH"
+command -v jq    >/dev/null 2>&1 || fail "jq not found on PATH"
+
+TARGET_DIR="$(cargo metadata --format-version 1 --no-deps | jq -r .target_directory)"
+[ -n "$TARGET_DIR" ] && [ "$TARGET_DIR" != "null" ] || fail "could not resolve cargo target directory"
+SRC="$TARGET_DIR/release/tcr"
+
+[ -f "$SRC" ] || fail "no release binary at $SRC -- build it first:  cargo build --release"
+[ -x "$SRC" ] || fail "$SRC is not executable"
+
+DEST_DIR="$(dirname "$DEST")"
+mkdir -p "$DEST_DIR"
+
+# Temp file must live in the destination's directory: rename(2) is only atomic
+# within a single filesystem, and /tmp is frequently a different one.
+TMP="$(mktemp "$DEST_DIR/.tcr.install.XXXXXX")"
+trap 'rm -f "$TMP"' EXIT
+
+cp "$SRC" "$TMP"
+chmod 755 "$TMP"
+
+if command -v codesign >/dev/null 2>&1; then
+  codesign -v "$TMP" 2>/dev/null || fail "codesign verification failed for $SRC -- refusing to install"
+fi
+
+mv -f "$TMP" "$DEST"
+trap - EXIT
+
+sha() { shasum -a 256 "$1" 2>/dev/null | awk '{print $1}' || sha256sum "$1" | awk '{print $1}'; }
+
+echo "source:    $SRC"
+echo "           $(sha "$SRC")"
+echo "installed: $DEST"
+echo "           $(sha "$DEST")"

--- a/src/update.rs
+++ b/src/update.rs
@@ -26,6 +26,11 @@ use anyhow::{bail, Context as _};
 pub enum InstallKind {
     /// Built from a git checkout at this root (`.git` + `Cargo.toml` present).
     GitCheckout(PathBuf),
+    /// Running from the CLI copy bundled inside a macOS `.app` (TcrBar bundles
+    /// it at `Contents/MacOS/tcr`). The payload is the bundle root. We only
+    /// notify: the bundled binary is a COPY, so rebuilding a checkout would not
+    /// replace it, and `cargo install` would write a third competing artifact.
+    AppBundle(PathBuf),
     /// Installed outside any checkout — we only notify, never self-replace.
     Installed,
 }
@@ -53,18 +58,47 @@ pub fn find_repo_root_from(start: &Path) -> Option<PathBuf> {
 }
 
 /// [`find_repo_root_from`] anchored at the running executable's path. The exe
-/// path is CANONICALIZED first: `tcr` is normally invoked through a PATH symlink
-/// (e.g. `~/.local/bin/tcr` → `…/target/release/tcr`), and `current_exe()` yields
-/// that symlink path — walking up from it never reaches the checkout. Resolving
-/// symlinks anchors the walk at the real binary under `target/release/`.
+/// path is CANONICALIZED first because `tcr` on PATH is not always the real
+/// binary: an install may place a symlink there (`~/.local/bin/tcr` →
+/// `<target-dir>/release/tcr`, or → `…/TcrBar.app/Contents/MacOS/tcr`), and
+/// `current_exe()` yields that symlink path — walking up from it never reaches
+/// the checkout. Resolving symlinks anchors the walk at the real binary.
+///
+/// The current install on this machine copies the binary instead (a plain file
+/// at `~/.local/bin/tcr`), for which canonicalization is a no-op and the walk
+/// correctly finds no checkout. Both shapes ship, so the defence stays.
 pub fn find_repo_root() -> Option<PathBuf> {
     let exe = std::env::current_exe().ok()?;
     let exe = std::fs::canonicalize(&exe).unwrap_or(exe);
     find_repo_root_from(&exe)
 }
 
+/// Walk UP from `start` to the first ancestor directory whose name ends in
+/// `.app` — the root of a macOS application bundle. `TcrBar.app` ships the CLI
+/// at `Contents/MacOS/tcr`, so a binary running from inside a bundle must be
+/// recognised as such rather than as a generic installed copy.
+pub fn find_app_bundle_from(start: &Path) -> Option<PathBuf> {
+    for dir in start.ancestors() {
+        let is_bundle = dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.ends_with(".app") && n.len() > ".app".len());
+        if is_bundle {
+            return Some(dir.to_path_buf());
+        }
+    }
+    None
+}
+
 /// Classify how the binary at `exe_path` was installed.
+///
+/// The bundle check runs FIRST: a `.app` nested inside a checkout (a build
+/// artifact under the target dir, say) still holds a *copy* of the binary, so
+/// pulling and rebuilding the checkout would not replace what is running.
 pub fn classify_install_from(exe_path: &Path) -> InstallKind {
+    if let Some(bundle) = find_app_bundle_from(exe_path) {
+        return InstallKind::AppBundle(bundle);
+    }
     match find_repo_root_from(exe_path) {
         Some(root) => InstallKind::GitCheckout(root),
         None => InstallKind::Installed,
@@ -75,9 +109,12 @@ pub fn classify_install_from(exe_path: &Path) -> InstallKind {
 /// if the executable path can't be resolved.
 pub fn classify_install() -> InstallKind {
     match std::env::current_exe() {
-        // Canonicalize so a PATH symlink (e.g. ~/.local/bin/tcr) resolves to the
-        // real binary before we look for the checkout — otherwise a symlinked
-        // invocation is misclassified as Installed and refuses to self-update.
+        // Canonicalize first: when the PATH entry is a symlink (~/.local/bin/tcr
+        // pointing into a target dir or into TcrBar.app) the link path itself has
+        // neither a checkout nor a `.app` above it, so an unresolved path is
+        // misclassified as Installed and refuses to self-update. When the PATH
+        // entry is a copied regular file — the current shape here —
+        // canonicalization changes nothing and Installed is the right answer.
         Ok(exe) => classify_install_from(&std::fs::canonicalize(&exe).unwrap_or(exe)),
         Err(_) => InstallKind::Installed,
     }
@@ -103,6 +140,51 @@ pub fn cargo_build_argv() -> [&'static str; 2] {
     ["build", "--release"]
 }
 
+/// Pure argv for the target-directory query — asserted in tests without
+/// spawning cargo.
+pub fn cargo_metadata_argv() -> [&'static str; 4] {
+    ["metadata", "--format-version", "1", "--no-deps"]
+}
+
+/// Extract `target_directory` from `cargo metadata` JSON.
+///
+/// Cargo does NOT always write to `<root>/target`: `CARGO_TARGET_DIR` (and
+/// `build.target-dir` in a config file) relocate it, and on this machine it is
+/// exported globally. Hardcoding `<root>/target/release/tcr` printed the path
+/// of a stale orphan from before that export — a different file, with a
+/// different hash, from the one the build had just produced. `cargo metadata`
+/// is the only source that answers where cargo actually writes.
+pub fn parse_target_directory(stdout: &str) -> anyhow::Result<PathBuf> {
+    let json: serde_json::Value =
+        serde_json::from_str(stdout).context("`cargo metadata` did not emit valid JSON")?;
+    match json.get("target_directory").and_then(|v| v.as_str()) {
+        Some(dir) if !dir.is_empty() => Ok(PathBuf::from(dir)),
+        _ => bail!("`cargo metadata` JSON has no usable `target_directory` field"),
+    }
+}
+
+/// Absolute path of the release binary cargo just built in `root`. Errors are
+/// returned, never swallowed into a guessed path — an invented path is exactly
+/// the defect this function exists to remove.
+fn built_binary_path(root: &Path) -> anyhow::Result<PathBuf> {
+    let output = Command::new("cargo")
+        .args(cargo_metadata_argv())
+        .current_dir(root)
+        .stderr(std::process::Stdio::inherit())
+        .output()
+        .context("failed to spawn `cargo` — is cargo on PATH?")?;
+
+    if !output.status.success() {
+        bail!(
+            "`cargo metadata` failed in {} — cannot determine the target directory.",
+            root.display()
+        );
+    }
+
+    let target_dir = parse_target_directory(&String::from_utf8_lossy(&output.stdout))?;
+    Ok(target_dir.join("release").join("tcr"))
+}
+
 /// `tcr update [--force]` — self-update entry point.
 pub fn run_update(force: bool) -> anyhow::Result<()> {
     run_update_with(classify_install(), force)
@@ -113,12 +195,25 @@ pub fn run_update(force: bool) -> anyhow::Result<()> {
 pub fn run_update_with(kind: InstallKind, force: bool) -> anyhow::Result<()> {
     match kind {
         InstallKind::GitCheckout(root) => update_checkout(&root, force),
+        InstallKind::AppBundle(bundle) => {
+            println!(
+                "tcr is running from the copy bundled inside {}, so it can't self-update.\n\
+                 Rebuild and reinstall the app from the source tree:\n\
+                 \n    git -C <teamclaude-rs> pull --ff-only && <teamclaude-rs>/apps/macos/scripts/install.sh\n\
+                 \nDo NOT `cargo install --path` here: that writes ~/.cargo/bin/tcr, a third copy \
+                 competing with the bundled one and with anything already on your PATH.",
+                bundle.display()
+            );
+            Ok(())
+        }
         InstallKind::Installed => {
             println!(
                 "tcr was not run from a git checkout, so it can't self-update.\n\
                  Reinstall from the source tree:\n\
                  \n    git -C <teamclaude-rs> pull --ff-only && cargo install --path <teamclaude-rs>\n\
-                 \n(or `cargo build --release` and copy target/release/tcr onto your PATH)."
+                 \n(or `cargo build --release` there and copy the built binary onto your PATH — \
+                 `cargo metadata --format-version 1 --no-deps` reports the target directory, which \
+                 CARGO_TARGET_DIR may move well outside the checkout)."
             );
             Ok(())
         }
@@ -185,8 +280,17 @@ fn update_checkout(root: &Path, force: bool) -> anyhow::Result<()> {
         );
     }
 
-    let built = root.join("target").join("release").join("tcr");
-    println!("tcr: built {}", built.display());
+    match built_binary_path(root) {
+        Ok(built) => println!("tcr: built {}", built.display()),
+        // The build itself succeeded, so this is not fatal — but we refuse to
+        // print a guessed path. Say plainly that we don't know where it landed.
+        Err(err) => eprintln!(
+            "tcr: the build succeeded, but locating the binary failed: {err:#}\n\
+             tcr: run `cargo metadata --format-version 1 --no-deps` in {} to find the \
+             target directory; the binary is at <target-dir>/release/tcr.",
+            root.display()
+        ),
+    }
     println!(
         "tcr: this process is still running the OLD binary — restart tcr to run the new build."
     );
@@ -228,11 +332,14 @@ mod tests {
         fs::remove_dir_all(&root).ok();
     }
 
-    /// Regression (found by a live `tcr update`): `tcr` is invoked through a PATH
-    /// symlink (~/.local/bin/tcr → …/target/release/tcr). Walking up from the
-    /// SYMLINK path never reaches the checkout; canonicalizing first — what
-    /// `find_repo_root`/`classify_install` now do — resolves to the real binary.
-    /// The injected-path unit tests missed this because they never symlinked.
+    /// Regression (found by a live `tcr update`): when the PATH entry is a
+    /// SYMLINK into the build output (`~/.local/bin/tcr` → `…/release/tcr`),
+    /// walking up from the symlink path never reaches the checkout;
+    /// canonicalizing first — what `find_repo_root`/`classify_install` now do —
+    /// resolves to the real binary. The injected-path unit tests missed this
+    /// because they never symlinked. Installs also ship the binary as a copied
+    /// regular file (the current shape on this machine), where canonicalization
+    /// is a no-op; this test covers the symlink shape specifically.
     #[test]
     fn find_repo_root_resolves_through_a_symlinked_exe() {
         use std::os::unix::fs::symlink;
@@ -306,6 +413,95 @@ mod tests {
     }
 
     #[test]
+    fn classify_install_app_bundle() {
+        // TcrBar.app/Contents/MacOS/tcr — no checkout above it.
+        let root = scratch("classify-bundle");
+        let bundle = root.join("TcrBar.app");
+        let exe = bundle.join("Contents").join("MacOS").join("tcr");
+        fs::create_dir_all(exe.parent().unwrap()).unwrap();
+        fs::write(&exe, b"fake").unwrap();
+
+        assert_eq!(
+            classify_install_from(&exe),
+            InstallKind::AppBundle(bundle.clone())
+        );
+        assert_eq!(
+            find_app_bundle_from(&exe).as_deref(),
+            Some(bundle.as_path())
+        );
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    /// A bundle nested INSIDE a checkout still holds a copy of the binary, so
+    /// the bundle classification must win over `GitCheckout` — rebuilding the
+    /// checkout would not replace what is running.
+    #[test]
+    fn classify_install_app_bundle_beats_enclosing_checkout() {
+        let root = scratch("bundle-in-checkout");
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("Cargo.toml"), "[package]\n").unwrap();
+        let bundle = root.join("dist").join("TcrBar.app");
+        let exe = bundle.join("Contents").join("MacOS").join("tcr");
+        fs::create_dir_all(exe.parent().unwrap()).unwrap();
+        fs::write(&exe, b"fake").unwrap();
+
+        assert_eq!(classify_install_from(&exe), InstallKind::AppBundle(bundle));
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    /// A directory literally named `.app` is a dotfile, not a bundle.
+    #[test]
+    fn find_app_bundle_ignores_bare_dot_app_and_plain_dirs() {
+        let root = scratch("bundle-negative");
+        let exe = root.join(".app").join("bin").join("tcr");
+        fs::create_dir_all(exe.parent().unwrap()).unwrap();
+        fs::write(&exe, b"fake").unwrap();
+
+        assert_eq!(find_app_bundle_from(&exe), None);
+        assert_eq!(classify_install_from(&exe), InstallKind::Installed);
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn run_update_app_bundle_notifies_without_spawning() {
+        let kind = InstallKind::AppBundle(PathBuf::from("/Applications/TcrBar.app"));
+        assert!(run_update_with(kind.clone(), false).is_ok());
+        assert!(run_update_with(kind, true).is_ok());
+    }
+
+    /// The whole point of defect #1: with `CARGO_TARGET_DIR` set, cargo writes
+    /// far outside the checkout, so the built path must come from metadata.
+    #[test]
+    fn parse_target_directory_reads_relocated_target_dir() {
+        let json = r#"{"packages":[],"workspace_root":"/repo","target_directory":"/elsewhere/cargo-target","version":1}"#;
+        assert_eq!(
+            parse_target_directory(json).unwrap(),
+            PathBuf::from("/elsewhere/cargo-target")
+        );
+        // …and the printed binary path is target_dir/release/tcr, NOT
+        // <root>/target/release/tcr.
+        let built = parse_target_directory(json)
+            .unwrap()
+            .join("release")
+            .join("tcr");
+        assert_eq!(built, PathBuf::from("/elsewhere/cargo-target/release/tcr"));
+        assert!(!built.starts_with("/repo"));
+    }
+
+    #[test]
+    fn parse_target_directory_errors_are_not_swallowed() {
+        // Missing field, wrong type, empty string and non-JSON must all error
+        // rather than degrade into a guessed path.
+        assert!(parse_target_directory(r#"{"workspace_root":"/repo"}"#).is_err());
+        assert!(parse_target_directory(r#"{"target_directory":null}"#).is_err());
+        assert!(parse_target_directory(r#"{"target_directory":""}"#).is_err());
+        assert!(parse_target_directory("error: no manifest found").is_err());
+    }
+
+    #[test]
     fn parse_pull_stdout_already_up_to_date() {
         assert_eq!(
             parse_pull_stdout("Already up to date.\n"),
@@ -324,6 +520,10 @@ mod tests {
     fn argv_shapes_are_stable() {
         assert_eq!(git_pull_argv(), ["pull", "--ff-only"]);
         assert_eq!(cargo_build_argv(), ["build", "--release"]);
+        assert_eq!(
+            cargo_metadata_argv(),
+            ["metadata", "--format-version", "1", "--no-deps"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Makes `TcrBar.app` ship the server it supervises, and makes every path that places a `tcr` binary honest about what it did.

## What started it

A menubar-app-spawned proxy looked like it was crash-looping. The logs held two unrelated failures.

**30 instant-death boots (2026-08-06, 11:29→13:36).** Every boot was followed by `ERROR tcr: tui error error=Device not configured (os error 6)` — ENXIO, no tty. The server was spawned without `--headless`, so ratatui's `enable_raw_mode()` failed and the `?` propagated. Worst instance: **20 boots in 13 seconds**, each taking over port 3456 from the last (`singleton: replacing incumbent proxy port=3456 replaced_pid=…`), so each cycle wiped the session→account pin map and cost every live session a cold prompt-cache prefix.

**25 processes SIGKILLed in 90 seconds (19:56:55→19:57:22).** All identical: `SIGKILL (Code Signature Invalid)` / `Taskgated Invalid Signature`. None reached `main`, so nothing appeared in the application log — which is why this read as the proxy dying rather than as every `tcr` invocation on the machine being shot. `~/.local/bin/tcr` was a symlink into `target/release/`, and a script did `cp` onto it: an in-place, same-inode rewrite of a binary other processes were exec'ing.

## The mechanism, measured

N=5 per arm, on a running ad-hoc-signed binary:

| arm | operation | fresh `exec` |
|---|---|---|
| A | `cp new old` (same inode) | **137 ×5** — SIGKILL |
| B | `mv staged old` (rename(2), new inode) | 0 ×5 |
| C | process exits first, *then* `cp` | 0 ×5 |

Arm C isolates *running* as the necessary condition. The cause is in XNU `osfmk/vm/vm_fault.c`: the kernel caches the signature against the file's mtime and rejects pages when `cs_mtime != mtime`.

**`codesign -v` returns 0 on the file that just killed five processes.** The artifact is valid; the kernel's per-vnode cache is stale. `codesign -v` cannot detect this class — only the rename avoids it. (Distinct from `codesign -v --deep --strict` in the build script, which checks nested-signature *ordering* and was independently confirmed to work: flipping one byte in the nested `tcr`, replacing it with a non-Mach-O, and signing in the wrong order each fail it.)

`cargo build --release` was never the trigger. It already replaces the inode correctly.

## The change

**Bundling.** `TcrTool.swift` resolves the CLI as `TCR_BIN` → a defaults key → the bundled `Contents/MacOS/tcr` → `PATH`, so a `tcr` shipped inside the bundle beats whatever is on `PATH` and the two cannot drift. `build-tcrbar.sh` builds and signs it nested-first, because signing a nested Mach-O after the outer bundle invalidates the outer signature. `ServerController.swift` discards the spawned server's stdout instead of handing it an unread `Pipe` whose 64KiB buffer would fill and wedge the proxy mid-serve while still reporting healthy.

**Placement.** `scripts/install-cli.sh` (new) installs with temp-file + `rename(2)`, resolving the artifact from `cargo metadata` rather than the literal `target/release` — with `CARGO_TARGET_DIR` set, cargo writes nowhere near the repo. It refuses a stale artifact (sha vs `HEAD`), a directory destination, a symlinked destination, and a hardlinked one; `--force` overrides deliberately and says so. `apps/macos/scripts/install.sh` stages to a sibling temp dir on the same filesystem, verifies the staged copy while the good one is still live, then swaps — `pkill` moved after verification, so a bad build no longer costs you the running app and its supervised server.

**Honesty.** `src/update.rs` gains `InstallKind::AppBundle`: a bundled CLI previously classified as `Installed` and was told to run `cargo install --path`, which writes `~/.cargo/bin/tcr` — a third competing artifact. Both notify arms now point at the right installer. The built-path print no longer names a stale orphan. `.githooks/post-merge` warns when the installed binary no longer matches `HEAD`.

## Scope and known limits, stated rather than implied

`install.sh` cleans up staging on every *catchable* path. A `SIGKILL` between the two directory renames leaves an orphan staging dir and `/Applications/TcrBar.app` briefly absent; the previous bundle is still recoverable at `.TcrBar.install.*/TcrBar.previous.app`. `rename(2)` cannot replace a non-empty directory and POSIX shell has no atomic swap, so a true zero-gap bundle swap would need `renamex_np` via FFI. What the sandbox gate proves is the weaker but sufficient invariant: across eight injected failure points the pre-existing bundle survives every catchable one.

`<target_dir>/release/tcr` is still joined by hand. `cargo metadata` has no target-triple field, so under `CARGO_BUILD_TARGET` the real path is `<target_dir>/<triple>/release/tcr`. The three shell call sites fail loudly if the file is absent; `update.rs` now checks existence before naming it. Parsing `cargo build --message-format=json` for the authoritative `executable` field is a deliberate follow-up.

`tcr update` refuses on a copied install rather than self-updating. That behavior change comes from this PR switching the README from a symlink to a copy, not from `classify_install`. It is the better of two failures: it was already a silent no-op here, rebuilding into `CARGO_TARGET_DIR` while the user kept executing the old binary. Wiring the `Installed` arm to fetch a published release artifact needs a release to exist first, so it is deliberately not in this PR.

`--force` currently waives the stale-artifact and hardlink refusals together. Splitting them is a small follow-up.

## Verification

`cargo test` (454 passing), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `shellcheck` + `bash -n` on all scripts — with a positive control confirming shellcheck actually fires, since an empty result is otherwise a claim about the probe. Test exit codes were captured directly rather than through a pipe; `cmd | tail` reports tail's status and is a fake green.

Every guard was watched fail before being trusted: the stale-binary refusal fires against the real six-commits-behind artifact and stays silent against a sha-matching one; the directory refusal leaves the destination genuinely empty where it previously held a 10MB dotfile; the hardlink refusal was exercised unforced against a fixture carrying HEAD's sha; the `.app` detector was compared old-vs-new over the same fixtures; the shallow-clone version guard exits before any build runs.

Nothing was tested against live state. The proxy serving `:3456` was never restarted or signalled, `/Applications/TcrBar.app` was never touched, and every installer run targeted a `mktemp -d` sandbox.
