### PR TITLE
fix: stop the installers and the updater reporting work they did not do

### DIFF
--- a/apps/macos/scripts/build-tcrbar.sh
+++ b/apps/macos/scripts/build-tcrbar.sh
@@ -55,6 +55,32 @@ if [ -z "$base_version" ]; then
   echo "WARNING: could not read version from Cargo.toml — falling back to 0.0" >&2
   base_version="0.0"
 fi
+
+# A shallow clone must not be allowed to build a version.
+#
+# PATCH is `git rev-list --count HEAD`, which counts the commits the clone
+# actually HAS. In a `--depth 1` clone that is 1, so the build emits
+# CFBundleShortVersionString 0.1.1 and CFBundleVersion 1 — numerically LOWER
+# than anything a full clone produces. macOS reads a decreasing CFBundleVersion
+# as a downgrade: LaunchServices can keep preferring the older copy, and any
+# updater comparing versions concludes there is nothing to install. The build
+# would report success while silently shipping a version that goes backwards.
+#
+# There is no fix inside this scheme — the count is simply not available — so
+# this fails loudly and names the unshallow command rather than inventing a
+# different version format.
+if [ "$(git -C "$repo_root" rev-parse --is-shallow-repository 2>/dev/null || echo false)" = "true" ]; then
+  {
+    echo "ERROR: this is a SHALLOW clone, so the version cannot be derived."
+    echo "ERROR: PATCH is the commit count (git rev-list --count HEAD), which a"
+    echo "ERROR: shallow clone reports as $build_number — a version LOWER than any"
+    echo "ERROR: full-clone build. macOS treats a decreasing CFBundleVersion as a"
+    echo "ERROR: downgrade, so the app would refuse to supersede an older copy."
+    echo "ERROR: Fix:  git -C \"\$repo_root\" fetch --unshallow"
+  } >&2
+  exit 1
+fi
+
 short_version="$base_version.$build_number"
 
 echo "==> swift build -c release --product $app_name"

--- a/apps/macos/scripts/install.sh
+++ b/apps/macos/scripts/install.sh
@@ -41,8 +41,13 @@
 # the old bundle is moved aside first; if the second rename fails it is moved
 # back. The only gap is between those two renames, and it is recoverable.
 #
-# Everything staged is removed by an EXIT trap on every path, success or failure,
-# so a failed install never leaves an orphan bundle sitting in /Applications.
+# Everything staged is removed by an EXIT trap on every CATCHABLE path, success
+# or failure, so a failed install does not leave an orphan bundle sitting in
+# /Applications. "Catchable" is the honest word and the limit is real: INT, TERM
+# and HUP are trapped and turned into ordinary exits precisely so cleanup runs
+# (see the traps below), but SIGKILL and a power loss cannot be caught by any
+# shell, and either one between the two renames leaves a `.TcrBar.install.*`
+# directory behind. Removing it by hand is the recovery.
 #
 # Idempotent: safe to re-run. Uninstall with scripts/uninstall.sh.
 set -euo pipefail
@@ -67,11 +72,30 @@ BACKUP="$STAGE_DIR/${APP_NAME}.previous.app"
 # missing and the old bundle is still in the staging directory — put it back
 # before the staging directory is removed, or the cleanup would delete the only
 # copy of the app.
+#
+# It also has to speak up about the app it stopped. Once the running TcrBar is
+# pkill'd, any later failure restores the OLD bundle to disk but leaves nothing
+# running — and the script used to exit silently, so the user was left with a
+# vanished menu-bar item and no statement that it had been deliberately stopped.
+# Relaunching automatically would be wrong (a failed install may have left the
+# reason for the failure in place), so say it plainly instead.
+STOPPED_APP=0
 cleanup() {
+  rc=$?
   if [ ! -e "$DEST" ] && [ -d "$BACKUP" ]; then
     mv "$BACKUP" "$DEST" || true
   fi
   rm -rf "$STAGE_DIR"
+  if [ "$rc" -ne 0 ] && [ "$STOPPED_APP" = "1" ]; then
+    echo "" >&2
+    echo "NOTE: ${APP_NAME} was stopped before this failed, and was NOT restarted." >&2
+    if [ -e "$DEST" ]; then
+      echo "      The previous install is still at $DEST — relaunch it with:" >&2
+      echo "        open \"$DEST\"" >&2
+    else
+      echo "      Nothing is installed at $DEST — re-run this script once the build is fixed." >&2
+    fi
+  fi
 }
 trap cleanup EXIT
 # A shell killed by an UNCAUGHT signal does not run its EXIT trap — verified in
@@ -102,6 +126,7 @@ fi
 if pgrep -f "${APP_NAME}.app/Contents/MacOS/${APP_NAME}" >/dev/null 2>&1; then
   echo "==> Stopping the running ${APP_NAME}…"
   pkill -f "${APP_NAME}.app/Contents/MacOS/${APP_NAME}" || true
+  STOPPED_APP=1
   # Give the supervised child, if any, a moment to be reaped cleanly.
   sleep 1
 fi

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -34,19 +34,74 @@
 #      error -- and binary drift between the app and the CLI is back. Refusing is
 #      the only way that undoing is visible; TCR_INSTALL_FORCE=1 (or --force) is
 #      the deliberate override.
+#
+#   4. The source binary is checked against HEAD, not merely for existence.
+#      `build.rs` stamps TCR_BUILD_SHA into the binary, so the file can be asked
+#      which commit it came from. Without that check this script installed a
+#      six-commits-old artifact and printed "installed" with exit 0 — reporting
+#      success for a build it did not do, which is the one thing this whole
+#      family of scripts exists to stop. apps/macos/scripts/build-tcrbar.sh and
+#      .githooks/post-merge already grep for the same stamp; this now matches.
+#
+# KNOWN LIMIT: the symlink refusal in note 3 catches symlinks, not HARDLINKS. A
+# hardlinked destination is detected by its link count where `stat` supports it
+# (BSD and GNU are probed separately) and refused the same way, but on a system
+# with neither `stat` form the check is skipped with a warning rather than
+# silently passing — a hardlink shared with the app bundle would otherwise be
+# split into two drifting inodes with no error at all.
 set -euo pipefail
 
 FORCE="${TCR_INSTALL_FORCE:-0}"
 DEST=""
+DEST_SET=0
+
+usage() {
+  cat <<'USAGE'
+Install the release `tcr` binary onto PATH.
+
+Usage: scripts/install-cli.sh [--force] [destination]
+
+  destination   Full path to the installed FILE, not a directory.
+                Default: ~/.local/bin/tcr
+  --force       Install even when the destination is a symlink or hardlink, or
+                when the built binary does not match HEAD.
+                Equivalent to TCR_INSTALL_FORCE=1.
+  -h, --help    Show this message.
+USAGE
+}
+
+fail() { printf '!! %s\n' "$1" >&2; exit 1; }
+
+# Unknown flags and surplus positionals are refused rather than absorbed.
+# Previously every non-`--force` token became the destination, so `--help` was
+# treated as a path (and died inside `dirname` with `illegal option`), and
+# `install-cli.sh a b` silently installed to `b` while looking like it honoured
+# `a`. Both are the same defect: an argument the script did not understand,
+# accepted anyway.
 for arg in "$@"; do
   case "$arg" in
-    --force) FORCE=1 ;;
-    *)       DEST="$arg" ;;
+    --force)
+      FORCE=1
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    -*)
+      usage >&2
+      fail "unknown option: $arg"
+      ;;
+    *)
+      if [ "$DEST_SET" = "1" ]; then
+        usage >&2
+        fail "too many arguments -- one destination only (got '$DEST' and '$arg')"
+      fi
+      DEST="$arg"
+      DEST_SET=1
+      ;;
   esac
 done
 DEST="${DEST:-$HOME/.local/bin/tcr}"
-
-fail() { printf '!! %s\n' "$1" >&2; exit 1; }
 
 command -v cargo >/dev/null 2>&1 || fail "cargo not found on PATH"
 command -v jq    >/dev/null 2>&1 || fail "jq not found on PATH"
@@ -57,6 +112,32 @@ SRC="$TARGET_DIR/release/tcr"
 
 [ -f "$SRC" ] || fail "no release binary at $SRC -- build it first:  cargo build --release"
 [ -x "$SRC" ] || fail "$SRC is not executable"
+
+# See note 4 in the header. `-f` proves a file is THERE, never that it is the
+# one this checkout describes; a binary built six commits ago satisfies it just
+# as well. build.rs stamps the short sha as TCR_BUILD_SHA, so grep the artifact
+# and make it a fact. Same test, same stamp, as apps/macos/scripts/build-tcrbar.sh
+# and .githooks/post-merge.
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+expected_sha="$(git -C "$repo_root" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+if [ "$expected_sha" = "unknown" ]; then
+  echo "note: no git sha available -- cannot verify $SRC matches this checkout." >&2
+elif grep -aq "$expected_sha" "$SRC"; then
+  : # the built binary carries this checkout's sha
+elif [ "$FORCE" = "1" ]; then
+  echo "note: $SRC does not carry HEAD's sha $expected_sha -- installing anyway (--force)." >&2
+else
+  fail "$(printf '%s\n' \
+    "stale binary -- refusing to install" \
+    "  $SRC" \
+    "does not carry this checkout's build sha $expected_sha, so it was built from" \
+    "a DIFFERENT commit. Installing it would ship old code under a new version and" \
+    "every 'the fix is live' claim afterwards would be false." \
+    "Rebuild first:" \
+    "  cargo build --release" \
+    "then re-run this script. To install the stale binary on purpose:" \
+    "  scripts/install-cli.sh --force  (TCR_INSTALL_FORCE=1)")"
+fi
 
 # See note 3 in the header: `mv -f` replaces a symlink destination rather than
 # following it, so installing over the app-bundle symlink would quietly split the
@@ -72,6 +153,45 @@ if [ -L "$DEST" ] && [ "$FORCE" != "1" ]; then
     "  update the bundle:  apps/macos/scripts/install.sh" \
     "  or install elsewhere:  scripts/install-cli.sh /some/other/path/tcr" \
     "  or override on purpose:  scripts/install-cli.sh --force  (TCR_INSTALL_FORCE=1)")"
+fi
+
+# The destination is a FILE path. Given a directory, `mv -f "$TMP" "$DEST"`
+# succeeds by moving the temp file INTO it under its hidden `.tcr.install.XXXXXX`
+# name -- so `scripts/install-cli.sh ~/.local/bin` exited 0, printed "installed",
+# and left a 10MB dotfile nothing will ever exec. Refuse instead, and say what
+# the argument should have been.
+if [ -d "$DEST" ]; then
+  fail "$(printf '%s\n' \
+    "destination is a directory -- refusing to install" \
+    "  $DEST" \
+    "This argument is the full path of the installed FILE, not the directory to" \
+    "put it in. Moving into a directory would land the binary under the installer's" \
+    "own hidden temp name, which nothing on your PATH would ever find." \
+    "Did you mean:" \
+    "  scripts/install-cli.sh ${DEST%/}/tcr")"
+fi
+
+# See the KNOWN LIMIT note in the header: `-L` is blind to hardlinks, which
+# split a shared app/CLI inode just as silently (measured: nlink 2 -> 1, no
+# error). Link count is the only portable-ish signal; BSD and GNU `stat` spell
+# it differently, and a system with neither gets a warning rather than a pass.
+if [ -f "$DEST" ] && [ ! -L "$DEST" ] && [ "$FORCE" != "1" ]; then
+  dest_links="$(stat -f %l "$DEST" 2>/dev/null || stat -c %h "$DEST" 2>/dev/null || echo "")"
+  if [ -z "$dest_links" ]; then
+    echo "note: no usable \`stat\` -- cannot check whether $DEST is hardlinked." >&2
+  elif [ "$dest_links" -gt 1 ]; then
+    fail "$(printf '%s\n' \
+      "hardlinked destination ($dest_links links) -- refusing to install" \
+      "  $DEST" \
+      "It shares an inode with at least one other path, most likely the TcrBar.app" \
+      "copy documented in apps/macos/README.md. This installer renames a new file" \
+      "over the destination, which gives it a NEW inode and breaks that sharing" \
+      "silently -- the app and the CLI would drift apart from the next build on." \
+      "Instead:" \
+      "  update the bundle:  apps/macos/scripts/install.sh" \
+      "  or install elsewhere:  scripts/install-cli.sh /some/other/path/tcr" \
+      "  or override on purpose:  scripts/install-cli.sh --force  (TCR_INSTALL_FORCE=1)")"
+  fi
 fi
 
 DEST_DIR="$(dirname "$DEST")"

--- a/src/update.rs
+++ b/src/update.rs
@@ -73,17 +73,33 @@ pub fn find_repo_root() -> Option<PathBuf> {
     find_repo_root_from(&exe)
 }
 
-/// Walk UP from `start` to the first ancestor directory whose name ends in
-/// `.app` — the root of a macOS application bundle. `TcrBar.app` ships the CLI
-/// at `Contents/MacOS/tcr`, so a binary running from inside a bundle must be
-/// recognised as such rather than as a generic installed copy.
+/// Walk UP from `start` to the first ancestor directory that is a macOS
+/// application bundle. `TcrBar.app` ships the CLI at `Contents/MacOS/tcr`, so a
+/// binary running from inside a bundle must be recognised as such rather than
+/// as a generic installed copy.
+///
+/// The name suffix ALONE is not the test, and that is the point. A checkout
+/// living under a directory a human happened to name `myapp.app` matched the
+/// old suffix-only check, and because [`classify_install_from`] tries the
+/// bundle first, that false positive beat the `GitCheckout` classification that
+/// would have worked — `tcr update` refused to self-update a perfectly ordinary
+/// checkout. So the candidate must also actually CONTAIN `Contents/MacOS`,
+/// which is what makes a directory a bundle rather than a name that ends in
+/// `.app`.
+///
+/// Two smaller corrections in the same check: the suffix is compared
+/// case-insensitively, because HFS+/APFS are case-insensitive by default and
+/// `TcrBar.APP` is the same directory as `TcrBar.app` there; and the name is
+/// read with `to_string_lossy` rather than `to_str`, so a path component that
+/// is not valid UTF-8 anywhere above the binary no longer silently drops the
+/// whole ancestor out of consideration.
 pub fn find_app_bundle_from(start: &Path) -> Option<PathBuf> {
     for dir in start.ancestors() {
-        let is_bundle = dir
-            .file_name()
-            .and_then(|n| n.to_str())
-            .is_some_and(|n| n.ends_with(".app") && n.len() > ".app".len());
-        if is_bundle {
+        let named_app = dir.file_name().is_some_and(|n| {
+            let n = n.to_string_lossy();
+            n.len() > ".app".len() && n.to_ascii_lowercase().ends_with(".app")
+        });
+        if named_app && dir.join("Contents").join("MacOS").is_dir() {
             return Some(dir.to_path_buf());
         }
     }
@@ -163,9 +179,22 @@ pub fn parse_target_directory(stdout: &str) -> anyhow::Result<PathBuf> {
     }
 }
 
-/// Absolute path of the release binary cargo just built in `root`. Errors are
-/// returned, never swallowed into a guessed path — an invented path is exactly
-/// the defect this function exists to remove.
+/// Absolute path of the release binary cargo just built in `root`.
+///
+/// What this DOES guarantee: the target directory is read from `cargo metadata`
+/// rather than assumed to be `<root>/target`, and a failure to obtain it is
+/// returned as an error instead of degrading into a hardcoded path.
+///
+/// What it does NOT guarantee: that the returned path exists. The final
+/// `release/tcr` is still joined by hand, and `cargo metadata` reports no
+/// target triple — so with `CARGO_BUILD_TARGET` set (or `[build] target` in a
+/// config file) cargo writes `<target-dir>/<triple>/release/tcr` and the path
+/// composed here is a file that is not there. Callers must therefore check for
+/// existence before presenting it as fact; [`update_checkout`] does.
+///
+/// Resolving that properly means reading the artifact path out of
+/// `cargo build --message-format=json`, which is a deliberate follow-up rather
+/// than part of this change.
 fn built_binary_path(root: &Path) -> anyhow::Result<PathBuf> {
     let output = Command::new("cargo")
         .args(cargo_metadata_argv())
@@ -206,14 +235,26 @@ pub fn run_update_with(kind: InstallKind, force: bool) -> anyhow::Result<()> {
             );
             Ok(())
         }
+        // Reinstall via `scripts/install-cli.sh`, NOT `cargo install --path`.
+        // The AppBundle arm above already refuses `cargo install` because it
+        // writes a third competing copy at ~/.cargo/bin/tcr; this arm used to
+        // recommend exactly that. README.md now installs with
+        // `scripts/install-cli.sh`, which writes a regular file, so every new
+        // user lands HERE — and was being routed straight into the artifact
+        // drift the installer exists to prevent. The installer resolves the
+        // build output from `cargo metadata`, refuses a stale binary, and
+        // renames it into place instead of rewriting a live inode.
         InstallKind::Installed => {
             println!(
                 "tcr was not run from a git checkout, so it can't self-update.\n\
                  Reinstall from the source tree:\n\
-                 \n    git -C <teamclaude-rs> pull --ff-only && cargo install --path <teamclaude-rs>\n\
-                 \n(or `cargo build --release` there and copy the built binary onto your PATH — \
-                 `cargo metadata --format-version 1 --no-deps` reports the target directory, which \
-                 CARGO_TARGET_DIR may move well outside the checkout)."
+                 \n    git -C <teamclaude-rs> pull --ff-only \\\n      \
+                 && cargo build --release --manifest-path <teamclaude-rs>/Cargo.toml \\\n      \
+                 && <teamclaude-rs>/scripts/install-cli.sh\n\
+                 \nDo NOT `cargo install --path` here: that writes ~/.cargo/bin/tcr, a copy \
+                 competing with whatever is already on your PATH. install-cli.sh reads the build \
+                 output location from `cargo metadata` (CARGO_TARGET_DIR may move it well outside \
+                 the checkout) and refuses to install a binary that does not match HEAD."
             );
             Ok(())
         }
@@ -281,7 +322,24 @@ fn update_checkout(root: &Path, force: bool) -> anyhow::Result<()> {
     }
 
     match built_binary_path(root) {
-        Ok(built) => println!("tcr: built {}", built.display()),
+        // The path is composed, not observed (see `built_binary_path`), so it
+        // is checked before it is announced. With a target triple configured
+        // cargo writes one directory deeper and this file does not exist;
+        // printing it anyway would name an artifact that is not there, which is
+        // the same lie as reporting a build that did not land.
+        Ok(built) if built.exists() => println!("tcr: built {}", built.display()),
+        Ok(built) => println!(
+            "tcr: the build succeeded, but the binary is not at {} — nothing is there.\n\
+             tcr: that is expected when a target triple is configured \
+             (CARGO_BUILD_TARGET, or `[build] target` in a cargo config): cargo then writes \
+             <target-dir>/<triple>/release/tcr. Look one level down from {}.",
+            built.display(),
+            built
+                .parent()
+                .and_then(Path::parent)
+                .unwrap_or(root)
+                .display()
+        ),
         // The build itself succeeded, so this is not fatal — but we refuse to
         // print a guessed path. Say plainly that we don't know where it landed.
         Err(err) => eprintln!(
@@ -465,6 +523,63 @@ mod tests {
         fs::remove_dir_all(&root).ok();
     }
 
+    /// False positive the suffix-only check produced: an ordinary checkout that
+    /// happens to live under a directory someone named `…app` is NOT a bundle,
+    /// and misclassifying it beat the `GitCheckout` answer that would have
+    /// worked (the bundle test runs first), so `tcr update` refused to update a
+    /// checkout it could perfectly well have pulled and rebuilt. What makes a
+    /// bundle is `Contents/MacOS`, not the name.
+    #[test]
+    fn checkout_under_an_app_named_directory_is_not_a_bundle() {
+        let base = scratch("app-named-parent");
+        let root = base.join("myapp.app").join("checkout");
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("Cargo.toml"), "[package]\n").unwrap();
+        let exe = root.join("target").join("release").join("tcr");
+        fs::create_dir_all(exe.parent().unwrap()).unwrap();
+        fs::write(&exe, b"fake").unwrap();
+
+        assert_eq!(find_app_bundle_from(&exe), None);
+        assert_eq!(classify_install_from(&exe), InstallKind::GitCheckout(root));
+
+        fs::remove_dir_all(&base).ok();
+    }
+
+    /// False negative in the other direction: APFS and HFS+ are case-insensitive
+    /// by default, so `TcrBar.APP` names the same bundle as `TcrBar.app` and must
+    /// classify the same way.
+    #[test]
+    fn find_app_bundle_matches_the_suffix_case_insensitively() {
+        let root = scratch("bundle-uppercase");
+        let bundle = root.join("TcrBar.APP");
+        let exe = bundle.join("Contents").join("MacOS").join("tcr");
+        fs::create_dir_all(exe.parent().unwrap()).unwrap();
+        fs::write(&exe, b"fake").unwrap();
+
+        assert_eq!(
+            find_app_bundle_from(&exe).as_deref(),
+            Some(bundle.as_path())
+        );
+        assert_eq!(classify_install_from(&exe), InstallKind::AppBundle(bundle));
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    /// A `.app` directory with no `Contents/MacOS` inside it is a name, not a
+    /// bundle — and with no checkout above it the honest answer is `Installed`.
+    #[test]
+    fn app_named_directory_without_contents_macos_is_not_a_bundle() {
+        let root = scratch("bundle-shell-only");
+        let exe = root.join("Empty.app").join("tcr");
+        fs::create_dir_all(exe.parent().unwrap()).unwrap();
+        fs::write(&exe, b"fake").unwrap();
+
+        assert_eq!(find_app_bundle_from(&exe), None);
+        assert_eq!(classify_install_from(&exe), InstallKind::Installed);
+
+        fs::remove_dir_all(&root).ok();
+    }
+
     #[test]
     fn run_update_app_bundle_notifies_without_spawning() {
         let kind = InstallKind::AppBundle(PathBuf::from("/Applications/TcrBar.app"));
@@ -523,6 +638,22 @@ mod tests {
         assert_eq!(
             cargo_metadata_argv(),
             ["metadata", "--format-version", "1", "--no-deps"]
+        );
+    }
+
+    /// The `Installed` arm tells the user to run `scripts/install-cli.sh`.
+    /// Naming a path that is not there is the same class of defect as printing
+    /// a built-binary path that does not exist, so the recommendation is
+    /// checked against the tree rather than trusted to stay true.
+    #[test]
+    fn the_recommended_installer_script_exists() {
+        let script = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("scripts")
+            .join("install-cli.sh");
+        assert!(
+            script.is_file(),
+            "run_update_with(Installed) recommends {}, which does not exist",
+            script.display()
         );
     }
 


### PR DESCRIPTION
Follow-up to #32. A reviewer finished after #32 merged and found eight defects, two of them blocking. They are in `main` now, and `README.md` routes every new user straight through the worst one.

The unifying theme is the one #32 was written to fix: **something reporting success for work it did not do.**

## Blocking

**`scripts/install-cli.sh` installed a stale binary and reported success.** It checked `[ -f "$SRC" ]` and never asked whether the artifact matched `HEAD`. Reproduced on a real tree: the cached artifact was six commits behind, and the installer printed two matching hashes and exited 0. Both sibling scripts already do this check — `build-tcrbar.sh` (hard `exit 1`) and `.githooks/post-merge` ("treat as UNTRUSTED"). The newest and most user-facing of the three, the one the README now tells everyone to run, was the one that skipped it. `build.rs` already stamps `TCR_BUILD_SHA`, so the check costs one `grep -a`.

**A directory destination exited 0 having installed nothing.** `scripts/install-cli.sh ~/.local/bin` — the most natural way to get the argument wrong — made `mv -f "$TMP" "$DEST"` move the temp file *into* the directory under its hidden temp name. Exit 0, the word "installed", and a hidden 10MB file nothing will ever exec. The only signal was a blank hash line.

## Also fixed

`src/update.rs` told users to run `cargo install --path` in the `Installed` arm while the `AppBundle` arm eleven lines above explicitly forbids it for writing a third competing copy to `~/.cargo/bin/tcr`. That was survivable when the README installed a symlink; #32 changed it to a copy, so every new user now lands in `Installed` and gets routed into the exact drift #32 exists to remove. Both arms now point at `scripts/install-cli.sh`.

`built_binary_path()` joined `<target_dir>/release/tcr` by hand and printed it as fact. `cargo metadata` has no target-triple field, so under `CARGO_BUILD_TARGET` the real path is `<target_dir>/<triple>/release/tcr` and the printed one does not exist. Now existence-checked, with the doc-comment narrowed to the guarantee it can actually make. Parsing `cargo build --message-format=json` for the authoritative `executable` field remains a deliberate follow-up.

`find_app_bundle_from()` matched on string suffix alone. Verified false positives (a checkout under `/Users/x/myapp.app/…` classified as `AppBundle`, beating a `GitCheckout` that would have worked, because the bundle check runs first) and false negatives (`.APP` on case-insensitive APFS; non-UTF8 components dropped by `to_str()`). Now requires the candidate to actually contain `Contents/MacOS` and compares case-insensitively, with a test in each direction.

The symlink guard missed hardlinks, silently splitting a shared app/CLI inode (nlink 2 → 1, no error). `install.sh` claimed staging is cleaned "on every path, success or failure" while lines below it already conceded the uncatchable-signal class — now says "every catchable path". A failure after `pkill` but before the swap left the user with the old app on disk but not running, and exited silently.

`build-tcrbar.sh` derived the app version from `git rev-list --count HEAD`, which returns 1 on a `--depth 1` clone — producing `CFBundleVersion=1`, *lower* than a full-clone build. macOS treats a decreasing `CFBundleVersion` as a downgrade. Now guarded on `git rev-parse --is-shallow-repository`, failing before any build runs rather than silently emitting a downgrade.

## Known coupling

`--force` currently waives the stale-artifact and hardlink refusals together, because the review asked for it to cover the first and the existing symlink guard already used it. Splitting into separate flags is a small follow-up.

## Verification

`cargo test` (454 passing), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `shellcheck` + `bash -n` on all three scripts — re-run on this base, which includes the dependabot bumps from #31. Exit codes captured directly, never through a pipe; `cmd | tail` reports tail's status and is a fake green.

Every guard was watched fail before being trusted. The stale-binary refusal fires against the real six-commits-behind artifact and stays silent against a sha-matching fixture, which is the control proving the grep is not pass-always. The directory refusal leaves the destination genuinely empty where it previously held a 10MB dotfile. The hardlink refusal needed a fixture carrying `HEAD`'s sha, because `--force` disables the sha gate and the hardlink gate together and a naive probe could never see it fire. The `.app` detector was compared old-vs-new over identical fixtures. The shallow-clone guard exits with zero build lines emitted, proving it precedes both `swift build` and `cargo build --release`.

No live state was touched: the proxy on `:3456` was never signalled, `/Applications/TcrBar.app` was never written to, and every installer run targeted a `mktemp -d` sandbox.
