### PR TITLE
fix: stop taking the port by default, and retry a blipped connection

### DIFF
--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -17,12 +17,16 @@ never handles a token and never sends an `Authorization` header.
 
 ## The one safety property
 
-`tcr`'s port singleton is a *takeover*: by default a starting server kills a proxy
-already holding the port, which wipes the session→account pin map and costs every
-live session a full cold prompt-cache prefix.
+`tcr`'s port singleton can take the port over: a starting server may kill a proxy
+already holding it, which wipes the session→account pin map and costs every live
+session a full cold prompt-cache prefix. That kill is now behind an explicit
+`--replace`; the default is to stand down and exit without binding.
 
-TcrBar therefore always spawns `tcr server --no-replace`, and only ever signals a
-child **it** spawned. A server that was already running is displayed and left
+TcrBar therefore always spawns `tcr server --no-replace` on the routine path, and
+reaches for `--replace` only from "Take over port…", behind a confirmation. (The
+flag is redundant against a current `tcr`, where standing down is the default, and
+load-bearing against an older one, where omitting it meant takeover.) It only ever
+signals a child **it** spawned. A server that was already running is displayed and left
 alone — there is no code path that can terminate it. A spawn that declines because
 an incumbent holds the port is reported as "already running", which is a success.
 

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -358,8 +358,8 @@ struct FleetView: View {
 
     /// The alert names the real cost in plain language, defaults to Cancel, and
     /// styles the other button as destructive. Only on an explicit confirm does
-    /// this call `startTakingOverPort()`, which spawns `tcr server` without
-    /// `--no-replace` — the replacement is performed by `tcr`'s own singleton.
+    /// this call `startTakingOverPort()`, which spawns `tcr server --replace`
+    /// — the replacement is performed by `tcr`'s own singleton.
     /// TcrBar signals nothing it did not spawn.
     private func confirmTakeover() {
         let alert = NSAlert()

--- a/apps/macos/Sources/TcrBarCore/ServerController.swift
+++ b/apps/macos/Sources/TcrBarCore/ServerController.swift
@@ -5,23 +5,25 @@ import Foundation
 ///
 /// The safety property this type exists to hold:
 ///
-/// `tcr`'s port singleton is a *takeover* by default — a starting server kills a
-/// recognised proxy already holding the port, because two proxies mutually
-/// invalidate each other's single-use OAuth refresh tokens. That kill also wipes
+/// `tcr`'s port singleton resolves the port down to exactly one proxy, because
+/// two proxies mutually invalidate each other's single-use OAuth refresh tokens.
+/// It can resolve it either way — replace the incumbent, or stand down and exit
+/// without binding — and replacing is by far the more expensive: that kill wipes
 /// the session→account pin map, and Anthropic's prompt cache is per-account, so
 /// every live session pays a full cold prefix. It is the most expensive event in
 /// this system.
 ///
-/// So: the routine path *always* spawns with `--no-replace`, and this controller
-/// signals **only** a child it spawned itself. An incumbent server it merely
-/// observed is never touched, and failing to start because one already holds the
-/// port is reported as "already running" — a success, not an error.
+/// So `tcr`'s default is to stand down, and the kill lives behind an explicit
+/// `--replace` (`src/singleton.rs`). This controller signals **only** a child it
+/// spawned itself. An incumbent server it merely observed is never touched, and
+/// failing to start because one already holds the port is reported as "already
+/// running" — a success, not an error.
 ///
 /// There is one deliberate exception, `startTakingOverPort()`, and it is still
-/// not a signal: it spawns `tcr server` *without* `--no-replace` and lets `tcr`'s
-/// own singleton (`src/singleton.rs`) do the replacing, inside the code written
-/// to do it safely. This app never sends a signal to a pid it did not spawn, and
-/// there is deliberately no code path here that could.
+/// not a signal: it spawns `tcr server` *with* `--replace` and lets `tcr`'s own
+/// singleton do the replacing, inside the code written to do it safely. This app
+/// never sends a signal to a pid it did not spawn, and there is deliberately no
+/// code path here that could.
 @MainActor
 public final class ServerController: ObservableObject {
     public enum State: Equatable {
@@ -81,19 +83,23 @@ public final class ServerController: ObservableObject {
 
     /// The two — and only two — argument sets this app will ever spawn.
     ///
-    /// `safeArguments` is the default for every routine start. `--no-replace`
-    /// makes `tcr` refuse the port if another proxy already holds it, so an
-    /// accidental click cannot cost anything: the worst outcome is
-    /// `.incumbentHoldsPort`, which is a report, not damage.
+    /// `safeArguments` is the default for every routine start. It withholds
+    /// `--replace`, so `tcr` refuses the port if another proxy already holds it
+    /// and an accidental click cannot cost anything: the worst outcome is
+    /// `.incumbentHoldsPort`, which is a report, not damage. `--no-replace` is
+    /// kept in the list even though standing down is now `tcr`'s default — the
+    /// flag is still accepted (`src/main.rs:192`), and passing it means this app
+    /// stays safe against an older `tcr` on `PATH`, where omitting it meant
+    /// takeover.
     ///
-    /// `takeoverArguments` omits that flag, which is precisely what asks `tcr`'s
+    /// `takeoverArguments` adds `--replace`, which is precisely what asks `tcr`'s
     /// singleton to replace the incumbent. That kill happens inside `tcr`, never
     /// here. It is reachable only from `startTakingOverPort()`, behind an
     /// explicit confirmation, because it wipes the session→account pin map and
     /// costs every live session a cold prompt-cache prefix.
     /// `--headless` is not optional here, it is what makes the child survive.
     ///
-    /// Without it `tcr server` runs its ratatui TUI (`src/main.rs:590`, "the TUI
+    /// Without it `tcr server` runs its ratatui TUI (`src/main.rs:615`, "the TUI
     /// owns the foreground"), which calls `enable_raw_mode()?` on stdout
     /// (`src/tui.rs:47`). This app spawns with a `Pipe`, so there is no terminal,
     /// raw mode fails, the `?` propagates and the process exits immediately.
@@ -105,9 +111,12 @@ public final class ServerController: ObservableObject {
     /// proxy rather than a missing argument in its launcher.
     public nonisolated static let safeArguments = ["server", "--headless", "--no-replace"]
 
-    /// Deliberately omits `--no-replace`. See `safeArguments`. Keeps `--headless`
-    /// for the same reason every other spawn does.
-    public nonisolated static let takeoverArguments = ["server", "--headless"]
+    /// Deliberately carries `--replace`, and deliberately never `--no-replace` —
+    /// when both are passed `tcr` lets the safe one win (`src/main.rs:486`), so a
+    /// takeover set containing both would silently do nothing. See
+    /// `safeArguments`. Keeps `--headless` for the same reason every other spawn
+    /// does.
+    public nonisolated static let takeoverArguments = ["server", "--headless", "--replace"]
 
     /// The default argument set. Kept as a distinct name so existing call sites
     /// and tests read as "the safe one" rather than "the only one".
@@ -120,7 +129,7 @@ public final class ServerController: ObservableObject {
     /// Start a server that *replaces* whatever holds the port.
     ///
     /// The replacement is performed by `tcr` itself, as a consequence of the
-    /// missing `--no-replace`. No pid is signalled from Swift. Callers must have
+    /// `--replace` flag. No pid is signalled from Swift. Callers must have
     /// confirmed with the operator first — this is the most expensive action in
     /// the app.
     public func startTakingOverPort() {
@@ -202,15 +211,22 @@ public final class ServerController: ObservableObject {
         stop()
     }
 
-    /// Markers `tcr` prints when `--no-replace` keeps it from taking the port, or
-    /// when the subsequent bind fails because the incumbent is still there.
+    /// Markers `tcr` prints when it stands down rather than take the port, or when
+    /// the subsequent bind fails because the incumbent is still there.
     ///
-    /// The first two come from the `--no-replace` refusal at `src/singleton.rs:146`;
-    /// `failed to bind` is the anyhow context wrapping the listener at
-    /// `src/main.rs:505`. Those three are strings *this project* owns, so they only
-    /// move when someone edits those lines. `Address already in use` is the OS
-    /// strerror, kept because it can still surface in the anyhow cause chain — but
-    /// it is the runtime's wording, not ours, and is never relied on alone.
+    /// `another proxy holds` is the live one: it is `singleton::INCUMBENT_MARKER`,
+    /// a named constant on the Rust side precisely because this list is the only
+    /// thing reading it, across a language boundary no compiler checks. Note that
+    /// a stand-down now exits **0** — the marker, not the exit code, is what says
+    /// an incumbent is there, and `classifyExit` matches markers first for exactly
+    /// that reason. `--no-replace was set` is the wording an older `tcr` used for
+    /// the same refusal, kept so this app still reads a build that predates the
+    /// `--replace` flip. `failed to bind` is the anyhow context wrapping the
+    /// listener at `src/main.rs:571`. Those three are strings *this project* owns,
+    /// so they only move when someone edits those lines. `Address already in use`
+    /// is the OS strerror, kept because it can still surface in the anyhow cause
+    /// chain — but it is the runtime's wording, not ours, and is never relied on
+    /// alone.
     nonisolated static let incumbentMarkers = [
         "--no-replace was set",
         "another proxy holds",
@@ -222,10 +238,10 @@ public final class ServerController: ObservableObject {
     /// Why the spawn was made. The same stderr means opposite things on the two
     /// paths, so classification cannot be argument-blind.
     public enum Intent: Equatable, Sendable {
-        /// `--no-replace`. Finding an incumbent is the expected, benign outcome.
+        /// No `--replace`. Finding an incumbent is the expected, benign outcome.
         case safeStart
-        /// No `--no-replace`. The user explicitly asked to replace the incumbent,
-        /// so finding one still there means the request did NOT happen.
+        /// `--replace`. The user explicitly asked to replace the incumbent, so
+        /// finding one still there means the request did NOT happen.
         case takeover
     }
 
@@ -243,8 +259,8 @@ public final class ServerController: ObservableObject {
     ///
     /// The common cause is not transient, so the message says so rather than
     /// inviting a retry: `tcr`'s port singleton deliberately refuses to replace a
-    /// proxy hosted inside a `tcr run` process (`src/singleton.rs:27,52`, asserted
-    /// at `:192`), because killing it would kill the Claude session running
+    /// proxy hosted inside a `tcr run` process (`src/singleton.rs:38,62`, asserted
+    /// at `:257`), because killing it would kill the Claude session running
     /// through it. No number of clicks will change that outcome.
     public nonisolated static func classifyExit(
         intent: Intent = .safeStart,

--- a/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
@@ -659,10 +659,10 @@ final class ServerControllerTests: XCTestCase {
     /// cannot lean on a non-zero exit code: without a marker match this would
     /// render "the server exited cleanly" for a server that never bound.
     func testTheStandDownIsRecognisedEvenThoughItExitsZero() {
-        let stderr = "[tcr] another proxy holds :3456 (pid 123) and it is healthy — leaving it "
-            + "alone and exiting without binding. Replacing it would wipe its session→account "
-            + "pin map and cold-start every live session's prompt cache, the most expensive "
-            + "event in this system. Pass --replace to take the port over anyway."
+        let stderr = "[tcr] another proxy holds :3456 (pid 123) and it is still listening — "
+            + "leaving it alone and exiting without binding. Replacing it would wipe its "
+            + "session→account pin map and cold-start every live session's prompt cache, the "
+            + "most expensive event in this system. Pass --replace to take the port over anyway."
         guard case .incumbentHoldsPort = ServerController.classifyExit(
             intent: .safeStart, exitCode: 0, stderr: stderr
         ) else {

--- a/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
@@ -582,16 +582,35 @@ final class ServerControllerTests: XCTestCase {
         XCTAssertEqual(ServerController.serverArguments, ServerController.safeArguments)
     }
 
-    func testTakeoverOmitsNoReplace() {
-        // The takeover is expressed *only* by dropping `--no-replace`: tcr's own
-        // singleton then does the replacing.
-        XCTAssertFalse(ServerController.takeoverArguments.contains("--no-replace"))
+    func testTakeoverAsksForTheReplacementExplicitly() {
+        // The takeover is expressed by the *presence* of `--replace`: tcr's own
+        // singleton then does the replacing. Standing down is tcr's default now,
+        // so an argument set that merely drops `--no-replace` takes over nothing —
+        // which is why asserting the absence of `--no-replace` cannot stand alone.
+        // That assertion stayed green through the entire window in which this
+        // button was a silent no-op.
+        XCTAssertTrue(
+            ServerController.takeoverArguments.contains("--replace"),
+            "\(ServerController.takeoverArguments) asks tcr for nothing — the takeover button is a no-op"
+        )
+        // Still checked, for a different reason than before: when both flags are
+        // passed tcr lets the safe one win (`src/main.rs:486`), so `--no-replace`
+        // sneaking in here would cancel the `--replace` above.
+        XCTAssertFalse(
+            ServerController.takeoverArguments.contains("--no-replace"),
+            "\(ServerController.takeoverArguments) cancels its own --replace"
+        )
+        // And the safe set must never acquire the flag it exists to withhold.
+        XCTAssertFalse(
+            ServerController.safeArguments.contains("--replace"),
+            "the routine start would kill a healthy incumbent: \(ServerController.safeArguments)"
+        )
     }
 
     /// The regression that made every spawn path dead on arrival.
     ///
     /// Without `--headless`, `tcr server` runs its ratatui TUI
-    /// (`src/main.rs:590`) which calls `enable_raw_mode()?` on stdout
+    /// (`src/main.rs:615`) which calls `enable_raw_mode()?` on stdout
     /// (`src/tui.rs:47`). A GUI spawns with a `Pipe`, so there is no terminal, raw
     /// mode fails and the child exits at once — the server appeared for an instant
     /// and vanished.
@@ -610,7 +629,7 @@ final class ServerControllerTests: XCTestCase {
     }
 
     func testNeitherArgumentSetCarriesAnythingUnexpected() {
-        let known: Set<String> = ["server", "--no-replace", "--headless"]
+        let known: Set<String> = ["server", "--no-replace", "--replace", "--headless"]
         for arguments in [ServerController.safeArguments, ServerController.takeoverArguments] {
             XCTAssertEqual(arguments.first, "server", "both sets are `tcr server`")
             XCTAssertTrue(
@@ -632,6 +651,30 @@ final class ServerControllerTests: XCTestCase {
             return XCTFail("an already-running server must not be reported as an error")
         }
         XCTAssertFalse(state.isOurChild, "an incumbent we did not spawn is never ours to signal")
+    }
+
+    /// The wording above is what an *older* `tcr` printed. A current one stands
+    /// down by default and says so differently — and, unlike the refusal, it exits
+    /// **0**, because standing down is now the success path. So the classifier
+    /// cannot lean on a non-zero exit code: without a marker match this would
+    /// render "the server exited cleanly" for a server that never bound.
+    func testTheStandDownIsRecognisedEvenThoughItExitsZero() {
+        let stderr = "[tcr] another proxy holds :3456 (pid 123) and it is healthy — leaving it "
+            + "alone and exiting without binding. Replacing it would wipe its session→account "
+            + "pin map and cold-start every live session's prompt cache, the most expensive "
+            + "event in this system. Pass --replace to take the port over anyway."
+        guard case .incumbentHoldsPort = ServerController.classifyExit(
+            intent: .safeStart, exitCode: 0, stderr: stderr
+        ) else {
+            return XCTFail("a stand-down must read as an incumbent, not as a clean exit")
+        }
+        // Same text on the takeover path is the opposite verdict: the user asked
+        // for the port and did not get it.
+        guard case .takeoverRefused = ServerController.classifyExit(
+            intent: .takeover, exitCode: 0, stderr: stderr
+        ) else {
+            return XCTFail("a takeover that stood down has failed, however it exited")
+        }
     }
 
     func testBindFailureIsAlsoTreatedAsAlreadyRunning() {

--- a/apps/macos/Tests/TcrBarTests/TakeoverIntentTests.swift
+++ b/apps/macos/Tests/TcrBarTests/TakeoverIntentTests.swift
@@ -7,12 +7,12 @@ import XCTest
 /// This is a regression test for a shipped bug. `classifyExit` was argument-blind:
 /// it matched an incumbent marker and returned the benign `incumbentHoldsPort` no
 /// matter why the spawn was made. So clicking "Take over port" — which runs
-/// `tcr server` *without* `--no-replace` — produced this sequence:
+/// `tcr server --replace` — produced this sequence:
 ///
 ///  1. `tcr`'s port singleton declined to replace the incumbent, because that
 ///     incumbent was a proxy hosted inside a `tcr run` process and
-///     `is_proxy_server` deliberately excludes those (`src/singleton.rs:27,52`,
-///     asserted at `:192`). Killing one would kill the Claude session running
+///     `is_proxy_server` deliberately excludes those (`src/singleton.rs:38,62`,
+///     asserted at `:257`). Killing one would kill the Claude session running
 ///     through it.
 ///  2. The subsequent bind failed: `failed to bind 127.0.0.1:3456`.
 ///  3. `classifyExit` matched `failed to bind`, reported "already running", and
@@ -36,7 +36,7 @@ final class TakeoverIntentTests: XCTestCase {
             intent: .safeStart, exitCode: 1, stderr: refusedBind
         )
         guard case .incumbentHoldsPort = state else {
-            return XCTFail("a --no-replace start finding an incumbent is expected, got \(state)")
+            return XCTFail("a start without --replace finding an incumbent is expected, got \(state)")
         }
     }
 

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -256,6 +256,63 @@ impl Drift {
     }
 }
 
+/// The build half of the message printed when startup finds a healthy proxy
+/// already on the port and stands down instead of replacing it.
+///
+/// # Why this line has to exist
+///
+/// Standing down is the right default (a takeover costs every live session its
+/// prompt cache) but it creates a trap the old kill-the-incumbent behaviour did
+/// not have: `cargo build && tcr` used to GUARANTEE the new binary was serving.
+/// Now it exits 0 with the OLD build still serving, and an exit 0 with no
+/// complaint reads exactly like success — the "the fix is in the source" vs "the
+/// fix is in the process serving traffic" confusion this whole module exists to
+/// end, reintroduced by the default path. So the stand-down always says which
+/// build keeps serving, and warns when that is not the one just run.
+///
+/// `running` is the incumbent's own stamp, read best-effort from its status
+/// endpoint; `None` means it would not answer, which renders as
+/// `build-skew-unknown` and never as agreement. Pure, so the whole decision table
+/// is unit-testable without a server.
+pub fn stand_down_build_line(port: u16, ours: &BuildInfo, running: Option<&BuildInfo>) -> String {
+    let Some(running) = running else {
+        return format!(
+            "[tcr] note build-skew-unknown: this binary={} but the proxy on :{port} did not report \
+             its build — it may be serving older code. `tcr status` reports the running build; \
+             `tcr --replace` restarts the port onto this binary.",
+            ours.sha
+        );
+    };
+    let keys = format!(
+        "running={} this_binary={} built_dirty={} this_binary_dirty={}",
+        running.sha,
+        ours.sha,
+        running.dirty_str(),
+        ours.dirty_str()
+    );
+    if !is_comparable_sha(&running.sha) || !is_comparable_sha(&ours.sha) {
+        return format!(
+            "[tcr] note build-skew-unknown: {keys} — cannot tell whether the proxy on :{port} is \
+             running this binary's code. `tcr --replace` restarts the port onto this binary."
+        );
+    }
+    if !same_commit(&running.sha, &ours.sha) {
+        return format!(
+            "[tcr] WARNING stale-server: {keys} — the proxy on :{port} is NOT running this \
+             binary's code and will keep serving its own until it is restarted. \
+             `tcr --replace` takes the port over with this build."
+        );
+    }
+    if running.dirty.unwrap_or(false) || ours.dirty.unwrap_or(false) {
+        return format!(
+            "[tcr] note dirty-build: {keys} — the shas match but at least one side was compiled \
+             from an uncommitted tree, so this is not proof the proxy on :{port} is running this \
+             binary's code."
+        );
+    }
+    format!("[tcr] build in sync: {keys} — the proxy on :{port} is running this binary's commit.")
+}
+
 /// Two shas name the same commit when the shorter is a prefix of the longer.
 ///
 /// Not string equality: `--short` abbreviates to the shortest UNAMBIGUOUS
@@ -566,6 +623,82 @@ mod tests {
             compare(&default, &checkout("cd146ce", Some(false), None)),
             Skew::Indeterminate { .. }
         ));
+    }
+
+    /// THE TRAP THE STAND-DOWN DEFAULT CREATES. `cargo build && tcr` no longer
+    /// guarantees the new binary serves; if the line said nothing, exit 0 would
+    /// read as "my fix is live" while the old build kept serving. A different sha
+    /// must be LOUD, name both builds, and name the escape hatch.
+    #[test]
+    fn standing_down_on_a_different_build_warns_loudly() {
+        let line = stand_down_build_line(
+            3456,
+            &build("9f3a1b2", Some(false)),
+            Some(&build("cd146ce", Some(false))),
+        );
+        assert!(line.contains("stale-server"), "greppable token: {line}");
+        assert!(line.contains("running=cd146ce"), "names the server: {line}");
+        assert!(
+            line.contains("this_binary=9f3a1b2"),
+            "names this build: {line}"
+        );
+        assert!(line.contains("--replace"), "names the escape hatch: {line}");
+    }
+
+    /// The incumbent would not report its build. That is "cannot tell", never
+    /// agreement — and it still has to point at the two commands that resolve it.
+    #[test]
+    fn standing_down_with_no_answer_from_the_incumbent_says_so() {
+        let line = stand_down_build_line(3456, &build("9f3a1b2", Some(false)), None);
+        assert!(line.contains("build-skew-unknown"), "{line}");
+        assert!(
+            !line.contains("in sync"),
+            "an unanswered probe is not agreement: {line}"
+        );
+        assert!(line.contains("tcr status"), "{line}");
+        assert!(line.contains("--replace"), "{line}");
+    }
+
+    /// Matching shas, both clean: say so plainly. This is the ordinary case and it
+    /// must not carry a warning, or the warning stops being read.
+    #[test]
+    fn standing_down_on_the_same_build_is_quiet() {
+        let line = stand_down_build_line(
+            3456,
+            &build("cd146ce", Some(false)),
+            Some(&build("cd146ce", Some(false))),
+        );
+        assert!(line.contains("in sync"), "{line}");
+        assert!(!line.contains("WARNING"), "{line}");
+        assert!(!line.contains("stale-server"), "{line}");
+    }
+
+    /// A dirty build on either side: the shas match and the code still may not.
+    /// Noted, not claimed in sync — the same honesty [`compare`] applies.
+    #[test]
+    fn standing_down_never_claims_a_dirty_build_is_in_sync() {
+        for (ours, theirs) in [(Some(true), Some(false)), (Some(false), Some(true))] {
+            let line = stand_down_build_line(
+                3456,
+                &build("cd146ce", ours),
+                Some(&build("cd146ce", theirs)),
+            );
+            assert!(line.contains("dirty-build"), "{line}");
+            assert!(!line.contains("in sync"), "{line}");
+        }
+    }
+
+    /// An unknown sha from an old server degrades to "cannot tell" rather than
+    /// manufacturing a stale-server warning out of a missing field.
+    #[test]
+    fn standing_down_on_an_unknown_sha_is_indeterminate_not_stale() {
+        let line = stand_down_build_line(
+            3456,
+            &build("cd146ce", Some(false)),
+            Some(&BuildInfo::default()),
+        );
+        assert!(line.contains("build-skew-unknown"), "{line}");
+        assert!(!line.contains("stale-server"), "{line}");
     }
 
     /// The git plumbing against a REAL repository — the half no amount of pure

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -737,6 +737,19 @@ async fn fetch_live_status(config: &Config) -> Result<StatusPayload, LiveStatusE
     Ok(payload)
 }
 
+/// Best-effort read of the build the RUNNING proxy is executing.
+///
+/// For the startup stand-down path in `main`: when a healthy incumbent holds the
+/// port we exit instead of replacing it, and the user needs to know whether the
+/// build they just compiled is the one serving. `None` on ANY failure — no
+/// server, a rejected key, an older tcr with no status route — because this is a
+/// diagnostic on a path that is already exiting, never a dependency of startup.
+/// Bounded by [`fetch_live_status`]'s own 2s connect / 5s total timeouts, so it
+/// cannot hang.
+pub async fn live_server_build(config: &Config) -> Option<BuildInfo> {
+    fetch_live_status(config).await.ok().map(|p| p.build)
+}
+
 /// `tcr status [--json]` — render the fleet as greppable text or a JSON array,
 /// preferring the RUNNING proxy's own numbers.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,9 +178,16 @@ struct ServerArgs {
     /// Run without the TUI, logging to stdout.
     #[arg(long)]
     headless: bool,
-    /// Do not replace an existing proxy already listening on the port. Default is
-    /// to take over the port (kill the incumbent proxy), since two proxies on the
-    /// same accounts mutually invalidate each other's single-use refresh tokens.
+    /// Take over the port: kill a proxy already listening on it, then bind. The
+    /// default is to leave a healthy incumbent alone and exit — replacing it wipes
+    /// its session→account pin map and cold-starts every live session's prompt
+    /// cache, which is the most expensive event in this system.
+    #[arg(long)]
+    replace: bool,
+    /// DEPRECATED and now a no-op: this is the default. Kept accepted so existing
+    /// scripts and launch agents that pass it keep working. Pass `--replace` for
+    /// the old default (take the port over); if both are given, this one wins,
+    /// since the safe outcome is the one that touches nothing.
     #[arg(long)]
     no_replace: bool,
 }
@@ -470,10 +477,27 @@ async fn run_server(args: ServerArgs) -> anyhow::Result<()> {
 
     init_tracing(args.headless);
 
-    // Take over the port BEFORE the Manager starts probing/refreshing, so our own
-    // startup can never token-war with the incumbent proxy we're replacing. Only a
-    // command-verified teamclaude/tcr server on THIS port is ever signalled.
-    singleton::takeover_port(port, args.no_replace);
+    // Resolve the port to ONE proxy BEFORE the Manager starts probing/refreshing,
+    // so our own startup can never token-war with the incumbent. Only a
+    // command-verified teamclaude/tcr server on THIS port is ever signalled — and
+    // only under `--replace`. `--no-replace` is the default now, so passing it
+    // simply withholds `--replace`.
+    if let singleton::Takeover::IncumbentPresent(_pid) =
+        singleton::takeover_port(port, args.replace && !args.no_replace)
+    {
+        // Standing down is cheap and correct, but silent success here would mean
+        // `cargo build && tcr` exits 0 with the OLD build still serving — say which
+        // build actually holds the port before we go.
+        eprintln!(
+            "{}",
+            build_info::stand_down_build_line(
+                port,
+                &build_info::BuildInfo::current(),
+                cli::live_server_build(&config).await.as_ref(),
+            )
+        );
+        return Ok(());
+    }
 
     let manager = Manager::with_live_refresher(config, persist_path);
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -848,6 +848,17 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
     // account that already failed it, in a loop. An account leaves this set the
     // moment it is re-admitted, so membership always means "currently parked".
     let mut parked_transient: HashSet<usize> = HashSet::new();
+    // Accounts already granted their ONE same-account transport retry in this
+    // request. The failing resource in a transport error is the CONNECTION, not
+    // the account: reqwest pools by `(scheme, authority)` and the account is only a
+    // Bearer header, so it is not in the pool key at all. Benching the account for
+    // the whole request therefore fails over on the wrong axis — and with a small
+    // eligible pool a single blip walks it to empty and answers a 502 (measured:
+    // 42 of 205 client-visible 502s fired at `transport_failures == 1`). A dead
+    // connection is evicted from the pool by the error itself, so the retry gets a
+    // fresh one. Bounded to one per account per request: the second failure IS
+    // evidence about the account, and `tried.insert` then behaves exactly as before.
+    let mut transport_retried: HashSet<usize> = HashSet::new();
 
     for _ in 0..max_attempts {
         let now = OffsetDateTime::now_utc();
@@ -1035,12 +1046,32 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
                 // attribute it to; `is_connect` / `is_timeout` separate "never
                 // reached the host" from "the host went quiet mid-request".
                 transport_failures += 1;
+                // `?err`, NOT `%err`. reqwest's `Display` prints only its own top
+                // frame and never walks `source()`, so the h2 sub-kind
+                // (`SendRequest` / `Canceled` / `ChannelClosed`) and its reason code
+                // — the only things that say WHY the connection died — are
+                // structurally unreachable from a `%` rendering. `Debug` carries the
+                // whole chain. Do not "tidy" this back to `%err`.
+                if transport_retried.insert(idx) {
+                    // First blip on this account this request: retry it on a fresh
+                    // connection rather than benching an account that is probably fine.
+                    tracing::warn!(
+                        account_index = idx,
+                        account = account_name.as_deref().unwrap_or("?"),
+                        is_connect = err.is_connect(),
+                        is_timeout = err.is_timeout(),
+                        error = ?err,
+                        "upstream transport failure — retrying the SAME account on a fresh connection"
+                    );
+                    next_idx = Some(idx);
+                    continue;
+                }
                 tracing::warn!(
                     account_index = idx,
                     account = account_name.as_deref().unwrap_or("?"),
                     is_connect = err.is_connect(),
                     is_timeout = err.is_timeout(),
-                    error = %err,
+                    error = ?err,
                     "upstream transport failure — rotating to another account"
                 );
                 tried.insert(idx);
@@ -4703,12 +4734,21 @@ mod tests {
     /// over the SOFT threshold so normal `select` benches it while the
     /// revalidation-serve may still use it. Reaching `c` at all requires surviving
     /// the check the bool used to fail. Old code: 502. New code: `c` serves a 200.
+    ///
+    /// The script carries TWO blips because a transport failure now buys the same
+    /// account one retry on a fresh connection
+    /// (`transport_failure_retries_the_same_account_first`), so it takes two to
+    /// bench `a` and reach `b`. The scenario under test is unchanged — one account
+    /// transport-benched, one real upstream 429, one revalidation serve; only the
+    /// number of sends it takes to set it up moved. A single blip here would leave
+    /// `a` retried into the 429 slot and never exercise the revalidation ladder.
     #[tokio::test]
     async fn transport_blip_does_not_disable_recovery() {
         let up_addr = spawn_scripted_upstream(vec![
             None,                        // attempt 1 — `a` fails in transport
-            Some(raw_429_rejected(120)), // attempt 2 — `b` answers, durably 429
-            Some(raw_200()),             // attempt 3 — `c` serves via revalidation
+            None,                        // attempt 2 — `a`'s one retry fails too
+            Some(raw_429_rejected(120)), // attempt 3 — `b` answers, durably 429
+            Some(raw_200()),             // attempt 4 — `c` serves via revalidation
         ])
         .await;
         let manager = fleet(up_addr, &["a", "b", "c"]);
@@ -4776,6 +4816,103 @@ mod tests {
             total, 0,
             "a transport failure serves nothing, so nothing counts"
         );
+    }
+
+    /// A transport failure kills a CONNECTION, not an account — reqwest pools by
+    /// `(scheme, authority)` and the account is only a Bearer header, so it is not
+    /// in the pool key. Retrying the same account on a fresh connection is
+    /// therefore the failover on the RIGHT axis, and it keeps the account's warm
+    /// prompt cache instead of paying a cold prefix for a network blip.
+    ///
+    /// Same shape as `overloaded_529_retries_the_same_account`: the fleet is LRU,
+    /// so a fresh fleet picks `a` and any rotation picks `b`. Scripting blip-then-200
+    /// makes the two behaviours distinguishable in the stats — retry-in-place
+    /// credits `a`, the old bench-and-rotate credits `b`.
+    #[tokio::test]
+    async fn transport_failure_retries_the_same_account_first() {
+        let up_addr = spawn_scripted_upstream(vec![
+            None,            // attempt 1 — `a`'s connection dies
+            Some(raw_200()), // attempt 2 — the SAME account, fresh connection
+        ])
+        .await;
+        let manager = fleet(up_addr, &["a", "b"]);
+
+        let status = post_one(manager.clone()).await;
+        assert_eq!(status, 200, "the retry must serve the client");
+
+        let snap = manager.snapshot(OffsetDateTime::now_utc());
+        let served: Vec<&str> = snap
+            .accounts
+            .iter()
+            .filter(|a| a.requests > 0)
+            .map(|a| a.name.as_str())
+            .collect();
+        assert_eq!(
+            served,
+            ["a"],
+            "a transport blip must retry the account it blipped on — landing on `b` \
+             means one dead connection benched a healthy account and threw away its \
+             warm prompt cache"
+        );
+    }
+
+    /// The other half of the bound: the retry is ONE per account per request. A
+    /// second failure is evidence about the account rather than the connection, so
+    /// it benches it and rotates exactly as before this arm existed.
+    ///
+    /// The attempt count is read from the upstream rather than inferred: exactly
+    /// three sends (`a`, `a` again, then `b`) — a fourth would mean the same-account
+    /// retry can repeat, which is how a blipping upstream would burn the whole
+    /// `max_attempts` budget on one account.
+    #[tokio::test]
+    async fn a_second_transport_failure_benches_the_account_and_rotates() {
+        let (up_addr, attempts) = spawn_counted_upstream(vec![
+            None,            // attempt 1 — `a` blips
+            None,            // attempt 2 — `a`'s fresh connection blips too
+            Some(raw_200()), // attempt 3 — rotated to `b`
+        ])
+        .await;
+        let manager = fleet(up_addr, &["a", "b"]);
+
+        let status = post_one(manager.clone()).await;
+        assert_eq!(status, 200, "`b` still serves the request");
+
+        let snap = manager.snapshot(OffsetDateTime::now_utc());
+        let served: Vec<&str> = snap
+            .accounts
+            .iter()
+            .filter(|a| a.requests > 0)
+            .map(|a| a.name.as_str())
+            .collect();
+        assert_eq!(
+            served,
+            ["b"],
+            "twice-failed `a` is benched for the rest of the request"
+        );
+        assert_eq!(
+            attempts.load(std::sync::atomic::Ordering::SeqCst),
+            3,
+            "one retry for `a`, then a rotation — not an unbounded same-account ladder"
+        );
+    }
+
+    /// The same-account transport retry doubles the sends a fleet can spend on
+    /// transport alone, so the rotation loop's budget has to cover it. Asserted
+    /// against [`max_attempts_for`] itself rather than a copy of the formula: a
+    /// budget narrowed to (say) `n + 4` would silently truncate the walk on any
+    /// fleet of 5+, and the request would stop early for a reason nothing logs.
+    #[test]
+    fn the_transport_retry_ladder_fits_the_attempt_budget() {
+        for accounts in 1..=16usize {
+            // Worst case: every account blips, is retried once, then benched.
+            let sends = accounts * 2;
+            assert!(
+                sends <= max_attempts_for(accounts),
+                "a {accounts}-account fleet can spend {sends} transport sends but the \
+                 loop allows only {} attempts",
+                max_attempts_for(accounts)
+            );
+        }
     }
 
     /// A 529 is transient upstream overload, so it is retried IN PLACE — the client

--- a/src/singleton.rs
+++ b/src/singleton.rs
@@ -158,6 +158,28 @@ pub fn takeover_decision(replaceable: &[u32], replace: bool) -> Takeover {
     }
 }
 
+/// A marker phrase in [`stand_down_message`] that a SECOND codebase parses.
+///
+/// TcrBar (`apps/macos`) supervises a spawned `tcr server` by scanning its
+/// stderr: `ServerController.incumbentMarkers` turns a match into
+/// `.incumbentHoldsPort` (a benign report) or `.takeoverRefused` (the takeover
+/// did not happen), and a miss into a bare `.exited(0)` — which for a stand-down
+/// would render "the server exited cleanly" for a server that never bound.
+/// The phrase is load-bearing across a language boundary that no compiler
+/// checks, so it is a named constant with a test, not an inline literal.
+pub const INCUMBENT_MARKER: &str = "another proxy holds";
+
+/// What we print before standing down, as a pure function so the cross-language
+/// marker contract above is testable.
+fn stand_down_message(port: u16, pid: u32) -> String {
+    format!(
+        "[tcr] {INCUMBENT_MARKER} :{port} (pid {pid}) and it is healthy — leaving it alone and \
+         exiting without binding. Replacing it would wipe its session→account pin map and \
+         cold-start every live session's prompt cache, the most expensive event in this system. \
+         Pass --replace to take the port over anyway."
+    )
+}
+
 /// Resolve `port` down to one proxy for this server.
 ///
 /// With `replace`, a recognized proxy incumbent is terminated (SIGTERM, then
@@ -186,9 +208,7 @@ pub fn takeover_port(port: u16, replace: bool) -> Takeover {
         // Only the pid and the instruction live here; `main` prints the build
         // comparison, because THAT is the part a user typing `tcr` after a rebuild
         // actually needs and it requires an async status read we must not do here.
-        eprintln!(
-            "[tcr] :{port} is already served by a tcr proxy (pid {pid}) — leaving it alone and exiting. Replacing it would wipe its session→account pin map and cold-start every live session's prompt cache. Pass --replace to take the port over anyway."
-        );
+        eprintln!("{}", stand_down_message(port, pid));
         return Takeover::IncumbentPresent(pid);
     }
 
@@ -293,6 +313,38 @@ mod tests {
     fn an_empty_port_always_proceeds() {
         assert_eq!(takeover_decision(&[], false), Takeover::Proceed);
         assert_eq!(takeover_decision(&[], true), Takeover::Proceed);
+    }
+
+    /// The stand-down message is read by TcrBar's `incumbentMarkers`, in another
+    /// language, with no compiler between the two. Dropping the phrase would make
+    /// a stand-down render in the menu-bar app as a clean `exited(0)` — "the
+    /// server started and stopped" for a server that never bound — and would turn
+    /// its takeover button into a silent no-op instead of a reported refusal.
+    #[test]
+    fn the_stand_down_message_carries_the_marker_tcrbar_greps_for() {
+        // The literal is SPELLED OUT rather than referenced through
+        // `INCUMBENT_MARKER`, deliberately. Asserting `message.contains(MARKER)`
+        // compares the constant with itself and passes for ANY value of it — the
+        // constant is exactly the thing that must not drift, so the test has to
+        // hold the other copy. This literal must equal the entry in
+        // `apps/macos/Sources/TcrBarCore/ServerController.swift`'s
+        // `incumbentMarkers`; nothing but this assertion couples them.
+        let tcrbar_greps_for = "another proxy holds";
+        assert_eq!(
+            INCUMBENT_MARKER, tcrbar_greps_for,
+            "the marker must stay the string TcrBar's incumbentMarkers list carries"
+        );
+        let message = stand_down_message(3456, 4242);
+        assert!(
+            message.contains(tcrbar_greps_for),
+            "apps/macos ServerController.incumbentMarkers greps for \
+             {tcrbar_greps_for:?}: {message}"
+        );
+        assert!(message.contains("4242"), "names the incumbent: {message}");
+        assert!(
+            message.contains("--replace"),
+            "names the override: {message}"
+        );
     }
 
     /// Several incumbents (a leftover JS `teamclaude` beside a `tcr`) report the

--- a/src/singleton.rs
+++ b/src/singleton.rs
@@ -171,12 +171,19 @@ pub const INCUMBENT_MARKER: &str = "another proxy holds";
 
 /// What we print before standing down, as a pure function so the cross-language
 /// marker contract above is testable.
+///
+/// Says "is listening", NOT "is healthy". All we established is that a
+/// command-verified proxy holds the port (`pids_to_replace` -> `is_proxy_server`);
+/// nothing here probes whether it still serves. A wedged proxy holds its port just
+/// fine, and the build line printed right after this one can say the incumbent never
+/// answered — so claiming health here would both overstate the check and contradict
+/// the next line. Assert only what the code checked.
 fn stand_down_message(port: u16, pid: u32) -> String {
     format!(
-        "[tcr] {INCUMBENT_MARKER} :{port} (pid {pid}) and it is healthy — leaving it alone and \
-         exiting without binding. Replacing it would wipe its session→account pin map and \
-         cold-start every live session's prompt cache, the most expensive event in this system. \
-         Pass --replace to take the port over anyway."
+        "[tcr] {INCUMBENT_MARKER} :{port} (pid {pid}) and it is still listening — leaving it \
+         alone and exiting without binding. Replacing it would wipe its session→account pin map \
+         and cold-start every live session's prompt cache, the most expensive event in this \
+         system. Pass --replace to take the port over anyway."
     )
 }
 

--- a/src/singleton.rs
+++ b/src/singleton.rs
@@ -3,9 +3,19 @@
 //! The recurring failure is two proxies — a leftover JS `teamclaude` and/or a
 //! `tcr` — both refreshing the same accounts. Each holds its own in-memory copy of
 //! the SINGLE-USE OAuth refresh tokens, so the first refresh by either revokes the
-//! other's copy and accounts flap to `error` (the "token war"). On startup we take
-//! over the configured port: if a recognized proxy already holds it, replace it,
-//! then bind.
+//! other's copy and accounts flap to `error` (the "token war"). On startup we
+//! resolve the configured port down to exactly ONE proxy.
+//!
+//! **Resolving it does not have to mean killing the incumbent, and by default it
+//! does not.** Both outcomes — replace, or attach-and-exit — leave one proxy
+//! running, so the token war is averted either way; the difference is only WHICH
+//! process survives. Killing the incumbent is by far the more expensive of the
+//! two: it wipes the in-memory session→account pin map, so every live session
+//! pays a full cold prompt prefix. Measured over 79.6h: 50 boots, 31 of the 49
+//! gaps between them under 120s — a bare `tcr` typed to "check on things" would
+//! silently take the port. So the default is now [`Takeover::IncumbentPresent`],
+//! which reports and exits without binding, and the kill lives behind an explicit
+//! `--replace`.
 //!
 //! Two safety properties, both load-bearing:
 //! - **Port-scoped.** Only the process listening on `127.0.0.1:<configured port>`
@@ -120,17 +130,49 @@ fn is_alive(pid: u32) -> bool {
         .is_ok_and(|s| s.success())
 }
 
-/// Take over `port` for this server. If a recognized proxy already holds it,
-/// terminate it (SIGTERM, then SIGKILL a survivor after a grace) so this instance
-/// can bind. A non-proxy holder is reported and LEFT ALONE. When `no_replace` is
-/// set, an incumbent proxy is only warned about, not killed.
-pub fn takeover_port(port: u16, no_replace: bool) {
+/// What the caller must do after [`takeover_port`] has looked at the port.
+///
+/// The enum exists so the decision stays HERE — with the port-scoped,
+/// command-verified knowledge of who holds it — while the exit belongs to
+/// `main`, which owns the process's exit code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Takeover {
+    /// Nothing replaceable is in the way (the port is free, held only by a
+    /// non-proxy, or the incumbent was just replaced). Bind.
+    Proceed,
+    /// A recognized proxy incumbent holds the port and was deliberately left
+    /// running. The caller must NOT bind; it should exit 0.
+    IncumbentPresent(u32),
+}
+
+/// The pure decision: given the replaceable incumbents on the port and whether
+/// `--replace` was passed, do we bind or stand down?
+///
+/// Split out from the side effects for the same reason as [`pids_to_replace`] —
+/// and it is the single gate on the kill loop below, so a test that pins this
+/// function pins whether a live proxy gets signalled.
+pub fn takeover_decision(replaceable: &[u32], replace: bool) -> Takeover {
+    match replaceable.first() {
+        Some(&pid) if !replace => Takeover::IncumbentPresent(pid),
+        _ => Takeover::Proceed,
+    }
+}
+
+/// Resolve `port` down to one proxy for this server.
+///
+/// With `replace`, a recognized proxy incumbent is terminated (SIGTERM, then
+/// SIGKILL a survivor after a grace) so this instance can bind. Without it — the
+/// DEFAULT — the incumbent is reported and left running, and the caller is told
+/// to exit rather than bind. A non-proxy holder is reported and LEFT ALONE in
+/// both cases (the bind then fails loudly with EADDRINUSE).
+#[must_use = "the caller must exit instead of binding on IncumbentPresent"]
+pub fn takeover_port(port: u16, replace: bool) -> Takeover {
     let holders = port_listeners(port);
-    let replace = pids_to_replace(&holders, std::process::id(), process_command);
+    let replaceable = pids_to_replace(&holders, std::process::id(), process_command);
 
     // Surface a non-proxy holder (we won't kill it; the bind will fail).
     for &pid in &holders {
-        if pid != std::process::id() && !replace.contains(&pid) {
+        if pid != std::process::id() && !replaceable.contains(&pid) {
             let cmd = process_command(pid);
             if !cmd.is_empty() {
                 eprintln!(
@@ -140,13 +182,17 @@ pub fn takeover_port(port: u16, no_replace: bool) {
         }
     }
 
-    for pid in replace {
-        if no_replace {
-            eprintln!(
-                "[tcr] another proxy holds :{port} (pid {pid}) and --no-replace was set; two proxies refreshing the same single-use tokens will token-war. Not replacing."
-            );
-            continue;
-        }
+    if let Takeover::IncumbentPresent(pid) = takeover_decision(&replaceable, replace) {
+        // Only the pid and the instruction live here; `main` prints the build
+        // comparison, because THAT is the part a user typing `tcr` after a rebuild
+        // actually needs and it requires an async status read we must not do here.
+        eprintln!(
+            "[tcr] :{port} is already served by a tcr proxy (pid {pid}) — leaving it alone and exiting. Replacing it would wipe its session→account pin map and cold-start every live session's prompt cache. Pass --replace to take the port over anyway."
+        );
+        return Takeover::IncumbentPresent(pid);
+    }
+
+    for pid in replaceable {
         eprintln!(
             "[tcr] replacing existing proxy on :{port} (pid {pid}) — one proxy per port, or the two mutually invalidate each other's single-use refresh tokens (token war)."
         );
@@ -162,6 +208,7 @@ pub fn takeover_port(port: u16, no_replace: bool) {
             sleep(Duration::from_millis(300));
         }
     }
+    Takeover::Proceed
 }
 
 #[cfg(test)]
@@ -219,5 +266,43 @@ mod tests {
     fn pids_to_replace_never_includes_self_even_if_it_looks_like_a_proxy() {
         let command = |_pid: u32| "/x/tcr server".to_string();
         assert!(pids_to_replace(&[42], 42, command).is_empty());
+    }
+
+    /// THE DEFAULT, and the whole point of the enum: a healthy proxy incumbent is
+    /// left running and the caller is told to stand down. `Proceed` here would
+    /// reach the kill loop and cost every live session its prompt cache.
+    #[test]
+    fn a_healthy_incumbent_is_left_alone_by_default() {
+        assert_eq!(
+            takeover_decision(&[4242], false),
+            Takeover::IncumbentPresent(4242)
+        );
+    }
+
+    /// `--replace` is the ONLY way to reach the kill loop.
+    #[test]
+    fn replace_flag_proceeds_to_the_takeover() {
+        assert_eq!(takeover_decision(&[4242], true), Takeover::Proceed);
+    }
+
+    /// Nothing replaceable on the port — bind, with or without the flag. Covers
+    /// both the free port and the non-proxy holder, which `pids_to_replace` has
+    /// already filtered out by the time we get here (the bind then fails loudly,
+    /// which is the documented behaviour and must not change).
+    #[test]
+    fn an_empty_port_always_proceeds() {
+        assert_eq!(takeover_decision(&[], false), Takeover::Proceed);
+        assert_eq!(takeover_decision(&[], true), Takeover::Proceed);
+    }
+
+    /// Several incumbents (a leftover JS `teamclaude` beside a `tcr`) report the
+    /// first rather than collapsing to `Proceed` — one of them is enough to make
+    /// binding wrong.
+    #[test]
+    fn multiple_incumbents_still_stand_down_by_default() {
+        assert_eq!(
+            takeover_decision(&[111, 222], false),
+            Takeover::IncumbentPresent(111)
+        );
     }
 }


### PR DESCRIPTION
## Why

Investigating "the proxy seems to crash or go slow at times" turned up two distinct
problems, neither of which was a crash.

**Restarts, not crashes.** `takeover_port` defaulted to SIGTERM-ing whatever proxy held
the port, so any bare `tcr` / `tcr server` / `tcr <flag>` killed the running server.
(`tcr run` never did — `is_proxy_server` excludes it, and it does not spawn a server at
all.) Measured from the boot marker: **50 `server started` lines in 79.6h**, 31 of 49
gaps under 120s. Each one wipes the session→account pin map, which `main.rs` itself
calls the most expensive cache event in this system. The token war the singleton exists
to prevent is visible in the same log — **13 of 29 `refresh token rejected` errors land
within 120s of a restart**, most at +1s.

**A blip benches an account.** A transport failure did `tried.insert(idx)`, barring that
account for the rest of the request. But the failing resource is a *connection*: the
reqwest pool key is `(scheme, authority)` (hyper-util `client.rs:92`), so the account is
only a Bearer header and is not in the key. Benching it is on the wrong axis. Of 205
client-visible 502s, **42 (20%) fired at `transport_failures=1`** — one blip emptying a
one-account eligible pool, and the 502 check sits *ahead* of the soft-wait and
revalidation ladder.

## What changed

1. **`--replace` is now required to take the port.** The default stands down and exits 0
   without binding. Because `cargo build && tcr` no longer guarantees the new binary
   serves, the stand-down prints a build line comparing this binary's commit against the
   incumbent's (read best-effort from the status endpoint, bounded, `None` on failure —
   it cannot fail startup because it runs only after we have decided to exit). Four
   greppable outcomes: `stale-server`, `build-skew-unknown`, `dirty-build`, `in sync`.
   `--no-replace` is kept, documented deprecated, and wins if both flags are passed.
2. **One same-account retry before rotating.** Each account gets exactly one retry on a
   fresh connection per request, then benches as before. Bounded by the existing
   `account_count * 2 + 4` budget, and paced by the existing throttle since it reuses the
   `next_idx` path the 401 and 429 retries already use.
3. **`?err` instead of `%err`** on the transport warn. reqwest's `Display` never walks
   `source()`, so the h2 sub-kind and reason code were *structurally* unknowable from the
   log. This is the instrument for diagnosing the largest failure bucket (809 of 1,290
   failures are post-connect deaths that we currently cannot name).
4. **TcrBar moved with it.** The app expressed takeover by *omitting* `--no-replace`, so
   the flip would have silently turned its takeover button into a no-op. Arguments, the
   test allowlist, both now-false doc sections (including the README's "one safety
   property"), and the intent tests are updated.

## Notes for review

- **CI does not build or test the macOS app** — `.github/workflows/` has no Swift step.
  The Swift gate here is a local `swift build` + `swift test` (76 tests, 0 failures). A
  green CI run says nothing about TcrBar; worth fixing separately.
- The pre-existing `XCTAssertFalse(takeoverArguments.contains("--no-replace"))` **stayed
  green** across the semantic inversion, because `--replace` is not `--no-replace`. It was
  a stale oracle, not a safety net, and is replaced with an assertion on what now matters.
- One pre-existing Rust test (`transport_blip_does_not_disable_recovery`) needed its
  fixture extended by one upstream response, since the new retry consumes a slot. The
  assertion was **not** relaxed — the guarded property is unchanged; only the number of
  sends needed to set the scenario up moved.
- Every new test in this PR was watched failing under a deliberate mutation before being
  trusted, per the repo's rule.

## Claims deliberately NOT acted on

An earlier pass concluded all accounts ride a single shared HTTP/2 connection, offering
"50% of transport failures co-occur across accounts within 100ms" as evidence. The pool-key
half is true, but the conclusion is **false**: `lsof` shows 17 established connections to
the API host. And the clustering evidence does not survive a label-shuffle control that
preserves burst timing — real/control ratio is 0.93–0.99 at every window from 100µs to
100ms, i.e. at or below chance. Burst density explains it entirely. Nothing here is built
on that claim.

Likewise `pool_idle_timeout` is **untouched**. Its 300s value has a documented rationale
(raised from reqwest's 90s default so a post-think-time request skips a reconnect), and the
hypothesis that the server reaps sooner is unevidenced. Change 3 is the instrument that
would actually test it; changing an unmeasured constant now would be guessing.

## Deploy note

None of this takes effect until the proxy restarts, and a restart is itself the expensive
event — hence one branch rather than four. Config-only changes are **not** cheaper:
`load_config` runs at boot only, so a knob turn and a code change both cost one restart and
one pin wipe.
