### PR TITLE
fix: repair the nine confirmed defects an adversarial review found in #35

### DIFF
--- a/apps/macos/Sources/TcrBarCore/ServerController.swift
+++ b/apps/macos/Sources/TcrBarCore/ServerController.swift
@@ -42,6 +42,10 @@ public final class ServerController: ObservableObject {
         case exited(exitCode: Int32, message: String)
         /// `tcr` could not be located.
         case toolMissing(searched: [String])
+        /// The `tcr` on disk predates a flag this app needs, so it rejected the
+        /// spawn with a clap usage error. Distinct from ``exited`` because the
+        /// remedy is "update tcr", not "read this stack trace".
+        case toolTooOld(message: String)
 
         /// True only when a stop is a legal operation: we spawned this process.
         public var isOurChild: Bool {
@@ -70,6 +74,13 @@ public final class ServerController: ObservableObject {
                 return "Server exited (\(code)): \(detail)"
             case .toolMissing(let searched):
                 return "tcr not found (searched \(searched.count) locations)"
+            case .toolTooOld(let message):
+                return """
+                    The `tcr` on this machine is too old for this action — it does \
+                    not accept `--replace`, the flag that asks its port singleton \
+                    to replace the incumbent. Update it (`tcr update`, or install \
+                    from a current build of this repository) and try again. \(message)
+                    """
             }
         }
     }
@@ -77,7 +88,10 @@ public final class ServerController: ObservableObject {
     @Published public private(set) var state: State = .idle
 
     private var child: Process?
-    private let stderrBuffer = LockedString()
+    /// A capability probe is in flight for the takeover path. Guards the window
+    /// between the click and the spawn, where `child` is still nil and a second
+    /// click would otherwise start a second server.
+    private var probing = false
 
     public init() {}
 
@@ -118,6 +132,76 @@ public final class ServerController: ObservableObject {
     /// does.
     public nonisolated static let takeoverArguments = ["server", "--headless", "--replace"]
 
+    /// How a `tcr` that predates the `--replace` flag is asked to take the port.
+    ///
+    /// On such a build taking over was the *default*, and `--no-replace` was the
+    /// only way to decline it — so the takeover is expressed by passing neither
+    /// flag. `--replace` does not exist there, and clap rejects unknown arguments
+    /// with a usage error and exit code 2, which is why the modern set cannot
+    /// simply be sent and hoped for.
+    public nonisolated static let legacyTakeoverArguments = ["server", "--headless"]
+
+    /// Whether the `tcr` we are about to spawn understands `--replace`.
+    public enum ReplaceFlagSupport: Equatable, Sendable {
+        case supported
+        case unsupported
+    }
+
+    /// The takeover argument set for a given binary vintage.
+    ///
+    /// Both spellings really do take the port on their own vintage, so gating on
+    /// the flag keeps the button working across the flip rather than trading one
+    /// broken half for the other. Both mistakes are safe by construction: modern
+    /// arguments sent to an old binary produce a usage error that ``classifyExit``
+    /// names as "your tcr is too old", and legacy arguments sent to a modern one
+    /// make it stand down, which is `.takeoverRefused` — a visible failure, never
+    /// an unwanted kill.
+    public nonisolated static func takeoverArgumentSet(
+        _ support: ReplaceFlagSupport
+    ) -> [String] {
+        switch support {
+        case .supported: return takeoverArguments
+        case .unsupported: return legacyTakeoverArguments
+        }
+    }
+
+    /// Read `--replace` support out of `tcr server --help`.
+    ///
+    /// Matching is on whole tokens. `"--no-replace"` does *not* contain
+    /// `"--replace"` — there is one hyphen before `replace`, not two — so the
+    /// obvious trap is not the live one; the live one is any *longer* flag
+    /// beginning with the same characters. A future `--replace-if-stale` would
+    /// make `text.contains("--replace")` report support for a flag the binary does
+    /// not have, which is the failure this whole probe exists to prevent, arrived
+    /// at from the other side.
+    ///
+    /// The default is `.supported`, and `.unsupported` is returned only on
+    /// positive evidence — help that offers `--no-replace` and no `--replace`.
+    /// Unreadable help means "assume modern": that path ends in a usage error this
+    /// controller explains, whereas guessing "old" against a modern binary would
+    /// send arguments that make it stand down instead of taking the port.
+    public nonisolated static func replaceFlagSupport(inHelpText text: String) -> ReplaceFlagSupport {
+        let tokens = Set(
+            text.components(separatedBy: CharacterSet(charactersIn: " \t\n\r,;[]<>=()"))
+        )
+        if tokens.contains("--replace") { return .supported }
+        if tokens.contains("--no-replace") { return .unsupported }
+        return .supported
+    }
+
+    /// Ask the binary itself. `--help` is answered by clap before any of `tcr`'s
+    /// own code runs, so this never binds a port, never signals anything and costs
+    /// one short-lived process.
+    ///
+    /// Blocking, so it is called off the main actor. Any failure to run or decode
+    /// falls back to `.supported`, for the reason given on ``replaceFlagSupport``.
+    nonisolated static func probeReplaceFlagSupport(executable: URL) -> ReplaceFlagSupport {
+        guard let output = try? TcrTool.run(executable: executable, arguments: ["server", "--help"])
+        else { return .supported }
+        let text = (String(data: output.stdout, encoding: .utf8) ?? "") + output.stderr
+        return replaceFlagSupport(inHelpText: text)
+    }
+
     /// The default argument set. Kept as a distinct name so existing call sites
     /// and tests read as "the safe one" rather than "the only one".
     public nonisolated static var serverArguments: [String] { safeArguments }
@@ -132,8 +216,33 @@ public final class ServerController: ObservableObject {
     /// `--replace` flag. No pid is signalled from Swift. Callers must have
     /// confirmed with the operator first — this is the most expensive action in
     /// the app.
+    ///
+    /// Unlike ``start()`` this asks the binary what it accepts before spawning,
+    /// because the flag that expresses "take the port" changed spelling and
+    /// TcrBar is routinely newer than the `tcr` on `PATH` — the app and the CLI
+    /// are separate installs. The probe runs off the main actor; the spawn itself
+    /// happens back on it.
     public func startTakingOverPort() {
-        launch(intent: .takeover, arguments: Self.takeoverArguments)
+        guard child == nil, !probing else { return }
+        switch TcrTool.resolve() {
+        case .failure(let notFound):
+            state = .toolMissing(searched: notFound.searched)
+        case .success(let executable):
+            probing = true
+            Task { [weak self] in
+                let support = await Task.detached(priority: .userInitiated) {
+                    Self.probeReplaceFlagSupport(executable: executable)
+                }.value
+                guard let self else { return }
+                self.probing = false
+                guard self.child == nil else { return }
+                self.spawn(
+                    executable: executable,
+                    intent: .takeover,
+                    arguments: Self.takeoverArgumentSet(support)
+                )
+            }
+        }
     }
 
     private func launch(intent: Intent, arguments: [String]) {
@@ -160,8 +269,8 @@ public final class ServerController: ObservableObject {
         // mid-serve, still alive, so `terminationHandler` never fires and this app
         // keeps reporting `.supervising`. A hung server displayed as healthy.
         //
-        // Only `standardError` gets a Pipe, and it is drained by the
-        // `readabilityHandler` below — that is what makes it safe.
+        // Only `standardError` gets a Pipe, and `ChildStderr` drains it
+        // continuously — that is what makes it safe.
         //
         // Nothing is lost: the server's durable log is `$TMPDIR/teamclaude-rs.log`,
         // which is where `tcr status` and every diagnostic already read from.
@@ -170,16 +279,10 @@ public final class ServerController: ObservableObject {
         // That fix let the server SURVIVE startup, which is precisely what let it
         // live long enough to reach this second wall.
         process.standardOutput = FileHandle.nullDevice
-        stderrBuffer.reset()
-        err.fileHandleForReading.readabilityHandler = { [stderrBuffer] handle in
-            let data = handle.availableData
-            guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else { return }
-            stderrBuffer.append(text)
-        }
-        process.terminationHandler = { [weak self, stderrBuffer] finished in
+        let stderr = ChildStderr(reading: err)
+        process.terminationHandler = { [weak self] finished in
             let code = finished.terminationStatus
-            let text = stderrBuffer.value
-            err.fileHandleForReading.readabilityHandler = nil
+            let text = stderr.finish()
             Task { @MainActor in
                 guard let self else { return }
                 self.child = nil
@@ -245,6 +348,20 @@ public final class ServerController: ObservableObject {
         case takeover
     }
 
+    /// What clap prints when it is handed an argument the binary does not define.
+    ///
+    /// Both spellings are kept: clap 4 says `unexpected argument '--replace'
+    /// found`, clap 3 said `Found argument '--replace' which wasn't expected`.
+    /// The binary is not ours to pin a version on — it is whatever `tcr` is
+    /// installed — so the older wording stays cheap insurance.
+    nonisolated static let unknownArgumentMarkers = [
+        "unexpected argument",
+        "wasn't expected",
+        "isn't valid in this context",
+        "Found argument",
+        "unrecognized",
+    ]
+
     /// Pure classification of a finished spawn.
     ///
     /// On `.safeStart`, "another proxy already holds the port" is the *success*
@@ -262,12 +379,25 @@ public final class ServerController: ObservableObject {
     /// proxy hosted inside a `tcr run` process (`src/singleton.rs:38,62`, asserted
     /// at `:257`), because killing it would kill the Claude session running
     /// through it. No number of clicks will change that outcome.
+    ///
+    /// A third outcome sits ahead of both: a `tcr` old enough to reject the
+    /// arguments outright. See ``unknownArgumentMarkers``.
     public nonisolated static func classifyExit(
         intent: Intent = .safeStart,
         exitCode: Int32,
         stderr: String
     ) -> State {
         let trimmed = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Checked first, and before the incumbent markers, because it is the more
+        // specific claim: this binary never even parsed the request. Reporting it
+        // as a bare `.exited(2, …)` would show the operator a raw clap usage dump
+        // right after they confirmed a destructive alert, with no hint that the
+        // remedy is to update `tcr` rather than to retry.
+        if trimmed.contains("--replace"),
+            unknownArgumentMarkers.contains(where: { trimmed.contains($0) })
+        {
+            return .toolTooOld(message: trimmed)
+        }
         if incumbentMarkers.contains(where: { trimmed.contains($0) }) {
             switch intent {
             case .safeStart:
@@ -277,6 +407,67 @@ public final class ServerController: ObservableObject {
             }
         }
         return .exited(exitCode: exitCode, message: trimmed)
+    }
+}
+
+/// Collects a child process's stderr, and — this is the point of the type —
+/// **drains the pipe** when the child exits instead of merely snapshotting what
+/// happened to have arrived.
+///
+/// Foundation delivers pipe readability on a background queue with no ordering
+/// guarantee against `terminationHandler`. A `tcr` that writes its stand-down
+/// message and exits in the same breath can therefore die with its final chunk
+/// still unread, and the previous code took its snapshot at that moment and then
+/// discarded the rest by clearing the handler. Measured on this machine over 400
+/// spawns of a child writing 600 bytes and exiting: 10 reads came back empty or
+/// truncated (a second run: 9). With the drain below, 0 of 400, twice.
+///
+/// Empty stderr is not a harmless loss here. A stand-down exits **0** since the
+/// `--replace` flip, so a lost message classifies as `.exited(0, "")` and the
+/// panel renders "Server exited (0): no output" — TcrBar reporting a clean start
+/// and stop while an incumbent proxy is still serving, which is verbatim the
+/// misreport `incumbentMarkers` exists to prevent. The old non-zero refusal made
+/// the same race at least *look* like an error.
+///
+/// `readToEnd()` blocks until EOF, which arrives when the last writer closes.
+/// `Process` closes the parent's copy of the write end at spawn, and `tcr server`
+/// forks nothing that could inherit it, so the only writer is the child that has
+/// already exited. `TcrTool.run` makes the identical assumption on every status
+/// poll (`readDataToEndOfFile()`), so this is the codebase's existing contract
+/// with the CLI, not a new one.
+final class ChildStderr: @unchecked Sendable {
+    private let handle: FileHandle
+    private let buffer = LockedString()
+
+    /// - Parameter installReadabilityHandler: false only in tests. It reproduces,
+    ///   deterministically, the state the race produces by accident — bytes in the
+    ///   pipe that the readability callback has not consumed — so a regression
+    ///   here fails every run rather than one run in forty.
+    init(reading pipe: Pipe, installReadabilityHandler: Bool = true) {
+        handle = pipe.fileHandleForReading
+        guard installReadabilityHandler else { return }
+        handle.readabilityHandler = { [buffer] handle in
+            let data = handle.availableData
+            guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else { return }
+            buffer.append(text)
+        }
+    }
+
+    /// Call once, after the child has exited. Stops the streaming reader, takes
+    /// whatever is still in the pipe, and returns everything the child wrote.
+    ///
+    /// A callback already in flight cannot duplicate text — a read consumes the
+    /// bytes it returns, so each byte reaches the buffer exactly once. It can in
+    /// principle interleave two chunks out of order; every consumer of this string
+    /// is a substring match, so ordering is not load-bearing.
+    func finish() -> String {
+        handle.readabilityHandler = nil
+        if let tail = try? handle.readToEnd(), !tail.isEmpty,
+            let text = String(data: tail, encoding: .utf8)
+        {
+            buffer.append(text)
+        }
+        return buffer.value
     }
 }
 

--- a/apps/macos/Sources/TcrBarCore/ServerController.swift
+++ b/apps/macos/Sources/TcrBarCore/ServerController.swift
@@ -202,6 +202,47 @@ public final class ServerController: ObservableObject {
         return replaceFlagSupport(inHelpText: text)
     }
 
+    /// How long the capability probe may take before the takeover proceeds
+    /// without it. `--help` is a parse and a write; anything slower is not a slow
+    /// answer, it is no answer.
+    static let probeTimeout: Double = 5
+
+    /// Run a probe under a deadline, falling back to `.supported` when it does not
+    /// answer in time.
+    ///
+    /// Without this, one unanswerable `--help` disables the takeover button for
+    /// the lifetime of the app: `probing` would stay true forever and every later
+    /// click would return at the guard, silently. `TCR_BIN` and the defaults key
+    /// let an operator point `tcr` at an arbitrary executable, so "the binary
+    /// always answers" is not something this app gets to assume.
+    ///
+    /// The abandoned probe is not cancellable mid-read; it is simply no longer
+    /// waited on. It holds no port and signals nothing.
+    ///
+    /// Deliberately *not* a `withTaskGroup` race, which is the obvious shape and
+    /// does not work: a task group awaits every child before it returns, so
+    /// `cancelAll()` cannot abandon a subprocess read that ignores cancellation —
+    /// the group returns the timeout's answer only once the probe has finished
+    /// anyway, which is the hang it was supposed to prevent. The first version of
+    /// this function did exactly that and took 30 seconds to honour a 0.2-second
+    /// deadline. The probe therefore runs on a Dispatch queue, off the cooperative
+    /// pool entirely, and is waited on by a semaphore that has its own deadline.
+    static func support(
+        within seconds: Double,
+        probe: @escaping @Sendable () -> ReplaceFlagSupport
+    ) async -> ReplaceFlagSupport {
+        let answer = LockedSupport()
+        let finished = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            answer.value = probe()
+            finished.signal()
+        }
+        return await Task.detached(priority: .userInitiated) {
+            _ = finished.wait(timeout: .now() + seconds)
+            return answer.value ?? .supported
+        }.value
+    }
+
     /// The default argument set. Kept as a distinct name so existing call sites
     /// and tests read as "the safe one" rather than "the only one".
     public nonisolated static var serverArguments: [String] { safeArguments }
@@ -230,9 +271,9 @@ public final class ServerController: ObservableObject {
         case .success(let executable):
             probing = true
             Task { [weak self] in
-                let support = await Task.detached(priority: .userInitiated) {
+                let support = await Self.support(within: Self.probeTimeout) {
                     Self.probeReplaceFlagSupport(executable: executable)
-                }.value
+                }
                 guard let self else { return }
                 self.probing = false
                 guard self.child == nil else { return }
@@ -468,6 +509,26 @@ final class ChildStderr: @unchecked Sendable {
             buffer.append(text)
         }
         return buffer.value
+    }
+}
+
+/// A capability answer written by a probe thread and read by whoever is still
+/// waiting when the deadline passes. `nil` means "no answer yet".
+final class LockedSupport: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: ServerController.ReplaceFlagSupport?
+
+    var value: ServerController.ReplaceFlagSupport? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+        set {
+            lock.lock()
+            storage = newValue
+            lock.unlock()
+        }
     }
 }
 

--- a/apps/macos/Sources/TcrBarCore/ServerController.swift
+++ b/apps/macos/Sources/TcrBarCore/ServerController.swift
@@ -38,6 +38,14 @@ public final class ServerController: ObservableObject {
         /// there. Distinct from ``incumbentHoldsPort`` because on the takeover path
         /// that same condition is a failure, not the benign outcome.
         case takeoverRefused(message: String)
+        /// A process holds the port and answered nothing. It is not serving, and
+        /// it is not ours to signal. The most alarming state this app can report:
+        /// every session pointed at the port is failing right now.
+        case incumbentNotAnswering(message: String)
+        /// The incumbent is serving, but from a different build than the one on
+        /// disk. Benign next to ``incumbentNotAnswering`` — the proxy works, it is
+        /// merely old — so it is a note, not an alarm.
+        case incumbentIsStale(message: String)
         /// The child exited (or never started). Reported verbatim.
         case exited(exitCode: Int32, message: String)
         /// `tcr` could not be located.
@@ -68,6 +76,25 @@ public final class ServerController: ObservableObject {
                     process, because killing it would kill the Claude session \
                     running through it. Stop that process from its own terminal \
                     instead; retrying here will not change the outcome. \(message)
+                    """
+            case .incumbentNotAnswering(let message):
+                return """
+                    NOT SERVING — a process holds the port but answered nothing, \
+                    so requests through it are failing. It was left alone rather \
+                    than replaced: a proxy that was merely slow to answer would \
+                    lose its session→account pin map, so this app will not make \
+                    that call for you. "Take over port…" is the recovery. If a \
+                    takeover is what produced this, tcr declined to replace this \
+                    particular holder — a proxy hosted inside a `tcr run` process \
+                    is deliberately never replaced — and it has to be stopped from \
+                    its own terminal. \(message)
+                    """
+            case .incumbentIsStale(let message):
+                return """
+                    Already running — not ours, left alone. It is serving an older \
+                    build than the `tcr` on disk, so a fix you just built is not \
+                    live on the port. "Take over port…" replaces it, at the cost of \
+                    every live session's prompt cache. \(message)
                     """
             case .exited(let code, let message):
                 let detail = message.isEmpty ? "no output" : message
@@ -389,12 +416,44 @@ public final class ServerController: ObservableObject {
         case takeover
     }
 
+    /// The stand-down exit codes `tcr` defines at `src/main.rs:479-494`.
+    ///
+    /// A stand-down no longer always means exit 0. These two codes carry facts
+    /// about the incumbent that the *markers cannot*, because a stand-down prints
+    /// the same "another proxy holds" line in all three cases — only the code
+    /// separates a healthy incumbent from a wedged one.
+    ///
+    /// Keying on the code rather than on the prose is deliberate and matches the
+    /// Rust side's own reasoning: a verdict grepped out of a sentence is disarmed
+    /// by any rewording. It also survives a lost stderr, which is not theoretical
+    /// here — see ``ChildStderr``.
+    ///
+    /// Neither code can arrive from a `tcr` predating them: those builds exit 0,
+    /// 1 or 2, so reading 3 and 4 costs nothing in version-robustness.
+    enum StandDownExit {
+        /// The incumbent is serving an older build than the binary just run.
+        static let stale: Int32 = 3
+        /// The incumbent never answered the liveness probe. It holds the socket
+        /// and serves nothing.
+        static let notAnswering: Int32 = 4
+    }
+
     /// What clap prints when it is handed an argument the binary does not define.
     ///
-    /// Both spellings are kept: clap 4 says `unexpected argument '--replace'
-    /// found`, clap 3 said `Found argument '--replace' which wasn't expected`.
-    /// The binary is not ours to pin a version on — it is whatever `tcr` is
-    /// installed — so the older wording stays cheap insurance.
+    /// Measured against clap 4 with this project's own `ServerArgs` wiring rather
+    /// than recalled: `error: unexpected argument '--replace' found`, followed by
+    /// `tip: a similar argument exists: '--no-replace'`. The clap 3 spellings are
+    /// kept as cheap insurance, since the binary is whatever `tcr` is installed
+    /// and this app does not get to pin its version.
+    ///
+    /// Deliberately excludes the *conflict* wording. `--replace` together with
+    /// `--no-replace` is now a hard clap conflict which also exits 2, and it reads
+    /// `error: the argument '--replace' cannot be used with '--no-replace'` —
+    /// measured, same run. Matching that as "your tcr is too old" would tell an
+    /// operator to rebuild a perfectly current binary. It carries none of the
+    /// markers below, so it falls through to a verbatim `.exited(2, …)`, which is
+    /// the honest report: no path in this app builds both flags, so seeing it at
+    /// all would mean a bug here, not a stale CLI.
     nonisolated static let unknownArgumentMarkers = [
         "unexpected argument",
         "wasn't expected",
@@ -423,6 +482,13 @@ public final class ServerController: ObservableObject {
     ///
     /// A third outcome sits ahead of both: a `tcr` old enough to reject the
     /// arguments outright. See ``unknownArgumentMarkers``.
+    ///
+    /// And ahead of the markers sit the stand-down exit codes. Every stand-down
+    /// prints the same "another proxy holds" line, so on the marker alone all
+    /// three are indistinguishable and all three read as the benign "already
+    /// running". For exit 4 that is the inverse of the truth — the port is held by
+    /// something serving nothing — and a panel that says a wedged proxy is fine is
+    /// worse than one that says nothing at all. See ``StandDownExit``.
     public nonisolated static func classifyExit(
         intent: Intent = .safeStart,
         exitCode: Int32,
@@ -438,6 +504,16 @@ public final class ServerController: ObservableObject {
             unknownArgumentMarkers.contains(where: { trimmed.contains($0) })
         {
             return .toolTooOld(message: trimmed)
+        }
+        // Both intents, deliberately. On the takeover path these are still the
+        // more useful facts than "refused": exit 4 says the thing that kept the
+        // port is not serving, which `.takeoverRefused`'s wording ("the existing
+        // proxy is still serving") would flatly contradict.
+        if exitCode == StandDownExit.notAnswering {
+            return .incumbentNotAnswering(message: trimmed)
+        }
+        if exitCode == StandDownExit.stale {
+            return .incumbentIsStale(message: trimmed)
         }
         if incumbentMarkers.contains(where: { trimmed.contains($0) }) {
             switch intent {

--- a/apps/macos/Tests/TcrBarTests/TakeoverIntentTests.swift
+++ b/apps/macos/Tests/TcrBarTests/TakeoverIntentTests.swift
@@ -183,6 +183,56 @@ final class StandDownExitCodeTests: XCTestCase {
             + "this_binary_dirty=false — the proxy on :3456 is running a DIFFERENT commit."
     }
 
+    /// The other half of a cross-language contract no compiler checks.
+    ///
+    /// These numbers are `EXIT_STOOD_DOWN_STALE` and
+    /// `EXIT_STOOD_DOWN_NOT_ANSWERING` in `src/main.rs`, and Rust's
+    /// `the_stand_down_exit_codes_are_the_numbers_tcrbar_switches_on` transcribes
+    /// them in the opposite direction. Both copies are needed, because each test
+    /// only catches a renumbering that starts on the *other* side: theirs pins
+    /// Rust against a copy of these values, so a change made here would leave it
+    /// green, and this one closes that direction.
+    ///
+    /// Renumbering is a one-character edit that every other test in either suite
+    /// survives, and the consequence is silent — TcrBar falls through to a bare
+    /// `.exited(5, …)` and reports a proxy serving NOTHING as a clean exit, which
+    /// is the misreport this whole round exists to eliminate.
+    ///
+    /// The numbers are SPELLED OUT rather than referenced through the constants.
+    /// `XCTAssertEqual(StandDownExit.stale, StandDownExit.stale)` compares a value
+    /// with itself and passes for every value of it — the constant is exactly the
+    /// thing that must not drift, so the test has to hold the other copy. This is
+    /// not hypothetical: a mutation earlier in this branch survived because an
+    /// assertion was written against the implementation instead of against an
+    /// independent statement of the expected value.
+    func testTheStandDownExitCodesAreTheNumbersTcrIsAsserting() {
+        XCTAssertEqual(
+            ServerController.StandDownExit.stale, 3,
+            "EXIT_STOOD_DOWN_STALE is 3 in src/main.rs — change one, change both"
+        )
+        XCTAssertEqual(
+            ServerController.StandDownExit.notAnswering, 4,
+            "EXIT_STOOD_DOWN_NOT_ANSWERING is 4 in src/main.rs — change one, change both"
+        )
+    }
+
+    /// The constants being right is worthless if the classifier does not act on
+    /// them, so the contract is asserted a second time through the function the
+    /// panel's text actually comes from, against the same literals rather than
+    /// through the constants.
+    func testTheLiteralCodesReachTheStatesTheyAreDefinedFor() {
+        guard case .incumbentIsStale = ServerController.classifyExit(
+            intent: .safeStart, exitCode: 3, stderr: standDown
+        ) else {
+            return XCTFail("literal 3 must classify as a stale incumbent")
+        }
+        guard case .incumbentNotAnswering = ServerController.classifyExit(
+            intent: .safeStart, exitCode: 4, stderr: standDown
+        ) else {
+            return XCTFail("literal 4 must classify as a wedged incumbent")
+        }
+    }
+
     func testASilentIncumbentIsNotReportedAsAlreadyRunning() {
         let state = ServerController.classifyExit(
             intent: .safeStart, exitCode: 4, stderr: silentIncumbent

--- a/apps/macos/Tests/TcrBarTests/TakeoverIntentTests.swift
+++ b/apps/macos/Tests/TcrBarTests/TakeoverIntentTests.swift
@@ -255,6 +255,31 @@ final class ReplaceFlagCapabilityTests: XCTestCase {
         }
     }
 
+    /// A probe that never answers must not disable the button forever. Before the
+    /// deadline, one unanswerable `--help` left `probing` true for the lifetime of
+    /// the app and every later click returned at the guard, in silence.
+    func testAProbeThatNeverAnswersFallsBackInsteadOfHanging() async {
+        let started = Date()
+        let support = await ServerController.support(within: 0.2) {
+            // Blocking and cancellation-deaf, exactly like the subprocess read it
+            // stands in for. A task-group race cannot abandon this.
+            Thread.sleep(forTimeInterval: 5)
+            return .unsupported
+        }
+        let elapsed = Date().timeIntervalSince(started)
+        XCTAssertEqual(support, .supported, "a timed-out probe assumes the current flag")
+        XCTAssertLessThan(
+            elapsed, 2,
+            "the deadline did not fire after \(elapsed)s — the takeover would hang"
+        )
+    }
+
+    /// And a probe that does answer is still the one that decides.
+    func testAnAnsweringProbeIsNotOverriddenByTheDeadline() async {
+        let support = await ServerController.support(within: 30) { .unsupported }
+        XCTAssertEqual(support, .unsupported)
+    }
+
     /// Neither vintage may ever name a pid or a signal: the replacement happens
     /// inside `tcr`, never here.
     func testNeitherVintageNamesAProcess() {

--- a/apps/macos/Tests/TcrBarTests/TakeoverIntentTests.swift
+++ b/apps/macos/Tests/TcrBarTests/TakeoverIntentTests.swift
@@ -75,6 +75,59 @@ final class TakeoverIntentTests: XCTestCase {
         )
     }
 
+    /// Verbatim clap 4 output when an argument the binary does not define is
+    /// passed — what a `tcr` predating the `--replace` flip answers the takeover
+    /// with, on exit code 2.
+    private let unknownArgument = """
+        error: unexpected argument '--replace' found
+
+          tip: to pass '--replace' as a value, use '-- --replace'
+
+        Usage: tcr server [OPTIONS]
+
+        For more information, try '--help'.
+        """
+
+    func testAnOldBinaryRejectingTheFlagIsReportedAsAnOutdatedTool() {
+        let state = ServerController.classifyExit(
+            intent: .takeover, exitCode: 2, stderr: unknownArgument
+        )
+        guard case .toolTooOld = state else {
+            return XCTFail("a clap usage error about --replace means the CLI is stale, got \(state)")
+        }
+        let summary = state.summary.lowercased()
+        XCTAssertTrue(summary.contains("too old"), "name the cause: \(state.summary)")
+        XCTAssertTrue(
+            summary.contains("update"),
+            "say what to do about it: \(state.summary)"
+        )
+    }
+
+    /// The failure this classification exists to prevent: an opaque
+    /// `Server exited (2): error: unexpected argument …` shown to someone who has
+    /// just confirmed a destructive alert.
+    func testTheStaleBinaryIsNotFiledAsAnOpaqueExit() {
+        let state = ServerController.classifyExit(
+            intent: .takeover, exitCode: 2, stderr: unknownArgument
+        )
+        if case .exited = state { XCTFail("a usage error is actionable, not an opaque exit") }
+        if case .incumbentHoldsPort = state { XCTFail("nothing was taken over and nothing is ours") }
+    }
+
+    /// Only `--replace` is version-gated. A usage error about any other argument
+    /// is a bug in this app, not a stale CLI, and must not be dressed up as one.
+    func testAUsageErrorAboutSomeOtherArgumentIsStillAPlainExit() {
+        let state = ServerController.classifyExit(
+            intent: .takeover,
+            exitCode: 2,
+            stderr: "error: unexpected argument '--frobnicate' found"
+        )
+        guard case .exited(let code, _) = state else {
+            return XCTFail("expected a plain exit, got \(state)")
+        }
+        XCTAssertEqual(code, 2)
+    }
+
     /// An unrelated failure must still surface verbatim rather than being folded
     /// into either incumbent case.
     func testAnUnrelatedFailureIsStillReportedAsAnExit() {
@@ -86,5 +139,215 @@ final class TakeoverIntentTests: XCTestCase {
         }
         XCTAssertEqual(code, 101)
         XCTAssertEqual(message, "config parse error")
+    }
+}
+
+/// The takeover button has to work against whatever `tcr` is installed, which is
+/// not necessarily the one this app shipped beside: TcrBar and the CLI are
+/// separate installs, and the flag that means "take the port" changed spelling.
+///
+/// Against a binary predating that change, `--replace` does not exist and clap
+/// rejects it outright — so the button that used to work became a usage error,
+/// and the version skew `safeArguments` documents itself as defending against was
+/// only defended on the safe path.
+final class ReplaceFlagCapabilityTests: XCTestCase {
+
+    /// Shape of `tcr server --help` on a build that has the flag. Both spellings
+    /// appear, because `--no-replace` is still accepted (`src/main.rs:187-192`).
+    private let modernHelp = """
+        Usage: tcr server [OPTIONS]
+
+        Options:
+              --port <PORT>      Port to bind (overrides `proxy.port` from the config)
+              --headless         Run without the TUI, logging to stdout
+              --replace          Take over the port: kill a proxy already listening on it
+              --no-replace       DEPRECATED and now a no-op: this is the default
+          -h, --help             Print help
+        """
+
+    /// The same screen on a build that predates the flip: `--no-replace` is the
+    /// only spelling, and taking the port is what happens by default.
+    private let legacyHelp = """
+        Usage: tcr server [OPTIONS]
+
+        Options:
+              --port <PORT>      Port to bind (overrides `proxy.port` from the config)
+              --headless         Run without the TUI, logging to stdout
+              --no-replace       Refuse the port if another proxy already holds it
+          -h, --help             Print help
+        """
+
+    /// A build whose help offers only `--no-replace` is an old one.
+    ///
+    /// Note for anyone tempted by the obvious shortcut: `"--no-replace"` does not
+    /// contain `"--replace"` (one hyphen before `replace`, not two), so this case
+    /// alone does not distinguish substring matching from token matching. The next
+    /// test is the one that does.
+    func testAnOlderHelpScreenIsNotReadAsSupportingTheFlag() {
+        XCTAssertEqual(
+            ServerController.replaceFlagSupport(inHelpText: legacyHelp),
+            .unsupported
+        )
+    }
+
+    /// The trap that is real: a *longer* flag starting with the same characters.
+    /// `text.contains("--replace")` answers "supported" for a binary that has no
+    /// `--replace` at all, and the takeover then dies on the usage error this
+    /// probe exists to avoid. Whole-token matching is what prevents it, and this
+    /// is the test that fails if anyone simplifies it back.
+    func testAFlagThatMerelyBeginsWithReplaceDoesNotCount() {
+        let help = """
+            Usage: tcr server [OPTIONS]
+
+            Options:
+                  --headless             Run without the TUI, logging to stdout
+                  --replace-if-stale     Take the port only from an outdated proxy
+                  --no-replace           Refuse the port if another proxy holds it
+            """
+        XCTAssertEqual(
+            ServerController.replaceFlagSupport(inHelpText: help),
+            .unsupported,
+            "`--replace-if-stale` is not `--replace` — matching must be on whole tokens"
+        )
+    }
+
+    func testACurrentHelpScreenReportsTheFlag() {
+        XCTAssertEqual(ServerController.replaceFlagSupport(inHelpText: modernHelp), .supported)
+    }
+
+    /// No evidence either way is treated as modern on purpose. That path ends in a
+    /// usage error this app explains; guessing "old" against a current binary
+    /// would instead send arguments that make it stand down, so the operator would
+    /// be told the takeover was refused by a proxy that was never asked.
+    func testUnreadableHelpAssumesTheCurrentFlag() {
+        for text in ["", "tcr: command not found", "Usage: tcr server [OPTIONS]"] {
+            XCTAssertEqual(ServerController.replaceFlagSupport(inHelpText: text), .supported)
+        }
+    }
+
+    func testEachVintageGetsTheArgumentThatActuallyTakesThePort() {
+        let modern = ServerController.takeoverArgumentSet(.supported)
+        XCTAssertTrue(modern.contains("--replace"), "\(modern) asks a current tcr for nothing")
+
+        // On an old binary taking over WAS the default, and `--no-replace` was the
+        // only way to decline it — so the takeover is expressed by passing neither.
+        let legacy = ServerController.takeoverArgumentSet(.unsupported)
+        XCTAssertFalse(
+            legacy.contains("--replace"),
+            "\(legacy) is rejected by the binary it exists for"
+        )
+        XCTAssertFalse(
+            legacy.contains("--no-replace"),
+            "\(legacy) tells an old tcr to do the opposite of what was asked"
+        )
+    }
+
+    func testBothVintagesStayHeadless() {
+        for arguments in [
+            ServerController.takeoverArgumentSet(.supported),
+            ServerController.takeoverArgumentSet(.unsupported),
+        ] {
+            XCTAssertEqual(arguments.first, "server")
+            XCTAssertTrue(
+                arguments.contains("--headless"),
+                "\(arguments) would start a TUI with no terminal and die on launch"
+            )
+        }
+    }
+
+    /// Neither vintage may ever name a pid or a signal: the replacement happens
+    /// inside `tcr`, never here.
+    func testNeitherVintageNamesAProcess() {
+        for arguments in [
+            ServerController.takeoverArgumentSet(.supported),
+            ServerController.takeoverArgumentSet(.unsupported),
+        ] {
+            XCTAssertFalse(arguments.contains { $0.contains("kill") || $0.contains("pid") })
+        }
+    }
+}
+
+/// `tcr` now stands down with exit code **0**, so stderr is the only thing that
+/// says an incumbent is there. Losing it is no longer a cosmetic loss: the panel
+/// renders "Server exited (0): no output" for a proxy that is still serving.
+///
+/// Measured before the fix, 400 spawns of a child writing 600 bytes and exiting
+/// under load: 10 snapshots came back empty or truncated (second run: 9). After
+/// it, 0 of 400 twice.
+final class ChildStderrTests: XCTestCase {
+
+    /// The race, made deterministic. `installReadabilityHandler: false` is exactly
+    /// the state the race produces by accident — bytes sitting in the pipe that
+    /// the streaming callback never got to. If `finish()` snapshots instead of
+    /// draining, this fails every single run.
+    func testFinishDrainsWhatTheStreamingReaderNeverSaw() throws {
+        let pipe = Pipe()
+        let stderr = ChildStderr(reading: pipe, installReadabilityHandler: false)
+        let message = "[tcr] another proxy holds :3456 (pid 123) and it is still listening"
+        try pipe.fileHandleForWriting.write(contentsOf: Data(message.utf8))
+        try pipe.fileHandleForWriting.close()
+
+        XCTAssertEqual(stderr.finish(), message, "the final stderr chunk was dropped")
+    }
+
+    /// And the consequence, spelled out: a dropped stand-down reads as a clean
+    /// exit, which is the app reporting success while an incumbent still serves.
+    func testADroppedStandDownWouldReadAsACleanExit() throws {
+        let pipe = Pipe()
+        let stderr = ChildStderr(reading: pipe, installReadabilityHandler: false)
+        let standDown = "[tcr] another proxy holds :3456 (pid 123) and it is still listening — "
+            + "leaving it alone and exiting without binding."
+        try pipe.fileHandleForWriting.write(contentsOf: Data(standDown.utf8))
+        try pipe.fileHandleForWriting.close()
+
+        let state = ServerController.classifyExit(
+            intent: .safeStart, exitCode: 0, stderr: stderr.finish()
+        )
+        guard case .incumbentHoldsPort = state else {
+            return XCTFail("a stand-down whose stderr was dropped reports success: \(state)")
+        }
+    }
+
+    /// The streaming path still works, and draining afterwards must not duplicate
+    /// what it already read — a read consumes its bytes, so each arrives once.
+    func testStreamedOutputIsCollectedExactlyOnce() throws {
+        let pipe = Pipe()
+        let stderr = ChildStderr(reading: pipe)
+        let chunk = "half"
+        try pipe.fileHandleForWriting.write(contentsOf: Data(chunk.utf8))
+        // Give the readability callback a chance to run before EOF.
+        Thread.sleep(forTimeInterval: 0.2)
+        try pipe.fileHandleForWriting.close()
+
+        let collected = stderr.finish()
+        XCTAssertEqual(
+            collected.components(separatedBy: chunk).count - 1,
+            1,
+            "stderr was collected twice: \(collected)"
+        )
+    }
+
+    /// End to end against a real child that writes and exits in the same breath —
+    /// the shape that produced the race.
+    func testARealChildsFinalChunkSurvivesItsExit() throws {
+        let payload = String(repeating: "x", count: 600)
+        for _ in 0..<20 {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/bin/sh")
+            process.arguments = ["-c", "printf '%s' '\(payload)' >&2"]
+            let pipe = Pipe()
+            process.standardError = pipe
+            process.standardOutput = FileHandle.nullDevice
+            let stderr = ChildStderr(reading: pipe)
+            let finished = expectation(description: "child exited")
+            let collected = LockedString()
+            process.terminationHandler = { _ in
+                collected.append(stderr.finish())
+                finished.fulfill()
+            }
+            try process.run()
+            wait(for: [finished], timeout: 10)
+            XCTAssertEqual(collected.value.count, payload.count, "stderr was lost or truncated")
+        }
     }
 }

--- a/apps/macos/Tests/TcrBarTests/TakeoverIntentTests.swift
+++ b/apps/macos/Tests/TcrBarTests/TakeoverIntentTests.swift
@@ -78,12 +78,17 @@ final class TakeoverIntentTests: XCTestCase {
     /// Verbatim clap 4 output when an argument the binary does not define is
     /// passed — what a `tcr` predating the `--replace` flip answers the takeover
     /// with, on exit code 2.
+    ///
+    /// Measured, not recalled: produced by compiling this project's own
+    /// `ServerArgs` wiring minus `--replace` against clap 4 and parsing
+    /// `["server", "--headless", "--replace"]`. The `tip:` line in particular is
+    /// not what one would guess — clap suggests the *similar* argument.
     private let unknownArgument = """
         error: unexpected argument '--replace' found
 
-          tip: to pass '--replace' as a value, use '-- --replace'
+          tip: a similar argument exists: '--no-replace'
 
-        Usage: tcr server [OPTIONS]
+        Usage: tcr server --headless --no-replace
 
         For more information, try '--help'.
         """
@@ -139,6 +144,214 @@ final class TakeoverIntentTests: XCTestCase {
         }
         XCTAssertEqual(code, 101)
         XCTAssertEqual(message, "config parse error")
+    }
+}
+
+/// A stand-down is no longer one outcome with one exit code.
+///
+/// `tcr` now distinguishes three (`src/main.rs:479-494`): 0 when it stood down
+/// and the incumbent answered, 3 when the incumbent is serving a stale build, and
+/// 4 when the incumbent answered *nothing* — it holds the listening socket and
+/// serves no requests.
+///
+/// All three print the same `another proxy holds` line, so classification on the
+/// marker alone collapses them into the benign "already running". For exit 4 that
+/// is the inverse of the truth, and it is the worst thing this panel can do: tell
+/// the operator the proxy is fine while every session through the port fails.
+final class StandDownExitCodeTests: XCTestCase {
+
+    /// Verbatim from `singleton::stand_down_message` — the line every stand-down
+    /// prints, regardless of which of the three it is.
+    private let standDown = "[tcr] another proxy holds :3456 (pid 123) and it is still "
+        + "listening — leaving it alone and exiting without binding. Replacing it would wipe "
+        + "its session→account pin map and cold-start every live session's prompt cache, the "
+        + "most expensive event in this system. Pass --replace to take the port over anyway."
+
+    /// Verbatim from the `Liveness::Silent` arm at `src/main.rs:559-565`.
+    private var silentIncumbent: String {
+        standDown + "\n"
+            + "[tcr] WARNING incumbent-not-answering: port=3456 pid=123 probe=\"timeout\" — the "
+            + "process holding :3456 did not respond, so standing down leaves NOTHING serving "
+            + "on it. Run `tcr --replace` to take the port over; that is the recovery for a "
+            + "wedged proxy, and it is not being done automatically because it also wipes the "
+            + "pin map of a proxy that was merely slow to answer."
+    }
+
+    private var staleIncumbent: String {
+        standDown + "\n"
+            + "[tcr] WARNING stale-server: running=abc1234 this_binary=def5678 built_dirty=false "
+            + "this_binary_dirty=false — the proxy on :3456 is running a DIFFERENT commit."
+    }
+
+    func testASilentIncumbentIsNotReportedAsAlreadyRunning() {
+        let state = ServerController.classifyExit(
+            intent: .safeStart, exitCode: 4, stderr: silentIncumbent
+        )
+        if case .incumbentHoldsPort = state {
+            XCTFail("a process serving nothing was reported as a healthy incumbent")
+        }
+        guard case .incumbentNotAnswering = state else {
+            return XCTFail("expected the not-answering state, got \(state)")
+        }
+    }
+
+    /// The panel must not claim service that is not happening, and must name the
+    /// recovery without performing it — the Rust side deliberately refuses to
+    /// auto-takeover on this evidence, and this app must not re-introduce that
+    /// decision quietly.
+    func testTheSilentIncumbentSummaryTellsTheTruthAndNamesTheRecovery() {
+        let summary = ServerController.classifyExit(
+            intent: .safeStart, exitCode: 4, stderr: silentIncumbent
+        ).summary
+
+        XCTAssertTrue(
+            summary.contains("NOT SERVING"),
+            "the headline fact is that nothing is being served: \(summary)"
+        )
+        XCTAssertFalse(
+            summary.contains("Already running — not ours, left alone."),
+            "that is the benign wording, and it is false here: \(summary)"
+        )
+        XCTAssertTrue(
+            summary.contains("Take over port"),
+            "name the recovery: \(summary)"
+        )
+        XCTAssertTrue(
+            summary.contains("will not make that call for you"),
+            "say that the takeover is the operator's decision, not ours: \(summary)"
+        )
+    }
+
+    /// On the takeover path the same code is still the more useful fact.
+    /// `.takeoverRefused` says "the existing proxy is still serving", which for
+    /// exit 4 would be a second lie on top of the first.
+    func testASilentIncumbentIsNotDressedUpAsAMerelyRefusedTakeover() {
+        let state = ServerController.classifyExit(
+            intent: .takeover, exitCode: 4, stderr: silentIncumbent
+        )
+        guard case .incumbentNotAnswering = state else {
+            return XCTFail("expected the not-answering state, got \(state)")
+        }
+        XCTAssertFalse(
+            state.summary.contains("the existing proxy is still serving"),
+            "it is not serving: \(state.summary)"
+        )
+    }
+
+    /// The exit code carries the verdict even when stderr does not arrive at all.
+    /// That is not hypothetical — the pipe race this file also tests could drop
+    /// the whole message, and a lost stand-down used to read as a clean exit.
+    func testTheVerdictSurvivesAnEmptyStderr() {
+        guard case .incumbentNotAnswering = ServerController.classifyExit(
+            intent: .safeStart, exitCode: 4, stderr: ""
+        ) else {
+            return XCTFail("the exit code alone must carry a wedged incumbent")
+        }
+        guard case .incumbentIsStale = ServerController.classifyExit(
+            intent: .safeStart, exitCode: 3, stderr: ""
+        ) else {
+            return XCTFail("the exit code alone must carry a stale incumbent")
+        }
+    }
+
+    func testAStaleIncumbentIsDistinguishableButNotAnAlarm() {
+        let state = ServerController.classifyExit(
+            intent: .safeStart, exitCode: 3, stderr: staleIncumbent
+        )
+        guard case .incumbentIsStale = state else {
+            return XCTFail("expected the stale state, got \(state)")
+        }
+        // It IS serving, so it must not borrow the not-answering alarm.
+        XCTAssertFalse(state.summary.contains("NOT SERVING"), state.summary)
+        XCTAssertTrue(
+            state.summary.contains("older build"),
+            "say what is actually wrong with it: \(state.summary)"
+        )
+        XCTAssertFalse(state.isOurChild)
+    }
+
+    /// Exit 0 is unchanged: a stand-down against an answering incumbent is the
+    /// benign outcome on a safe start and a failure on a takeover, exactly as
+    /// before the exit codes existed.
+    func testAnAnsweringIncumbentKeepsTheOldBehaviourOnBothPaths() {
+        guard case .incumbentHoldsPort = ServerController.classifyExit(
+            intent: .safeStart, exitCode: 0, stderr: standDown
+        ) else {
+            return XCTFail("exit 0 on a safe start is still the benign outcome")
+        }
+        guard case .takeoverRefused = ServerController.classifyExit(
+            intent: .takeover, exitCode: 0, stderr: standDown
+        ) else {
+            return XCTFail("exit 0 on a takeover is still a failure")
+        }
+    }
+
+    /// All three stand-downs print the same marker line, which is precisely why
+    /// the code has to be read: on the marker alone these are one state.
+    func testTheThreeStandDownsAreNotDistinguishableByTheirMarker() {
+        for text in [standDown, silentIncumbent, staleIncumbent] {
+            XCTAssertTrue(
+                text.contains("another proxy holds"),
+                "the marker is common to all three — the exit code is the only separator"
+            )
+        }
+        let states = [Int32(0), 3, 4].map {
+            ServerController.classifyExit(intent: .safeStart, exitCode: $0, stderr: standDown)
+        }
+        XCTAssertEqual(Set(states.map(\.summary)).count, 3, "identical stderr, three verdicts")
+    }
+}
+
+/// `--replace` together with `--no-replace` is now a hard clap conflict
+/// (`conflicts_with`), and it exits 2 — the same code as an unknown argument.
+///
+/// The two must not be confused. Telling an operator their `tcr` is too old and
+/// to go rebuild it, when the binary is current and the real fault is a
+/// contradictory flag pair, is confidently wrong in the direction that wastes the
+/// most of their time.
+final class FlagConflictTests: XCTestCase {
+
+    /// Measured against clap 4 with this project's own `ServerArgs` wiring,
+    /// including `#[arg(long, conflicts_with = "replace")]`.
+    private let flagConflict = """
+        error: the argument '--replace' cannot be used with '--no-replace'
+
+        Usage: tcr server --headless --replace
+
+        For more information, try '--help'.
+        """
+
+    func testAFlagConflictIsNotReportedAsAnOutdatedTool() {
+        let state = ServerController.classifyExit(
+            intent: .takeover, exitCode: 2, stderr: flagConflict
+        )
+        if case .toolTooOld = state {
+            XCTFail("a current binary would be sent to be rebuilt for no reason: \(state.summary)")
+        }
+        guard case .exited(let code, let message) = state else {
+            return XCTFail("a flag conflict is a bug in this app, reported verbatim, got \(state)")
+        }
+        XCTAssertEqual(code, 2)
+        XCTAssertTrue(message.contains("cannot be used with"))
+    }
+
+    /// The reason the collision cannot happen in the field, asserted rather than
+    /// assumed: no argument set this app can spawn carries both flags. Checked
+    /// across every set, not just the takeover one.
+    func testNoArgumentSetThisAppCanSpawnCarriesBothFlags() {
+        for arguments in [
+            ServerController.safeArguments,
+            ServerController.serverArguments,
+            ServerController.takeoverArguments,
+            ServerController.legacyTakeoverArguments,
+            ServerController.takeoverArgumentSet(.supported),
+            ServerController.takeoverArgumentSet(.unsupported),
+        ] {
+            XCTAssertFalse(
+                arguments.contains("--replace") && arguments.contains("--no-replace"),
+                "\(arguments) is now rejected by clap outright — tcr exits 2 and nothing starts"
+            )
+        }
     }
 }
 

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -256,6 +256,33 @@ impl Drift {
     }
 }
 
+/// What the stand-down established about the incumbent's build, as a value
+/// rather than as words in a line.
+///
+/// `main` turns this into the process's exit code, and an exit code must key on
+/// a STRUCTURAL fact — grepping our own rendered sentence for "WARNING" would be
+/// a gate that any rewording silently disarms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StandDownBuild {
+    /// Same commit, and neither side has any evidence of uncommitted code.
+    InSync,
+    /// Shas match, but at least one side is not provably that commit's code.
+    DirtyBuild,
+    /// The incumbent is executing a DIFFERENT commit than this binary.
+    Stale,
+    /// Not comparable: the incumbent would not report a build, or a sha is
+    /// unknown. Never collapses into agreement.
+    Unknown,
+}
+
+/// [`stand_down_build_report`]'s output: the verdict a caller can branch on and
+/// the line a human reads, produced together so they can never disagree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StandDownReport {
+    pub verdict: StandDownBuild,
+    pub line: String,
+}
+
 /// The build half of the message printed when startup finds a healthy proxy
 /// already on the port and stands down instead of replacing it.
 ///
@@ -274,43 +301,96 @@ impl Drift {
 /// endpoint; `None` means it would not answer, which renders as
 /// `build-skew-unknown` and never as agreement. Pure, so the whole decision table
 /// is unit-testable without a server.
-pub fn stand_down_build_line(port: u16, ours: &BuildInfo, running: Option<&BuildInfo>) -> String {
+///
+/// # Why `checkout` is an input and not a build stamp
+///
+/// `ours.dirty` comes from `build.rs`, which re-runs only when a git REF moves
+/// (its own doc-comment states the limitation verbatim: "editing a tracked file
+/// and rebuilding does NOT restamp"). So the ordinary loop — edit a file,
+/// `cargo build --release`, run `tcr` — produces a binary whose `dirty` stamp
+/// still reads `false`. Comparing that stamp against the incumbent's equally
+/// stale one prints "build in sync" for a proxy that predates the edit, which is
+/// the exact false all-clear this function exists to prevent.
+///
+/// [`compare`] does not have the bug because it pairs the running stamp with a
+/// LIVE [`read_checkout_state`]. This takes the same input for the same reason:
+/// uncommitted changes in the checkout we are standing in, at the commit this
+/// binary was built from, mean neither side is provably this commit's code. When
+/// no checkout is available (run from outside the source tree, no git) the
+/// verdict degrades to the build stamps — which is what it was before, so the
+/// degradation is never worse than the old behaviour.
+pub fn stand_down_build_report(
+    port: u16,
+    ours: &BuildInfo,
+    running: Option<&BuildInfo>,
+    checkout: Option<&CheckoutState>,
+) -> StandDownReport {
     let Some(running) = running else {
-        return format!(
-            "[tcr] note build-skew-unknown: this binary={} but the proxy on :{port} did not report \
-             its build — it may be serving older code. `tcr status` reports the running build; \
-             `tcr --replace` restarts the port onto this binary.",
-            ours.sha
-        );
+        return StandDownReport {
+            verdict: StandDownBuild::Unknown,
+            line: format!(
+                "[tcr] note build-skew-unknown: this_binary={} but the proxy on :{port} did not \
+                 report its build — it may be serving older code. `tcr status` reports the \
+                 running build; `tcr --replace` restarts the port onto this binary.",
+                ours.sha
+            ),
+        };
     };
+    // The LIVE half. `Some(true)` only when git actually said the checkout we are
+    // standing in has uncommitted tracked changes AND its HEAD is the commit this
+    // binary claims — anywhere else the answer is about a different commit and
+    // says nothing about whether this binary matches that one.
+    let checkout_dirty_now = checkout
+        .filter(|state| same_commit(&state.head, &ours.sha))
+        .and_then(|state| state.dirty);
+    // A dirty checkout at our own commit is evidence about THIS binary that its
+    // build stamp structurally cannot carry, so it counts the same as the stamp.
+    let ours_dirty = ours.dirty.unwrap_or(false) || checkout_dirty_now.unwrap_or(false);
+
     let keys = format!(
-        "running={} this_binary={} built_dirty={} this_binary_dirty={}",
+        "running={} this_binary={} built_dirty={} this_binary_dirty={} checkout_dirty={}",
         running.sha,
         ours.sha,
         running.dirty_str(),
-        ours.dirty_str()
+        ours.dirty_str(),
+        tri_bool_str(checkout_dirty_now),
     );
     if !is_comparable_sha(&running.sha) || !is_comparable_sha(&ours.sha) {
-        return format!(
-            "[tcr] note build-skew-unknown: {keys} — cannot tell whether the proxy on :{port} is \
-             running this binary's code. `tcr --replace` restarts the port onto this binary."
-        );
+        return StandDownReport {
+            verdict: StandDownBuild::Unknown,
+            line: format!(
+                "[tcr] note build-skew-unknown: {keys} — cannot tell whether the proxy on :{port} \
+                 is running this binary's code. `tcr --replace` restarts the port onto this binary."
+            ),
+        };
     }
     if !same_commit(&running.sha, &ours.sha) {
-        return format!(
-            "[tcr] WARNING stale-server: {keys} — the proxy on :{port} is NOT running this \
-             binary's code and will keep serving its own until it is restarted. \
-             `tcr --replace` takes the port over with this build."
-        );
+        return StandDownReport {
+            verdict: StandDownBuild::Stale,
+            line: format!(
+                "[tcr] WARNING stale-server: {keys} — the proxy on :{port} is NOT running this \
+                 binary's code and will keep serving its own until it is restarted. \
+                 `tcr --replace` takes the port over with this build."
+            ),
+        };
     }
-    if running.dirty.unwrap_or(false) || ours.dirty.unwrap_or(false) {
-        return format!(
-            "[tcr] note dirty-build: {keys} — the shas match but at least one side was compiled \
-             from an uncommitted tree, so this is not proof the proxy on :{port} is running this \
-             binary's code."
-        );
+    if running.dirty.unwrap_or(false) || ours_dirty {
+        return StandDownReport {
+            verdict: StandDownBuild::DirtyBuild,
+            line: format!(
+                "[tcr] note dirty-build: {keys} — the shas match but at least one side is not \
+                 provably this commit's code (a build was compiled from an uncommitted tree, or \
+                 this checkout has uncommitted changes now — a build stamp cannot see edits made \
+                 since the last commit). Not proof the proxy on :{port} is running this binary."
+            ),
+        };
     }
-    format!("[tcr] build in sync: {keys} — the proxy on :{port} is running this binary's commit.")
+    StandDownReport {
+        verdict: StandDownBuild::InSync,
+        line: format!(
+            "[tcr] build in sync: {keys} — the proxy on :{port} is running this binary's commit."
+        ),
+    }
 }
 
 /// Two shas name the same commit when the shorter is a prefix of the longer.
@@ -631,11 +711,18 @@ mod tests {
     /// must be LOUD, name both builds, and name the escape hatch.
     #[test]
     fn standing_down_on_a_different_build_warns_loudly() {
-        let line = stand_down_build_line(
+        let report = stand_down_build_report(
             3456,
             &build("9f3a1b2", Some(false)),
             Some(&build("cd146ce", Some(false))),
+            None,
         );
+        assert_eq!(
+            report.verdict,
+            StandDownBuild::Stale,
+            "the verdict, not just the wording, is what main exits on"
+        );
+        let line = report.line;
         assert!(line.contains("stale-server"), "greppable token: {line}");
         assert!(line.contains("running=cd146ce"), "names the server: {line}");
         assert!(
@@ -649,7 +736,9 @@ mod tests {
     /// agreement — and it still has to point at the two commands that resolve it.
     #[test]
     fn standing_down_with_no_answer_from_the_incumbent_says_so() {
-        let line = stand_down_build_line(3456, &build("9f3a1b2", Some(false)), None);
+        let report = stand_down_build_report(3456, &build("9f3a1b2", Some(false)), None, None);
+        assert_eq!(report.verdict, StandDownBuild::Unknown);
+        let line = report.line;
         assert!(line.contains("build-skew-unknown"), "{line}");
         assert!(
             !line.contains("in sync"),
@@ -657,20 +746,107 @@ mod tests {
         );
         assert!(line.contains("tcr status"), "{line}");
         assert!(line.contains("--replace"), "{line}");
+        // The KEY SPELLING, not just the value. Every other branch emits
+        // `this_binary=`; this branch used to write `this binary=` with a space,
+        // so `grep 'this_binary='` over tcr's stderr silently dropped the one
+        // case that most needs surfacing — the incumbent would not say what it
+        // is running. The module's contract (see `Skew::report_line`) is that
+        // every line is `token key=value …`, so the key is the assertion.
+        assert!(
+            line.contains("this_binary=9f3a1b2"),
+            "the sha must carry the same greppable key as every other branch: {line}"
+        );
+        assert!(
+            !line.contains("this binary="),
+            "a space here breaks `grep this_binary=`: {line}"
+        );
     }
 
     /// Matching shas, both clean: say so plainly. This is the ordinary case and it
     /// must not carry a warning, or the warning stops being read.
     #[test]
     fn standing_down_on_the_same_build_is_quiet() {
-        let line = stand_down_build_line(
+        let report = stand_down_build_report(
             3456,
             &build("cd146ce", Some(false)),
             Some(&build("cd146ce", Some(false))),
+            // A checkout that is clean AT our commit corroborates the stamps.
+            Some(&checkout("cd146ce", Some(false), None)),
         );
+        assert_eq!(report.verdict, StandDownBuild::InSync);
+        let line = report.line;
         assert!(line.contains("in sync"), "{line}");
         assert!(!line.contains("WARNING"), "{line}");
         assert!(!line.contains("stale-server"), "{line}");
+        assert!(line.contains("checkout_dirty=false"), "{line}");
+    }
+
+    /// THE STALE-STAMP CASE, and the reason this function takes a live checkout.
+    ///
+    /// `build.rs` re-runs only when a git ref MOVES — its own doc says editing a
+    /// tracked file and rebuilding does not restamp — so the ordinary
+    /// edit → `cargo build --release` → `tcr` loop leaves BOTH `dirty` stamps
+    /// reading `false` at the SAME sha. Comparing the two stamps against each
+    /// other therefore prints "build in sync" for a proxy that predates the edit:
+    /// the developer reads exit 0 plus "in sync" as "my fix is live" and debugs
+    /// against a binary that cannot contain it. The live read is the only input
+    /// that can see the edit, which is exactly why `compare` takes one too.
+    #[test]
+    fn a_live_dirty_checkout_beats_a_stale_clean_build_stamp() {
+        let stamps_say_clean = || build("cd146ce", Some(false));
+        // Control: with no live checkout to consult, the stamps are all we have
+        // and the old (wrong-in-this-scenario) verdict is the honest best effort.
+        assert_eq!(
+            stand_down_build_report(3456, &stamps_say_clean(), Some(&stamps_say_clean()), None)
+                .verdict,
+            StandDownBuild::InSync,
+            "without a checkout there is no evidence of the edit"
+        );
+
+        // The real loop: same commit, both stamps stale-clean, and the checkout
+        // has uncommitted tracked changes RIGHT NOW.
+        let report = stand_down_build_report(
+            3456,
+            &stamps_say_clean(),
+            Some(&stamps_say_clean()),
+            Some(&checkout("cd146ce", Some(true), None)),
+        );
+        assert_eq!(
+            report.verdict,
+            StandDownBuild::DirtyBuild,
+            "an edited checkout at our own commit is not proof of a match"
+        );
+        assert!(
+            !report.line.contains("in sync"),
+            "the false all-clear this function exists to prevent: {}",
+            report.line
+        );
+        assert!(report.line.contains("dirty-build"), "{}", report.line);
+        assert!(
+            report.line.contains("checkout_dirty=true"),
+            "the live evidence has to be IN the line, or the verdict is unexplainable: {}",
+            report.line
+        );
+    }
+
+    /// The live read is scoped to OUR commit. A checkout sitting on a different
+    /// commit says nothing about whether this binary matches the one it claims,
+    /// and must not manufacture a `dirty-build` note out of an unrelated tree —
+    /// `tcr status`/[`compare`] is what reports a moved HEAD.
+    #[test]
+    fn a_dirty_checkout_at_another_commit_does_not_taint_the_verdict() {
+        let report = stand_down_build_report(
+            3456,
+            &build("cd146ce", Some(false)),
+            Some(&build("cd146ce", Some(false))),
+            Some(&checkout("9f3a1b2", Some(true), Some(3))),
+        );
+        assert_eq!(report.verdict, StandDownBuild::InSync);
+        assert!(
+            report.line.contains("checkout_dirty=unknown"),
+            "unmeasured for THIS commit is `unknown`, never a bare `false`: {}",
+            report.line
+        );
     }
 
     /// A dirty build on either side: the shas match and the code still may not.
@@ -678,11 +854,14 @@ mod tests {
     #[test]
     fn standing_down_never_claims_a_dirty_build_is_in_sync() {
         for (ours, theirs) in [(Some(true), Some(false)), (Some(false), Some(true))] {
-            let line = stand_down_build_line(
+            let report = stand_down_build_report(
                 3456,
                 &build("cd146ce", ours),
                 Some(&build("cd146ce", theirs)),
+                Some(&checkout("cd146ce", Some(false), None)),
             );
+            assert_eq!(report.verdict, StandDownBuild::DirtyBuild);
+            let line = report.line;
             assert!(line.contains("dirty-build"), "{line}");
             assert!(!line.contains("in sync"), "{line}");
         }
@@ -692,11 +871,14 @@ mod tests {
     /// manufacturing a stale-server warning out of a missing field.
     #[test]
     fn standing_down_on_an_unknown_sha_is_indeterminate_not_stale() {
-        let line = stand_down_build_line(
+        let report = stand_down_build_report(
             3456,
             &build("cd146ce", Some(false)),
             Some(&BuildInfo::default()),
+            None,
         );
+        assert_eq!(report.verdict, StandDownBuild::Unknown);
+        let line = report.line;
         assert!(line.contains("build-skew-unknown"), "{line}");
         assert!(!line.contains("stale-server"), "{line}");
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -659,15 +659,63 @@ pub async fn list_accounts(config_path: &Path, probe: bool) -> anyhow::Result<()
 }
 
 /// Why a live status read did not produce a payload.
+///
+/// The three variants are not interchangeable, and collapsing them is what made
+/// a wedged proxy unrecoverable: [`incumbent_liveness`] turns them into
+/// "is anything actually serving on this port", and that answer is the
+/// difference between "leave a working proxy alone" and "this process is holding
+/// the socket and answering nothing".
 enum LiveStatusError {
     /// Nothing is listening on the configured port — the ORDINARY case (`tcr
     /// status` with no server running). Falling back is expected, so it is
     /// reported by the `offline` label alone rather than by a warning.
     NoServer,
-    /// A server answered but the read was not usable. Always warned about: a
-    /// silently-swallowed rejection here would look exactly like "no server",
-    /// which is how an api-key typo becomes a mysterious all-zero status.
+    /// Something is listening but produced no response before the deadline: no
+    /// bytes back within the 2s connect / 5s total budget, or the connection
+    /// dropped mid-read. This is the WEDGED shape.
+    NoAnswer(String),
+    /// A server answered — an HTTP response came back — but the read was not
+    /// usable: a rejected api-key, an older tcr with no status route, a payload
+    /// that is not ours. The process is SERVING; we just cannot read it. Always
+    /// warned about: a silently-swallowed rejection here would look exactly like
+    /// "no server", which is how an api-key typo becomes a mysterious all-zero
+    /// status.
     Unusable(String),
+}
+
+impl LiveStatusError {
+    /// Did an HTTP response come back at all?
+    ///
+    /// The load-bearing distinction for the startup stand-down. A 401 or an
+    /// unparseable body is a process that ACCEPTED the connection, routed the
+    /// request and wrote a response — the opposite of wedged — while a timeout
+    /// means the listening socket is all that is left of it.
+    fn answered(&self) -> bool {
+        matches!(self, LiveStatusError::Unusable(_))
+    }
+
+    fn why(&self) -> String {
+        match self {
+            LiveStatusError::NoServer => "nothing is listening".to_string(),
+            LiveStatusError::NoAnswer(why) | LiveStatusError::Unusable(why) => why.clone(),
+        }
+    }
+}
+
+/// Whether the incumbent holding the port is actually serving anything.
+///
+/// Deliberately NOT `Option<BuildInfo>::is_none()`. That conflates four states,
+/// two of which are a perfectly healthy proxy: an api-key mismatch and an older
+/// `tcr` with no status route both answer, and killing either would be a
+/// takeover of a live server on the strength of a diagnostic read failing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Liveness {
+    /// It answered. Whatever else is true, it is serving requests.
+    Answering,
+    /// Nothing came back before the deadline. It holds the socket and serves
+    /// nothing; `why` is the probe's own account of what happened, for the
+    /// operator-facing line.
+    Silent { why: String },
 }
 
 /// Read the live fleet snapshot from the running proxy's [`crate::proxy::STATUS_PATH`].
@@ -702,11 +750,13 @@ async fn fetch_live_status(config: &Config) -> Result<StatusPayload, LiveStatusE
         Ok(r) => r,
         Err(e) if e.is_connect() => return Err(LiveStatusError::NoServer),
         Err(e) if e.is_timeout() => {
-            return Err(LiveStatusError::Unusable(
+            return Err(LiveStatusError::NoAnswer(
                 "the server did not answer within 5s".to_string(),
             ))
         }
-        Err(e) => return Err(LiveStatusError::Unusable(e.to_string())),
+        // No response object came back, and it was neither a refused connect nor
+        // the deadline: a reset or a truncated read. Nothing was served.
+        Err(e) => return Err(LiveStatusError::NoAnswer(e.to_string())),
     };
 
     let status = response.status();
@@ -737,17 +787,39 @@ async fn fetch_live_status(config: &Config) -> Result<StatusPayload, LiveStatusE
     Ok(payload)
 }
 
-/// Best-effort read of the build the RUNNING proxy is executing.
+/// One probe of the incumbent on the port, answering BOTH questions the startup
+/// stand-down has to decide on.
 ///
-/// For the startup stand-down path in `main`: when a healthy incumbent holds the
-/// port we exit instead of replacing it, and the user needs to know whether the
-/// build they just compiled is the one serving. `None` on ANY failure — no
-/// server, a rejected key, an older tcr with no status route — because this is a
-/// diagnostic on a path that is already exiting, never a dependency of startup.
-/// Bounded by [`fetch_live_status`]'s own 2s connect / 5s total timeouts, so it
-/// cannot hang.
-pub async fn live_server_build(config: &Config) -> Option<BuildInfo> {
-    fetch_live_status(config).await.ok().map(|p| p.build)
+/// * `build` — which commit it is executing, so the user learns whether the
+///   binary they just compiled is the one serving. `None` on any failure to read
+///   it; this is a diagnostic on a path that is already exiting.
+/// * `liveness` — whether it responded AT ALL. Separate from `build` on purpose:
+///   `build == None` is true for a healthy proxy behind a rejected api-key and
+///   for one wedged solid, and the stand-down must not treat those alike.
+///
+/// One probe, not two, so the decision and the message can never disagree about
+/// what the incumbent did. Bounded by [`fetch_live_status`]'s own 2s connect /
+/// 5s total timeouts, so it cannot hang.
+pub struct IncumbentProbe {
+    pub build: Option<BuildInfo>,
+    pub liveness: Liveness,
+}
+
+pub async fn probe_incumbent(config: &Config) -> IncumbentProbe {
+    match fetch_live_status(config).await {
+        Ok(payload) => IncumbentProbe {
+            build: Some(payload.build),
+            liveness: Liveness::Answering,
+        },
+        Err(err) => IncumbentProbe {
+            build: None,
+            liveness: if err.answered() {
+                Liveness::Answering
+            } else {
+                Liveness::Silent { why: err.why() }
+            },
+        },
+    }
 }
 
 /// `tcr status [--json]` — render the fleet as greppable text or a JSON array,
@@ -778,7 +850,10 @@ pub async fn status(config_path: &Path, json: bool) -> anyhow::Result<()> {
             (StatusSource::Live, Some(build), snapshot, thresholds)
         }
         Err(reason) => {
-            if let LiveStatusError::Unusable(why) = reason {
+            // Both "it answered something unusable" and "it answered nothing"
+            // warn; only the ordinary no-server case stays quiet.
+            if !matches!(reason, LiveStatusError::NoServer) {
+                let why = reason.why();
                 eprintln!(
                     "[tcr] warning: could not read live status from the proxy on :{} ({why}) — falling back to an offline snapshot, whose serving counters are all zero.",
                     config.proxy.port
@@ -1319,7 +1394,7 @@ mod tests {
         let payload = match fetch_live_status(&config).await {
             Ok(p) => p,
             Err(LiveStatusError::NoServer) => panic!("the spawned server did not answer"),
-            Err(LiveStatusError::Unusable(why)) => panic!("live status unusable: {why}"),
+            Err(err) => panic!("live status unusable: {}", err.why()),
         };
         let build = payload.build.clone();
         let (snapshot, thresholds) = payload.into_snapshot();
@@ -1437,11 +1512,95 @@ mod tests {
 
         match fetch_live_status(&config).await {
             Err(LiveStatusError::NoServer) => {}
-            Err(LiveStatusError::Unusable(why)) => {
-                panic!("a dead port is the ordinary no-server case, not a warning: {why}")
-            }
+            Err(err) => panic!(
+                "a dead port is the ordinary no-server case, not a warning: {}",
+                err.why()
+            ),
             Ok(_) => panic!("nothing is listening on {port}"),
         }
+    }
+
+    // --- incumbent liveness -------------------------------------------------
+
+    /// THE CASE THAT MUST NOT BE A TAKEOVER. A healthy proxy whose api-key we do
+    /// not have answers `401` — it accepted the connection, routed the request
+    /// and wrote a response, which is the opposite of wedged. `build` is `None`
+    /// here exactly as it is for a wedged proxy, so a stand-down that decided on
+    /// `build.is_none()` would SIGKILL a server that is serving every request
+    /// fine. The liveness verdict is what separates them.
+    #[tokio::test]
+    async fn a_rejected_api_key_is_an_answering_incumbent_not_a_wedged_one() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let mut served = load_from(TWO_ACCOUNTS);
+        served.proxy.port = port;
+        served.proxy.api_key = Some("the-real-key".to_string());
+
+        let manager = Manager::with_live_refresher(served.clone(), None);
+        tokio::spawn(async move { crate::mitm::serve(listener, manager, None).await });
+
+        // Same port, WRONG key — what an operator with a stale config has.
+        let mut probing = served.clone();
+        probing.proxy.api_key = Some("the-wrong-key".to_string());
+        let probe = probe_incumbent(&probing).await;
+
+        assert!(
+            probe.build.is_none(),
+            "the build read fails, which is precisely why it cannot be the liveness signal"
+        );
+        assert_eq!(
+            probe.liveness,
+            Liveness::Answering,
+            "a 401 is a serving process; taking its port would be a takeover of a healthy proxy"
+        );
+    }
+
+    /// The WEDGED shape: something holds the listening socket, the connect even
+    /// succeeds off the kernel backlog, and no response is ever written. This is
+    /// the state a deadlocked proxy leaves the port in, and the one the startup
+    /// stand-down has to be able to name — before this, `tcr` reported it as a
+    /// healthy incumbent and exited 0, and the port was unrecoverable.
+    ///
+    /// Costs the probe's own 5s deadline by construction: the assertion IS that
+    /// we wait for it and then call it silent.
+    #[tokio::test]
+    async fn a_listener_that_never_answers_is_silent_not_answering() {
+        // Bound and never accepted: connections queue in the backlog forever.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let mut config = load_from(TWO_ACCOUNTS);
+        config.proxy.port = port;
+
+        let probe = probe_incumbent(&config).await;
+        assert!(probe.build.is_none());
+        match probe.liveness {
+            Liveness::Silent { why } => assert!(
+                !why.is_empty(),
+                "the operator-facing line needs the probe's own account of what happened"
+            ),
+            Liveness::Answering => {
+                panic!("a socket that never wrote a byte is not an answering proxy")
+            }
+        }
+        drop(listener);
+    }
+
+    /// The classification the two tests above exercise, pinned directly so a
+    /// future variant cannot be added on the wrong side of it by accident.
+    #[test]
+    fn only_an_http_response_counts_as_answered() {
+        assert!(
+            !LiveStatusError::NoServer.answered(),
+            "nothing listening answered nothing"
+        );
+        assert!(
+            !LiveStatusError::NoAnswer("the server did not answer within 5s".into()).answered(),
+            "a deadline with no bytes back is the wedged shape"
+        );
+        assert!(
+            LiveStatusError::Unusable("HTTP 401 Unauthorized".into()).answered(),
+            "an HTTP response — any HTTP response — means the process is serving"
+        );
     }
 
     // --- no-persist guarantee ----------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,9 +186,16 @@ struct ServerArgs {
     replace: bool,
     /// DEPRECATED and now a no-op: this is the default. Kept accepted so existing
     /// scripts and launch agents that pass it keep working. Pass `--replace` for
-    /// the old default (take the port over); if both are given, this one wins,
-    /// since the safe outcome is the one that touches nothing.
-    #[arg(long)]
+    /// the old default (take the port over).
+    ///
+    /// `conflicts_with` rather than a silent precedence rule: the two flags are a
+    /// contradiction, and the previous wiring resolved it by quietly discarding
+    /// `--replace`. An operator whose launchd plist or shell alias already carries
+    /// `--no-replace`, adding `--replace` to force a rebuilt binary onto the port,
+    /// got a stand-down and exit 0 — while `--help` told them the flag they left
+    /// in place does nothing. clap now rejects the pair by name, which is the only
+    /// outcome that cannot be misread.
+    #[arg(long, conflicts_with = "replace")]
     no_replace: bool,
 }
 
@@ -467,6 +474,48 @@ async fn run_login(args: LoginArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// A stand-down that resolved cleanly: a peer proxy holds the port and is
+/// serving this binary's code (or something we have no reason to doubt).
+const EXIT_STOOD_DOWN_OK: i32 = 0;
+/// A stand-down where the incumbent is serving a DIFFERENT commit than the
+/// binary that was just run.
+///
+/// `cargo build && tcr` used to GUARANTEE the new binary was serving; standing
+/// down silently broke that guarantee, and a warning on stderr is routinely
+/// unread in a headless or piped context. This is the machine-readable half, so
+/// `tcr && <next step>` stops instead of proceeding as if the new build were
+/// live. Not `1`: that is a genuine startup failure, and not `2`, which clap
+/// uses for a usage error.
+const EXIT_STOOD_DOWN_STALE: i32 = 3;
+/// A stand-down where the incumbent never answered the liveness probe — it holds
+/// the listening socket and serves nothing. Distinct from [`EXIT_STOOD_DOWN_STALE`]
+/// because the operator's next command is different: `--replace` is a recovery
+/// here, not an upgrade.
+const EXIT_STOOD_DOWN_NOT_ANSWERING: i32 = 4;
+
+/// The stand-down's exit code, as a pure function of what was actually measured.
+///
+/// Keyed on the probe's verdict values, never on the rendered sentence: an exit
+/// code grepped out of our own prose is a gate any rewording silently disarms.
+///
+/// Liveness outranks build skew because it is the more urgent fact — nothing is
+/// serving at all — and because a proxy that would not answer also could not
+/// report a build, so its build verdict is `Unknown` by construction.
+fn stand_down_exit_code(liveness: &cli::Liveness, verdict: build_info::StandDownBuild) -> i32 {
+    if matches!(liveness, cli::Liveness::Silent { .. }) {
+        return EXIT_STOOD_DOWN_NOT_ANSWERING;
+    }
+    match verdict {
+        build_info::StandDownBuild::Stale => EXIT_STOOD_DOWN_STALE,
+        // `Unknown` stays 0: an older tcr that answers but ships no build stamp
+        // is a working proxy, and failing every such start would be noise for a
+        // question that was never answered either way.
+        build_info::StandDownBuild::InSync
+        | build_info::StandDownBuild::DirtyBuild
+        | build_info::StandDownBuild::Unknown => EXIT_STOOD_DOWN_OK,
+    }
+}
+
 async fn run_server(args: ServerArgs) -> anyhow::Result<()> {
     let config_path = args.config.clone().unwrap_or_else(config::default_path);
     let (mut config, persist_path) = load_config(&config_path);
@@ -479,24 +528,43 @@ async fn run_server(args: ServerArgs) -> anyhow::Result<()> {
 
     // Resolve the port to ONE proxy BEFORE the Manager starts probing/refreshing,
     // so our own startup can never token-war with the incumbent. Only a
-    // command-verified teamclaude/tcr server on THIS port is ever signalled — and
-    // only under `--replace`. `--no-replace` is the default now, so passing it
-    // simply withholds `--replace`.
-    if let singleton::Takeover::IncumbentPresent(_pid) =
-        singleton::takeover_port(port, args.replace && !args.no_replace)
+    // command-verified teamclaude/tcr server on THIS port is ever signalled — a
+    // `tcr` peer only under `--replace`, a legacy JS `teamclaude` always, since
+    // displacing that one is what the takeover exists for. `--no-replace` is the
+    // default now, and clap rejects it alongside `--replace`.
+    if let singleton::Takeover::IncumbentPresent(pid) = singleton::takeover_port(port, args.replace)
     {
+        // ONE probe of the incumbent, answering two questions: which build it is
+        // executing, and whether it is executing anything at all.
+        let probe = cli::probe_incumbent(&config).await;
+        // Read the checkout LIVE. The build stamps alone cannot see an edit made
+        // since the last commit (build.rs re-runs only when a git ref moves), so
+        // comparing two stamps would print "build in sync" for a proxy that
+        // predates the edit — see `build_info::stand_down_build_report`.
+        let checkout = std::env::current_dir()
+            .ok()
+            .and_then(|cwd| build_info::find_tcr_checkout(&cwd))
+            .map(|root| build_info::read_checkout_state(&root, build_info::SHA));
         // Standing down is cheap and correct, but silent success here would mean
         // `cargo build && tcr` exits 0 with the OLD build still serving — say which
         // build actually holds the port before we go.
-        eprintln!(
-            "{}",
-            build_info::stand_down_build_line(
-                port,
-                &build_info::BuildInfo::current(),
-                cli::live_server_build(&config).await.as_ref(),
-            )
+        let report = build_info::stand_down_build_report(
+            port,
+            &build_info::BuildInfo::current(),
+            probe.build.as_ref(),
+            checkout.as_ref(),
         );
-        return Ok(());
+        eprintln!("{}", report.line);
+        if let cli::Liveness::Silent { why } = &probe.liveness {
+            eprintln!(
+                "[tcr] WARNING incumbent-not-answering: port={port} pid={pid} probe={why:?} — the \
+                 process holding :{port} did not respond, so standing down leaves NOTHING serving \
+                 on it. Run `tcr --replace` to take the port over; that is the recovery for a \
+                 wedged proxy, and it is not being done automatically because it also wipes the \
+                 pin map of a proxy that was merely slow to answer."
+            );
+        }
+        std::process::exit(stand_down_exit_code(&probe.liveness, report.verdict));
     }
 
     let manager = Manager::with_live_refresher(config, persist_path);
@@ -726,7 +794,104 @@ fn init_tracing(headless: bool) {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use build_info::StandDownBuild;
+    use clap::Parser as _;
     use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
+
+    fn silent() -> cli::Liveness {
+        cli::Liveness::Silent {
+            why: "the server did not answer within 5s".to_string(),
+        }
+    }
+
+    /// The ordinary stand-down: a peer is serving this binary's commit. Exit 0,
+    /// or every `tcr` in a script becomes a failure.
+    #[test]
+    fn a_clean_stand_down_exits_zero() {
+        for verdict in [
+            StandDownBuild::InSync,
+            StandDownBuild::DirtyBuild,
+            StandDownBuild::Unknown,
+        ] {
+            assert_eq!(
+                stand_down_exit_code(&cli::Liveness::Answering, verdict),
+                0,
+                "{verdict:?} is a working incumbent"
+            );
+        }
+    }
+
+    /// DETECTED BUILD SKEW MUST NOT EXIT 0. The whole point of the stale-server
+    /// warning is that `cargo build && tcr` no longer guarantees the new binary
+    /// is serving; returning success anyway leaves the guarantee broken for every
+    /// script, CI step and launchd job, which read the code and not the stderr.
+    #[test]
+    fn a_stale_incumbent_exits_non_zero() {
+        let code = stand_down_exit_code(&cli::Liveness::Answering, StandDownBuild::Stale);
+        assert_ne!(code, 0, "a detected skew must be visible to `tcr && next`");
+        assert_ne!(code, 1, "1 is a genuine startup failure");
+        assert_ne!(code, 2, "2 is clap's usage error");
+        assert_eq!(code, EXIT_STOOD_DOWN_STALE);
+    }
+
+    /// THE WEDGED PROXY. Nothing is serving on the port, so exiting 0 tells every
+    /// caller — and TcrBar — that the server is up. The code has to say
+    /// otherwise, and it outranks the build verdict: a proxy that will not answer
+    /// cannot report a build either, so `Unknown` is what it always comes with.
+    #[test]
+    fn a_silent_incumbent_exits_its_own_non_zero_code() {
+        assert_eq!(
+            stand_down_exit_code(&silent(), StandDownBuild::Unknown),
+            EXIT_STOOD_DOWN_NOT_ANSWERING
+        );
+        assert_ne!(EXIT_STOOD_DOWN_NOT_ANSWERING, 0);
+        assert_ne!(
+            EXIT_STOOD_DOWN_NOT_ANSWERING, EXIT_STOOD_DOWN_STALE,
+            "the two need different recoveries, so they need different codes"
+        );
+        // Liveness outranks every build verdict, including a comparable one.
+        assert_eq!(
+            stand_down_exit_code(&silent(), StandDownBuild::InSync),
+            EXIT_STOOD_DOWN_NOT_ANSWERING,
+            "a matching sha from a process that answers nothing is not a healthy port"
+        );
+    }
+
+    /// `--no-replace` is documented as a deprecated no-op, and used to be wired as
+    /// a SILENT VETO over `--replace`: an operator whose launchd plist or alias
+    /// already carried it, adding `--replace` to force a rebuilt binary onto the
+    /// port, took over nothing and got exit 0. clap must reject the contradiction
+    /// by name instead.
+    #[test]
+    fn replace_and_no_replace_together_are_a_usage_error() {
+        let err = Cli::try_parse_from(["tcr", "server", "--replace", "--no-replace"])
+            .expect_err("the pair is a contradiction, not a precedence puzzle");
+        assert_eq!(
+            err.kind(),
+            clap::error::ErrorKind::ArgumentConflict,
+            "it must fail as a conflict, not as some other parse error: {err}"
+        );
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("--no-replace") && rendered.contains("--replace"),
+            "the message must name BOTH flags so the operator knows what to remove: {rendered}"
+        );
+    }
+
+    /// Each flag alone still parses — the deprecated one is accepted, as promised
+    /// to the scripts and launch agents that already pass it.
+    #[test]
+    fn each_replace_flag_alone_still_parses() {
+        for args in [
+            vec!["tcr", "server", "--replace"],
+            vec!["tcr", "server", "--no-replace"],
+            vec!["tcr", "--no-replace"],
+            vec!["tcr", "server"],
+        ] {
+            Cli::try_parse_from(&args).unwrap_or_else(|e| panic!("{args:?} must parse: {e}"));
+        }
+    }
 
     /// The TUI log file (account emails + request paths) must be created
     /// owner-only. `.mode(0o600)` carries only owner bits, so it survives any

--- a/src/main.rs
+++ b/src/main.rs
@@ -857,6 +857,92 @@ mod tests {
         );
     }
 
+    /// THE EXIT CODES ARE A CROSS-LANGUAGE CONTRACT, exactly like
+    /// `singleton::INCUMBENT_MARKER`, and nothing but this test couples them.
+    ///
+    /// TcrBar switches on the numbers: `ServerController.StandDownExit` in
+    /// `apps/macos/Sources/TcrBarCore/ServerController.swift` declares
+    /// `stale = 3` and `notAnswering = 4`, and `classifyExit` turns them into
+    /// `.incumbentIsStale` and `.incumbentNotAnswering`. Renumbering a constant
+    /// here is a one-character edit that every other Rust test survives, while
+    /// the menu-bar app silently falls through to a bare `.exited(5, …)` and
+    /// reports a wedged proxy — one serving NOTHING — as a clean exit. That is
+    /// the misreport this whole round exists to eliminate.
+    ///
+    /// The numbers are SPELLED OUT rather than referenced through the constants,
+    /// deliberately: `assert_eq!(EXIT_STOOD_DOWN_STALE, EXIT_STOOD_DOWN_STALE)`
+    /// compares a value with itself and passes for every value of it. The
+    /// constant is the thing that must not drift, so the test has to hold the
+    /// other copy — the one Swift carries.
+    #[test]
+    fn the_stand_down_exit_codes_are_the_numbers_tcrbar_switches_on() {
+        // Transcribed from ServerController.StandDownExit.
+        let tcrbar_stale: i32 = 3;
+        let tcrbar_not_answering: i32 = 4;
+
+        assert_eq!(
+            EXIT_STOOD_DOWN_OK, 0,
+            "a clean stand-down is success; anything else fails every `tcr && next`"
+        );
+        assert_eq!(
+            EXIT_STOOD_DOWN_STALE, tcrbar_stale,
+            "ServerController.StandDownExit.stale is 3 — change one, change both"
+        );
+        assert_eq!(
+            EXIT_STOOD_DOWN_NOT_ANSWERING, tcrbar_not_answering,
+            "ServerController.StandDownExit.notAnswering is 4 — change one, change both"
+        );
+
+        // The constants being right is worthless if the mapping does not emit
+        // them, so the contract is asserted through the function TcrBar's input
+        // actually comes from, against the same literals.
+        assert_eq!(
+            stand_down_exit_code(&cli::Liveness::Answering, StandDownBuild::InSync),
+            0
+        );
+        assert_eq!(
+            stand_down_exit_code(&cli::Liveness::Answering, StandDownBuild::Stale),
+            3,
+            "a stale incumbent must reach Swift as .incumbentIsStale"
+        );
+        assert_eq!(
+            stand_down_exit_code(&silent(), StandDownBuild::Unknown),
+            4,
+            "a wedged incumbent must reach Swift as .incumbentNotAnswering"
+        );
+
+        // Liveness outranks build skew across the boundary too: a proxy that
+        // answers nothing is not merely stale, and 4 must win over 3 — the
+        // operator's next command differs (recover, not upgrade).
+        assert_eq!(
+            stand_down_exit_code(&silent(), StandDownBuild::Stale),
+            4,
+            "NOT SERVING outranks a stale build; reporting 3 here understates it"
+        );
+
+        // Three outcomes, three codes. Two of them collapsing would make the
+        // Swift switch pick one arm for both.
+        let codes = [
+            EXIT_STOOD_DOWN_OK,
+            EXIT_STOOD_DOWN_STALE,
+            EXIT_STOOD_DOWN_NOT_ANSWERING,
+        ];
+        for (i, a) in codes.iter().enumerate() {
+            for b in &codes[i + 1..] {
+                assert_ne!(a, b, "the stand-down codes must stay distinct: {codes:?}");
+            }
+        }
+        // And neither may take a code that already means something else.
+        assert!(
+            !codes[1..].contains(&1),
+            "1 is a genuine startup failure (anyhow::Error out of main)"
+        );
+        assert!(
+            !codes[1..].contains(&2),
+            "2 is clap's usage error, which TcrBar maps to the unknown-argument hint"
+        );
+    }
+
     /// `--no-replace` is documented as a deprecated no-op, and used to be wired as
     /// a SILENT VETO over `--replace`: an operator whose launchd plist or alias
     /// already carried it, adding `--replace` to force a rebuilt binary onto the

--- a/src/main.rs
+++ b/src/main.rs
@@ -796,7 +796,6 @@ fn init_tracing(headless: bool) {
 mod tests {
     use super::*;
     use build_info::StandDownBuild;
-    use clap::Parser as _;
     use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
 
     fn silent() -> cli::Liveness {
@@ -865,8 +864,11 @@ mod tests {
     /// by name instead.
     #[test]
     fn replace_and_no_replace_together_are_a_usage_error() {
-        let err = Cli::try_parse_from(["tcr", "server", "--replace", "--no-replace"])
-            .expect_err("the pair is a contradiction, not a precedence puzzle");
+        // `let Err(..) else`, not `expect_err`: the Ok side is `Cli`, which does
+        // not implement Debug (nor should it — it would print the config path).
+        let Err(err) = Cli::try_parse_from(["tcr", "server", "--replace", "--no-replace"]) else {
+            panic!("the pair is a contradiction, not a precedence puzzle — clap accepted it");
+        };
         assert_eq!(
             err.kind(),
             clap::error::ErrorKind::ArgumentConflict,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -241,16 +241,48 @@ fn soft_wait_secs(soonest_free_secs: i64, already_waited: bool) -> Option<u64> {
     }
 }
 
-/// The rotation loop's TOTAL attempt budget for a fleet of `account_count` — two
-/// sends per account plus a small constant, so the per-account retry ladders (401
-/// force-refresh, transient-429 inline wait, the 529 backoff ladder and its
-/// failovers) can never spin [`handle`]'s loop.
+/// The most upstream sends ONE account can absorb inside a single client
+/// request, derived from the per-account ladders rather than guessed.
 ///
-/// Extracted from the loop so the headroom assertion in
-/// `overloaded_529_failover_worst_case_latency_is_bounded` binds THIS formula
-/// instead of a copy of it that could silently drift from it.
+/// Every term is a counter in [`handle`] that is monotone per account, so this
+/// is a real ceiling and not an estimate:
+///
+/// * `1` — the send itself.
+/// * `1` — the same-account transport retry (`transport_retried`).
+/// * `1` — the 401 force-refresh retry (`forced_401`).
+/// * [`MAX_SAME_ACCOUNT_429`] — transient-429 inline waits (`retried_429`).
+/// * [`MAX_SAME_ACCOUNT_529_RETRIES`] — 529 in-place backoffs (`retried_529`).
+const MAX_SENDS_PER_ACCOUNT: usize =
+    3 + MAX_SAME_ACCOUNT_429 as usize + MAX_SAME_ACCOUNT_529_RETRIES as usize;
+
+/// The rotation loop's TOTAL attempt budget for a fleet of `account_count`: the
+/// per-account ladder ceiling times the fleet, plus a small constant for the
+/// iterations that consume a turn without sending (the one-shot exhaustion
+/// soft-wait). Bounds [`handle`]'s loop without ever truncating a walk the
+/// ladders themselves permit.
+///
+/// It used to be `2n + 4` — "two sends per account plus a small constant" — which
+/// stopped being true when the same-account transport retry added a third
+/// potential send. The failure was silent and specifically MIXED: a blip on one
+/// account plus the 529 ladder on the next spends 4 sends per account, so a
+/// 3-account walk needs 12 against a budget of 10. The loop fell out mid-walk,
+/// `every_attempt_transport_failed` was false, and the client got a SYNTHESIZED
+/// 429 ("all accounts exhausted", with a fabricated retry-after) in place of the
+/// real 529 — or of a 200 from an account that was never tried.
+///
+/// Every ladder in the sum is independently bounded and each rung is capped
+/// (`RETRY_529_MAX_BACKOFF_SECS`, `INLINE_WAIT_MAX_SECS`), so widening this does
+/// not widen any latency ceiling; it removes a truncation, not a guard.
+///
+/// Extracted from the loop so the headroom assertions in
+/// `overloaded_529_failover_worst_case_latency_is_bounded` and
+/// `the_mixed_transport_and_529_ladder_fits_the_attempt_budget` bind THIS
+/// formula instead of a copy of it that could silently drift from it.
 fn max_attempts_for(account_count: usize) -> usize {
-    account_count.saturating_mul(2).saturating_add(4).max(1)
+    account_count
+        .saturating_mul(MAX_SENDS_PER_ACCOUNT)
+        .saturating_add(4)
+        .max(1)
 }
 
 /// The client's socket address, injected into request extensions by the hybrid

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -4943,23 +4943,126 @@ mod tests {
         );
     }
 
-    /// The same-account transport retry doubles the sends a fleet can spend on
-    /// transport alone, so the rotation loop's budget has to cover it. Asserted
-    /// against [`max_attempts_for`] itself rather than a copy of the formula: a
-    /// budget narrowed to (say) `n + 4` would silently truncate the walk on any
-    /// fleet of 5+, and the request would stop early for a reason nothing logs.
+    /// A CONNECT failure is not retried on the same account.
+    ///
+    /// The retry exists because a pooled connection can die between requests: the
+    /// error itself evicts it, so the retry gets a fresh one and the account —
+    /// which was never the failing resource — keeps its warm prompt cache. None
+    /// of that holds when the connect itself failed: there was no pooled
+    /// connection, nothing was evicted, and the second send is the identical
+    /// operation. What it does buy is a second full `connect_timeout` (10s), and
+    /// on a blackholed route (no RST, no reply) that doubles every request's
+    /// worst-case time-to-502 — ~80s to ~160s on an eight-account fleet — with a
+    /// per-account in-flight slot held for the whole of it.
+    ///
+    /// Read off the 502 the client actually receives, whose body carries the
+    /// attempt count: two accounts that each fail to connect ONCE is `2`, and the
+    /// retry firing here would make it `4`. An unreachable upstream is a dead
+    /// port — the one shape that produces `is_connect()` for real rather than by
+    /// simulation.
+    #[tokio::test]
+    async fn a_connect_failure_is_not_retried_on_the_same_account() {
+        // Bind then drop: the address is guaranteed to have been free, and now
+        // refuses. `spawn_counted_upstream`'s no-reply script cannot produce this
+        // — dropping an ACCEPTED socket is a mid-request error, not a connect one.
+        let dead = {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            listener.local_addr().unwrap()
+        };
+        let manager = fleet(dead, &["a", "b"]);
+
+        let (status, body) = post_one_with_body(manager).await;
+        assert_eq!(
+            status, 502,
+            "nothing reached an upstream, so the honest answer is a gateway error: {body}"
+        );
+        assert!(
+            body.contains("all 2 attempt(s)"),
+            "one connect attempt per account. `all 4 attempt(s)` means each was \
+             retried into a second connect timeout for no new information: {body}"
+        );
+    }
+
+    /// The MIXED ladder — a transport blip AND the 529 walk on one request — must
+    /// fit the rotation loop's budget.
+    ///
+    /// This replaces a guard that could not fail. The previous version asserted
+    /// `accounts * 2 <= max_attempts_for(accounts)` against a formula of
+    /// `2n + 4`, i.e. `2n <= 2n + 4`: true by construction for every input and
+    /// for every fleet size, so it passed unchanged through the very change it
+    /// was written to guard. A gate that cannot go red is not a gate.
+    ///
+    /// The ladder below is derived from the LADDER constants instead, so it is
+    /// an independent claim about the loop and not a restatement of the budget:
+    ///
+    /// * Each of the (up to `1 + MAX_529_FAILOVERS_PER_REQUEST`) accounts on the
+    ///   529 walk can spend `1` send, `1` transport retry, and
+    ///   `MAX_SAME_ACCOUNT_529_RETRIES` in-place retries before it fails over.
+    /// * Every remaining account in the fleet is still reachable by the plain
+    ///   transport ladder, at `1` send plus `1` retry each.
+    ///
+    /// Under the old `2n + 4` this is false from three accounts up (12 sends
+    /// against a budget of 10) — which is the truncation
+    /// [`the_mixed_ladder_forwards_the_real_529_instead_of_synthesizing_a_429`]
+    /// shows a client actually receiving.
     #[test]
-    fn the_transport_retry_ladder_fits_the_attempt_budget() {
+    fn the_mixed_transport_and_529_ladder_fits_the_attempt_budget() {
+        let walked = 1 + MAX_529_FAILOVERS_PER_REQUEST as usize;
         for accounts in 1..=16usize {
-            // Worst case: every account blips, is retried once, then benched.
-            let sends = accounts * 2;
+            let on_the_529_walk = accounts.min(walked);
+            let sends = on_the_529_walk * (2 + MAX_SAME_ACCOUNT_529_RETRIES as usize)
+                + (accounts - on_the_529_walk) * 2;
             assert!(
                 sends <= max_attempts_for(accounts),
-                "a {accounts}-account fleet can spend {sends} transport sends but the \
-                 loop allows only {} attempts",
+                "a {accounts}-account fleet can spend {sends} sends on a blip-plus-529 \
+                 ladder but the loop allows only {} attempts — the walk is truncated \
+                 mid-request and the client gets a synthesized 429",
                 max_attempts_for(accounts)
             );
         }
+    }
+
+    /// THE CLIENT-VISIBLE CONSEQUENCE of the budget above, end to end through
+    /// `handle`: a fleet where every account blips once and is then overloaded.
+    ///
+    /// Each account spends 4 sends (blip, retry, then the two in-place 529
+    /// backoffs) before failing over, so the full three-account walk is 12 —
+    /// against the old budget of `2*3 + 4 = 10`. Truncated, the loop falls out
+    /// mid-walk, `every_attempt_transport_failed` is false because upstreams did
+    /// respond, and the client is handed `exhausted_response`: HTTP 429 "All 3
+    /// accounts exhausted" with a FABRICATED retry-after, for a request whose
+    /// honest answer is the upstream's own 529. The status is the assertion; the
+    /// attempt count is what proves the whole mixed ladder actually ran rather
+    /// than the test having accidentally taken a shorter path to the same code.
+    #[tokio::test]
+    async fn the_mixed_ladder_forwards_the_real_529_instead_of_synthesizing_a_429() {
+        let blip_then_overloaded = || vec![None, Some(raw_529()), Some(raw_529()), Some(raw_529())];
+        let script: Vec<Option<String>> = (0..3).flat_map(|_| blip_then_overloaded()).collect();
+        assert_eq!(
+            script.len(),
+            12,
+            "three accounts of blip + a full 529 ladder"
+        );
+
+        let (up_addr, attempts) = spawn_counted_upstream(script).await;
+        let manager = fleet(up_addr, &["a", "b", "c"]);
+
+        let (status, body) = post_one_with_body(manager).await;
+        assert_eq!(
+            status, 529,
+            "the upstream's own 529 must reach the client, not a 429 we invented \
+             because the loop ran out of attempts: {body}"
+        );
+        assert!(
+            !body.contains("exhausted"),
+            "a synthesized exhaustion body means the walk was truncated: {body}"
+        );
+        assert_eq!(
+            attempts.load(std::sync::atomic::Ordering::SeqCst),
+            12,
+            "every rung of the mixed ladder has to have been walked — a smaller \
+             number means the request stopped early and the 529 above was luck"
+        );
     }
 
     /// A 529 is transient upstream overload, so it is retried IN PLACE — the client

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -890,6 +890,10 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
     // connection is evicted from the pool by the error itself, so the retry gets a
     // fresh one. Bounded to one per account per request: the second failure IS
     // evidence about the account, and `tried.insert` then behaves exactly as before.
+    //
+    // Gated on the error KIND at the arm below: that rationale is about a pooled
+    // connection dying, so it does not hold for a CONNECT failure, where there was
+    // no connection to evict and the retry only pays a second connect timeout.
     let mut transport_retried: HashSet<usize> = HashSet::new();
 
     for _ in 0..max_attempts {
@@ -1084,7 +1088,18 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
                 // — the only things that say WHY the connection died — are
                 // structurally unreachable from a `%` rendering. `Debug` carries the
                 // whole chain. Do not "tidy" this back to `%err`.
-                if transport_retried.insert(idx) {
+                // A CONNECT-phase failure is not a blip on a pooled connection —
+                // there was no connection. Nothing was evicted, nothing is
+                // refreshed by trying again, and the retry is the identical
+                // operation with no new information; all it buys is a second full
+                // `connect_timeout` (10s, `manager/mod.rs`) on a route that is
+                // already not answering. On a blackholed upstream (VPN drop,
+                // captive portal, edge unreachable — no RST, no reply) that
+                // doubles every request's time-to-502 — ~80s to ~160s on an
+                // 8-account fleet — while each request holds its per-account
+                // in-flight slot for the whole of it. Bench the account and let
+                // the rotation do its job.
+                if !err.is_connect() && transport_retried.insert(idx) {
                     // First blip on this account this request: retry it on a fresh
                     // connection rather than benching an account that is probably fine.
                     tracing::warn!(

--- a/src/singleton.rs
+++ b/src/singleton.rs
@@ -30,15 +30,40 @@ use std::process::Command;
 use std::thread::sleep;
 use std::time::Duration;
 
+/// Which proxy a recognized incumbent is. The distinction is load-bearing for
+/// [`takeover_decision`], not cosmetic: a `tcr` peer is a program that is doing
+/// this program's job and whose session pins cost real money to discard, while a
+/// leftover JS `teamclaude` is the thing this module was written to displace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProxyKind {
+    /// The Rust proxy — a peer of ours.
+    Tcr,
+    /// The legacy JS proxy (`node …/teamclaude server`).
+    LegacyJs,
+}
+
+/// A recognized, replaceable proxy holding the port.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Incumbent {
+    pub pid: u32,
+    pub kind: ProxyKind,
+}
+
 /// Does this command line look like a teamclaude/tcr *server* — a process safe to
 /// replace as a proxy incumbent on the port? Recognizes the JS proxy
 /// (`node …/teamclaude server`) and the Rust proxy (`…/tcr` at argv0, with the
 /// `server` subcommand, no subcommand, or a flag — since bare `tcr` defaults to the
 /// server). Never matches a bare `grep`/editor/`tcr run`/`teamclaude run`/etc.
 pub fn is_proxy_server(cmd: &str) -> bool {
+    classify_proxy_server(cmd).is_some()
+}
+
+/// [`is_proxy_server`] plus WHICH proxy it is. Same recognition rules — the bool
+/// version delegates here, so the two can never drift apart.
+pub fn classify_proxy_server(cmd: &str) -> Option<ProxyKind> {
     let tokens: Vec<&str> = cmd.split_whitespace().collect();
     if tokens.is_empty() {
-        return false;
+        return None;
     }
     let is_node = |t: &str| t == "node" || t.ends_with("/node");
     let is_teamclaude = |t: &str| t == "teamclaude" || t.ends_with("/teamclaude");
@@ -49,7 +74,7 @@ pub fn is_proxy_server(cmd: &str) -> bool {
     if let Some(i) = tokens.iter().position(|t| is_teamclaude(t)) {
         let is_program = i == 0 || is_node(tokens[i - 1]);
         if is_program && tokens.get(i + 1) == Some(&"server") {
-            return true;
+            return Some(ProxyKind::LegacyJs);
         }
     }
 
@@ -57,13 +82,13 @@ pub fn is_proxy_server(cmd: &str) -> bool {
     // NON-server verb; bare `tcr`, `tcr server`, and `tcr --flag` are all servers.
     if is_tcr(tokens[0]) {
         return match tokens.get(1).copied() {
-            None => true,
-            Some(t) if t.starts_with('-') || t == "server" => true,
-            Some(_) => false, // `tcr run`, `tcr status`, `tcr accounts`, …
+            None => Some(ProxyKind::Tcr),
+            Some(t) if t.starts_with('-') || t == "server" => Some(ProxyKind::Tcr),
+            Some(_) => None, // `tcr run`, `tcr status`, `tcr accounts`, …
         };
     }
 
-    false
+    None
 }
 
 /// The command line of `pid` (via `ps`); empty if the process is gone.
@@ -93,23 +118,25 @@ fn port_listeners(port: u16) -> Vec<u32> {
 }
 
 /// The pure takeover DECISION: of the processes holding the port, which are
-/// replaceable proxy incumbents? Excludes self and any non-proxy holder. Split out
-/// from the side-effecting kill so it is unit-testable with injected inputs.
-pub fn pids_to_replace(
+/// replaceable proxy incumbents, and which proxy is each? Excludes self and any
+/// non-proxy holder. Split out from the side-effecting kill so it is unit-testable
+/// with injected inputs.
+pub fn replaceable_incumbents(
     holders: &[u32],
     self_pid: u32,
     command: impl Fn(u32) -> String,
-) -> Vec<u32> {
+) -> Vec<Incumbent> {
     holders
         .iter()
         .copied()
-        .filter(|&pid| pid != self_pid && is_proxy_server(&command(pid)))
+        .filter(|&pid| pid != self_pid)
+        .filter_map(|pid| classify_proxy_server(&command(pid)).map(|kind| Incumbent { pid, kind }))
         .collect()
 }
 
 /// Detection-only: the PID of a live teamclaude/tcr *server* currently holding
 /// `port`, if any. Reuses the exact port-scoped, command-verified decision as
-/// [`takeover_port`] ([`pids_to_replace`]) but signals NOTHING — `tcr login` uses
+/// [`takeover_port`] ([`replaceable_incumbents`]) but signals NOTHING — `tcr login` uses
 /// it to REFUSE to run beside a live server (the server reads config only at boot,
 /// and its next `persist_tokens` writes its boot-time TOKENS back over the file,
 /// clobbering the login's fresh ones). Returns the first replaceable proxy PID;
@@ -117,9 +144,10 @@ pub fn pids_to_replace(
 /// port is free or held only by a non-proxy process.
 pub fn live_proxy_server(port: u16) -> Option<u32> {
     let holders = port_listeners(port);
-    pids_to_replace(&holders, std::process::id(), process_command)
+    replaceable_incumbents(&holders, std::process::id(), process_command)
         .into_iter()
         .next()
+        .map(|incumbent| incumbent.pid)
 }
 
 /// Is `pid` still alive? (`kill -0`.)
@@ -148,14 +176,41 @@ pub enum Takeover {
 /// The pure decision: given the replaceable incumbents on the port and whether
 /// `--replace` was passed, do we bind or stand down?
 ///
-/// Split out from the side effects for the same reason as [`pids_to_replace`] —
-/// and it is the single gate on the kill loop below, so a test that pins this
-/// function pins whether a live proxy gets signalled.
-pub fn takeover_decision(replaceable: &[u32], replace: bool) -> Takeover {
-    match replaceable.first() {
-        Some(&pid) if !replace => Takeover::IncumbentPresent(pid),
-        _ => Takeover::Proceed,
+/// Split out from the side effects for the same reason as
+/// [`replaceable_incumbents`] — and it is the single gate on the kill loop below,
+/// so a test that pins this function pins whether a live proxy gets signalled.
+///
+/// A [`ProxyKind::Tcr`] incumbent is the one that is protected by default: it is
+/// doing this program's job, and replacing it wipes its session→account pin map.
+/// A [`ProxyKind::LegacyJs`] incumbent is NOT protected, because displacing it is
+/// the reason this module exists. Standing down for it would leave the JS proxy
+/// serving forever and make `tcr` unable to complete the migration it was
+/// installed for — and the two would token-war the moment tcr did bind elsewhere.
+pub fn takeover_decision(replaceable: &[Incumbent], replace: bool) -> Takeover {
+    if replace {
+        return Takeover::Proceed;
     }
+    match replaceable
+        .iter()
+        .find(|incumbent| incumbent.kind == ProxyKind::Tcr)
+    {
+        Some(peer) => Takeover::IncumbentPresent(peer.pid),
+        None => Takeover::Proceed,
+    }
+}
+
+/// Which of the recognized incumbents this run will actually signal.
+///
+/// With `--replace`, all of them. Without it, only the legacy JS proxy — the
+/// pairing of [`takeover_decision`]'s `Proceed` with the kill loop, kept as one
+/// pure function so "we proceeded" and "we killed exactly the JS incumbents"
+/// cannot drift apart.
+fn incumbents_to_signal(replaceable: &[Incumbent], replace: bool) -> Vec<Incumbent> {
+    replaceable
+        .iter()
+        .copied()
+        .filter(|incumbent| replace || incumbent.kind == ProxyKind::LegacyJs)
+        .collect()
 }
 
 /// A marker phrase in [`stand_down_message`] that a SECOND codebase parses.
@@ -173,7 +228,8 @@ pub const INCUMBENT_MARKER: &str = "another proxy holds";
 /// marker contract above is testable.
 ///
 /// Says "is listening", NOT "is healthy". All we established is that a
-/// command-verified proxy holds the port (`pids_to_replace` -> `is_proxy_server`);
+/// command-verified proxy holds the port (`replaceable_incumbents` ->
+/// `classify_proxy_server`);
 /// nothing here probes whether it still serves. A wedged proxy holds its port just
 /// fine, and the build line printed right after this one can say the incumbent never
 /// answered — so claiming health here would both overstate the check and contradict
@@ -191,17 +247,18 @@ fn stand_down_message(port: u16, pid: u32) -> String {
 ///
 /// With `replace`, a recognized proxy incumbent is terminated (SIGTERM, then
 /// SIGKILL a survivor after a grace) so this instance can bind. Without it — the
-/// DEFAULT — the incumbent is reported and left running, and the caller is told
-/// to exit rather than bind. A non-proxy holder is reported and LEFT ALONE in
-/// both cases (the bind then fails loudly with EADDRINUSE).
+/// DEFAULT — a `tcr` incumbent is reported and left running, and the caller is
+/// told to exit rather than bind; a LEGACY JS incumbent is still replaced, since
+/// displacing it is what this module is for. A non-proxy holder is reported and
+/// LEFT ALONE in every case (the bind then fails loudly with EADDRINUSE).
 #[must_use = "the caller must exit instead of binding on IncumbentPresent"]
 pub fn takeover_port(port: u16, replace: bool) -> Takeover {
     let holders = port_listeners(port);
-    let replaceable = pids_to_replace(&holders, std::process::id(), process_command);
+    let replaceable = replaceable_incumbents(&holders, std::process::id(), process_command);
 
     // Surface a non-proxy holder (we won't kill it; the bind will fail).
     for &pid in &holders {
-        if pid != std::process::id() && !replaceable.contains(&pid) {
+        if pid != std::process::id() && !replaceable.iter().any(|i| i.pid == pid) {
             let cmd = process_command(pid);
             if !cmd.is_empty() {
                 eprintln!(
@@ -219,10 +276,15 @@ pub fn takeover_port(port: u16, replace: bool) -> Takeover {
         return Takeover::IncumbentPresent(pid);
     }
 
-    for pid in replaceable {
-        eprintln!(
-            "[tcr] replacing existing proxy on :{port} (pid {pid}) — one proxy per port, or the two mutually invalidate each other's single-use refresh tokens (token war)."
-        );
+    for Incumbent { pid, kind } in incumbents_to_signal(&replaceable, replace) {
+        match kind {
+            ProxyKind::LegacyJs => eprintln!(
+                "[tcr] replacing the legacy JS teamclaude proxy on :{port} (pid {pid}) — migrating the port to tcr; leaving it running would token-war over the same single-use refresh tokens."
+            ),
+            ProxyKind::Tcr => eprintln!(
+                "[tcr] replacing existing proxy on :{port} (pid {pid}) — one proxy per port, or the two mutually invalidate each other's single-use refresh tokens (token war)."
+            ),
+        }
         // The other half of the boot marker: in TUI mode this eprintln lands on a
         // terminal that the alternate screen is about to cover, so the durable log
         // is the only place a takeover is recoverable. Pairs with "server started"
@@ -273,8 +335,36 @@ mod tests {
         assert!(!is_proxy_server("node /path/other server"));
     }
 
+    fn tcr(pid: u32) -> Incumbent {
+        Incumbent {
+            pid,
+            kind: ProxyKind::Tcr,
+        }
+    }
+
+    fn legacy_js(pid: u32) -> Incumbent {
+        Incumbent {
+            pid,
+            kind: ProxyKind::LegacyJs,
+        }
+    }
+
     #[test]
-    fn pids_to_replace_filters_self_and_non_proxies() {
+    fn classify_names_which_proxy_it_found() {
+        assert_eq!(
+            classify_proxy_server("node /opt/nvm/bin/teamclaude server"),
+            Some(ProxyKind::LegacyJs)
+        );
+        assert_eq!(
+            classify_proxy_server("/opt/teamclaude-rs/target/release/tcr server"),
+            Some(ProxyKind::Tcr)
+        );
+        assert_eq!(classify_proxy_server("tcr"), Some(ProxyKind::Tcr));
+        assert_eq!(classify_proxy_server("/x/tcr status"), None);
+    }
+
+    #[test]
+    fn replaceable_incumbents_filters_self_and_non_proxies() {
         let command = |pid: u32| -> String {
             match pid {
                 111 => "node /x/teamclaude server".to_string(),
@@ -284,42 +374,76 @@ mod tests {
                 _ => String::new(),
             }
         };
-        // 999 is self; 333/444 are non-proxies → only 111 and 222 are replaced.
-        let replace = pids_to_replace(&[111, 222, 333, 444, 999], 999, command);
-        assert_eq!(replace, vec![111, 222]);
+        // 999 is self; 333/444 are non-proxies → only 111 and 222 survive, each
+        // carrying WHICH proxy it is, because the default treats them differently.
+        let replace = replaceable_incumbents(&[111, 222, 333, 444, 999], 999, command);
+        assert_eq!(replace, vec![legacy_js(111), tcr(222)]);
     }
 
     #[test]
-    fn pids_to_replace_never_includes_self_even_if_it_looks_like_a_proxy() {
+    fn replaceable_incumbents_never_includes_self_even_if_it_looks_like_a_proxy() {
         let command = |_pid: u32| "/x/tcr server".to_string();
-        assert!(pids_to_replace(&[42], 42, command).is_empty());
+        assert!(replaceable_incumbents(&[42], 42, command).is_empty());
     }
 
-    /// THE DEFAULT, and the whole point of the enum: a healthy proxy incumbent is
-    /// left running and the caller is told to stand down. `Proceed` here would
-    /// reach the kill loop and cost every live session its prompt cache.
+    /// THE DEFAULT, and the whole point of the enum: a healthy `tcr` PEER is left
+    /// running and the caller is told to stand down. `Proceed` here would reach
+    /// the kill loop and cost every live session its prompt cache.
     #[test]
-    fn a_healthy_incumbent_is_left_alone_by_default() {
+    fn a_healthy_tcr_peer_is_left_alone_by_default() {
         assert_eq!(
-            takeover_decision(&[4242], false),
+            takeover_decision(&[tcr(4242)], false),
             Takeover::IncumbentPresent(4242)
+        );
+        assert_eq!(
+            incumbents_to_signal(&[tcr(4242)], false),
+            vec![],
+            "a protected peer must not be signalled"
         );
     }
 
-    /// `--replace` is the ONLY way to reach the kill loop.
+    /// `--replace` is the only way to reach the kill loop for a `tcr` peer.
     #[test]
     fn replace_flag_proceeds_to_the_takeover() {
-        assert_eq!(takeover_decision(&[4242], true), Takeover::Proceed);
+        assert_eq!(takeover_decision(&[tcr(4242)], true), Takeover::Proceed);
+        assert_eq!(
+            incumbents_to_signal(&[tcr(4242)], true),
+            vec![tcr(4242)],
+            "and it is the incumbent that gets signalled"
+        );
+    }
+
+    /// THE MIGRATION CASE. `classify_proxy_server` recognizes the JS proxy
+    /// precisely so the port can be RECLAIMED from it — the failure this module's
+    /// doc-comment names. Standing down for it would leave `node …/teamclaude
+    /// server` serving every request forever, and a user who installed tcr to
+    /// replace it would never get the port without a flag nothing tells them
+    /// about. It is not a peer whose prompt cache we are protecting; it is the
+    /// other half of the token war.
+    #[test]
+    fn a_legacy_js_incumbent_is_replaced_by_default() {
+        assert_eq!(
+            takeover_decision(&[legacy_js(111)], false),
+            Takeover::Proceed,
+            "the JS proxy is the incumbent this module exists to displace"
+        );
+        assert_eq!(
+            incumbents_to_signal(&[legacy_js(111)], false),
+            vec![legacy_js(111)],
+            "proceeding past a JS incumbent means SIGNALLING it — leaving it \
+             running would land the bind on EADDRINUSE instead"
+        );
     }
 
     /// Nothing replaceable on the port — bind, with or without the flag. Covers
-    /// both the free port and the non-proxy holder, which `pids_to_replace` has
-    /// already filtered out by the time we get here (the bind then fails loudly,
-    /// which is the documented behaviour and must not change).
+    /// both the free port and the non-proxy holder, which `replaceable_incumbents`
+    /// has already filtered out by the time we get here (the bind then fails
+    /// loudly, which is the documented behaviour and must not change).
     #[test]
     fn an_empty_port_always_proceeds() {
         assert_eq!(takeover_decision(&[], false), Takeover::Proceed);
         assert_eq!(takeover_decision(&[], true), Takeover::Proceed);
+        assert_eq!(incumbents_to_signal(&[], false), vec![]);
     }
 
     /// The stand-down message is read by TcrBar's `incumbentMarkers`, in another
@@ -354,14 +478,26 @@ mod tests {
         );
     }
 
-    /// Several incumbents (a leftover JS `teamclaude` beside a `tcr`) report the
-    /// first rather than collapsing to `Proceed` — one of them is enough to make
-    /// binding wrong.
+    /// Several incumbents at once (a leftover JS `teamclaude` beside a `tcr`):
+    /// the `tcr` peer wins the protection whatever order `lsof` returned them in,
+    /// and standing down signals NOTHING — a half-kill would leave the port held
+    /// by the survivor and this process refusing to bind anyway.
     #[test]
-    fn multiple_incumbents_still_stand_down_by_default() {
-        assert_eq!(
-            takeover_decision(&[111, 222], false),
-            Takeover::IncumbentPresent(111)
-        );
+    fn a_tcr_peer_protects_the_port_even_beside_a_legacy_js_incumbent() {
+        for holders in [
+            vec![legacy_js(111), tcr(222)],
+            vec![tcr(222), legacy_js(111)],
+        ] {
+            assert_eq!(
+                takeover_decision(&holders, false),
+                Takeover::IncumbentPresent(222),
+                "the protected peer is the one named: {holders:?}"
+            );
+            assert_eq!(
+                incumbents_to_signal(&holders, false),
+                vec![],
+                "standing down kills nothing: {holders:?}"
+            );
+        }
     }
 }

--- a/src/singleton.rs
+++ b/src/singleton.rs
@@ -201,11 +201,19 @@ pub fn takeover_decision(replaceable: &[Incumbent], replace: bool) -> Takeover {
 
 /// Which of the recognized incumbents this run will actually signal.
 ///
-/// With `--replace`, all of them. Without it, only the legacy JS proxy — the
-/// pairing of [`takeover_decision`]'s `Proceed` with the kill loop, kept as one
-/// pure function so "we proceeded" and "we killed exactly the JS incumbents"
-/// cannot drift apart.
+/// Gated on [`takeover_decision`] rather than reimplementing its reasoning, so
+/// "we proceeded" and "we signalled exactly these" cannot drift apart: a
+/// stand-down signals NOTHING, including a legacy JS proxy sharing the port with
+/// the `tcr` peer we are standing down for. Half-killing there would leave the
+/// port held by the survivor and this process refusing to bind anyway — all cost,
+/// no benefit.
+///
+/// Past that gate: with `--replace`, every incumbent. Without it, only the legacy
+/// JS proxy, which is the one case that reaches `Proceed` unasked.
 fn incumbents_to_signal(replaceable: &[Incumbent], replace: bool) -> Vec<Incumbent> {
+    if takeover_decision(replaceable, replace) != Takeover::Proceed {
+        return Vec::new();
+    }
     replaceable
         .iter()
         .copied()


### PR DESCRIPTION
Follow-up to #35. An adversarial review of that PR — run after it merged — found **nine confirmed correctness defects** in it, plus one plausible race that turned out to reproduce under load. This fixes all of them.

Both halves are in one PR deliberately. They are a single cross-language contract, and landing either alone regresses the other: the Rust half alone leaves TcrBar reporting a wedged proxy as healthy, and the Swift half alone maps exit codes nothing emits.

## Rust

1. **A wedged proxy could no longer be recovered.** #35's stand-down never checked whether the incumbent was *serving*, so a hung proxy holding the listening socket blocked every restart — where the previous behavior always evicted it. `tcr` now probes once and, on silence, refuses **loudly** with `WARNING incumbent-not-answering` and exit 4 rather than standing down quietly.

   It deliberately does **not** auto-take-over: the evidence for "wedged" is a single 5s timeout, a takeover is irreversible and is the most expensive event in this system, and every future cause of an unreachable status endpoint would escalate to killing a live proxy. Because the verdict drives a message and an exit code rather than a SIGKILL, a wrong "silent" costs a sentence, not a fleet.

   Note the review's *suggested* fix — gate on `live_server_build(...).is_none()` — was not taken, because it would have been worse than the bug. That value is also `None` for a healthy proxy behind a rejected api-key (HTTP 401) or an older tcr with no status route, so it would have SIGKILLed working servers on a config typo. `LiveStatusError` is split into NoServer / NoAnswer / Unusable instead, with a test pinning the 401 case as *answering*.

2. **A leftover JS `teamclaude` incumbent** was treated as an equal peer, permanently blocking tcr from reclaiming the port the singleton exists to reclaim. Now `ProxyKind::{Tcr, LegacyJs}`: a legacy incumbent is replaced by default, a tcr peer is protected.

3. **Attempt-budget overrun.** #35's same-account retry added a send per account but left `max_attempts_for` at `2n + 4`, so a transport blip combined with the 529 failover ladder truncated the walk and returned a synthesized `All N accounts exhausted` 429 where a 529 was owed — with accounts never tried. The guard test that was supposed to cover this asserted `n*2 <= n*2+4`, true by construction for every input; it is replaced with an arithmetic test and an end-to-end one that both fail under the old budget.

4. **The retry now skips connect-phase failures.** For `is_connect()` errors there is no pooled connection to refresh, so the retry just pays a second 10s `connect_timeout` — measured as a doubling of time-to-502 on a blackholed route.

5. **Exit codes**: 0 stood down / incumbent answering, 3 stale incumbent build, 4 incumbent not answering. Keyed on a verdict value, never on grepping our own output.

6. **`--replace` + `--no-replace`** is a hard clap conflict instead of a silent veto.

7. **`this binary=`** → `this_binary=`, restoring a greppable field in the branch that most needs surfacing.

8. **The build-skew warning could report a false all-clear** — the exact thing it exists to prevent. It compared two build-*time* `dirty` stamps, but `build.rs` only restamps when a git ref moves (documented verbatim in its own header), so the ordinary edit → rebuild → run loop printed "build in sync" for a binary predating the edit. It now takes a live `CheckoutState`, matching how `compare` already does it.

## Swift (TcrBar)

- **`--replace` against an older `tcr`** hard-failed with an opaque clap usage error. Fixed as a hybrid: a `tcr server --help` capability probe (answered by clap before any tcr code runs — no bind, no signal) plus a `.toolTooOld` state that names the problem. What makes the hybrid safe is that both probe misreadings are non-destructive; neither can replace a proxy the operator did not ask to replace.
- **A stderr drain race**, filed only as *plausible*, reproduces: 10/400 spawns empty-or-truncated under load, 0/400 with the pipe drained, and 0/300 sequentially — which is why a single unloaded test concludes it does not exist. Since a stand-down now exits 0, each occurrence read as "exited cleanly" while an incumbent still served.
- **Exit codes 3 and 4 are now mapped.** Previously `classifyExit` matched stderr markers *before* the exit code, so all three stand-downs were one state — and exit 4 reported as "already running", the exact opposite of the truth for a proxy serving nothing.

## Verification

- `cargo fmt --check` 0 · `cargo clippy --all-targets -- -D warnings` 0 · `cargo test` 0 (483 + 7 + 11, 0 failed)
- `swift build` 0 · `swift test` 0 (103 tests, 0 failures; was 76 at #35)
- Both suites re-run against the **merged** tree, not only each branch. File-disjointness makes this pair feel safe while the real coupling is semantic and invisible to git.
- **13 mutation rounds, all killed**, harness sha256-verifying that each mutation landed and each restore matched. One mutant initially *survived* and exposed a false claim in a doc-comment; one "kill" had its evidence consumed by other tests' output and was re-run under `--filter` to get per-assertion proof.
- The end-to-end budget mutation reproduced the reviewer's predicted client body verbatim — predicted before the test was written, which makes it the one piece of genuinely independent confirmation here.

## Known gaps, stated rather than buried

- `stand_down_build_report` degrades to the old stamp comparison when `tcr` runs outside a checkout, since there is no live state to read. No worse than before; a test pins the control.
- The clap-usage matcher carries five spellings and was measured by compiling this project's own arg wiring against clap 4. Its failure mode is a confusing message, not a wrong action.
- An abandoned capability probe leaks a thread blocked in a read until the child exits. It holds no port and signals nothing, on a rare human-initiated path.
- CI still builds no Swift at all, so none of the 103 tests run in CI. That is how a one-line Rust default change silently broke TcrBar's takeover button in #35 with every check green. Worth its own issue.
