### PR TITLE
feat: persist session affinity pins across restarts

### DIFF
--- a/src/affinity.rs
+++ b/src/affinity.rs
@@ -1,0 +1,535 @@
+//! Durable session→account pins: the on-disk half of `Manager::affinity`.
+//!
+//! The pin map is what keeps one client session on one account so Anthropic's
+//! prompt cache stays warm for it. It has always been memory-only, so every
+//! restart cold-started every live session's prefix — the most expensive event
+//! in this system, and it happened 50 times in 79.6 hours. This module makes the
+//! map survive a bounce.
+//!
+//! Three properties the file has to have, each of which is a way the naive
+//! version silently does the wrong thing:
+//!
+//! 1. **It stores an account IDENTITY, never the index.** The in-memory map is
+//!    keyed on `usize` positions into the account list. A position is only
+//!    meaningful against the exact list it was taken from: add, remove or reorder
+//!    an account between boots and a restored index points at a DIFFERENT
+//!    account, which is strictly worse than having no pin — the session is routed
+//!    somewhere cold while the proxy believes it is warm, and the migration logic
+//!    sees a settled pin and leaves it alone. So each pin stores the identity
+//!    fields [`crate::identity`] already treats as an account's identity
+//!    (`account_uuid` + org, falling back to `name`) and is resolved back to an
+//!    index at load through [`crate::identity::resolve`]. Anything that does not
+//!    resolve to EXACTLY one account is DROPPED — a [`Resolved::Many`] tie is
+//!    refused here for the same reason `save_disabled` refuses one: a guess that
+//!    lands on the wrong record is the failure being prevented, not a lesser
+//!    version of success.
+//! 2. **Every pin carries a timestamp and expires at load.** A restored pin is
+//!    worth something only while that account's prompt cache is still warm; see
+//!    [`PIN_TTL_MS`] for the number and the reasoning behind it.
+//! 3. **It is written incrementally, atomically, and can never take the proxy
+//!    down.** Shutdown-only persistence would miss exactly the case this exists
+//!    to survive: `--replace` follows SIGTERM with SIGKILL, and no shutdown hook
+//!    runs for a SIGKILL. The write goes through [`crate::config::write_atomic`]
+//!    (same-dir temp + `rename`), so a crash mid-write leaves the previous file
+//!    intact rather than a truncated one. And every read failure — missing,
+//!    truncated, corrupt, wrong version — degrades to "no pins" plus a log line.
+//!    This is a cache; a cache that can panic the process is a downgrade on the
+//!    memory-only version it replaces.
+//!
+//! The file is NOT the credential config, deliberately: `~/.config/teamclaude.json`
+//! holds live OAuth tokens behind a delicate read-modify-write merge, and a
+//! high-frequency cache write has no business anywhere near it. Pins live under
+//! the cache dir ([`default_path`]) and are written `0600` because they name
+//! accounts.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::{Account, ConfigError};
+use crate::identity::{self, Resolved};
+
+/// How stale a pin may be at load and still be restored: **15 minutes** since
+/// its last touch (a pin's stamp is the time of the last request served on it).
+///
+/// Anthropic's default `cache_control` TTL is 5 minutes, refreshed on every
+/// cache read — so a session that served a request within the last 5 minutes has
+/// a warm prefix, and one idle far longer does not under any setting except the
+/// 1-hour extended TTL. The window has to cover last-request → first-request-
+/// after-the-restart, which includes the restart itself: a `--replace` upgrade is
+/// a SIGTERM, a SIGKILL, a boot and often a `cargo build --release` in front of
+/// it, so a 5-minute window would expire pins during the very event it exists to
+/// survive. 15 minutes is that 5-minute warm window plus room for the bounce,
+/// and still well under the 1-hour ceiling past which no cache can be warm.
+///
+/// Restoring a pin whose cache HAS gone cold is not free but it is cheap: the
+/// session simply prefers an account it would otherwise have been assigned by
+/// rotation, and the normal eligibility, migration and re-pin paths all still
+/// apply on the next request. The expensive error is the mis-resolution in
+/// property (1) above, not a slightly stale preference.
+pub const PIN_TTL_MS: i64 = 15 * 60 * 1000;
+
+/// Maximum pins written to disk, mirroring the in-memory `AFFINITY_CAP`. On
+/// overflow the freshest are kept, matching the in-memory LRU-by-last-touch
+/// eviction, so a restore can never produce a map larger than the process would
+/// have held anyway.
+pub const PIN_CAP: usize = 1024;
+
+/// Bumped whenever the meaning of a field changes. A file written by a different
+/// version is ignored wholesale rather than half-read.
+const FORMAT_VERSION: u32 = 1;
+
+/// One persisted pin: the session key, the identity of the account it points at,
+/// and when it was last touched.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct StoredPin {
+    /// The stable session key — `stable_hash` over the client's durable identity
+    /// (see [`crate::proxy`]). Deterministic across processes for a given build,
+    /// which is what makes any of this work; a `std` hash change between Rust
+    /// releases would simply make the keys stop matching, and unmatched keys are
+    /// inert (they pin sessions that will never ask again, and age out).
+    pub key: u64,
+    /// Display name of the pinned account — also the identity fallback for
+    /// records with no `account_uuid`, exactly as [`identity::same_identity`]
+    /// falls back.
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub org_uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub org_name: Option<String>,
+    /// Epoch ms of the last request served on this pin. Compared against
+    /// [`PIN_TTL_MS`] at load.
+    pub touched_at_ms: i64,
+}
+
+impl StoredPin {
+    /// The identity probe this pin resolves through, in the shape
+    /// [`identity::resolve`] compares against stored records.
+    fn probe(&self) -> Account {
+        identity::probe(
+            &self.name,
+            self.account_uuid.clone(),
+            self.org_uuid.clone(),
+            self.org_name.clone(),
+        )
+    }
+}
+
+/// The file itself.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PinFile {
+    pub version: u32,
+    pub saved_at_ms: i64,
+    pub pins: Vec<StoredPin>,
+}
+
+/// What a [`load`] made of the file. Every field except `pins` exists so the
+/// caller can say out loud what it threw away — a silent drop here is
+/// indistinguishable from the feature not working.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct LoadReport {
+    /// Restored pins, in the in-memory map's own shape: key → (account index,
+    /// last-touch ms).
+    pub pins: HashMap<u64, (usize, i64)>,
+    /// Dropped because their last touch was older than the TTL.
+    pub expired: usize,
+    /// Dropped because no live account carries that identity (removed, renamed).
+    pub unresolved: usize,
+    /// Dropped because two or more live accounts carry that identity and the tie
+    /// could not be broken. Refused, never guessed.
+    pub ambiguous: usize,
+    /// Set when the file was ignored ENTIRELY — unreadable, corrupt, truncated,
+    /// or a version this build does not understand. `None` on a clean read and on
+    /// a simple "no file yet".
+    pub degraded: Option<String>,
+}
+
+/// Default pin-file path: `$XDG_CACHE_HOME/teamclaude/session-affinity.json`,
+/// else `$HOME/.cache/teamclaude/session-affinity.json`.
+///
+/// A cache dir, not `~/.config`: this is regenerable state written on a timer,
+/// and the config file next door holds live OAuth credentials behind a merge
+/// path that must not acquire a second high-frequency writer.
+pub fn default_path() -> PathBuf {
+    let base = std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .map(PathBuf::from)
+                .map(|home| home.join(".cache"))
+        })
+        .unwrap_or_else(|| PathBuf::from("."));
+    base.join("teamclaude").join("session-affinity.json")
+}
+
+/// Write `pins` to `path` atomically at `0600`, keeping at most [`PIN_CAP`] of
+/// them (freshest first).
+///
+/// Returns how many were written. The caller decides what a failure means; it is
+/// never fatal here.
+pub fn save(path: &Path, pins: &[StoredPin], now_ms: i64) -> Result<usize, ConfigError> {
+    let mut pins = pins.to_vec();
+    if pins.len() > PIN_CAP {
+        pins.sort_by_key(|p| std::cmp::Reverse(p.touched_at_ms));
+        pins.truncate(PIN_CAP);
+    }
+    // Stable order keeps the file diff-friendly and the write byte-identical when
+    // nothing changed.
+    pins.sort_by_key(|p| p.key);
+    let count = pins.len();
+    let file = PinFile {
+        version: FORMAT_VERSION,
+        saved_at_ms: now_ms,
+        pins,
+    };
+    crate::config::write_atomic(path, &serde_json::to_string_pretty(&file)?)?;
+    Ok(count)
+}
+
+/// Read `path` and resolve each pin against `accounts`, dropping anything stale
+/// or not resolvable to exactly one account.
+///
+/// Infallible by construction — every failure mode returns an empty map with
+/// `degraded` set. See the module docs for why this must never propagate an
+/// error, let alone panic.
+pub fn load(path: &Path, accounts: &[Account], now_ms: i64, ttl_ms: i64) -> LoadReport {
+    let data = match std::fs::read_to_string(path) {
+        Ok(data) => data,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            // The ordinary first-boot case, and the case right after this feature
+            // ships. Not a degradation.
+            return LoadReport::default();
+        }
+        Err(err) => {
+            return LoadReport {
+                degraded: Some(format!("unreadable: {err}")),
+                ..LoadReport::default()
+            };
+        }
+    };
+
+    let file: PinFile = match serde_json::from_str(&data) {
+        Ok(file) => file,
+        Err(err) => {
+            // Truncated (a SIGKILL between `write` and `rename` cannot produce
+            // this, but a full disk or a hand-edit can) or otherwise corrupt.
+            return LoadReport {
+                degraded: Some(format!("corrupt: {err}")),
+                ..LoadReport::default()
+            };
+        }
+    };
+    if file.version != FORMAT_VERSION {
+        return LoadReport {
+            degraded: Some(format!(
+                "format version {} is not {FORMAT_VERSION}",
+                file.version
+            )),
+            ..LoadReport::default()
+        };
+    }
+
+    let mut report = LoadReport::default();
+    for pin in file.pins {
+        if now_ms.saturating_sub(pin.touched_at_ms) > ttl_ms {
+            report.expired += 1;
+            continue;
+        }
+        match identity::resolve(accounts.iter().enumerate(), &pin.probe()) {
+            Resolved::One(index) => {
+                report.pins.insert(pin.key, (index, pin.touched_at_ms));
+            }
+            Resolved::None => report.unresolved += 1,
+            Resolved::Many => report.ambiguous += 1,
+        }
+        if report.pins.len() >= PIN_CAP {
+            break;
+        }
+    }
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn acct(name: &str, uuid: Option<&str>, org: Option<&str>) -> Account {
+        identity::probe(
+            name,
+            uuid.map(str::to_string),
+            org.map(str::to_string),
+            None,
+        )
+    }
+
+    fn pin(key: u64, name: &str, uuid: Option<&str>, org: Option<&str>, touched: i64) -> StoredPin {
+        StoredPin {
+            key,
+            name: name.to_string(),
+            account_uuid: uuid.map(str::to_string),
+            org_uuid: org.map(str::to_string),
+            org_name: None,
+            touched_at_ms: touched,
+        }
+    }
+
+    fn tmp(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "tcr-affinity-test-{}-{label}-{}",
+            std::process::id(),
+            crate::now_ms()
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir.join("session-affinity.json")
+    }
+
+    /// The whole point: pins written by one process are read back by the next and
+    /// land on the SAME accounts, resolved by identity rather than by position.
+    #[test]
+    fn round_trip_restores_the_same_accounts() {
+        let path = tmp("round-trip");
+        let accounts = [
+            acct("a@example.com", Some("uuid-a"), Some("org-1")),
+            acct("b@example.com", Some("uuid-b"), Some("org-1")),
+        ];
+        let now = 1_000_000;
+        let written = save(
+            &path,
+            &[
+                pin(11, "a@example.com", Some("uuid-a"), Some("org-1"), now),
+                pin(22, "b@example.com", Some("uuid-b"), Some("org-1"), now),
+            ],
+            now,
+        )
+        .expect("save");
+        assert_eq!(written, 2);
+
+        let report = load(&path, &accounts, now, PIN_TTL_MS);
+        assert_eq!(report.degraded, None);
+        assert_eq!(report.pins.get(&11), Some(&(0, now)));
+        assert_eq!(report.pins.get(&22), Some(&(1, now)));
+        assert_eq!(
+            (report.expired, report.unresolved, report.ambiguous),
+            (0, 0, 0)
+        );
+    }
+
+    /// The index trap. The saved pins are positions 0 and 1 in a list that is
+    /// reordered, and has an account inserted in front of it, before the next
+    /// boot. A position-based restore would silently point session 11 at the
+    /// wrong account; identity resolution follows the account.
+    #[test]
+    fn reordered_accounts_resolve_by_identity_not_position() {
+        let path = tmp("reorder");
+        let now = 2_000_000;
+        save(
+            &path,
+            &[
+                pin(11, "a@example.com", Some("uuid-a"), Some("org-1"), now),
+                pin(22, "b@example.com", Some("uuid-b"), Some("org-1"), now),
+            ],
+            now,
+        )
+        .expect("save");
+
+        // Next boot: a new account first, and a and b swapped.
+        let accounts = [
+            acct("c@example.com", Some("uuid-c"), Some("org-1")),
+            acct("b@example.com", Some("uuid-b"), Some("org-1")),
+            acct("a@example.com", Some("uuid-a"), Some("org-1")),
+        ];
+        let report = load(&path, &accounts, now, PIN_TTL_MS);
+        assert_eq!(
+            report.pins.get(&11),
+            Some(&(2, now)),
+            "session 11 must follow account a to its new position, not stay at 0"
+        );
+        assert_eq!(report.pins.get(&22), Some(&(1, now)));
+    }
+
+    /// A removed account drops its pins rather than mis-resolving them.
+    #[test]
+    fn removed_account_drops_its_pin() {
+        let path = tmp("removed");
+        let now = 3_000_000;
+        save(
+            &path,
+            &[
+                pin(11, "a@example.com", Some("uuid-a"), Some("org-1"), now),
+                pin(22, "b@example.com", Some("uuid-b"), Some("org-1"), now),
+            ],
+            now,
+        )
+        .expect("save");
+
+        let accounts = [acct("b@example.com", Some("uuid-b"), Some("org-1"))];
+        let report = load(&path, &accounts, now, PIN_TTL_MS);
+        assert_eq!(report.unresolved, 1);
+        assert!(
+            !report.pins.contains_key(&11),
+            "a is gone; its pin must not survive"
+        );
+        assert_eq!(report.pins.get(&22), Some(&(0, now)));
+    }
+
+    /// An unbreakable identity tie is refused, not guessed. Two entries sharing a
+    /// name with no UUID are genuinely indistinguishable (see `identity::resolve`).
+    #[test]
+    fn ambiguous_identity_is_dropped_never_guessed() {
+        let path = tmp("ambiguous");
+        let now = 4_000_000;
+        save(&path, &[pin(11, "twin@example.com", None, None, now)], now).expect("save");
+
+        let accounts = [
+            acct("twin@example.com", None, None),
+            acct("twin@example.com", None, None),
+        ];
+        let report = load(&path, &accounts, now, PIN_TTL_MS);
+        assert_eq!(report.ambiguous, 1);
+        assert!(
+            report.pins.is_empty(),
+            "a tie routes nothing rather than the wrong thing"
+        );
+    }
+
+    /// Stale pins are dropped at load: a warm-cache bet is only worth making
+    /// while the cache can still be warm.
+    #[test]
+    fn expiry_drops_stale_pins_and_keeps_fresh_ones() {
+        let path = tmp("expiry");
+        let now = 10 * PIN_TTL_MS;
+        save(
+            &path,
+            &[
+                pin(
+                    11,
+                    "a@example.com",
+                    Some("uuid-a"),
+                    Some("org-1"),
+                    now - 60_000,
+                ),
+                pin(
+                    22,
+                    "b@example.com",
+                    Some("uuid-b"),
+                    Some("org-1"),
+                    now - PIN_TTL_MS - 1,
+                ),
+            ],
+            now,
+        )
+        .expect("save");
+
+        let accounts = [
+            acct("a@example.com", Some("uuid-a"), Some("org-1")),
+            acct("b@example.com", Some("uuid-b"), Some("org-1")),
+        ];
+        let report = load(&path, &accounts, now, PIN_TTL_MS);
+        assert_eq!(report.expired, 1);
+        assert!(report.pins.contains_key(&11), "a minute old is warm");
+        assert!(!report.pins.contains_key(&22), "past the TTL is cold");
+    }
+
+    /// Every read failure degrades to "no pins" plus a stated reason. None of
+    /// these may panic or propagate: this is a cache.
+    #[test]
+    fn unreadable_file_shapes_degrade_to_empty() {
+        let accounts = [acct("a@example.com", Some("uuid-a"), Some("org-1"))];
+        let now = 5_000_000;
+
+        // Missing — the ordinary first boot, not a degradation.
+        let missing = tmp("missing").with_file_name("does-not-exist.json");
+        let report = load(&missing, &accounts, now, PIN_TTL_MS);
+        assert!(report.pins.is_empty());
+        assert_eq!(report.degraded, None);
+
+        // Truncated mid-object.
+        let path = tmp("truncated");
+        save(
+            &path,
+            &[pin(11, "a@example.com", Some("uuid-a"), Some("org-1"), now)],
+            now,
+        )
+        .expect("save");
+        let full = std::fs::read_to_string(&path).expect("read back");
+        std::fs::write(&path, &full[..full.len() / 2]).expect("truncate");
+        let report = load(&path, &accounts, now, PIN_TTL_MS);
+        assert!(report.pins.is_empty());
+        assert!(
+            report
+                .degraded
+                .as_deref()
+                .unwrap_or_default()
+                .contains("corrupt"),
+            "a truncated file must be reported, not silently empty: {:?}",
+            report.degraded
+        );
+
+        // Not JSON at all.
+        std::fs::write(&path, "\0\0\0 not json").expect("write garbage");
+        let report = load(&path, &accounts, now, PIN_TTL_MS);
+        assert!(report.pins.is_empty());
+        assert!(report.degraded.is_some());
+
+        // Valid JSON, wrong shape.
+        std::fs::write(&path, "[1, 2, 3]").expect("write array");
+        let report = load(&path, &accounts, now, PIN_TTL_MS);
+        assert!(report.pins.is_empty());
+        assert!(report.degraded.is_some());
+
+        // A future format version is ignored wholesale rather than half-read.
+        std::fs::write(&path, r#"{"version":99,"savedAtMs":0,"pins":[]}"#).expect("write v99");
+        let report = load(&path, &accounts, now, PIN_TTL_MS);
+        assert!(report.pins.is_empty());
+        assert!(
+            report
+                .degraded
+                .as_deref()
+                .unwrap_or_default()
+                .contains("version"),
+            "{:?}",
+            report.degraded
+        );
+    }
+
+    /// The file is written `0600`: it names accounts, and it sits in a shared
+    /// cache dir.
+    #[test]
+    fn save_writes_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let path = tmp("perms");
+        save(&path, &[pin(11, "a@example.com", None, None, 1)], 1).expect("save");
+        let mode = std::fs::metadata(&path).expect("stat").permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "mode was {:o}", mode & 0o777);
+    }
+
+    /// Overflow keeps the freshest pins, mirroring the in-memory LRU eviction.
+    #[test]
+    fn save_caps_the_file_at_pin_cap_keeping_the_freshest() {
+        let path = tmp("cap");
+        let pins: Vec<StoredPin> = (0..(PIN_CAP as u64 + 10))
+            .map(|i| pin(i, "a@example.com", Some("uuid-a"), Some("org-1"), i as i64))
+            .collect();
+        let written = save(&path, &pins, PIN_CAP as i64 + 100).expect("save");
+        assert_eq!(written, PIN_CAP);
+
+        let accounts = [acct("a@example.com", Some("uuid-a"), Some("org-1"))];
+        // A TTL wide enough that nothing expires, so this measures the cap alone.
+        let report = load(&path, &accounts, 0, i64::MAX);
+        assert_eq!(report.pins.len(), PIN_CAP);
+        assert!(
+            report.pins.contains_key(&(PIN_CAP as u64 + 9)),
+            "the freshest pin must survive the cap"
+        );
+        assert!(
+            !report.pins.contains_key(&0),
+            "the oldest pin is the one dropped"
+        );
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -277,9 +277,12 @@ pub fn save(path: &Path, config: &Config) -> Result<(), ConfigError> {
     write_atomic(path, &serde_json::to_string_pretty(config)?)
 }
 
-/// The atomic 0600 write itself, shared by [`save`] and [`save_tokens`] so both
-/// paths get the same durability and permission guarantees.
-fn write_atomic(path: &Path, json: &str) -> Result<(), ConfigError> {
+/// The atomic 0600 write itself, shared by [`save`], [`save_tokens`] and the
+/// session-affinity pin file ([`crate::affinity::save`]) so every path gets the
+/// same durability and permission guarantees. One implementation deliberately:
+/// a second hand-rolled temp+rename is a second place for the ordering to be
+/// subtly wrong.
+pub(crate) fn write_atomic(path: &Path, json: &str) -> Result<(), ConfigError> {
     let dir = path.parent().filter(|p| !p.as_os_str().is_empty());
     let dir = dir.unwrap_or_else(|| Path::new("."));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 )]
 
 pub mod account_uuid;
+pub mod affinity;
 pub mod build_info;
 pub mod cli;
 pub mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use teamclaude_rs::cli::{self, PriorityArg};
 use teamclaude_rs::config::{self, Config, ConfigError};
 use teamclaude_rs::manager::Manager;
-use teamclaude_rs::{build_info, demo, mitm, oauth, singleton, tui, update};
+use teamclaude_rs::{affinity, build_info, demo, mitm, oauth, singleton, tui, update};
 
 #[derive(Parser)]
 #[command(
@@ -569,6 +569,63 @@ async fn run_server(args: ServerArgs) -> anyhow::Result<()> {
 
     let manager = Manager::with_live_refresher(config, persist_path);
 
+    // Session-affinity pins survive a restart via their own cache file (NOT the
+    // credential config — see `teamclaude_rs::affinity`). Restore before the
+    // listener binds, so the first request after a bounce already routes on its
+    // old pin instead of cold-starting the account's prompt cache.
+    //
+    // Only when affinity is enabled: with the feature off the map is never
+    // consulted, and a restore would put entries in it that nothing reads.
+    let affinity_path = affinity::default_path();
+    if manager.session_affinity_enabled() {
+        let report = manager.restore_affinity(&affinity_path, affinity::PIN_TTL_MS);
+        if let Some(reason) = &report.degraded {
+            // Never fatal: the pin file is a cache, so an unusable one costs the
+            // warm start it would have bought and nothing else.
+            tracing::warn!(
+                path = %affinity_path.display(),
+                reason = %reason,
+                "session-affinity pins ignored; starting with an empty pin map"
+            );
+        } else {
+            tracing::info!(
+                path = %affinity_path.display(),
+                restored = report.pins.len(),
+                expired = report.expired,
+                unresolved = report.unresolved,
+                ambiguous = report.ambiguous,
+                ttl_minutes = affinity::PIN_TTL_MS / 60_000,
+                "session-affinity pins restored"
+            );
+        }
+
+        // Debounced incremental flush. Shutdown-only would miss the case this
+        // exists to survive: `--replace` follows SIGTERM with SIGKILL, and a
+        // SIGKILL runs no shutdown path at all. A 5-second timer that writes only
+        // when the map actually changed bounds the loss to one interval while
+        // keeping a busy proxy to at most one small atomic write per interval;
+        // pins settle early in a session, so steady state is no writes.
+        let flusher = manager.clone();
+        let flush_path = affinity_path.clone();
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(Duration::from_secs(5));
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                ticker.tick().await;
+                if !flusher.take_affinity_dirty() {
+                    continue;
+                }
+                if let Err(err) = flusher.flush_affinity(&flush_path) {
+                    tracing::warn!(
+                        path = %flush_path.display(),
+                        error = %err,
+                        "could not write the session-affinity pin file; pins will not survive this restart"
+                    );
+                }
+            }
+        });
+    }
+
     // Background probe loop: refresh every account's quota on the configured
     // cadence (a value <= 0 in `quotaProbeSeconds` disables it). The first tick
     // fires immediately, so the bars populate at startup rather than after a lag.
@@ -718,6 +775,23 @@ async fn run_server(args: ServerArgs) -> anyhow::Result<()> {
     // incrementally; this is the final belt-and-suspenders write).
     server.abort();
     manager.persist_now();
+    // Final pin flush on a CLEAN shutdown, capturing whatever changed inside the
+    // last flusher interval. Belt-and-braces only — the timer above is what makes
+    // the pins survive a SIGKILL, which is the case that actually matters.
+    if manager.session_affinity_enabled() {
+        match manager.flush_affinity(&affinity_path) {
+            Ok(count) => tracing::info!(
+                path = %affinity_path.display(),
+                pins = count,
+                "session-affinity pins written for the next boot"
+            ),
+            Err(err) => tracing::warn!(
+                path = %affinity_path.display(),
+                error = %err,
+                "final session-affinity pin write failed; pins will not survive this restart"
+            ),
+        }
+    }
     Ok(())
 }
 

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -38,6 +38,7 @@ use crate::stats::{
 };
 use crate::warmer::{AccountWarmer, LiveWarmer};
 
+mod pins;
 mod probing;
 mod refresh;
 mod select;
@@ -466,6 +467,13 @@ pub struct Manager {
     /// held while the accounts lock is taken (read the pin, drop this lock, then do
     /// eligibility) so the two can never deadlock.
     affinity: Mutex<HashMap<u64, (usize, i64)>>,
+    /// Set whenever `affinity` is mutated, cleared by the flusher task that
+    /// writes the map to disk (see [`Manager::mark_affinity_dirty`] and
+    /// [`crate::affinity`]). A relaxed atomic rather than a channel because the
+    /// setter sits on the request path and the reader is a 5-second timer: the
+    /// only ordering that matters is "a change eventually causes a write", and a
+    /// tick that observes the flag late simply writes on the next one.
+    affinity_dirty: AtomicBool,
     /// Per-session serving stats (session key → account/count/last-seen), for
     /// live per-session visibility in the TUI. Separate from `affinity` so the
     /// routing pin stays byte-for-byte unchanged; bounded in `record_served`.
@@ -650,6 +658,7 @@ impl Manager {
             current: Mutex::new(None),
             select_seq: AtomicU64::new(1),
             affinity: Mutex::new(HashMap::new()),
+            affinity_dirty: AtomicBool::new(false),
             sessions: Mutex::new(HashMap::new()),
             session_seq: AtomicU64::new(1),
             next_revalidation_at_ms: std::sync::atomic::AtomicI64::new(0),

--- a/src/manager/pins.rs
+++ b/src/manager/pins.rs
@@ -114,3 +114,246 @@ impl Manager {
         report
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::affinity::PIN_TTL_MS;
+    use crate::config::Account;
+    use crate::manager::AccountRuntime;
+
+    /// The store's own tests in [`crate::affinity`] cover the FILE half — format,
+    /// expiry, identity resolution. These cover the half only the manager has: the
+    /// live map's `usize` indices being translated OUT to identities on save and
+    /// back IN to (possibly different) indices on load. A snapshot that wrote the
+    /// wrong account's identity would pass every test over there and still route
+    /// every restored session to a cold account.
+    fn account(name: &str, uuid: &str) -> Account {
+        Account {
+            name: name.to_string(),
+            account_type: "oauth".to_string(),
+            account_uuid: Some(uuid.to_string()),
+            org_uuid: Some("org-1".to_string()),
+            org_name: None,
+            access_token: format!("at-{name}"),
+            refresh_token: Some(format!("rt-{name}")),
+            expires_at: Some(crate::now_ms() + 3_600_000),
+            priority: Some(0),
+            switch_threshold: None,
+            disabled: None,
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    /// A manager holding exactly `accounts`, in that order. `from_runtimes` never
+    /// invokes its refresher/prober/warmer, and nothing here reaches the network.
+    fn manager_over(accounts: &[Account]) -> Arc<Manager> {
+        Manager::from_runtimes(accounts.iter().map(AccountRuntime::from_config).collect())
+    }
+
+    /// A unique path per test: the suite runs tests in parallel threads of ONE
+    /// process, so a pid-only name collides between them.
+    fn tmp(label: &str) -> PathBuf {
+        static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+        let dir =
+            std::env::temp_dir().join(format!("tcr-pins-{label}-{}-{seq}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir.join("session-affinity.json")
+    }
+
+    /// Seed the live pin map directly. The selection path is what does this in
+    /// production; driving a full rotation here would test `select`, not the
+    /// persistence bridge these tests are about.
+    fn seed_pins(manager: &Manager, pins: &[(u64, usize, i64)]) {
+        let mut map = manager.affinity.lock().expect("affinity lock poisoned");
+        for &(key, index, touched) in pins {
+            map.insert(key, (index, touched));
+        }
+    }
+
+    fn pins_of(manager: &Manager) -> std::collections::HashMap<u64, (usize, i64)> {
+        manager
+            .affinity
+            .lock()
+            .expect("affinity lock poisoned")
+            .clone()
+    }
+
+    /// The feature's whole claim: pins written by one process are read back by the
+    /// next and point at the SAME accounts.
+    #[test]
+    fn pins_round_trip_through_two_managers() {
+        let path = tmp("round-trip");
+        let accounts = [
+            account("a@example.com", "uuid-a"),
+            account("b@example.com", "uuid-b"),
+        ];
+        let now = crate::now_ms();
+
+        let first = manager_over(&accounts);
+        seed_pins(&first, &[(11, 0, now), (22, 1, now)]);
+        assert_eq!(first.flush_affinity(&path).expect("flush"), 2);
+
+        let second = manager_over(&accounts);
+        let report = second.restore_affinity(&path, PIN_TTL_MS);
+        assert_eq!(report.degraded, None);
+        let restored = pins_of(&second);
+        assert_eq!(restored.get(&11).map(|&(i, _)| i), Some(0));
+        assert_eq!(restored.get(&22).map(|&(i, _)| i), Some(1));
+    }
+
+    /// The index trap, at the layer that can actually commit it. Session 11 is
+    /// pinned to position 1 (account b); the next boot lists the accounts in the
+    /// opposite order, so b is position 0. A snapshot that persisted the POSITION
+    /// would restore 11 onto account a — warm in the proxy's belief, cold in fact.
+    #[test]
+    fn a_reordered_account_list_restores_by_identity_not_position() {
+        let path = tmp("reorder");
+        let a = account("a@example.com", "uuid-a");
+        let b = account("b@example.com", "uuid-b");
+        let now = crate::now_ms();
+
+        let first = manager_over(&[a.clone(), b.clone()]);
+        seed_pins(&first, &[(11, 1, now)]);
+        first.flush_affinity(&path).expect("flush");
+
+        // The file itself must name b, not "index 1".
+        let raw = std::fs::read_to_string(&path).expect("read pin file");
+        assert!(
+            raw.contains("uuid-b"),
+            "the pin must store b's identity: {raw}"
+        );
+        assert!(
+            !raw.contains("uuid-a"),
+            "no other account belongs in it: {raw}"
+        );
+
+        // Next boot: b first, a second.
+        let second = manager_over(&[b, a]);
+        second.restore_affinity(&path, PIN_TTL_MS);
+        assert_eq!(
+            pins_of(&second).get(&11).map(|&(i, _)| i),
+            Some(0),
+            "session 11 must follow account b to position 0"
+        );
+    }
+
+    /// An account removed between boots takes its pins with it, rather than
+    /// leaving them to land on whoever now occupies that index.
+    #[test]
+    fn a_removed_account_drops_its_pin_instead_of_mis_resolving() {
+        let path = tmp("removed");
+        let a = account("a@example.com", "uuid-a");
+        let b = account("b@example.com", "uuid-b");
+        let now = crate::now_ms();
+
+        let first = manager_over(&[a, b.clone()]);
+        seed_pins(&first, &[(11, 0, now), (22, 1, now)]);
+        first.flush_affinity(&path).expect("flush");
+
+        // a is gone; b is now the only account, at position 0.
+        let second = manager_over(&[b]);
+        let report = second.restore_affinity(&path, PIN_TTL_MS);
+        assert_eq!(report.unresolved, 1);
+        let restored = pins_of(&second);
+        assert!(
+            !restored.contains_key(&11),
+            "a's pin must not survive a's removal"
+        );
+        assert_eq!(restored.get(&22).map(|&(i, _)| i), Some(0));
+    }
+
+    /// A pin older than the TTL is dropped: the bet it encodes is that the
+    /// account's prompt cache is still warm, and past the window it is not.
+    #[test]
+    fn a_stale_pin_is_dropped_at_restore() {
+        let path = tmp("expiry");
+        let accounts = [
+            account("a@example.com", "uuid-a"),
+            account("b@example.com", "uuid-b"),
+        ];
+        let now = crate::now_ms();
+
+        let first = manager_over(&accounts);
+        seed_pins(
+            &first,
+            &[(11, 0, now - 60_000), (22, 1, now - PIN_TTL_MS - 60_000)],
+        );
+        first.flush_affinity(&path).expect("flush");
+
+        let second = manager_over(&accounts);
+        let report = second.restore_affinity(&path, PIN_TTL_MS);
+        assert_eq!(report.expired, 1);
+        let restored = pins_of(&second);
+        assert!(restored.contains_key(&11), "a minute old is still warm");
+        assert!(!restored.contains_key(&22), "past the TTL is cold");
+    }
+
+    /// A corrupt file degrades to an empty map and SAYS so. This is a cache: it
+    /// may cost the warm start it would have bought, and nothing else.
+    #[test]
+    fn a_corrupt_file_degrades_to_no_pins_without_panicking() {
+        let path = tmp("corrupt");
+        let accounts = [account("a@example.com", "uuid-a")];
+        std::fs::write(&path, "{\"version\":1,\"pins\":[{\"key\":1,").expect("write truncated");
+
+        let manager = manager_over(&accounts);
+        let report = manager.restore_affinity(&path, PIN_TTL_MS);
+        assert!(report.degraded.is_some(), "the reason must be reportable");
+        assert!(pins_of(&manager).is_empty(), "a bad file restores nothing");
+    }
+
+    /// A missing file is the ordinary first boot, not a degradation — the flusher
+    /// must not spend every interval logging a warning about it.
+    #[test]
+    fn a_missing_file_restores_nothing_and_is_not_a_degradation() {
+        let path = tmp("missing").with_file_name("no-such-file.json");
+        let manager = manager_over(&[account("a@example.com", "uuid-a")]);
+        let report = manager.restore_affinity(&path, PIN_TTL_MS);
+        assert_eq!(report.degraded, None);
+        assert!(pins_of(&manager).is_empty());
+    }
+
+    /// The debounce contract the flusher task runs on: a change raises the flag,
+    /// one take consumes it, and a second take reports nothing more to write. Were
+    /// the take not consuming, an idle proxy would rewrite the file every interval
+    /// forever.
+    #[test]
+    fn the_dirty_flag_is_raised_by_a_change_and_consumed_by_one_take() {
+        let manager = manager_over(&[account("a@example.com", "uuid-a")]);
+        assert!(
+            !manager.take_affinity_dirty(),
+            "a fresh map has nothing to flush"
+        );
+        manager.mark_affinity_dirty();
+        assert!(manager.take_affinity_dirty(), "a change must be observed");
+        assert!(
+            !manager.take_affinity_dirty(),
+            "and consumed by that observation"
+        );
+    }
+
+    /// A pin whose index names no account is skipped rather than written against
+    /// whichever account happens to sit at index 0.
+    #[test]
+    fn a_pin_pointing_past_the_account_list_is_not_written() {
+        let path = tmp("out-of-range");
+        let manager = manager_over(&[account("a@example.com", "uuid-a")]);
+        seed_pins(
+            &manager,
+            &[(11, 0, crate::now_ms()), (22, 7, crate::now_ms())],
+        );
+        assert_eq!(
+            manager.flush_affinity(&path).expect("flush"),
+            1,
+            "only the resolvable pin belongs in the file"
+        );
+        let raw = std::fs::read_to_string(&path).expect("read pin file");
+        assert!(raw.contains("\"key\": 11"), "{raw}");
+        assert!(!raw.contains("\"key\": 22"), "{raw}");
+    }
+}

--- a/src/manager/pins.rs
+++ b/src/manager/pins.rs
@@ -1,0 +1,116 @@
+//! Durability for the session-affinity pin map: snapshot it to disk, and restore
+//! it at boot.
+//!
+//! The file format, the identity resolution and the expiry rule live in
+//! [`crate::affinity`]; this is only the bridge between that file and the live
+//! `Manager::affinity` map. Two things it is responsible for and the store is
+//! not:
+//!
+//! - **Lock discipline.** The affinity mutex is never held while the accounts
+//!   lock is taken (see the field's doc-comment on `Manager::affinity`, and the
+//!   ordering `select` follows). Both methods here take one lock, copy what they
+//!   need, drop it, and only then take the other. Nothing below awaits, and no
+//!   I/O happens under either lock.
+//! - **Translating index ↔ identity.** The live map is positional; the file is
+//!   not. Saving maps each index to that account's identity fields; restoring
+//!   resolves each identity back to whatever index it occupies THIS boot.
+
+use std::path::Path;
+use std::sync::atomic::Ordering;
+
+use crate::affinity::{self, LoadReport, StoredPin};
+use crate::config::ConfigError;
+use crate::identity;
+
+use super::Manager;
+
+impl Manager {
+    /// Flag the pin map as changed since the last flush. Called from the
+    /// selection path, so it is a single relaxed store and nothing more — the
+    /// actual write is done off the request path by the flusher task.
+    pub fn mark_affinity_dirty(&self) {
+        self.affinity_dirty.store(true, Ordering::Relaxed);
+    }
+
+    /// Consume the dirty flag: `true` when something changed since the last call.
+    pub fn take_affinity_dirty(&self) -> bool {
+        self.affinity_dirty.swap(false, Ordering::Relaxed)
+    }
+
+    /// The pin map as persistable records — each live pin's index replaced by the
+    /// identity of the account at that index.
+    ///
+    /// A pin whose index names no account is skipped rather than written: it
+    /// could only come from a map mutated against a shorter account list, and
+    /// writing a placeholder identity is precisely the mis-resolution this whole
+    /// design exists to prevent.
+    pub fn affinity_pin_snapshot(&self) -> Vec<StoredPin> {
+        let pins: Vec<(u64, usize, i64)> = {
+            let map = self.affinity.lock().expect("affinity lock poisoned");
+            map.iter()
+                .map(|(&key, &(index, touched))| (key, index, touched))
+                .collect()
+        };
+        if pins.is_empty() {
+            return Vec::new();
+        }
+        let accounts = self.accounts.read().expect("accounts lock poisoned");
+        pins.into_iter()
+            .filter_map(|(key, index, touched_at_ms)| {
+                let account = accounts.get(index)?;
+                Some(StoredPin {
+                    key,
+                    name: account.name.clone(),
+                    account_uuid: account.account_uuid.clone(),
+                    org_uuid: account.org_uuid.clone(),
+                    org_name: account.org_name.clone(),
+                    touched_at_ms,
+                })
+            })
+            .collect()
+    }
+
+    /// Write the pin map to `path`, atomically. Returns how many pins landed.
+    ///
+    /// The caller logs the failure and carries on; a proxy that cannot write its
+    /// pin cache still serves traffic exactly as it did before this file existed.
+    pub fn flush_affinity(&self, path: &Path) -> Result<usize, ConfigError> {
+        affinity::save(path, &self.affinity_pin_snapshot(), crate::now_ms())
+    }
+
+    /// Restore pins from `path` into the live map, resolving each stored identity
+    /// against the accounts loaded THIS boot and dropping everything that is
+    /// stale or does not resolve to exactly one account.
+    ///
+    /// Existing in-memory pins win: a key already pinned by a request served
+    /// between boot and this call is fresher than anything on disk. In practice
+    /// the map is empty here — this runs before the listener binds.
+    ///
+    /// Returns the store's report so the caller can state what was dropped.
+    /// Restoring nothing is a legitimate outcome (first boot, everything expired,
+    /// accounts all replaced) and never an error.
+    pub fn restore_affinity(&self, path: &Path, ttl_ms: i64) -> LoadReport {
+        let candidates: Vec<crate::config::Account> = {
+            let accounts = self.accounts.read().expect("accounts lock poisoned");
+            accounts
+                .iter()
+                .map(|a| {
+                    identity::probe(
+                        &a.name,
+                        a.account_uuid.clone(),
+                        a.org_uuid.clone(),
+                        a.org_name.clone(),
+                    )
+                })
+                .collect()
+        };
+        let report = affinity::load(path, &candidates, crate::now_ms(), ttl_ms);
+        {
+            let mut map = self.affinity.lock().expect("affinity lock poisoned");
+            for (&key, &value) in &report.pins {
+                map.entry(key).or_insert(value);
+            }
+        }
+        report
+    }
+}

--- a/src/manager/select.rs
+++ b/src/manager/select.rs
@@ -398,6 +398,10 @@ impl Manager {
                         // Re-pin the session (migration target, or the honoured/kept X)
                         // and refresh its last-touch for LRU eviction.
                         pins.insert(key, (committed, now_ms));
+                        // The map changed, so the on-disk copy is now behind. A
+                        // relaxed store under the lock: no allocation, no second
+                        // lock, nothing that can block the request path.
+                        self.mark_affinity_dirty();
                         return Some(committed);
                     }
                 }
@@ -459,6 +463,7 @@ impl Manager {
                 let mut pins = self.affinity.lock().expect("affinity lock poisoned");
                 let previous = pins.get(&key).map(|&(i, _)| i);
                 pins.insert(key, (pin_idx, now_ms));
+                self.mark_affinity_dirty();
                 // Bound the map by size + LRU-by-last-touch: once over AFFINITY_CAP, evict
                 // the single oldest-last-touch entry (not the one we just inserted). Stable
                 // pins survive reconnects, so this size cap — not a disconnect hook — is
@@ -698,6 +703,7 @@ impl Manager {
                 let mut pins = self.affinity.lock().expect("affinity lock poisoned");
                 let previous = pins.get(&key).map(|&(i, _)| i);
                 pins.insert(key, (pin_idx, now_ms));
+                self.mark_affinity_dirty();
                 previous
             };
             // Until now this arm emitted nothing, so a request served off-pin by the


### PR DESCRIPTION
A restart wipes the in-memory session→account pin map, and `main.rs`'s own boot-marker doc-comment calls that the most expensive cache event in this system: every live session lands on a different account and pays a full cold prompt-cache prefix. Measured earlier today: **50 restarts in 79.6h**.

This persists the map so a bounce stops cold-starting everything.

It works because the pin key is `stable_hash(prefix, value)` over a durable client identity using `DefaultHasher::new()` — deterministic across processes, not the randomized `RandomState`. Had it been per-connection, persisting would buy nothing.

## The three things that make it more than a HashMap dump

**Identity, not index.** The in-memory map stores a positional `usize`. Add, remove or reorder an account between boots and a restored index points at a *different* account — worse than no pin, because the session lands cold while the proxy believes it is warm. Each entry stores name + account/org uuid + org name, resolved at load through the existing `identity::resolve`, which returns One/None/Many. Only `One` restores; `None` and `Many` are counted and dropped. A tie is refused rather than guessed, matching what `save_disabled` already does.

**Expiry.** TTL is 15 minutes since last touch. Anthropic's default `cache_control` TTL is 5 minutes refreshed per read, but the window has to span last-request → restart → first-request-after, and that gap *contains* the bounce (SIGTERM, SIGKILL, boot, often a release build). A 5-minute TTL would expire pins during the exact event this exists to survive. Restoring a pin whose cache did go cold is cheap — the session merely prefers an account rotation might not have picked, and all eligibility and migration logic still applies. Mis-resolving is not cheap. The asymmetry argues for generous.

**Write cadence.** A 5s interval task writes only when a dirty flag set at the three pin mutations has been raised, consumed by swap — an idle proxy writes nothing. Shutdown-only would miss the case that matters, since SIGKILL runs no shutdown path. Writes go through the existing `config::write_atomic` (same-dir temp, fsync, rename, 0600), made `pub(crate)` rather than duplicated. Every read failure — missing, truncated, non-JSON, wrong shape, future version — returns an empty map with a stated reason. Nothing propagates, nothing panics: this is a cache, and a cache that can crash the proxy is a downgrade.

Stored at `$XDG_CACHE_HOME/teamclaude/session-affinity.json` (else `$HOME/.cache/...`), 0600, its own file. Never `~/.config/teamclaude.json`, which holds credentials and has a delicate merge path.

## Verification

`cargo fmt --check` 0 · `cargo clippy --all-targets -- -D warnings` 0 · `cargo test` 0 — **499 + 10 + 11 passed, 0 failed** (491 on main; 16 new).

**7 mutations, 7 killed.** The harness shas the file before and after and refuses to report unless the bytes changed, then restores from git and re-shas.

| mutation | result |
|---|---|
| restore by position instead of identity | killed |
| unresolved pin guesses account 0 | killed |
| ambiguous tie guessed instead of refused | killed |
| expiry check disabled | killed |
| corrupt file panics instead of degrading | killed |
| snapshot writes account 0's identity for every pin | killed |
| dirty flag never consumed | killed |

The snapshot mutation is the one worth noting: `affinity_pin_snapshot`, `restore_affinity` and `take_affinity_dirty` had **zero** tests. The store tests covered the file; the index→identity translation on the *save* side — precisely where the index trap gets committed — was untested. That mutation passes every pre-existing test and turns four new ones red.

## Rebase note

This branch was cut before #37 (headless logging) and its old merge-base lacked `headless_subscriber`/`open_log_file`, so merging it then would have silently reverted that fix while the diff read as a cache feature. Rebased onto `bd4ba3e`; the gate `git grep -c 'headless_subscriber\|open_log_file' HEAD -- src/main.rs` returns 9, matching main, and `main.rs` shows 75 insertions against **1** deletion (an extended `use` line).

## Residual limitation

The session key is a `stable_hash` deterministic for a given build. If that hash implementation changes between builds the keys stop matching and restored pins become inert and age out — degrading to today's memory-only behavior rather than mis-routing. Correct failure direction, but it does mean the feature can quietly stop paying off across a toolchain change. Documented on `StoredPin`.