### PR TITLE
ci: run the app's Swift tests on a macOS runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,56 @@ jobs:
       - name: Build (release)
         run: cargo build --release --locked
 
+  # The only job on a macOS runner, and the only place any Swift is compiled.
+  # Before this existed the app's Swift tests had never run in CI at all, so a
+  # Rust-side change could silently break TcrBar with every check green.
+  #
+  # Deliberately does NOT re-run fmt/clippy: those are platform-independent and
+  # already gated by `ci`. macOS runner minutes are billed at a multiple of
+  # Linux, so this job runs only what Linux cannot answer.
+  macos:
+    name: macos
+    runs-on: macos-latest
+    # macOS runners are slower than ubuntu-latest and this job compiles both
+    # toolchains; 20 (the `ci` budget) is too tight for a cold cache.
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      # Auto-keys on runner OS as well as Cargo.lock, so this shares nothing
+      # with the ubuntu jobs' caches.
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      # Not a duplicate of the ubuntu `cargo test`: several modules take a
+      # different code path here. src/singleton.rs shells out to `ps`/`lsof`
+      # (BSD flags, different output columns), install placement relies on
+      # rename(2) semantics, and $TMPDIR is a per-user sandbox path on macOS
+      # rather than /tmp. macOS is also the only platform this app ships on.
+      - name: Test (rust)
+        run: cargo test --all --locked
+
+      # Recorded so a runner-image bump that changes the Swift language mode is
+      # attributable from the log rather than looking like a source regression.
+      - name: Swift toolchain version
+        run: swift --version
+
+      # No SwiftPM cache: the package declares zero external dependencies, so
+      # there is nothing to fetch, and .build artifacts key on the toolchain
+      # and every source file — it would miss on essentially every run.
+      - name: Build (swift)
+        working-directory: apps/macos
+        run: swift build
+
+      # Reads tests/fixtures/status-contract.json by walking up from #filePath,
+      # so it also proves the repo-relative fixture resolves on a clean checkout.
+      - name: Test (swift)
+        working-directory: apps/macos
+        run: swift test
+
   audit:
     name: audit
     runs-on: ubuntu-latest

--- a/apps/macos/Tests/TcrBarTests/RealWorldDecodeTests.swift
+++ b/apps/macos/Tests/TcrBarTests/RealWorldDecodeTests.swift
@@ -258,7 +258,7 @@ final class RealWorldDecodeTests: XCTestCase {
             fleet.unreadable.isEmpty,
             "every row of the committed contract must decode; unreadable: \(fleet.unreadable)"
         )
-        XCTAssertEqual(fleet.accounts.count, 4)
+        XCTAssertEqual(fleet.accounts.count, 5, "THROWAWAY: proves the macOS job can go red")
         XCTAssertEqual(
             fleet.accounts.map(\.name),
             [

--- a/apps/macos/Tests/TcrBarTests/RealWorldDecodeTests.swift
+++ b/apps/macos/Tests/TcrBarTests/RealWorldDecodeTests.swift
@@ -258,7 +258,7 @@ final class RealWorldDecodeTests: XCTestCase {
             fleet.unreadable.isEmpty,
             "every row of the committed contract must decode; unreadable: \(fleet.unreadable)"
         )
-        XCTAssertEqual(fleet.accounts.count, 5, "THROWAWAY: proves the macOS job can go red")
+        XCTAssertEqual(fleet.accounts.count, 4)
         XCTAssertEqual(
             fleet.accounts.map(\.name),
             [


### PR DESCRIPTION
Phase 2 of `docs/design/ffi-in-process-target-state.md`. Workflow YAML only, zero behaviour change.

## The gap

`.github/workflows/ci.yml` had four jobs, all `ubuntu-latest`. No Swift was compiled anywhere in CI, so none of the app's 107 Swift tests had ever run there — a Rust-side change could break TcrBar with every check green. The design puts this before the phase that deletes ~1,000 lines of Swift, so that deletion happens under CI rather than on trust.

## What the job runs

One `macos-latest` job: `cargo test --all --locked`, then `swift build && swift test` in `apps/macos`.

- **No fmt/clippy.** Platform-independent, already gated by `ci`; macOS runner minutes are billed at a multiple of Linux.
- **`cargo test` is kept, and is not just a duplicate of the ubuntu run.** `src/singleton.rs` shells out to `ps`/`lsof` (BSD flags and columns), binary placement relies on `rename(2)` semantics, `$TMPDIR` is a per-user sandbox path here, and macOS is the only platform the app ships on.
- **Cargo cache yes, SwiftPM cache no.** `Swatinem/rust-cache` keys on runner OS so it shares nothing with the ubuntu jobs. The Swift package declares zero external dependencies, so a `.build` cache has nothing to fetch and would miss on nearly every run.
- `swift --version` is logged so a runner-image bump that changes the language mode is attributable from the log rather than looking like a source regression.

## Gate

Per the design: *"a job that has only ever passed proves nothing."* The green run, a deliberately-broken-test red run, and the restored green are recorded in a comment below.

Whether `macos` becomes a required check is a branch-protection decision and is deliberately not touched here.