### PR TITLE
refactor: extract serve() so the proxy can start without the binary

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod oauth;
 pub mod probe;
 pub mod proxy;
 pub mod quota;
+pub mod server;
 pub mod singleton;
 pub mod stats;
 pub mod status;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,24 @@
 //! `tcr` — the teamclaude-rs binary.
 //!
-//! Boot sequence (DESIGN §main): load the drop-in config → build the [`Manager`]
-//! → spawn the axum proxy task and the background probe loop → run the TUI (or
-//! block in `--headless`) → flush the config on exit.
+//! Boot sequence (DESIGN §main): load the drop-in config → hand it to
+//! [`teamclaude_rs::server::serve`], which builds the [`Manager`], spawns the
+//! axum proxy task and the background loops, and binds → run the TUI (or block
+//! in `--headless`) → shut the handle down, which flushes on exit.
+//!
+//! What is left in THIS file is what only a binary may do: parse clap, install a
+//! logging subscriber, print operator diagnostics, and turn a stand-down into a
+//! process exit code. Everything reusable lives in the library.
+//!
+//! [`Manager`]: teamclaude_rs::manager::Manager
 
 use std::path::{Path, PathBuf};
-use std::time::Duration;
 
 use anyhow::Context as _;
 use clap::{Parser, Subcommand};
 
-use std::sync::Arc;
-
 use teamclaude_rs::cli::{self, PriorityArg};
 use teamclaude_rs::config::{self, Config, ConfigError};
-use teamclaude_rs::manager::Manager;
-use teamclaude_rs::{affinity, build_info, demo, mitm, oauth, singleton, tui, update};
+use teamclaude_rs::{affinity, build_info, demo, mitm, oauth, server, tui, update};
 
 #[derive(Parser)]
 #[command(
@@ -516,225 +519,42 @@ fn stand_down_exit_code(liveness: &cli::Liveness, verdict: build_info::StandDown
     }
 }
 
+/// `tcr server` — the clap→[`server::ServeOptions`] adapter.
+///
+/// Everything that actually boots the proxy lives in [`teamclaude_rs::server`],
+/// which is usable from a test or any other embedder. What stays here is what
+/// only a *binary* may do: choose the logging subscriber, print the operator's
+/// stand-down diagnosis, turn that stand-down into a process exit code, and pick
+/// how to wait (the TUI, or a headless block on Ctrl-C).
 async fn run_server(args: ServerArgs) -> anyhow::Result<()> {
     let config_path = args.config.clone().unwrap_or_else(config::default_path);
-    let (mut config, persist_path) = load_config(&config_path);
-    if let Some(port) = args.port {
-        config.proxy.port = port;
-    }
-    let port = config.proxy.port;
+    let (config, persist_path) = load_config(&config_path);
 
     init_tracing(args.headless);
 
-    // Resolve the port to ONE proxy BEFORE the Manager starts probing/refreshing,
-    // so our own startup can never token-war with the incumbent. Only a
-    // command-verified teamclaude/tcr server on THIS port is ever signalled — a
-    // `tcr` peer only under `--replace`, a legacy JS `teamclaude` always, since
-    // displacing that one is what the takeover exists for. `--no-replace` is the
-    // default now, and clap rejects it alongside `--replace`.
-    if let singleton::Takeover::IncumbentPresent(pid) = singleton::takeover_port(port, args.replace)
-    {
-        // ONE probe of the incumbent, answering two questions: which build it is
-        // executing, and whether it is executing anything at all.
-        let probe = cli::probe_incumbent(&config).await;
-        // Read the checkout LIVE. The build stamps alone cannot see an edit made
-        // since the last commit (build.rs re-runs only when a git ref moves), so
-        // comparing two stamps would print "build in sync" for a proxy that
-        // predates the edit — see `build_info::stand_down_build_report`.
-        let checkout = std::env::current_dir()
-            .ok()
-            .and_then(|cwd| build_info::find_tcr_checkout(&cwd))
-            .map(|root| build_info::read_checkout_state(&root, build_info::SHA));
-        // Standing down is cheap and correct, but silent success here would mean
-        // `cargo build && tcr` exits 0 with the OLD build still serving — say which
-        // build actually holds the port before we go.
-        let report = build_info::stand_down_build_report(
-            port,
-            &build_info::BuildInfo::current(),
-            probe.build.as_ref(),
-            checkout.as_ref(),
-        );
-        eprintln!("{}", report.line);
-        if let cli::Liveness::Silent { why } = &probe.liveness {
-            eprintln!(
-                "[tcr] WARNING incumbent-not-answering: port={port} pid={pid} probe={why:?} — the \
-                 process holding :{port} did not respond, so standing down leaves NOTHING serving \
-                 on it. Run `tcr --replace` to take the port over; that is the recovery for a \
-                 wedged proxy, and it is not being done automatically because it also wipes the \
-                 pin map of a proxy that was merely slow to answer."
-            );
-        }
-        std::process::exit(stand_down_exit_code(&probe.liveness, report.verdict));
-    }
-
-    let manager = Manager::with_live_refresher(config, persist_path);
-
-    // Session-affinity pins survive a restart via their own cache file (NOT the
-    // credential config — see `teamclaude_rs::affinity`). Restore before the
-    // listener binds, so the first request after a bounce already routes on its
-    // old pin instead of cold-starting the account's prompt cache.
-    //
-    // Only when affinity is enabled: with the feature off the map is never
-    // consulted, and a restore would put entries in it that nothing reads.
-    let affinity_path = affinity::default_path();
-    if manager.session_affinity_enabled() {
-        let report = manager.restore_affinity(&affinity_path, affinity::PIN_TTL_MS);
-        if let Some(reason) = &report.degraded {
-            // Never fatal: the pin file is a cache, so an unusable one costs the
-            // warm start it would have bought and nothing else.
-            tracing::warn!(
-                path = %affinity_path.display(),
-                reason = %reason,
-                "session-affinity pins ignored; starting with an empty pin map"
-            );
-        } else {
-            tracing::info!(
-                path = %affinity_path.display(),
-                restored = report.pins.len(),
-                expired = report.expired,
-                unresolved = report.unresolved,
-                ambiguous = report.ambiguous,
-                ttl_minutes = affinity::PIN_TTL_MS / 60_000,
-                "session-affinity pins restored"
-            );
-        }
-
-        // Debounced incremental flush. Shutdown-only would miss the case this
-        // exists to survive: `--replace` follows SIGTERM with SIGKILL, and a
-        // SIGKILL runs no shutdown path at all. A 5-second timer that writes only
-        // when the map actually changed bounds the loss to one interval while
-        // keeping a busy proxy to at most one small atomic write per interval;
-        // pins settle early in a session, so steady state is no writes.
-        let flusher = manager.clone();
-        let flush_path = affinity_path.clone();
-        tokio::spawn(async move {
-            let mut ticker = tokio::time::interval(Duration::from_secs(5));
-            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-            loop {
-                ticker.tick().await;
-                if !flusher.take_affinity_dirty() {
-                    continue;
-                }
-                if let Err(err) = flusher.flush_affinity(&flush_path) {
-                    tracing::warn!(
-                        path = %flush_path.display(),
-                        error = %err,
-                        "could not write the session-affinity pin file; pins will not survive this restart"
-                    );
-                }
-            }
-        });
-    }
-
-    // Background probe loop: refresh every account's quota on the configured
-    // cadence (a value <= 0 in `quotaProbeSeconds` disables it). The first tick
-    // fires immediately, so the bars populate at startup rather than after a lag.
-    let probe_seconds = manager.probe_interval_seconds();
-    if probe_seconds > 0 {
-        let prober = manager.clone();
-        tokio::spawn(async move {
-            let mut ticker = tokio::time::interval(Duration::from_secs(probe_seconds));
-            loop {
-                ticker.tick().await;
-                prober.probe_all().await;
-            }
-        });
-    }
-
-    // Opt-in keep-warm loop: periodically warm idle accounts so their 5h session
-    // window stays live. Ships DARK — `warmupSeconds` defaults to 0, and when it is
-    // absent/0 NO task is spawned here at all (unlike the probe, warming spends real
-    // quota). `MissedTickBehavior::Skip` drops a missed tick rather than bursting a
-    // catch-up warm after the process was suspended.
-    let warmup_seconds = manager.warmup_interval_seconds();
-    if warmup_seconds > 0 {
-        let m = manager.clone();
-        tokio::spawn(async move {
-            let mut ticker = tokio::time::interval(Duration::from_secs(warmup_seconds));
-            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-            loop {
-                // Two things start a sweep: the configured cadence, and the probe
-                // reporting that it has READ an account's quota for the first time.
-                // The second is what keeps `warm_targets`' boot gate from being a
-                // kill switch — the ticker's immediate first tick necessarily finds
-                // no targets (no quota read yet) and `Skip` puts the next one a whole
-                // `warmupSeconds` away, so at 3600s a proxy restarted more often than
-                // hourly would otherwise warm nothing, ever. A wake arriving while
-                // this task is inside `warm_all` is stored as a permit by
-                // `notify_one` and consumed by the next `notified()`, so it is never
-                // lost; the flip fires at most once per account per process, so this
-                // cannot spin.
-                tokio::select! {
-                    _ = ticker.tick() => {}
-                    _ = m.warm_wake().notified() => {}
-                }
-                m.warm_all().await;
-            }
-        });
-    }
-
-    // Load the MITM TLS material (reuse the existing leaf, else mint one). A
-    // failure here is non-fatal: base-URL mode still serves; only CONNECT
-    // (forward-proxy) mode is unavailable until the cert issue is fixed.
-    let tls = match mitm::load_tls() {
-        Ok(assets) => {
-            if let Some(ca) = &assets.ca_path {
-                tracing::info!(ca = %ca.display(), "MITM: advertise this CA via NODE_EXTRA_CA_CERTS");
-            }
-            Some(Arc::new(assets.acceptor))
-        }
-        Err(err) => {
-            tracing::warn!(error = %err, "MITM disabled: could not load/generate TLS material (base-URL mode still works)");
-            None
-        }
+    let options = server::ServeOptions {
+        config,
+        persist_path,
+        port: args.port,
+        replace: args.replace,
+        affinity_path: affinity::default_path(),
+        tls: server::TlsSetup::Load,
     };
 
-    // Hybrid proxy server task: base-URL mode and HTTPS_PROXY/CONNECT mode on the
-    // same port. The listener peeks each connection and routes accordingly.
-    let listener = tokio::net::TcpListener::bind(("127.0.0.1", port))
-        .await
-        .with_context(|| format!("failed to bind 127.0.0.1:{port}"))?;
-    let bound = listener.local_addr()?;
+    let handle = match server::serve(options).await? {
+        server::ServeOutcome::Started(handle) => handle,
+        // A binary may exit; the library returned this as a value.
+        server::ServeOutcome::StoodDown(stand_down) => stand_down_exit(&stand_down),
+    };
+    let bound = handle.addr();
 
-    // The boot marker. `$TMPDIR/teamclaude-rs.log` is appended forever and never
-    // rotated, so without this line a restart is invisible: request lines run
-    // unbroken across a bounce and the log cannot be sliced "since this boot".
-    // Emitted here deliberately — after `init_tracing` (else it goes nowhere) and
-    // after the bind SUCCEEDED — so one line means "this pid is live on this port",
-    // not "this pid tried". A restart also wipes the in-memory session→account pin
-    // map, the most expensive cache event in this system; counting these lines is
-    // how that cost becomes measurable:  rg 'server started' "$TMPDIR/teamclaude-rs.log"
-    //
-    // `version` alone could not tell two boots apart: it is `CARGO_PKG_VERSION`,
-    // the literal 0.1.0 from Cargo.toml, identical across every build ever made.
-    // The build stamp beside it is the field that actually identifies the code
-    // this pid is executing — the thing that used to need an `lsof -p <pid>`
-    // inode comparison to establish. See `build_info`.
-    tracing::info!(
-        version = env!("CARGO_PKG_VERSION"),
-        sha = build_info::SHA,
-        dirty = build_info::DIRTY,
-        built_at = build_info::BUILT_AT,
-        pid = std::process::id(),
-        port = bound.port(),
-        "server started"
-    );
-
-    let serve_manager = manager.clone();
-    let mut server = tokio::spawn(async move {
-        mitm::serve(listener, serve_manager, tls).await;
-    });
-
+    let mut handle = handle;
     if args.headless {
         tracing::info!("teamclaude-rs listening on http://{bound} (headless)");
         // Block until Ctrl-C or the server task exits.
         tokio::select! {
             _ = tokio::signal::ctrl_c() => tracing::info!("shutdown signal received"),
-            res = &mut server => {
-                if let Err(err) = res {
-                    tracing::error!(error = %err, "server task join error");
-                }
-            }
+            () = handle.serving_stopped() => {}
         }
     } else {
         // The TUI owns the foreground. Under raw mode Ctrl-C arrives as a keystroke,
@@ -750,7 +570,7 @@ async fn run_server(args: ServerArgs) -> anyhow::Result<()> {
         if sigterm.is_none() {
             tracing::warn!("could not install SIGTERM handler; terminal may not restore if killed");
         }
-        let tui_fut = tui::run(manager.clone());
+        let tui_fut = tui::run(handle.manager().clone());
         tokio::pin!(tui_fut);
         tokio::select! {
             res = &mut tui_fut => {
@@ -771,28 +591,39 @@ async fn run_server(args: ServerArgs) -> anyhow::Result<()> {
         }
     }
 
-    // Stop serving, then flush the config (refreshed tokens already persisted
-    // incrementally; this is the final belt-and-suspenders write).
-    server.abort();
-    manager.persist_now();
-    // Final pin flush on a CLEAN shutdown, capturing whatever changed inside the
-    // last flusher interval. Belt-and-braces only — the timer above is what makes
-    // the pins survive a SIGKILL, which is the case that actually matters.
-    if manager.session_affinity_enabled() {
-        match manager.flush_affinity(&affinity_path) {
-            Ok(count) => tracing::info!(
-                path = %affinity_path.display(),
-                pins = count,
-                "session-affinity pins written for the next boot"
-            ),
-            Err(err) => tracing::warn!(
-                path = %affinity_path.display(),
-                error = %err,
-                "final session-affinity pin write failed; pins will not survive this restart"
-            ),
-        }
-    }
+    // Stop serving, then flush the config and the affinity pins. The whole
+    // sequence — including the final pin write a clean shutdown owes the next
+    // boot — lives in `ServerHandle::shutdown`, so an embedder gets it too.
+    handle.shutdown().await;
     Ok(())
+}
+
+/// Print the stand-down diagnosis and exit with the code it earned. Never returns.
+///
+/// This is the half of the stand-down a *library* must not do, which is why
+/// [`server::serve`] hands the facts back as a [`server::StandDown`] instead.
+/// The wording is a cross-language contract: TcrBar scans this stderr, and
+/// `ServerController.StandDownExit` switches on the code.
+fn stand_down_exit(stand_down: &server::StandDown) -> ! {
+    // Standing down is cheap and correct, but silent success here would mean
+    // `cargo build && tcr` exits 0 with the OLD build still serving — say which
+    // build actually holds the port before we go.
+    eprintln!("{}", stand_down.report.line);
+    if let cli::Liveness::Silent { why } = &stand_down.probe.liveness {
+        let port = stand_down.port;
+        let pid = stand_down.pid;
+        eprintln!(
+            "[tcr] WARNING incumbent-not-answering: port={port} pid={pid} probe={why:?} — the \
+             process holding :{port} did not respond, so standing down leaves NOTHING serving \
+             on it. Run `tcr --replace` to take the port over; that is the recovery for a \
+             wedged proxy, and it is not being done automatically because it also wipes the \
+             pin map of a proxy that was merely slow to answer."
+        );
+    }
+    std::process::exit(stand_down_exit_code(
+        &stand_down.probe.liveness,
+        stand_down.report.verdict,
+    ));
 }
 
 /// Load the config, deciding what may be written back:

--- a/src/main.rs
+++ b/src/main.rs
@@ -532,12 +532,20 @@ async fn run_server(args: ServerArgs) -> anyhow::Result<()> {
 
     init_tracing(args.headless);
 
+    // Spelled out rather than built from `ServeOptions::new`, which is
+    // deliberately inert: writing the config back, owning the shared pin cache
+    // and signalling whatever holds the port are all things only the BINARY may
+    // do, so the binary is the place they are written down.
     let options = server::ServeOptions {
         config,
         persist_path,
         port: args.port,
-        replace: args.replace,
-        affinity_path: affinity::default_path(),
+        incumbent: if args.replace {
+            server::IncumbentPolicy::kill_the_incumbent_proxy()
+        } else {
+            server::IncumbentPolicy::replace_legacy_js_only()
+        },
+        affinity_path: Some(affinity::default_path()),
         tls: server::TlsSetup::Load,
     };
 
@@ -594,7 +602,15 @@ async fn run_server(args: ServerArgs) -> anyhow::Result<()> {
     // Stop serving, then flush the config and the affinity pins. The whole
     // sequence — including the final pin write a clean shutdown owes the next
     // boot — lives in `ServerHandle::shutdown`, so an embedder gets it too.
-    handle.shutdown().await;
+    // Bounded there, so a wedged filesystem cannot turn quitting the TUI into a
+    // hang with the terminal already restored and nothing left serving.
+    let report = handle.shutdown().await;
+    if report.tasks_aborted > 0 {
+        tracing::warn!(
+            aborted = report.tasks_aborted,
+            "background task(s) did not stop within the shutdown grace and were aborted"
+        );
+    }
     Ok(())
 }
 

--- a/src/mitm.rs
+++ b/src/mitm.rs
@@ -309,13 +309,47 @@ fn write_file(path: &Path, data: &[u8], mode: u32) -> io::Result<()> {
     Ok(())
 }
 
-/// Run the hybrid listener until the task is aborted: accept, classify each
-/// connection (`CONNECT` → MITM, else base-URL), and serve it on its own task.
-/// `tls` is `None` only when TLS material could not be loaded at all — CONNECT
-/// then answers `503`, while base-URL mode keeps working.
+/// Run the hybrid listener forever: accept, classify each connection
+/// (`CONNECT` → MITM, else base-URL), and serve it on its own task. `tls` is
+/// `None` only when TLS material could not be loaded at all — CONNECT then
+/// answers `503`, while base-URL mode keeps working.
+///
+/// Never returns. A caller that needs to stop serving wants
+/// [`serve_with_shutdown`]; this is the shape the in-process tests use, where
+/// the loop dies with the test's runtime.
 pub async fn serve(listener: TcpListener, manager: Arc<Manager>, tls: Option<Arc<TlsAcceptor>>) {
+    serve_with_shutdown(listener, manager, tls, std::future::pending::<()>()).await;
+}
+
+/// [`serve`], plus a shutdown branch on the accept loop.
+///
+/// Returning drops the `listener`, so the port stops accepting the moment
+/// `shutdown` resolves — no `abort()` from outside, which is what a library
+/// caller could not rely on. Connections already accepted are NOT touched: each
+/// runs on its own detached task and a proxied response can be a long stream, so
+/// cutting one at shutdown would be strictly worse than letting it finish. Same
+/// property the old `server.abort()` had, now stated instead of incidental.
+///
+/// `biased` so a pending shutdown wins over a ready accept: under load an
+/// unbiased `select!` picks randomly, and shutdown must not be starved by
+/// traffic.
+pub async fn serve_with_shutdown(
+    listener: TcpListener,
+    manager: Arc<Manager>,
+    tls: Option<Arc<TlsAcceptor>>,
+    shutdown: impl std::future::Future<Output = ()>,
+) {
+    let mut shutdown = std::pin::pin!(shutdown);
     loop {
-        let (stream, peer) = match listener.accept().await {
+        let accepted = tokio::select! {
+            biased;
+            () = &mut shutdown => {
+                tracing::info!("accept loop shutting down; no longer accepting connections");
+                return;
+            }
+            accepted = listener.accept() => accepted,
+        };
+        let (stream, peer) = match accepted {
             Ok(pair) => pair,
             Err(err) => {
                 tracing::warn!(error = %err, "accept failed");

--- a/src/server.rs
+++ b/src/server.rs
@@ -939,13 +939,21 @@ mod tests {
         let (shutdown, _rx) = watch::channel(false);
         let keepalive = shutdown.clone();
         // Ignores the signal for 300ms, then stops: long enough for the first
-        // attempt to be cancelled while joining it.
+        // attempt to be cancelled while joining it. The accept loop is already
+        // finished, so the cancellation lands inside the BACKGROUND join — the
+        // loop whose bookkeeping is what cancel-safety is about. (Cancelling on
+        // the server join instead leaves the background vec untouched, which a
+        // consuming implementation would also survive.)
         let slow = || {
             tokio::spawn(async {
                 tokio::time::sleep(Duration::from_millis(300)).await;
             })
         };
-        let mut handle = handle_owning(shutdown, slow(), vec![slow(), slow()]);
+        let mut handle = handle_owning(
+            shutdown,
+            tokio::spawn(std::future::ready(())),
+            vec![slow(), slow()],
+        );
 
         assert!(
             tokio::time::timeout(

--- a/src/server.rs
+++ b/src/server.rs
@@ -781,9 +781,27 @@ mod tests {
     /// A manager with no accounts: nothing to probe, refresh or warm, and
     /// `config_path: None` so no file can be written.
     fn inert_manager() -> Arc<Manager> {
-        let config: Config = serde_json::from_str(r#"{"accounts": []}"#)
-            .expect("an empty account list is a valid config");
+        manager_with(r#"{"accounts": []}"#)
+    }
+
+    fn manager_with(config: &str) -> Arc<Manager> {
+        let config: Config = serde_json::from_str(config).expect("the inline test config parses");
         Manager::with_live_refresher(config, None)
+    }
+
+    /// A path under an existing REGULAR FILE, so any write to it fails. Never
+    /// near [`affinity::default_path`] — a test may not touch the live cache.
+    fn unwritable_path(tag: &str) -> PathBuf {
+        let blocker = std::env::temp_dir().join(format!(
+            "tcr-server-unit-{}-{tag}-{:?}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or_default()
+        ));
+        std::fs::write(&blocker, b"not a directory").expect("the scratch blocker file is writable");
+        blocker.join("affinity.json")
     }
 
     /// A handle owning `server` plus `background`, wired to `shutdown`, that can
@@ -793,13 +811,23 @@ mod tests {
         server: JoinHandle<()>,
         background: Vec<JoinHandle<()>>,
     ) -> ServerHandle {
+        handle_full(shutdown, server, background, inert_manager(), None)
+    }
+
+    fn handle_full(
+        shutdown: watch::Sender<bool>,
+        server: JoinHandle<()>,
+        background: Vec<JoinHandle<()>>,
+        manager: Arc<Manager>,
+        affinity_path: Option<PathBuf>,
+    ) -> ServerHandle {
         ServerHandle {
             addr: "127.0.0.1:0"
                 .parse()
                 .expect("a literal loopback addr parses"),
             shutdown,
-            manager: inert_manager(),
-            affinity_path: None,
+            manager,
+            affinity_path,
             tasks_joined: 0,
             tasks_aborted: 0,
             server: Some(server),
@@ -858,6 +886,145 @@ mod tests {
             ),
         }
         drop(keepalive);
+    }
+
+    /// `shutdown` must not be able to HANG on a task that will not stop.
+    ///
+    /// The affinity flusher writes with blocking `std::fs` inside async code, so
+    /// on a full or wedged filesystem it reaches no cancellation point; an
+    /// unbounded join there meant `tcr` quitting into a hang with the terminal
+    /// already restored, nothing serving, and `persist_now` never reached. A
+    /// `pending()` task is that condition with the filesystem left out of it.
+    ///
+    /// The outer `timeout` is the assertion: it is 30x the grace, so it can only
+    /// fire if the join is unbounded.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shutdown_aborts_a_task_that_will_not_stop_instead_of_hanging() {
+        let (shutdown, _rx) = watch::channel(false);
+        let keepalive = shutdown.clone();
+        let wedged = tokio::spawn(std::future::pending::<()>());
+        let wedged_abort = wedged.abort_handle();
+        let mut handle =
+            handle_owning(shutdown, tokio::spawn(std::future::ready(())), vec![wedged]);
+
+        let grace = Duration::from_millis(100);
+        let report = tokio::time::timeout(grace * 30, handle.shutdown_within(grace))
+            .await
+            .expect("shutdown hung on a task that never stops");
+
+        assert_eq!(report.tasks_joined, 1, "the accept loop stopped on its own");
+        assert_eq!(
+            report.tasks_aborted, 1,
+            "the wedged task must be aborted, not waited for"
+        );
+        assert!(
+            wedged_abort.is_finished() || {
+                tokio::time::sleep(grace).await;
+                wedged_abort.is_finished()
+            },
+            "the wedged task was abandoned rather than aborted"
+        );
+        drop(keepalive);
+    }
+
+    /// `shutdown` must be cancel-safe and re-issuable.
+    ///
+    /// It used to consume `self`, so a caller bounding it with a deadline — the
+    /// pattern the integration test itself models — lost the handle along with
+    /// the future, skipping `persist_now` and the final pin write with nothing
+    /// left to retry. Here the first attempt is cancelled mid-join and the second
+    /// still accounts for every task.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_cancelled_shutdown_can_be_re_issued_and_still_accounts_for_every_task() {
+        let (shutdown, _rx) = watch::channel(false);
+        let keepalive = shutdown.clone();
+        // Ignores the signal for 300ms, then stops: long enough for the first
+        // attempt to be cancelled while joining it.
+        let slow = || {
+            tokio::spawn(async {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+            })
+        };
+        let mut handle = handle_owning(shutdown, slow(), vec![slow(), slow()]);
+
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(20),
+                handle.shutdown_within(Duration::from_secs(30))
+            )
+            .await
+            .is_err(),
+            "the first attempt was supposed to be cancelled mid-join"
+        );
+
+        // The handle survived the cancellation, and every task it still owns is
+        // joinable — nothing was dropped on the floor by the abandoned future.
+        let report = tokio::time::timeout(Duration::from_secs(5), handle.shutdown())
+            .await
+            .expect("the re-issued shutdown must finish");
+        assert_eq!(
+            report.tasks_joined + report.tasks_aborted,
+            3,
+            "every task must be accounted for across the cancelled and re-issued \
+             attempts, saw {report:?}"
+        );
+        assert_eq!(
+            report.tasks_aborted, 0,
+            "the tasks stop well inside the grace, so none should need aborting: {report:?}"
+        );
+        drop(keepalive);
+    }
+
+    /// A FAILED final pin write must be distinguishable from affinity being off.
+    ///
+    /// Both were `affinity_pins_written: None`, and the difference lived only in
+    /// a `tracing::warn!` that a library caller — which installs no subscriber —
+    /// never sees. So total pin loss reported as a clean shutdown.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_failed_final_pin_write_is_reported_not_swallowed() {
+        let path = unwritable_path("flush-fails");
+        let (shutdown, _rx) = watch::channel(false);
+        let mut handle = handle_full(
+            shutdown,
+            tokio::spawn(std::future::ready(())),
+            Vec::new(),
+            manager_with(r#"{"sessionAffinity": true, "accounts": []}"#),
+            Some(path.clone()),
+        );
+
+        let report = handle.shutdown().await;
+        assert!(
+            report.affinity.failed(),
+            "a pin write to {} cannot have succeeded; report said {:?}",
+            path.display(),
+            report.affinity
+        );
+        assert_eq!(
+            report.affinity.pins_written(),
+            None,
+            "a failed write wrote no pins"
+        );
+        assert_ne!(
+            report.affinity,
+            AffinityFlush::Disabled,
+            "a failed write must not read as 'affinity is off'"
+        );
+    }
+
+    /// With no pin cache path the shutdown flush must be a no-op, not a write to
+    /// some default — this is the guard on `affinity_path: None` meaning
+    /// "in memory only".
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn no_pin_cache_path_means_no_final_write() {
+        let (shutdown, _rx) = watch::channel(false);
+        let mut handle = handle_full(
+            shutdown,
+            tokio::spawn(std::future::ready(())),
+            Vec::new(),
+            manager_with(r#"{"sessionAffinity": true, "accounts": []}"#),
+            None,
+        );
+        assert_eq!(handle.shutdown().await.affinity, AffinityFlush::Disabled);
     }
 
     /// `Drop` must also SIGNAL — the accept loop and every background loop stop

--- a/src/server.rs
+++ b/src/server.rs
@@ -27,6 +27,12 @@ use crate::config::Config;
 use crate::manager::Manager;
 use crate::{affinity, build_info, cli, mitm, singleton};
 
+/// How long [`ServerHandle::shutdown`] waits for a task to stop before aborting
+/// it. Long enough for a loop to finish an iteration and an in-progress atomic
+/// write to land; short enough that quitting `tcr` on a wedged filesystem is a
+/// pause and not a hang.
+pub const DEFAULT_SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
+
 /// Where the MITM listener's TLS material comes from.
 ///
 /// `tcr` always uses [`TlsSetup::Load`], which is what `run_server` did inline.
@@ -43,7 +49,79 @@ pub enum TlsSetup {
     Disabled,
 }
 
+/// What [`serve`] may do to a process that already holds the port.
+///
+/// This was a `bool` named `replace`, which is how the most destructive
+/// operation in this system ended up one keystroke from every caller: setting it
+/// reaches [`singleton::takeover_port`], which SIGTERMs and then SIGKILLs a
+/// command-verified proxy holding the port, wiping its session→account pin map.
+/// Under the `--replace` flag that is the intended, operator-typed recovery.
+/// From an embedder or a test it is a catastrophe with the same spelling.
+///
+/// So the signalling choices are not values a caller can land on — they are
+/// *named constructors* that say what they do, and the private field means
+/// `Default`, struct-literal syntax and `..Default::default()` can only ever
+/// produce [`never_signal`](Self::never_signal). "Follow the docs and you cannot
+/// kill anything" is the property being bought.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct IncumbentPolicy(Signal);
+
+/// The private half of [`IncumbentPolicy`]. Deliberately unnameable outside this
+/// module so no caller can construct the signalling variants directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+enum Signal {
+    /// Signal nothing, ever. A recognized incumbent means stand down.
+    #[default]
+    Never,
+    /// The binary's default (`--no-replace`): replace a legacy JS proxy, stand
+    /// down for a `tcr` peer.
+    LegacyJsOnly,
+    /// `--replace`: replace whichever recognized proxy holds the port.
+    Recognized,
+}
+
+impl IncumbentPolicy {
+    /// **The default.** Send no signal to any process under any circumstance; a
+    /// recognized proxy on the port produces [`ServeOutcome::StoodDown`].
+    ///
+    /// The only correct policy for a library caller or a test, which is why it
+    /// is what you get for free.
+    pub fn never_signal() -> Self {
+        Self(Signal::Never)
+    }
+
+    /// `tcr server` without `--replace`: SIGTERM/SIGKILL a **legacy JS**
+    /// `teamclaude` proxy on the port (displacing it is why the takeover exists,
+    /// and leaving it running would token-war over single-use refresh tokens),
+    /// but stand down for a `tcr` peer.
+    pub fn replace_legacy_js_only() -> Self {
+        Self(Signal::LegacyJsOnly)
+    }
+
+    /// `tcr server --replace`: **SIGTERM, then SIGKILL after 800ms**, whichever
+    /// recognized proxy holds the port — including a live `tcr` serving real
+    /// traffic. That wipes its in-memory session→account pin map and every live
+    /// session then pays a full cold prompt-cache prefix.
+    ///
+    /// Reserve this for an operator who typed `--replace`. Nothing in a test or
+    /// an embedder should call it.
+    pub fn kill_the_incumbent_proxy() -> Self {
+        Self(Signal::Recognized)
+    }
+
+    /// Whether this policy can signal a process at all — for a caller that wants
+    /// to assert it is holding the harmless one.
+    pub fn signals_anything(&self) -> bool {
+        !matches!(self.0, Signal::Never)
+    }
+}
+
 /// Everything [`serve`] needs, derived from what `run_server` actually read.
+///
+/// Every field that can reach outside this process — the config file, the pin
+/// cache, the incumbent on the port — defaults to the inert choice, so the
+/// *dangerous* configuration is the one you have to spell out. See
+/// [`ServeOptions::new`].
 ///
 /// Note what is NOT here. `--headless` is not a serving parameter: it selects
 /// the *logging subscriber* and *how the caller waits*, both of which stay with
@@ -55,29 +133,51 @@ pub struct ServeOptions {
     pub config: Config,
     /// Where the config may be written back, or `None` to make every persist a
     /// no-op (a corrupt file must never be clobbered with defaults).
+    ///
+    /// `None` also means **refreshed OAuth tokens are never written to disk**.
+    /// Anthropic's refresh tokens are single-use, so a long-lived embedder that
+    /// leaves this `None` while pointing at a real config leaves already-spent
+    /// tokens on disk and every account fails to refresh on the next boot. If
+    /// you serve from a real config, pass its path.
     pub persist_path: Option<PathBuf>,
     /// Overrides `config.proxy.port` when set — the `--port` flag. `Some(0)`
     /// binds an ephemeral port, which is how a test gets a real server without
     /// contending for the configured one.
     pub port: Option<u16>,
-    /// Take the port over from a recognized proxy incumbent (`--replace`).
-    pub replace: bool,
-    /// The session-affinity pin cache. Split out so a caller can point it
-    /// somewhere disposable; the binary passes [`affinity::default_path`].
-    pub affinity_path: PathBuf,
+    /// What to do about a recognized proxy already holding the port. Defaults to
+    /// [`IncumbentPolicy::never_signal`]; the binary maps `--replace` onto it.
+    pub incumbent: IncumbentPolicy,
+    /// The session-affinity pin cache, or `None` to keep pins **in memory only**
+    /// — nothing is read at boot and nothing is written at shutdown.
+    ///
+    /// `None` is the default because the binary's path ([`affinity::default_path`])
+    /// is one shared file: a second process that serves briefly and shuts down
+    /// atomically replaces the live proxy's pin map with its own (usually empty)
+    /// one, and the live proxy — whose flusher only writes when its map changed —
+    /// never repairs it. The next boot then cold-starts every session's prompt
+    /// cache. Point this somewhere disposable, or leave it `None`.
+    pub affinity_path: Option<PathBuf>,
     /// Where the MITM TLS material comes from.
     pub tls: TlsSetup,
 }
 
 impl ServeOptions {
-    /// The binary's defaults for everything but the config itself.
+    /// Serve this config while touching **nothing outside this process**: no
+    /// config write-back, no pin cache, no signal to whatever holds the port,
+    /// and (via [`TlsSetup::Load`]) the same TLS material the binary uses.
+    ///
+    /// This deliberately is NOT "the binary's defaults" — it used to say so
+    /// while defaulting `persist_path` to `None`, which is the opposite of what
+    /// the binary passes. The binary spells its own options out in
+    /// `main::run_server`, because every one of them is a decision about files
+    /// and processes a library caller must not make by accident.
     pub fn new(config: Config) -> Self {
         Self {
             config,
             persist_path: None,
             port: None,
-            replace: false,
-            affinity_path: affinity::default_path(),
+            incumbent: IncumbentPolicy::never_signal(),
+            affinity_path: None,
             tls: TlsSetup::Load,
         }
     }
@@ -125,16 +225,55 @@ impl ServeOutcome {
     }
 }
 
+/// What the final session-affinity pin write did.
+///
+/// Three states, not `Option<usize>`. "Affinity is off" and "the write FAILED
+/// and every pin is lost" are the same value in an `Option`, and the only place
+/// the difference survived was a `tracing::warn!` — which a library embedder,
+/// having installed no subscriber, never sees. A caller reading a clean report
+/// while the next boot cold-starts every session's prompt cache is exactly the
+/// silence this type exists to break.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AffinityFlush {
+    /// Nothing to write: session affinity is off in the config, or no pin cache
+    /// path was configured ([`ServeOptions::affinity_path`] was `None`).
+    Disabled,
+    /// The pins were written for the next boot. Zero is a normal count.
+    Written(usize),
+    /// The write failed and the pins are **lost**. Carries the rendered error
+    /// because the caller may have no tracing subscriber to read the warning in.
+    Failed(String),
+}
+
+impl AffinityFlush {
+    /// The pin count when one was actually written, else `None`.
+    pub fn pins_written(&self) -> Option<usize> {
+        match self {
+            AffinityFlush::Written(count) => Some(*count),
+            _ => None,
+        }
+    }
+
+    /// Did a write that was supposed to happen fail? The one condition a caller
+    /// should surface even though shutdown is not fallible.
+    pub fn failed(&self) -> bool {
+        matches!(self, AffinityFlush::Failed(_))
+    }
+}
+
 /// What a clean [`ServerHandle::shutdown`] did, so a caller can assert on it
 /// instead of trusting that the function returned.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ShutdownReport {
     /// How many tasks the handle owned and joined: the accept loop plus every
     /// background loop that was actually spawned for this config.
     pub tasks_joined: usize,
-    /// Pins written by the final affinity flush, `None` when affinity is off or
-    /// the write failed (it is a cache; a failure is logged, never fatal).
-    pub affinity_pins_written: Option<usize>,
+    /// How many tasks did NOT stop inside the grace period and were aborted.
+    /// Non-zero means a loop was wedged — the flush below still ran, which is
+    /// the whole reason the grace exists.
+    pub tasks_aborted: usize,
+    /// What the final pin write did.
+    pub affinity: AffinityFlush,
 }
 
 /// A bound, running proxy — and the owner of every task [`serve`] spawned.
@@ -147,7 +286,12 @@ pub struct ServerHandle {
     addr: SocketAddr,
     shutdown: watch::Sender<bool>,
     manager: Arc<Manager>,
-    affinity_path: PathBuf,
+    affinity_path: Option<PathBuf>,
+    /// Tasks joined and tasks aborted so far. Kept on the handle, not in a local,
+    /// so a `shutdown` future that is dropped mid-join and re-issued reports the
+    /// whole truth rather than only what the last attempt saw.
+    tasks_joined: usize,
+    tasks_aborted: usize,
     /// The `mitm::serve` accept loop. `None` once [`Self::shutdown`] joined it.
     server: Option<JoinHandle<()>>,
     /// Whether that task has already been awaited to completion. A `JoinHandle`
@@ -209,19 +353,71 @@ impl ServerHandle {
     /// long stream and killing it mid-flight would be a behaviour change and a
     /// worse one. What stops immediately is *accepting new* connections — the
     /// listener is dropped with the accept loop, so the port refuses at once.
-    pub async fn shutdown(mut self) -> ShutdownReport {
+    ///
+    /// Bounded by [`DEFAULT_SHUTDOWN_GRACE`] and **cannot hang** — see
+    /// [`shutdown_within`](Self::shutdown_within) for why that is not optional.
+    pub async fn shutdown(&mut self) -> ShutdownReport {
+        self.shutdown_within(DEFAULT_SHUTDOWN_GRACE).await
+    }
+
+    /// [`shutdown`](Self::shutdown) with the join deadline spelled out.
+    ///
+    /// # Why there is a deadline at all
+    ///
+    /// `run_server` called `server.abort()` and flushed immediately; it could not
+    /// hang. Joining instead is better — a loop gets to finish its current
+    /// iteration — but only if the join is bounded, because the affinity flusher
+    /// performs a **blocking `std::fs` write inside async code**
+    /// (`flush_affinity` → `config::write_atomic`) and cancellation only lands at
+    /// an await point. On a full, slow or hung filesystem an unbounded join means
+    /// `tcr` quits into a hang with the terminal already restored, no listener
+    /// bound, no prompt — and `persist_now` never runs. So a task that has not
+    /// stopped within `grace` is aborted, counted in
+    /// [`ShutdownReport::tasks_aborted`], and left behind; the config persist and
+    /// the final pin write happen either way.
+    ///
+    /// # Cancel-safety
+    ///
+    /// Takes `&mut self`, and a task is removed from the handle only once it has
+    /// actually been joined. A caller that bounds this with its own deadline and
+    /// drops the future keeps a usable handle, keeps every un-joined task owned
+    /// (so `Drop` still aborts them), and may simply call it again — the counters
+    /// carry over and the flushes are idempotent.
+    pub async fn shutdown_within(&mut self, grace: Duration) -> ShutdownReport {
         let _ = self.shutdown.send(true);
-        let mut tasks_joined = 0usize;
-        if let Some(server) = self.server.take() {
-            if !self.server_finished {
-                let _ = server.await;
+        let deadline = tokio::time::Instant::now() + grace;
+
+        if let Some(server) = self.server.as_mut() {
+            // `&mut JoinHandle` polls the join without consuming it: losing the
+            // race to the caller's own timeout leaves the task owned here.
+            let stopped = self.server_finished
+                || match tokio::time::timeout_at(deadline, &mut *server).await {
+                    Ok(_) => true,
+                    Err(_) => {
+                        // NOT awaited after the abort: a task wedged in a
+                        // synchronous write never reaches a cancellation point,
+                        // so awaiting it back would reintroduce the hang.
+                        server.abort();
+                        false
+                    }
+                };
+            self.server = None;
+            if stopped {
                 self.server_finished = true;
+                self.tasks_joined += 1;
+            } else {
+                self.tasks_aborted += 1;
             }
-            tasks_joined += 1;
         }
-        for task in std::mem::take(&mut self.background) {
-            let _ = task.await;
-            tasks_joined += 1;
+        while let Some(task) = self.background.last_mut() {
+            match tokio::time::timeout_at(deadline, &mut *task).await {
+                Ok(_) => self.tasks_joined += 1,
+                Err(_) => {
+                    task.abort();
+                    self.tasks_aborted += 1;
+                }
+            }
+            self.background.pop();
         }
 
         self.manager.persist_now();
@@ -229,28 +425,41 @@ impl ServerHandle {
         // Final pin flush on a CLEAN shutdown, capturing whatever changed inside
         // the last flusher interval. Belt-and-braces only — the 5s timer is what
         // makes the pins survive a SIGKILL, which is the case that matters.
-        let mut affinity_pins_written = None;
-        if self.manager.session_affinity_enabled() {
-            match self.manager.flush_affinity(&self.affinity_path) {
-                Ok(count) => {
-                    tracing::info!(
-                        path = %self.affinity_path.display(),
-                        pins = count,
-                        "session-affinity pins written for the next boot"
-                    );
-                    affinity_pins_written = Some(count);
-                }
-                Err(err) => tracing::warn!(
-                    path = %self.affinity_path.display(),
-                    error = %err,
-                    "final session-affinity pin write failed; pins will not survive this restart"
-                ),
-            }
-        }
+        let affinity = self.flush_affinity_finally();
 
         ShutdownReport {
-            tasks_joined,
-            affinity_pins_written,
+            tasks_joined: self.tasks_joined,
+            tasks_aborted: self.tasks_aborted,
+            affinity,
+        }
+    }
+
+    /// The shutdown pin write, as a value. Logs as before for the binary's
+    /// operator, and returns the same fact for a caller with no subscriber.
+    fn flush_affinity_finally(&self) -> AffinityFlush {
+        let Some(path) = self.affinity_path.as_ref() else {
+            return AffinityFlush::Disabled;
+        };
+        if !self.manager.session_affinity_enabled() {
+            return AffinityFlush::Disabled;
+        }
+        match self.manager.flush_affinity(path) {
+            Ok(count) => {
+                tracing::info!(
+                    path = %path.display(),
+                    pins = count,
+                    "session-affinity pins written for the next boot"
+                );
+                AffinityFlush::Written(count)
+            }
+            Err(err) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %err,
+                    "final session-affinity pin write failed; pins will not survive this restart"
+                );
+                AffinityFlush::Failed(err.to_string())
+            }
         }
     }
 }
@@ -279,7 +488,7 @@ pub async fn serve(options: ServeOptions) -> anyhow::Result<ServeOutcome> {
         mut config,
         persist_path,
         port: port_override,
-        replace,
+        incumbent,
         affinity_path,
         tls,
     } = options;
@@ -295,7 +504,23 @@ pub async fn serve(options: ServeOptions) -> anyhow::Result<ServeOutcome> {
     // `tcr` peer only under `--replace`, a legacy JS `teamclaude` always, since
     // displacing that one is what the takeover exists for. `--no-replace` is the
     // default now, and clap rejects it alongside `--replace`.
-    if let singleton::Takeover::IncumbentPresent(pid) = singleton::takeover_port(port, replace) {
+    //
+    // Which of those a caller gets is [`IncumbentPolicy`], and the default sends
+    // no signal at all: it uses `live_proxy_server`, the detection-only half of
+    // the same port-scoped, command-verified decision, and stands down for
+    // anything it finds. Port 0 short-circuits the whole question — the kernel
+    // picks an ephemeral port, so no process can be "holding" it and there is
+    // nothing an ephemeral-port caller could possibly want signalled.
+    let takeover = match (port, incumbent.0) {
+        (0, _) => singleton::Takeover::Proceed,
+        (_, Signal::Never) => match singleton::live_proxy_server(port) {
+            Some(pid) => singleton::Takeover::IncumbentPresent(pid),
+            None => singleton::Takeover::Proceed,
+        },
+        (_, Signal::LegacyJsOnly) => singleton::takeover_port(port, false),
+        (_, Signal::Recognized) => singleton::takeover_port(port, true),
+    };
+    if let singleton::Takeover::IncumbentPresent(pid) = takeover {
         // ONE probe of the incumbent, answering two questions: which build it is
         // executing, and whether it is executing anything at all.
         let probe = cli::probe_incumbent(&config).await;
@@ -339,8 +564,12 @@ pub async fn serve(options: ServeOptions) -> anyhow::Result<ServeOutcome> {
     //
     // Only when affinity is enabled: with the feature off the map is never
     // consulted, and a restore would put entries in it that nothing reads.
-    if manager.session_affinity_enabled() {
-        let report = manager.restore_affinity(&affinity_path, affinity::PIN_TTL_MS);
+    //
+    // And only when a pin cache path was given: with `affinity_path: None` the
+    // pins are an in-memory routing table for this process alone, so there is
+    // nothing to restore from and nothing to spawn a flusher for.
+    if let (true, Some(affinity_path)) = (manager.session_affinity_enabled(), &affinity_path) {
+        let report = manager.restore_affinity(affinity_path, affinity::PIN_TTL_MS);
         if let Some(reason) = &report.degraded {
             // Never fatal: the pin file is a cache, so an unusable one costs the
             // warm start it would have bought and nothing else.
@@ -524,8 +753,151 @@ pub async fn serve(options: ServeOptions) -> anyhow::Result<ServeOutcome> {
         shutdown: shutdown_tx,
         manager,
         affinity_path,
+        tasks_joined: 0,
+        tasks_aborted: 0,
         server: Some(server),
         server_finished: false,
         background,
     }))
+}
+
+/// Unit tests for what only in-crate access can pin: [`Drop for ServerHandle`].
+///
+/// The integration test (`tests/serve_library_path.rs`) drops a real handle and
+/// watches the port refuse — which proves the loop stopped, but NOT that `Drop`
+/// stopped it: the handle owns the `watch::Sender`, so dropping it closes the
+/// channel and every `stop.changed()` returns `Err` on its own. That test stayed
+/// green with `impl Drop` deleted.
+///
+/// These build a `ServerHandle` by hand and hold a **`Sender` clone**, so the
+/// channel survives the drop and sender-close is off the table as an
+/// explanation. Each half of `Drop` then has exactly one thing that can satisfy
+/// it: `send(true)` for the tasks that watch the channel, `abort()` for the ones
+/// that do not.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A manager with no accounts: nothing to probe, refresh or warm, and
+    /// `config_path: None` so no file can be written.
+    fn inert_manager() -> Arc<Manager> {
+        let config: Config = serde_json::from_str(r#"{"accounts": []}"#)
+            .expect("an empty account list is a valid config");
+        Manager::with_live_refresher(config, None)
+    }
+
+    /// A handle owning `server` plus `background`, wired to `shutdown`, that can
+    /// touch nothing outside this process when dropped.
+    fn handle_owning(
+        shutdown: watch::Sender<bool>,
+        server: JoinHandle<()>,
+        background: Vec<JoinHandle<()>>,
+    ) -> ServerHandle {
+        ServerHandle {
+            addr: "127.0.0.1:0"
+                .parse()
+                .expect("a literal loopback addr parses"),
+            shutdown,
+            manager: inert_manager(),
+            affinity_path: None,
+            tasks_joined: 0,
+            tasks_aborted: 0,
+            server: Some(server),
+            server_finished: false,
+            background,
+        }
+    }
+
+    async fn all_finished_within(
+        aborts: &[tokio::task::AbortHandle],
+        budget: Duration,
+    ) -> Result<(), usize> {
+        let deadline = tokio::time::Instant::now() + budget;
+        loop {
+            let live = aborts.iter().filter(|a| !a.is_finished()).count();
+            if live == 0 {
+                return Ok(());
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(live);
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    /// `Drop` must ABORT. Every task here ignores the shutdown channel entirely,
+    /// so nothing but `JoinHandle::abort` can end it — and a retained `Sender`
+    /// clone keeps the channel open, so closing it is not available either.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dropping_the_handle_aborts_tasks_that_ignore_the_shutdown_signal() {
+        let (shutdown, _rx) = watch::channel(false);
+        let keepalive = shutdown.clone();
+
+        let deaf = || tokio::spawn(std::future::pending::<()>());
+        let server = deaf();
+        let background: Vec<JoinHandle<()>> = (0..3).map(|_| deaf()).collect();
+        let aborts: Vec<tokio::task::AbortHandle> = std::iter::once(server.abort_handle())
+            .chain(background.iter().map(|task| task.abort_handle()))
+            .collect();
+
+        let handle = handle_owning(shutdown, server, background);
+        assert_eq!(
+            aborts.iter().filter(|a| a.is_finished()).count(),
+            0,
+            "the tasks must still be running before the handle is dropped"
+        );
+
+        drop(handle);
+
+        match all_finished_within(&aborts, Duration::from_secs(5)).await {
+            Ok(()) => {}
+            Err(live) => panic!(
+                "Drop leaked {live} of {} tasks: a task that ignores the shutdown \
+                 channel can only be stopped by `abort()`",
+                aborts.len()
+            ),
+        }
+        drop(keepalive);
+    }
+
+    /// `Drop` must also SIGNAL — the accept loop and every background loop stop
+    /// on `stop.changed()`, and the sender-close that currently masks this is
+    /// removed here by holding a `Sender` clone.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dropping_the_handle_signals_tasks_that_watch_the_shutdown_channel() {
+        let (shutdown, _rx) = watch::channel(false);
+        let keepalive = shutdown.clone();
+
+        // Ends only on a `true`: a bare close would leave `changed()` returning
+        // `Err` and this loop spinning back to `pending`, never finishing.
+        let watcher = |mut stop: watch::Receiver<bool>| {
+            tokio::spawn(async move {
+                loop {
+                    if stop.changed().await.is_err() {
+                        std::future::pending::<()>().await;
+                    }
+                    if *stop.borrow_and_update() {
+                        return;
+                    }
+                }
+            })
+        };
+        let server = watcher(shutdown.subscribe());
+        let background: Vec<JoinHandle<()>> =
+            (0..2).map(|_| watcher(shutdown.subscribe())).collect();
+        let aborts: Vec<tokio::task::AbortHandle> = std::iter::once(server.abort_handle())
+            .chain(background.iter().map(|task| task.abort_handle()))
+            .collect();
+
+        drop(handle_owning(shutdown, server, background));
+
+        assert!(
+            *keepalive.borrow(),
+            "Drop must publish `true` on the shutdown channel, not merely close it"
+        );
+        if let Err(live) = all_finished_within(&aborts, Duration::from_secs(5)).await {
+            panic!("{live} task(s) never saw the shutdown signal");
+        }
+        drop(keepalive);
+    }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,0 +1,531 @@
+//! The proxy's boot sequence as a **library** call.
+//!
+//! This is the body of what used to be `main.rs::run_server`, with the two
+//! things a library may not do removed:
+//!
+//! * it never calls `std::process::exit` — the stand-down is returned as a
+//!   [`StandDown`] value and the *binary* maps it to an exit code;
+//! * it never blocks until shutdown — [`serve`] returns as soon as the listener
+//!   is bound, handing back a [`ServerHandle`] that OWNS every task it spawned.
+//!   The caller decides how to wait (`tcr` runs the TUI or blocks on Ctrl-C; a
+//!   test issues one request and shuts down).
+//!
+//! Everything else is unchanged on purpose: the same takeover decision, the same
+//! affinity restore/flush, the same background loops, the same `server started`
+//! boot marker emitted only after a SUCCESSFUL bind.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context as _;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+
+use crate::config::Config;
+use crate::manager::Manager;
+use crate::{affinity, build_info, cli, mitm, singleton};
+
+/// Where the MITM listener's TLS material comes from.
+///
+/// `tcr` always uses [`TlsSetup::Load`], which is what `run_server` did inline.
+/// [`TlsSetup::Disabled`] exists because loading mints/reads a CA on disk, and a
+/// caller that only needs base-URL mode (an in-process test) must be able to opt
+/// out of that side effect rather than work around it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TlsSetup {
+    /// Load (or mint) the MITM CA + leaf, as the binary does. A failure is
+    /// non-fatal: base-URL mode still serves, CONNECT answers 503.
+    #[default]
+    Load,
+    /// Do not touch the TLS material at all. CONNECT answers 503.
+    Disabled,
+}
+
+/// Everything [`serve`] needs, derived from what `run_server` actually read.
+///
+/// Note what is NOT here. `--headless` is not a serving parameter: it selects
+/// the *logging subscriber* and *how the caller waits*, both of which stay with
+/// the binary. The config is passed already loaded rather than as a path,
+/// because loading it prints operator-facing `[tcr]` diagnostics and decides
+/// whether the file may be written back — a binary concern (`main::load_config`).
+pub struct ServeOptions {
+    /// The already-loaded config.
+    pub config: Config,
+    /// Where the config may be written back, or `None` to make every persist a
+    /// no-op (a corrupt file must never be clobbered with defaults).
+    pub persist_path: Option<PathBuf>,
+    /// Overrides `config.proxy.port` when set — the `--port` flag. `Some(0)`
+    /// binds an ephemeral port, which is how a test gets a real server without
+    /// contending for the configured one.
+    pub port: Option<u16>,
+    /// Take the port over from a recognized proxy incumbent (`--replace`).
+    pub replace: bool,
+    /// The session-affinity pin cache. Split out so a caller can point it
+    /// somewhere disposable; the binary passes [`affinity::default_path`].
+    pub affinity_path: PathBuf,
+    /// Where the MITM TLS material comes from.
+    pub tls: TlsSetup,
+}
+
+impl ServeOptions {
+    /// The binary's defaults for everything but the config itself.
+    pub fn new(config: Config) -> Self {
+        Self {
+            config,
+            persist_path: None,
+            port: None,
+            replace: false,
+            affinity_path: affinity::default_path(),
+            tls: TlsSetup::Load,
+        }
+    }
+}
+
+/// A recognized proxy incumbent holds the port, so we did not bind.
+///
+/// Returned as DATA. The exit code, the build line and the operator warning are
+/// the binary's job (`main::run_server`); a library caller gets the same facts
+/// without a process exit and can decide for itself.
+pub struct StandDown {
+    /// The port that was contended.
+    pub port: u16,
+    /// The incumbent's pid, as `singleton` identified it.
+    pub pid: u32,
+    /// ONE probe of the incumbent: which build it runs, and whether it answers
+    /// at all. Both halves are needed to pick an exit code.
+    pub probe: cli::IncumbentProbe,
+    /// The build comparison, verdict + human line produced together.
+    pub report: build_info::StandDownReport,
+}
+
+/// What [`serve`] did.
+pub enum ServeOutcome {
+    /// The listener is bound and every background task is running.
+    Started(ServerHandle),
+    /// An incumbent holds the port and was deliberately left alone. Nothing was
+    /// bound and nothing was spawned.
+    StoodDown(StandDown),
+}
+
+impl ServeOutcome {
+    /// The handle, or a panic — for callers (tests) that require a bound server.
+    ///
+    /// # Panics
+    /// If the outcome was a stand-down.
+    pub fn expect_started(self) -> ServerHandle {
+        match self {
+            ServeOutcome::Started(handle) => handle,
+            ServeOutcome::StoodDown(stand_down) => panic!(
+                "expected a bound server; an incumbent (pid {}) holds :{}",
+                stand_down.pid, stand_down.port
+            ),
+        }
+    }
+}
+
+/// What a clean [`ServerHandle::shutdown`] did, so a caller can assert on it
+/// instead of trusting that the function returned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShutdownReport {
+    /// How many tasks the handle owned and joined: the accept loop plus every
+    /// background loop that was actually spawned for this config.
+    pub tasks_joined: usize,
+    /// Pins written by the final affinity flush, `None` when affinity is off or
+    /// the write failed (it is a cache; a failure is logged, never fatal).
+    pub affinity_pins_written: Option<usize>,
+}
+
+/// A bound, running proxy — and the owner of every task [`serve`] spawned.
+///
+/// Ownership is the point. `run_server` could hand its background loops to "the
+/// process is about to exit"; a library caller cannot, so dropping this handle
+/// aborts them and [`shutdown`](Self::shutdown) stops them in order and gives
+/// the affinity map its final write.
+pub struct ServerHandle {
+    addr: SocketAddr,
+    shutdown: watch::Sender<bool>,
+    manager: Arc<Manager>,
+    affinity_path: PathBuf,
+    /// The `mitm::serve` accept loop. `None` once [`Self::shutdown`] joined it.
+    server: Option<JoinHandle<()>>,
+    /// Whether that task has already been awaited to completion. A `JoinHandle`
+    /// may only be polled to completion once, and [`Self::serving_stopped`] can
+    /// get there before [`Self::shutdown`] does.
+    server_finished: bool,
+    /// The affinity flusher / quota prober / keep-warm loops, whichever this
+    /// config enabled.
+    background: Vec<JoinHandle<()>>,
+}
+
+impl ServerHandle {
+    /// The address actually bound — the resolved port when `0` was requested.
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    /// The live [`Manager`], for a caller that wants the same state the TUI reads.
+    pub fn manager(&self) -> &Arc<Manager> {
+        &self.manager
+    }
+
+    /// How many background loops this config spawned (the accept loop excluded).
+    pub fn background_task_count(&self) -> usize {
+        self.background.len()
+    }
+
+    /// Resolves when the accept loop stops **on its own** — which in practice
+    /// means it panicked, since it otherwise runs until shutdown. Pends forever
+    /// once that has happened (or if shutdown already joined it), so it is safe
+    /// to park a `select!` arm on it.
+    ///
+    /// Cancel-safe: nothing is taken out of `self` until the join actually
+    /// completes, so losing the race leaves the task owned — and therefore still
+    /// aborted by `Drop`.
+    pub async fn serving_stopped(&mut self) {
+        if self.server_finished {
+            std::future::pending::<()>().await;
+        }
+        let result = match self.server.as_mut() {
+            Some(server) => server.await,
+            None => std::future::pending().await,
+        };
+        self.server_finished = true;
+        if let Err(err) = result {
+            tracing::error!(error = %err, "server task join error");
+        }
+    }
+
+    /// Stop serving, then flush.
+    ///
+    /// The order is `run_server`'s: stop the accept loop, persist the config
+    /// (refreshed tokens are already written incrementally; this is the final
+    /// belt-and-braces write), then write the session-affinity pins.
+    ///
+    /// **In-flight connections are left to finish.** Each accepted connection
+    /// runs on its own detached task, exactly as before this extraction, so
+    /// cancelling the accept loop has never cut one; a proxied response can be a
+    /// long stream and killing it mid-flight would be a behaviour change and a
+    /// worse one. What stops immediately is *accepting new* connections — the
+    /// listener is dropped with the accept loop, so the port refuses at once.
+    pub async fn shutdown(mut self) -> ShutdownReport {
+        let _ = self.shutdown.send(true);
+        let mut tasks_joined = 0usize;
+        if let Some(server) = self.server.take() {
+            if !self.server_finished {
+                let _ = server.await;
+                self.server_finished = true;
+            }
+            tasks_joined += 1;
+        }
+        for task in std::mem::take(&mut self.background) {
+            let _ = task.await;
+            tasks_joined += 1;
+        }
+
+        self.manager.persist_now();
+
+        // Final pin flush on a CLEAN shutdown, capturing whatever changed inside
+        // the last flusher interval. Belt-and-braces only — the 5s timer is what
+        // makes the pins survive a SIGKILL, which is the case that matters.
+        let mut affinity_pins_written = None;
+        if self.manager.session_affinity_enabled() {
+            match self.manager.flush_affinity(&self.affinity_path) {
+                Ok(count) => {
+                    tracing::info!(
+                        path = %self.affinity_path.display(),
+                        pins = count,
+                        "session-affinity pins written for the next boot"
+                    );
+                    affinity_pins_written = Some(count);
+                }
+                Err(err) => tracing::warn!(
+                    path = %self.affinity_path.display(),
+                    error = %err,
+                    "final session-affinity pin write failed; pins will not survive this restart"
+                ),
+            }
+        }
+
+        ShutdownReport {
+            tasks_joined,
+            affinity_pins_written,
+        }
+    }
+}
+
+/// Dropping the handle must not leak the accept loop, the prober, the warmer or
+/// the affinity flusher. The binary never relied on this (the process exited);
+/// a library caller has nothing else to fall back on.
+impl Drop for ServerHandle {
+    fn drop(&mut self) {
+        let _ = self.shutdown.send(true);
+        if let Some(server) = &self.server {
+            server.abort();
+        }
+        for task in &self.background {
+            task.abort();
+        }
+    }
+}
+
+/// Boot the proxy and return once the listener is bound.
+///
+/// Returns [`ServeOutcome::StoodDown`] rather than exiting when a recognized
+/// proxy incumbent holds the port. Errors only when the bind itself fails.
+pub async fn serve(options: ServeOptions) -> anyhow::Result<ServeOutcome> {
+    let ServeOptions {
+        mut config,
+        persist_path,
+        port: port_override,
+        replace,
+        affinity_path,
+        tls,
+    } = options;
+
+    if let Some(port) = port_override {
+        config.proxy.port = port;
+    }
+    let port = config.proxy.port;
+
+    // Resolve the port to ONE proxy BEFORE the Manager starts probing/refreshing,
+    // so our own startup can never token-war with the incumbent. Only a
+    // command-verified teamclaude/tcr server on THIS port is ever signalled — a
+    // `tcr` peer only under `--replace`, a legacy JS `teamclaude` always, since
+    // displacing that one is what the takeover exists for. `--no-replace` is the
+    // default now, and clap rejects it alongside `--replace`.
+    if let singleton::Takeover::IncumbentPresent(pid) = singleton::takeover_port(port, replace) {
+        // ONE probe of the incumbent, answering two questions: which build it is
+        // executing, and whether it is executing anything at all.
+        let probe = cli::probe_incumbent(&config).await;
+        // Read the checkout LIVE. The build stamps alone cannot see an edit made
+        // since the last commit (build.rs re-runs only when a git ref moves), so
+        // comparing two stamps would print "build in sync" for a proxy that
+        // predates the edit — see `build_info::stand_down_build_report`.
+        let checkout = std::env::current_dir()
+            .ok()
+            .and_then(|cwd| build_info::find_tcr_checkout(&cwd))
+            .map(|root| build_info::read_checkout_state(&root, build_info::SHA));
+        // Standing down is cheap and correct, but silent success here would mean
+        // `cargo build && tcr` exits 0 with the OLD build still serving — the
+        // caller is handed which build actually holds the port so it can say so.
+        let report = build_info::stand_down_build_report(
+            port,
+            &build_info::BuildInfo::current(),
+            probe.build.as_ref(),
+            checkout.as_ref(),
+        );
+        return Ok(ServeOutcome::StoodDown(StandDown {
+            port,
+            pid,
+            probe,
+            report,
+        }));
+    }
+
+    let manager = Manager::with_live_refresher(config, persist_path);
+
+    // One trigger for every task this function spawns. `watch` rather than a
+    // one-shot so each loop can hold its own receiver and shutdown is
+    // idempotent (both `shutdown()` and `Drop` may fire it).
+    let (shutdown_tx, _) = watch::channel(false);
+    let mut background: Vec<JoinHandle<()>> = Vec::new();
+
+    // Session-affinity pins survive a restart via their own cache file (NOT the
+    // credential config — see `teamclaude_rs::affinity`). Restore before the
+    // listener binds, so the first request after a bounce already routes on its
+    // old pin instead of cold-starting the account's prompt cache.
+    //
+    // Only when affinity is enabled: with the feature off the map is never
+    // consulted, and a restore would put entries in it that nothing reads.
+    if manager.session_affinity_enabled() {
+        let report = manager.restore_affinity(&affinity_path, affinity::PIN_TTL_MS);
+        if let Some(reason) = &report.degraded {
+            // Never fatal: the pin file is a cache, so an unusable one costs the
+            // warm start it would have bought and nothing else.
+            tracing::warn!(
+                path = %affinity_path.display(),
+                reason = %reason,
+                "session-affinity pins ignored; starting with an empty pin map"
+            );
+        } else {
+            tracing::info!(
+                path = %affinity_path.display(),
+                restored = report.pins.len(),
+                expired = report.expired,
+                unresolved = report.unresolved,
+                ambiguous = report.ambiguous,
+                ttl_minutes = affinity::PIN_TTL_MS / 60_000,
+                "session-affinity pins restored"
+            );
+        }
+
+        // Debounced incremental flush. Shutdown-only would miss the case this
+        // exists to survive: `--replace` follows SIGTERM with SIGKILL, and a
+        // SIGKILL runs no shutdown path at all. A 5-second timer that writes only
+        // when the map actually changed bounds the loss to one interval while
+        // keeping a busy proxy to at most one small atomic write per interval;
+        // pins settle early in a session, so steady state is no writes.
+        let flusher = manager.clone();
+        let flush_path = affinity_path.clone();
+        let mut stop = shutdown_tx.subscribe();
+        background.push(tokio::spawn(async move {
+            let flush = async {
+                let mut ticker = tokio::time::interval(Duration::from_secs(5));
+                ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                loop {
+                    ticker.tick().await;
+                    if !flusher.take_affinity_dirty() {
+                        continue;
+                    }
+                    if let Err(err) = flusher.flush_affinity(&flush_path) {
+                        tracing::warn!(
+                            path = %flush_path.display(),
+                            error = %err,
+                            "could not write the session-affinity pin file; pins will not survive this restart"
+                        );
+                    }
+                }
+            };
+            // The write itself is synchronous, so cancelling here can never tear
+            // a half-written pin file; the loss is at most one interval, which
+            // `ServerHandle::shutdown`'s final flush then recovers.
+            tokio::select! {
+                _ = flush => {}
+                _ = stop.changed() => {}
+            }
+        }));
+    }
+
+    // Background probe loop: refresh every account's quota on the configured
+    // cadence (a value <= 0 in `quotaProbeSeconds` disables it). The first tick
+    // fires immediately, so the bars populate at startup rather than after a lag.
+    let probe_seconds = manager.probe_interval_seconds();
+    if probe_seconds > 0 {
+        let prober = manager.clone();
+        let mut stop = shutdown_tx.subscribe();
+        background.push(tokio::spawn(async move {
+            let probe = async {
+                let mut ticker = tokio::time::interval(Duration::from_secs(probe_seconds));
+                loop {
+                    ticker.tick().await;
+                    prober.probe_all().await;
+                }
+            };
+            tokio::select! {
+                _ = probe => {}
+                _ = stop.changed() => {}
+            }
+        }));
+    }
+
+    // Opt-in keep-warm loop: periodically warm idle accounts so their 5h session
+    // window stays live. Ships DARK — `warmupSeconds` defaults to 0, and when it is
+    // absent/0 NO task is spawned here at all (unlike the probe, warming spends real
+    // quota). `MissedTickBehavior::Skip` drops a missed tick rather than bursting a
+    // catch-up warm after the process was suspended.
+    let warmup_seconds = manager.warmup_interval_seconds();
+    if warmup_seconds > 0 {
+        let m = manager.clone();
+        let mut stop = shutdown_tx.subscribe();
+        background.push(tokio::spawn(async move {
+            let warm = async {
+                let mut ticker = tokio::time::interval(Duration::from_secs(warmup_seconds));
+                ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                loop {
+                    // Two things start a sweep: the configured cadence, and the probe
+                    // reporting that it has READ an account's quota for the first time.
+                    // The second is what keeps `warm_targets`' boot gate from being a
+                    // kill switch — the ticker's immediate first tick necessarily finds
+                    // no targets (no quota read yet) and `Skip` puts the next one a whole
+                    // `warmupSeconds` away, so at 3600s a proxy restarted more often than
+                    // hourly would otherwise warm nothing, ever. A wake arriving while
+                    // this task is inside `warm_all` is stored as a permit by
+                    // `notify_one` and consumed by the next `notified()`, so it is never
+                    // lost; the flip fires at most once per account per process, so this
+                    // cannot spin.
+                    tokio::select! {
+                        _ = ticker.tick() => {}
+                        _ = m.warm_wake().notified() => {}
+                    }
+                    m.warm_all().await;
+                }
+            };
+            tokio::select! {
+                _ = warm => {}
+                _ = stop.changed() => {}
+            }
+        }));
+    }
+
+    // Load the MITM TLS material (reuse the existing leaf, else mint one). A
+    // failure here is non-fatal: base-URL mode still serves; only CONNECT
+    // (forward-proxy) mode is unavailable until the cert issue is fixed.
+    let tls = match tls {
+        TlsSetup::Load => match mitm::load_tls() {
+            Ok(assets) => {
+                if let Some(ca) = &assets.ca_path {
+                    tracing::info!(ca = %ca.display(), "MITM: advertise this CA via NODE_EXTRA_CA_CERTS");
+                }
+                Some(Arc::new(assets.acceptor))
+            }
+            Err(err) => {
+                tracing::warn!(error = %err, "MITM disabled: could not load/generate TLS material (base-URL mode still works)");
+                None
+            }
+        },
+        TlsSetup::Disabled => None,
+    };
+
+    // Hybrid proxy server task: base-URL mode and HTTPS_PROXY/CONNECT mode on the
+    // same port. The listener peeks each connection and routes accordingly.
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", port))
+        .await
+        .with_context(|| format!("failed to bind 127.0.0.1:{port}"))?;
+    let bound = listener.local_addr()?;
+
+    // The boot marker. `$TMPDIR/teamclaude-rs.log` is appended forever and never
+    // rotated, so without this line a restart is invisible: request lines run
+    // unbroken across a bounce and the log cannot be sliced "since this boot".
+    // Emitted here deliberately — after the subscriber is installed (else it goes
+    // nowhere) and after the bind SUCCEEDED — so one line means "this pid is live
+    // on this port", not "this pid tried". A restart also wipes the in-memory
+    // session→account pin map, the most expensive cache event in this system;
+    // counting these lines is how that cost becomes measurable:
+    //   rg 'server started' "$TMPDIR/teamclaude-rs.log"
+    //
+    // `version` alone could not tell two boots apart: it is `CARGO_PKG_VERSION`,
+    // the literal 0.1.0 from Cargo.toml, identical across every build ever made.
+    // The build stamp beside it is the field that actually identifies the code
+    // this pid is executing — the thing that used to need an `lsof -p <pid>`
+    // inode comparison to establish. See `build_info`.
+    tracing::info!(
+        version = env!("CARGO_PKG_VERSION"),
+        sha = build_info::SHA,
+        dirty = build_info::DIRTY,
+        built_at = build_info::BUILT_AT,
+        pid = std::process::id(),
+        port = bound.port(),
+        "server started"
+    );
+
+    let serve_manager = manager.clone();
+    let mut stop = shutdown_tx.subscribe();
+    let server = tokio::spawn(async move {
+        mitm::serve_with_shutdown(listener, serve_manager, tls, async move {
+            let _ = stop.changed().await;
+        })
+        .await;
+    });
+
+    Ok(ServeOutcome::Started(ServerHandle {
+        addr: bound,
+        shutdown: shutdown_tx,
+        manager,
+        affinity_path,
+        server: Some(server),
+        server_finished: false,
+        background,
+    }))
+}

--- a/tests/serve_library_path.rs
+++ b/tests/serve_library_path.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 
 use teamclaude_rs::config::Config;
 use teamclaude_rs::proxy::STATUS_PATH;
-use teamclaude_rs::server::{serve, ServeOptions, TlsSetup};
+use teamclaude_rs::server::{serve, AffinityFlush, IncumbentPolicy, ServeOptions, TlsSetup};
 
 /// The port `tcr` uses by default. Named here so the assertion below says what
 /// it is protecting rather than showing a bare number.
@@ -69,9 +69,10 @@ fn options(tag: &str) -> ServeOptions {
         // Belt and braces with the config's own 0 — whichever is read, it is not
         // the live proxy's port.
         port: Some(0),
-        // NEVER true here: `--replace` is what signals an incumbent.
-        replace: false,
-        affinity_path: scratch_affinity_path(tag),
+        // The default, and the only policy that signals nothing: a test that
+        // could reach `takeover_port` could SIGKILL the developer's live proxy.
+        incumbent: IncumbentPolicy::never_signal(),
+        affinity_path: Some(scratch_affinity_path(tag)),
         // Loading the MITM material mints/reads a CA on disk. Base-URL mode is
         // all this file exercises, so do not touch it.
         tls: TlsSetup::Disabled,
@@ -103,7 +104,7 @@ async fn port_refuses_within(port: u16, budget: Duration) -> bool {
 /// connection went through the production accept path and not some shortcut.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn the_library_can_start_serve_and_stop_the_proxy_with_no_binary() {
-    let handle = serve(options("gate"))
+    let mut handle = serve(options("gate"))
         .await
         .expect("binding an ephemeral port cannot fail")
         .expect_started();
@@ -162,8 +163,12 @@ async fn the_library_can_start_serve_and_stop_the_proxy_with_no_binary() {
         "the accept loop plus both background loops must be joined"
     );
     assert_eq!(
-        report.affinity_pins_written,
-        Some(0),
+        report.tasks_aborted, 0,
+        "no task should need the grace period's abort on a clean shutdown"
+    );
+    assert_eq!(
+        report.affinity,
+        AffinityFlush::Written(0),
         "a clean shutdown owes the next boot its final pin write, even when empty"
     );
 
@@ -176,19 +181,46 @@ async fn the_library_can_start_serve_and_stop_the_proxy_with_no_binary() {
     );
 }
 
-/// A library caller that simply DROPS the handle must not leak the accept loop.
+/// A library caller that simply DROPS the handle must not leak the accept loop
+/// **or any background loop**.
 ///
 /// `run_server` never needed this — the process exited — which is exactly why it
 /// could not be embedded. Dropping is the failure mode an embedder hits first
 /// (an early return, a panic, a `?`), so it gets its own test.
+///
+/// # What this test can and cannot prove
+///
+/// The port refusing is NOT evidence about `impl Drop for ServerHandle`: the
+/// handle owns the `watch::Sender`, so dropping it closes the channel and every
+/// loop's `stop.changed()` returns `Err` — the accept loop would stop with the
+/// `Drop` impl deleted entirely. What is added here is the *other* four fifths
+/// of the claim: every spawned task holds an `Arc<Manager>` clone, so watching
+/// the strong count fall back to the one this test holds proves the prober and
+/// the flusher are gone too, not just the listener.
+///
+/// The `Drop` impl itself is pinned by the unit tests in `src/server.rs`, which
+/// can hold a `Sender` clone (keeping the channel open) and so isolate `abort()`
+/// as the only thing that can stop a task. Deleting `impl Drop` turns those red;
+/// it cannot turn this one red, and pretending otherwise is what the first
+/// version of this test did.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn dropping_the_handle_stops_the_accept_loop() {
+async fn dropping_the_handle_stops_the_accept_loop_and_every_background_loop() {
     let handle = serve(options("drop"))
         .await
         .expect("binding an ephemeral port cannot fail")
         .expect_started();
     let port = handle.addr().port();
     assert_ne!(port, LIVE_PROXY_PORT);
+    assert_eq!(handle.background_task_count(), 2);
+
+    // Every task `serve` spawned captured one of these.
+    let manager = handle.manager().clone();
+    let live_tasks = || std::sync::Arc::strong_count(&manager) - 1;
+    assert!(
+        live_tasks() >= 3,
+        "expected the accept loop and both background loops to hold a manager clone, saw {}",
+        live_tasks()
+    );
 
     // It is serving right now.
     assert!(
@@ -204,4 +236,60 @@ async fn dropping_the_handle_stops_the_accept_loop() {
         port_refuses_within(port, Duration::from_secs(5)).await,
         "the accept loop outlived its handle: :{port} is still accepting"
     );
+
+    // Polled: aborting is asynchronous — the task's future (and with it the
+    // manager clone) is dropped when the runtime next gets to it.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while live_tasks() > 0 && tokio::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert_eq!(
+        live_tasks(),
+        0,
+        "a task outlived the handle that owned it: {} manager clone(s) still held",
+        live_tasks()
+    );
+}
+
+/// The documented convenience constructor must not reach the binary's files.
+///
+/// `ServeOptions::new` used to point `affinity_path` at [the live proxy's shared
+/// pin cache], so an embedder following the docs would atomically replace the
+/// running proxy's session→account map with its own empty one at shutdown, and
+/// the next boot would cold-start every session's prompt cache. Nothing guarded
+/// it, because every test hand-built a scratch path instead.
+///
+/// Asserted as *values*, without serving: this test may not create a proxy that
+/// could write anywhere.
+///
+/// [the live proxy's shared pin cache]: teamclaude_rs::affinity::default_path
+#[test]
+fn the_convenience_constructor_touches_nothing_outside_the_process() {
+    let options = ServeOptions::new(test_config());
+
+    assert_eq!(
+        options.affinity_path, None,
+        "ServeOptions::new must not adopt the live proxy's shared pin cache"
+    );
+    assert_eq!(
+        options.persist_path, None,
+        "ServeOptions::new must not adopt a config file to write back"
+    );
+    assert!(
+        !options.incumbent.signals_anything(),
+        "ServeOptions::new must not be able to signal whatever holds the port"
+    );
+}
+
+/// The default incumbent policy — what `..Default::default()`, a struct literal
+/// with an omitted field, or a copied example gives you — signals nothing.
+///
+/// `replace: bool` made the SIGTERM-then-SIGKILL path one keystroke from every
+/// caller; only a named constructor reaches it now.
+#[test]
+fn the_default_incumbent_policy_cannot_signal_anything() {
+    assert!(!IncumbentPolicy::default().signals_anything());
+    assert!(!IncumbentPolicy::never_signal().signals_anything());
+    assert!(IncumbentPolicy::replace_legacy_js_only().signals_anything());
+    assert!(IncumbentPolicy::kill_the_incumbent_proxy().signals_anything());
 }

--- a/tests/serve_library_path.rs
+++ b/tests/serve_library_path.rs
@@ -1,0 +1,207 @@
+//! The proxy booted as a **library**, with no `tcr` process anywhere.
+//!
+//! This is the gate for the `run_server` → [`teamclaude_rs::server::serve`]
+//! extraction. Before it, starting the proxy required `main`: the boot path
+//! called `std::process::exit` in its middle and handed its background tasks to
+//! "the process is about to die anyway", so nothing but the binary could run one
+//! and nothing at all could stop one. The claims under test are exactly those
+//! two — that a caller can bind, serve a real request, and then get every task
+//! it started back *stopped*.
+//!
+//! # Port 0, never 3456
+//!
+//! A real proxy is very likely serving on the configured port on this machine,
+//! and binding it here would fight it (and a takeover wipes its session→account
+//! pin map, the most expensive event in this system). Every test in this file
+//! binds port 0 — the kernel's free ephemeral port — and asserts it did not land
+//! on the configured default. Nothing here signals, restarts or probes a live
+//! proxy.
+
+use std::time::Duration;
+
+use teamclaude_rs::config::Config;
+use teamclaude_rs::proxy::STATUS_PATH;
+use teamclaude_rs::server::{serve, ServeOptions, TlsSetup};
+
+/// The port `tcr` uses by default. Named here so the assertion below says what
+/// it is protecting rather than showing a bare number.
+const LIVE_PROXY_PORT: u16 = 3456;
+
+/// A config that binds an ephemeral port and enables exactly the two background
+/// loops this file counts: the session-affinity flusher and the quota prober.
+/// `warmupSeconds` stays 0, so the keep-warm loop is not spawned at all (it
+/// spends real quota; it ships dark).
+///
+/// No accounts: the rotation never has anything to pick, which is deliberate —
+/// nothing in this file may reach Anthropic.
+fn test_config() -> Config {
+    serde_json::from_str(
+        r#"{
+            "proxy": { "port": 0 },
+            "sessionAffinity": true,
+            "quotaProbeSeconds": 3600,
+            "warmupSeconds": 0,
+            "accounts": []
+        }"#,
+    )
+    .expect("the inline test config parses")
+}
+
+/// A disposable path for the affinity pin cache. The real one is a live cache
+/// belonging to the running proxy and must never be written by a test.
+fn scratch_affinity_path(tag: &str) -> std::path::PathBuf {
+    let unique = format!(
+        "tcr-serve-test-{}-{tag}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or_default()
+    );
+    std::env::temp_dir().join(unique).join("affinity.json")
+}
+
+fn options(tag: &str) -> ServeOptions {
+    ServeOptions {
+        config: test_config(),
+        // No persist path: this test may not write a config file anywhere.
+        persist_path: None,
+        // Belt and braces with the config's own 0 — whichever is read, it is not
+        // the live proxy's port.
+        port: Some(0),
+        // NEVER true here: `--replace` is what signals an incumbent.
+        replace: false,
+        affinity_path: scratch_affinity_path(tag),
+        // Loading the MITM material mints/reads a CA on disk. Base-URL mode is
+        // all this file exercises, so do not touch it.
+        tls: TlsSetup::Disabled,
+    }
+}
+
+/// Is anything still accepting on `port`? Polled, because the listener is closed
+/// asynchronously with the accept task returning.
+async fn port_refuses_within(port: u16, budget: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + budget;
+    loop {
+        match tokio::net::TcpStream::connect(("127.0.0.1", port)).await {
+            Err(_) => return true,
+            Ok(_) if tokio::time::Instant::now() >= deadline => return false,
+            Ok(_) => tokio::time::sleep(Duration::from_millis(25)).await,
+        }
+    }
+}
+
+/// THE PHASE 3 GATE: bind, serve a real request, shut down, and prove the tasks
+/// stopped — all without a `tcr` process.
+///
+/// The request is `GET /_tcr/status`, which the proxy answers itself: it is the
+/// one route that never forwards upstream, so a real HTTP round trip crosses the
+/// real hybrid listener (peek → base-URL → router) and reaches the real handler
+/// without any network egress. With no `proxy.apiKey` configured the endpoint's
+/// key gate does not apply, and the loopback origin it does require is proven by
+/// the `ClientAddr` the listener injects — so a 200 here is also evidence the
+/// connection went through the production accept path and not some shortcut.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_library_can_start_serve_and_stop_the_proxy_with_no_binary() {
+    let handle = serve(options("gate"))
+        .await
+        .expect("binding an ephemeral port cannot fail")
+        .expect_started();
+
+    let addr = handle.addr();
+    assert_ne!(addr.port(), 0, "the bound port must be resolved, not 0");
+    assert_ne!(
+        addr.port(),
+        LIVE_PROXY_PORT,
+        "a test must never bind the port a live proxy serves on"
+    );
+    assert!(addr.ip().is_loopback(), "the proxy binds loopback only");
+
+    // The two loops this config enables: affinity flush + quota probe. The
+    // keep-warm loop is off, so it must NOT have been spawned.
+    assert_eq!(
+        handle.background_task_count(),
+        2,
+        "expected the affinity flusher and the quota prober, and no keep-warm loop"
+    );
+
+    // One real request, over a real socket, through the real listener.
+    let client = reqwest::Client::builder()
+        // HTTP_PROXY very commonly points AT tcr; routing this through it would
+        // send the request to the live proxy instead of ours.
+        .no_proxy()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .expect("http client");
+    let response = client
+        .get(format!("http://{addr}{STATUS_PATH}"))
+        .send()
+        .await
+        .expect("the library-started proxy answered nothing");
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::OK,
+        "the status route is answered locally by the proxy itself"
+    );
+    let body: serde_json::Value = response.json().await.expect("a JSON status payload");
+    assert_eq!(
+        body["kind"],
+        teamclaude_rs::status::STATUS_KIND,
+        "the payload came from this proxy's own status handler: {body}"
+    );
+
+    // Shutdown must COMPLETE, not merely be called: every task is joined here,
+    // so a loop that ignored the shutdown signal hangs this await and the
+    // timeout fails the test. That is the assertion — `shutdown()` returning is
+    // itself the proof the tasks ended.
+    let report = tokio::time::timeout(Duration::from_secs(10), handle.shutdown())
+        .await
+        .expect("shutdown did not finish: a background task ignored the shutdown signal");
+    assert_eq!(
+        report.tasks_joined, 3,
+        "the accept loop plus both background loops must be joined"
+    );
+    assert_eq!(
+        report.affinity_pins_written,
+        Some(0),
+        "a clean shutdown owes the next boot its final pin write, even when empty"
+    );
+
+    // Independent of our own bookkeeping: the accept loop really is gone, so the
+    // port refuses. (`shutdown` drops the listener with the loop.)
+    assert!(
+        port_refuses_within(addr.port(), Duration::from_secs(5)).await,
+        "something is still accepting on :{} after shutdown",
+        addr.port()
+    );
+}
+
+/// A library caller that simply DROPS the handle must not leak the accept loop.
+///
+/// `run_server` never needed this — the process exited — which is exactly why it
+/// could not be embedded. Dropping is the failure mode an embedder hits first
+/// (an early return, a panic, a `?`), so it gets its own test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dropping_the_handle_stops_the_accept_loop() {
+    let handle = serve(options("drop"))
+        .await
+        .expect("binding an ephemeral port cannot fail")
+        .expect_started();
+    let port = handle.addr().port();
+    assert_ne!(port, LIVE_PROXY_PORT);
+
+    // It is serving right now.
+    assert!(
+        tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .is_ok(),
+        "the proxy should be accepting before the handle is dropped"
+    );
+
+    drop(handle);
+
+    assert!(
+        port_refuses_within(port, Duration::from_secs(5)).await,
+        "the accept loop outlived its handle: :{port} is still accepting"
+    );
+}


### PR DESCRIPTION
Phase 3 of `docs/design/ffi-in-process-target-state.md`. **No behaviour change to `tcr`** — this makes the boot path callable, nothing more.

## Why

`run_server` was the only way to start the proxy, and it was a binary entry point: it called `std::process::exit` mid-flight and handed every background task to "the process is about to die anyway". That made it unusable from anything but `main`, and untestable end to end.

## What changed

`src/server.rs` — `serve(ServeOptions) -> anyhow::Result<ServeOutcome>`, returning once the listener is bound. The caller decides how to wait.

`ServerHandle` owns the accept loop plus whichever background loops the config enables — the affinity flusher, the quota prober, and the opt-in keep-warm loop (which ships dark at `warmupSeconds: 0` and is not spawned at all). One `watch` channel drives them; each loop `select!`s its body against shutdown. `shutdown()` joins them and performs the final pin write in the old order; `Drop` signals and aborts, so an embedder that returns early leaks nothing.

`mitm::serve_with_shutdown` puts the shutdown branch on the accept loop. **Already-accepted connections are left to finish** — that is what `server.abort()` did too, and a proxied response can be a long stream, so cutting one would be the behaviour change, not preserving it. The old property was incidental; it is now stated in the doc-comment. `mitm::serve` remains as a thin wrapper for three existing callers.

**The stand-down is now a value.** `ServeOutcome::StoodDown` carries it; `run_server` is a clap adapter that prints and exits. A binary may exit; a library must return.

## Unchanged, and pinned by existing tests

Exit codes 0/3/4, `INCUMBENT_MARKER` and the stand-down wording (a Swift test decodes it), the `server started` marker emitted only after a successful bind, headless logging to both stdout and the file, affinity restore-on-boot and debounced flush.

## The gate

`tests/serve_library_path.rs` calls `serve()` with no binary involved, asserts the bound port resolved, issues a real request, shuts down cleanly, and asserts the background tasks actually **stopped** — the property old tests cannot see, because the binary path exits and the OS cleans up regardless.

It binds **port 0** and asserts it did not land on 3456, uses a scratch affinity path rather than the real pin cache, and disables TLS so it cannot mint a CA. A live proxy is usually serving on this machine; the test is written not to touch it.

Watched red under four mutations: no-op `shutdown()`, handle leaks tasks on drop, accept loop loses its shutdown branch, and `serve` reporting the requested port instead of `local_addr()`.

**The harness caught its own theatre first.** Cutting only `Drop`'s `abort()` correctly stays green — dropping the `watch` sender is itself a shutdown — so the first run printed `GATE-IS-THEATRE`. The mutation was strengthened rather than the test weakened.

`cargo fmt --check` 0 · `clippy -D warnings` 0 · `cargo test` 0 (501 + 10 + 2 new + 11) · `swift build` 0 · `swift test` 0 at 107 executed, matching baseline.

## Note for Phase 4

`shutdown()` now also stops the probe and keep-warm loops, which previously ran until process exit. Unobservable for the binary, which exits immediately after — but it is the piece that makes an embedded server genuinely stoppable.