### PR TITLE
feat: identify the proxy by a verified claim, not by its process name

### DIFF
--- a/apps/macos/Sources/TcrBarCore/ServerController.swift
+++ b/apps/macos/Sources/TcrBarCore/ServerController.swift
@@ -560,6 +560,39 @@ public final class ServerController: ObservableObject {
 final class ChildStderr: @unchecked Sendable {
     private let handle: FileHandle
     private let buffer = LockedString()
+    private let streaming: Bool
+
+    /// Signalled by the streaming callback when it reaches EOF, and waited on by
+    /// ``finish()``. Draining the pipe is not enough on its own: the callback that
+    /// took the child's bytes out of the pipe runs on Foundation's queue, and
+    /// `readabilityHandler = nil` does not wait for a callback already inside its
+    /// body. A callback that has returned from `availableData` but not yet reached
+    /// `buffer.append` holds the entire message in a local — invisible to both the
+    /// buffer and the pipe. `finish()` then drains an empty pipe and returns an
+    /// empty buffer while the bytes are in flight, which is why the loss is
+    /// all-or-nothing rather than a truncated tail.
+    ///
+    /// Measured on this machine, unchanged test, 1000 spawns: 9 empty. With a 50ms
+    /// delay inserted between `availableData` and `append` — which only widens the
+    /// window, it does not create it — 19 of 20 empty. With this wait: 0 of 2000,
+    /// and 0 of 20 under the same 50ms delay.
+    ///
+    /// Foundation serialises one handle's readability callbacks, so the EOF
+    /// callback cannot overtake the data callback that precedes it. Waiting for
+    /// EOF therefore happens-after every `append`. That ordering is what makes this
+    /// a fix rather than a narrower window.
+    private let drained = DispatchSemaphore(value: 0)
+
+    /// How long ``finish()`` will wait for that EOF before giving up.
+    ///
+    /// Bounded, because EOF needs every writer to close: a child that forked a
+    /// grandchild holding the inherited write end would never produce one, and an
+    /// unbounded wait would hang `terminationHandler` — trading lost stderr for a
+    /// UI that never leaves `.supervising`. On expiry the behaviour degrades to
+    /// exactly what it was before this wait existed, never worse. `tcr server`
+    /// forks nothing, so the timeout is a backstop, not a code path: the wait
+    /// measured at most 12ms over 2000 spawns.
+    private static let eofWait: DispatchTimeInterval = .seconds(2)
 
     /// - Parameter installReadabilityHandler: false only in tests. It reproduces,
     ///   deterministically, the state the race produces by accident — bytes in the
@@ -567,10 +600,18 @@ final class ChildStderr: @unchecked Sendable {
     ///   here fails every run rather than one run in forty.
     init(reading pipe: Pipe, installReadabilityHandler: Bool = true) {
         handle = pipe.fileHandleForReading
+        streaming = installReadabilityHandler
         guard installReadabilityHandler else { return }
-        handle.readabilityHandler = { [buffer] handle in
+        handle.readabilityHandler = { [buffer, drained] handle in
             let data = handle.availableData
-            guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else { return }
+            // Empty means EOF: the child exited and every writer has closed. It is
+            // delivered after the callbacks carrying the data, so signalling here
+            // tells `finish()` that nothing is still in flight.
+            guard !data.isEmpty else {
+                drained.signal()
+                return
+            }
+            guard let text = String(data: data, encoding: .utf8) else { return }
             buffer.append(text)
         }
     }
@@ -583,6 +624,10 @@ final class ChildStderr: @unchecked Sendable {
     /// principle interleave two chunks out of order; every consumer of this string
     /// is a substring match, so ordering is not load-bearing.
     func finish() -> String {
+        // Let the streaming reader finish handing over what it already took out of
+        // the pipe. Without this the drain below can run while the child's only
+        // chunk sits in a callback local, and this returns "". See ``drained``.
+        if streaming { _ = drained.wait(timeout: .now() + Self.eofWait) }
         handle.readabilityHandler = nil
         if let tail = try? handle.readToEnd(), !tail.isEmpty,
             let text = String(data: tail, encoding: .utf8)

--- a/src/main.rs
+++ b/src/main.rs
@@ -633,6 +633,32 @@ async fn run_server(args: ServerArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// How to recover from a WEDGED incumbent — the half of the not-answering warning
+/// that depends on which proxy is holding the port.
+///
+/// `--replace` is the recovery for a proxy this process may signal. It is not one
+/// for a [`singleton::ProxyKind::TcrEmbedded`] incumbent, and offering it there is
+/// worse than offering nothing: `takeover_decision` refuses that kind on every
+/// path, so the operator runs the suggested command, sees the same stand-down, and
+/// the advice that DOES work — quitting the host application — was never printed.
+/// An instruction that cannot succeed is a bug even when the code behind it is
+/// correct.
+fn wedged_incumbent_recovery(kind: singleton::ProxyKind) -> &'static str {
+    match kind {
+        singleton::ProxyKind::TcrEmbedded => {
+            "`tcr --replace` cannot take this one over: the pid belongs to the host application \
+             serving the proxy in-process, and signalling it would kill the app without its \
+             normal shutdown, losing the session→account pin map. Quit the host application and \
+             start it again to recover a wedged embedded proxy."
+        }
+        singleton::ProxyKind::Tcr | singleton::ProxyKind::LegacyJs => {
+            "Run `tcr --replace` to take the port over; that is the recovery for a wedged proxy, \
+             and it is not being done automatically because it also wipes the pin map of a proxy \
+             that was merely slow to answer."
+        }
+    }
+}
+
 /// Print the stand-down diagnosis and exit with the code it earned. Never returns.
 ///
 /// This is the half of the stand-down a *library* must not do, which is why
@@ -647,12 +673,11 @@ fn stand_down_exit(stand_down: &server::StandDown) -> ! {
     if let cli::Liveness::Silent { why } = &stand_down.probe.liveness {
         let port = stand_down.port;
         let pid = stand_down.pid;
+        let recovery = wedged_incumbent_recovery(stand_down.kind);
         eprintln!(
             "[tcr] WARNING incumbent-not-answering: port={port} pid={pid} probe={why:?} — the \
              process holding :{port} did not respond, so standing down leaves NOTHING serving \
-             on it. Run `tcr --replace` to take the port over; that is the recovery for a \
-             wedged proxy, and it is not being done automatically because it also wipes the \
-             pin map of a proxy that was merely slow to answer."
+             on it. {recovery}"
         );
     }
     std::process::exit(stand_down_exit_code(
@@ -792,6 +817,36 @@ mod tests {
     fn silent() -> cli::Liveness {
         cli::Liveness::Silent {
             why: "the server did not answer within 5s".to_string(),
+        }
+    }
+
+    /// A WEDGED INCUMBENT MUST NOT BE OFFERED A RECOVERY THAT CANNOT WORK.
+    ///
+    /// `--replace` is refused for an embedded incumbent on every path in
+    /// `singleton::takeover_decision`, deliberately: the pid is the host
+    /// application's. Printing "Run `tcr --replace`" for that kind sends the
+    /// operator around a loop that ends in the same stand-down, while the
+    /// instruction that does work — quit the host application — never appears.
+    #[test]
+    fn a_wedged_embedded_incumbent_is_not_told_to_run_replace() {
+        let embedded = wedged_incumbent_recovery(singleton::ProxyKind::TcrEmbedded);
+        assert!(
+            !embedded.contains("Run `tcr --replace`"),
+            "must not prescribe an override that this kind refuses: {embedded}"
+        );
+        assert!(
+            embedded.contains("Quit the host application"),
+            "must name the recovery that works: {embedded}"
+        );
+        // The control: for the kinds `--replace` CAN take over, the prescription is
+        // unchanged — so the assertions above are about the kind, not about the
+        // advice having been dropped for everyone.
+        for kind in [singleton::ProxyKind::Tcr, singleton::ProxyKind::LegacyJs] {
+            let advice = wedged_incumbent_recovery(kind);
+            assert!(
+                advice.contains("Run `tcr --replace`"),
+                "{kind:?} is recoverable by --replace: {advice}"
+            );
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use clap::{Parser, Subcommand};
 
 use teamclaude_rs::cli::{self, PriorityArg};
 use teamclaude_rs::config::{self, Config, ConfigError};
-use teamclaude_rs::{affinity, build_info, demo, mitm, oauth, server, tui, update};
+use teamclaude_rs::{affinity, build_info, demo, mitm, oauth, server, singleton, tui, update};
 
 #[derive(Parser)]
 #[command(
@@ -532,6 +532,11 @@ async fn run_server(args: ServerArgs) -> anyhow::Result<()> {
 
     init_tracing(args.headless);
 
+    // The port `serve` will resolve to, computed the same way it does
+    // (`--port` overrides `config.proxy.port`) because the owner file is NAMED
+    // after the port and has to match the one that gets bound.
+    let resolved_port = args.port.unwrap_or(config.proxy.port);
+
     // Spelled out rather than built from `ServeOptions::new`, which is
     // deliberately inert: writing the config back, owning the shared pin cache
     // and signalling whatever holds the port are all things only the BINARY may
@@ -547,6 +552,20 @@ async fn run_server(args: ServerArgs) -> anyhow::Result<()> {
         },
         affinity_path: Some(affinity::default_path()),
         tls: server::TlsSetup::Load,
+        // This is a standalone `tcr` process, stated rather than sniffed from
+        // `argv[0]`: the owner file is what makes a proxy identifiable when its
+        // process name is NOT `tcr` (see `teamclaude_rs::singleton`), so the value
+        // has to come from the caller that knows.
+        host: singleton::ProxyHost::Cli,
+        // Claim the port for the next `tcr` (and for `tcr login`) to read. A
+        // binary-only side effect, like the pin cache above: it is a shared file
+        // named after the port, so a library caller must opt in with its own path.
+        //
+        // Except for `--port 0`, which asks the kernel for an ephemeral port: the
+        // name would say 0 while the contents said the real port, and nothing can
+        // look a claim up by a port number that was never bound. No claim is the
+        // honest answer there.
+        owner_path: (resolved_port != 0).then(|| singleton::default_owner_path(resolved_port)),
     };
 
     let handle = match server::serve(options).await? {

--- a/src/main.rs
+++ b/src/main.rs
@@ -532,11 +532,6 @@ async fn run_server(args: ServerArgs) -> anyhow::Result<()> {
 
     init_tracing(args.headless);
 
-    // The port `serve` will resolve to, computed the same way it does
-    // (`--port` overrides `config.proxy.port`) because the owner file is NAMED
-    // after the port and has to match the one that gets bound.
-    let resolved_port = args.port.unwrap_or(config.proxy.port);
-
     // Spelled out rather than built from `ServeOptions::new`, which is
     // deliberately inert: writing the config back, owning the shared pin cache
     // and signalling whatever holds the port are all things only the BINARY may
@@ -558,14 +553,15 @@ async fn run_server(args: ServerArgs) -> anyhow::Result<()> {
         // has to come from the caller that knows.
         host: singleton::ProxyHost::Cli,
         // Claim the port for the next `tcr` (and for `tcr login`) to read. A
-        // binary-only side effect, like the pin cache above: it is a shared file
-        // named after the port, so a library caller must opt in with its own path.
+        // binary-only side effect, like the pin cache above: it is a shared
+        // directory, so a library caller must opt in with its own.
         //
-        // Except for `--port 0`, which asks the kernel for an ephemeral port: the
-        // name would say 0 while the contents said the real port, and nothing can
-        // look a claim up by a port number that was never bound. No claim is the
-        // honest answer there.
-        owner_path: (resolved_port != 0).then(|| singleton::default_owner_path(resolved_port)),
+        // The DIRECTORY, not a path: `serve` names the file after the port it
+        // actually binds. Re-deriving `--port unwrap_or config.proxy.port` here to
+        // build the name would be a second copy of a resolution rule that lives in
+        // `serve`, and the two silently disagreeing means a claim named for a port
+        // this process never bound — which every reader looks straight past.
+        owner_dir: Some(singleton::default_owner_dir()),
     };
 
     let handle = match server::serve(options).await? {

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -744,16 +744,37 @@ fn login_target_port(config_path: &Path) -> u16 {
         .port
 }
 
-/// The pure login-guard DECISION: given the PID of any live proxy server detected
-/// on the port, the port, and the `--force` flag, return the one-line refusal
-/// message to abort with, or `None` to proceed. Split from the impure lsof-based
-/// detection ([`crate::singleton::live_proxy_server`]) so the refuse/allow logic is
+/// The pure login-guard DECISION: given any live proxy server detected on the
+/// port, the port, and the `--force` flag, return the one-line refusal message to
+/// abort with, or `None` to proceed. Split from the impure lsof-based detection
+/// ([`crate::singleton::live_proxy_server`]) so the refuse/allow logic is
 /// unit-testable, mirroring singleton's pure-decision / impure-executor split.
-fn login_guard_refusal(server_pid: Option<u32>, port: u16, force: bool) -> Option<String> {
-    match server_pid {
-        Some(pid) if !force => Some(format!(
-            "a tcr server is already running on port {port} (pid {pid}); logging in now would be overwritten by the server's next token refresh — stop it (kill {pid}, or Ctrl-C in its terminal), run 'tcr login', then restart 'tcr server'. Re-run with --force to log in anyway."
-        )),
+///
+/// The incumbent's KIND decides the instruction, and it is not cosmetic. Since
+/// the owner file, detection reaches a proxy served INSIDE a host application,
+/// and the pid reported is then the HOST's. "kill {pid}" would SIGTERM a GUI
+/// process that installs no handler for it: no `applicationWillTerminate`, no
+/// final session→account pin write, and every live session cold-starts its
+/// prompt cache at the next boot. `takeover_decision` and `incumbents_to_signal`
+/// are both hardened against exactly that signal; a message that ADVISES it would
+/// walk around both. So an embedded incumbent is told to be quit, not killed.
+fn login_guard_refusal(
+    incumbent: Option<singleton::Incumbent>,
+    port: u16,
+    force: bool,
+) -> Option<String> {
+    match incumbent {
+        Some(incumbent) if !force => {
+            let pid = incumbent.pid;
+            Some(match incumbent.kind {
+                singleton::ProxyKind::TcrEmbedded => format!(
+                    "a tcr server is already running on port {port} (pid {pid}); logging in now would be overwritten by the server's next token refresh — that pid is the HOST APPLICATION serving the proxy in-process, so do not signal it: quit the host application (killing it skips its shutdown and loses the session pin map), run 'tcr login', then start it again. Re-run with --force to log in anyway."
+                ),
+                singleton::ProxyKind::Tcr | singleton::ProxyKind::LegacyJs => format!(
+                    "a tcr server is already running on port {port} (pid {pid}); logging in now would be overwritten by the server's next token refresh — stop it (kill {pid}, or Ctrl-C in its terminal), run 'tcr login', then restart 'tcr server'. Re-run with --force to log in anyway."
+                ),
+            })
+        }
         _ => None,
     }
 }
@@ -1212,9 +1233,15 @@ mod tests {
         );
     }
 
+    /// A live proxy of the given kind, as `singleton::live_proxy_server` reports
+    /// it — pid 4242 throughout, so a message assertion naming it is unambiguous.
+    fn incumbent(kind: singleton::ProxyKind) -> Option<singleton::Incumbent> {
+        Some(singleton::Incumbent { pid: 4242, kind })
+    }
+
     #[test]
     fn login_guard_refusal_message_carries_pid_and_stop_login_restart_sequence() {
-        let msg = login_guard_refusal(Some(4242), 3456, false)
+        let msg = login_guard_refusal(incumbent(singleton::ProxyKind::Tcr), 3456, false)
             .expect("a live server without --force must refuse");
         // Actionable + greppable: names the port, the PID, and the escape hatch.
         assert!(msg.contains("3456"), "names the port: {msg}");
@@ -1243,9 +1270,52 @@ mod tests {
     #[test]
     fn login_guard_allows_with_force_or_no_server() {
         // --force is the deliberate escape hatch even when a server is live.
-        assert!(login_guard_refusal(Some(4242), 3456, true).is_none());
+        assert!(login_guard_refusal(incumbent(singleton::ProxyKind::Tcr), 3456, true).is_none());
         // No server on the port → nothing to refuse.
         assert!(login_guard_refusal(None, 3456, false).is_none());
+    }
+
+    /// THE ADVICE MUST BE SURVIVABLE. `live_proxy_server` can now name the pid of
+    /// the host application that serves the proxy in-process, and telling the
+    /// operator to `kill` it is the one action `singleton` is hardened against
+    /// twice over: AppKit installs no SIGTERM handler, so the app dies without
+    /// `applicationWillTerminate` and the final session→account pin write is lost.
+    /// A guard that refuses correctly and then advises the destructive fix is worse
+    /// than no guard, because the operator does what the tool says.
+    #[test]
+    fn the_login_guard_never_tells_an_operator_to_kill_a_host_application() {
+        let msg = login_guard_refusal(incumbent(singleton::ProxyKind::TcrEmbedded), 3456, false)
+            .expect("an embedded server must still block a login");
+        assert!(
+            !msg.contains("kill 4242"),
+            "must not advise signalling the host application: {msg}"
+        );
+        assert!(
+            !msg.contains("Ctrl-C"),
+            "the host application is not a foreground process to interrupt: {msg}"
+        );
+        assert!(
+            msg.contains("quit the host application"),
+            "must name the one action that stops an embedded proxy safely: {msg}"
+        );
+        // Everything the CLI refusal is load-bearing for still holds: one line,
+        // names the port, the pid and the escape hatch.
+        assert!(
+            msg.contains("3456") && msg.contains("4242") && msg.contains("--force"),
+            "{msg}"
+        );
+        assert_eq!(
+            msg.lines().count(),
+            1,
+            "the refusal is a single line: {msg}"
+        );
+
+        // And the control: a plain CLI peer, which the operator CAN signal, still
+        // gets the kill instruction — so the assertions above are about the kind,
+        // not about the message having been softened for everyone.
+        let cli = login_guard_refusal(incumbent(singleton::ProxyKind::Tcr), 3456, false)
+            .expect("a live CLI server must block a login");
+        assert!(cli.contains("kill 4242"), "{cli}");
     }
 
     #[test]
@@ -1255,8 +1325,14 @@ mod tests {
         // recognized tcr/teamclaude *server*. Compose the pure classifier with the
         // pure guard decision — refuse / refuse / allow.
         let refuses = |cmd: &str| {
-            let server_pid = is_proxy_server(cmd).then_some(4242u32);
-            login_guard_refusal(server_pid, 3456, false).is_some()
+            let server = singleton::classify_proxy_server(cmd)
+                .map(|kind| singleton::Incumbent { pid: 4242, kind });
+            assert_eq!(
+                server.is_some(),
+                is_proxy_server(cmd),
+                "the bool and the classifying form must agree: {cmd}"
+            );
+            login_guard_refusal(server, 3456, false).is_some()
         };
         assert!(
             refuses("/opt/teamclaude-rs/target/release/tcr server"),

--- a/src/server.rs
+++ b/src/server.rs
@@ -159,6 +159,33 @@ pub struct ServeOptions {
     pub affinity_path: Option<PathBuf>,
     /// Where the MITM TLS material comes from.
     pub tls: TlsSetup,
+    /// What is hosting this proxy — a standalone `tcr` process
+    /// ([`singleton::ProxyHost::Cli`]) or an application serving it in-process
+    /// ([`singleton::ProxyHost::Embedded`]).
+    ///
+    /// **Every caller states this; the library never infers it.** Inferring it
+    /// from `argv[0]` is precisely the bug the owner file exists to fix (see
+    /// [`crate::singleton`]): an embedded proxy's `argv[0]` is the host
+    /// application's, which the name matcher does not recognize at all, and the
+    /// consequence is `tcr login` no longer refusing to run beside a live server
+    /// that will then overwrite its fresh single-use refresh tokens.
+    ///
+    /// Recorded in the owner file, and only there — so it has no effect unless
+    /// [`Self::owner_path`] is set.
+    pub host: singleton::ProxyHost,
+    /// Where to write `proxy-owner-<port>.json` claiming the port, or `None` to
+    /// write no claim at all.
+    ///
+    /// `None` is the default because the file is *shared state named after the
+    /// port*: a second process serving briefly would otherwise leave its own claim
+    /// where the live proxy's belongs. The binary passes
+    /// [`singleton::default_owner_path`]; a test points it somewhere disposable.
+    ///
+    /// Omitting it is safe, never silent: identity then falls back to the
+    /// command-line matcher, which is what every `tcr` did before this file
+    /// existed. It is only an *embedded* proxy that the matcher cannot see, and an
+    /// embedder must therefore pass a path.
+    pub owner_path: Option<PathBuf>,
 }
 
 impl ServeOptions {
@@ -179,6 +206,12 @@ impl ServeOptions {
             incumbent: IncumbentPolicy::never_signal(),
             affinity_path: None,
             tls: TlsSetup::Load,
+            // Inert, like every other field here: with no owner path, `host` is
+            // recorded nowhere and this value cannot be read by anyone. A caller
+            // that DOES claim the port must state its host, and both callers that
+            // write a file spell the pair out together.
+            host: singleton::ProxyHost::Cli,
+            owner_path: None,
         }
     }
 }
@@ -287,6 +320,10 @@ pub struct ServerHandle {
     shutdown: watch::Sender<bool>,
     manager: Arc<Manager>,
     affinity_path: Option<PathBuf>,
+    /// The port claim written after the bind, to be removed on shutdown. `None`
+    /// when the caller asked for no claim (or the write failed — a claim that was
+    /// never written is nothing to remove).
+    owner_path: Option<PathBuf>,
     /// Tasks joined and tasks aborted so far. Kept on the handle, not in a local,
     /// so a `shutdown` future that is dropped mid-join and re-issued reports the
     /// whole truth rather than only what the last attempt saw.
@@ -420,6 +457,16 @@ impl ServerHandle {
             self.background.pop();
         }
 
+        // Withdraw the port claim once the accept loop is done, so the next `tcr`
+        // does not read a claim for a proxy that has stopped listening. Ordered
+        // after the joins above and before the persists below for exactly that
+        // reason. Taken (not just read) so a re-issued `shutdown` does not try
+        // again — and a leftover file is harmless anyway: `singleton` re-checks the
+        // pid against the live listeners before believing any claim.
+        if let Some(path) = self.owner_path.take() {
+            singleton::remove_owner_file(&path);
+        }
+
         self.manager.persist_now();
 
         // Final pin flush on a CLEAN shutdown, capturing whatever changed inside
@@ -491,6 +538,8 @@ pub async fn serve(options: ServeOptions) -> anyhow::Result<ServeOutcome> {
         incumbent,
         affinity_path,
         tls,
+        host,
+        owner_path,
     } = options;
 
     if let Some(port) = port_override {
@@ -739,6 +788,51 @@ pub async fn serve(options: ServeOptions) -> anyhow::Result<ServeOutcome> {
         "server started"
     );
 
+    // Claim the port by NAME-FREE identity, in the same place and for the same
+    // reason as the boot marker above: after the bind SUCCEEDED, so the file means
+    // "this pid is serving this port" rather than "this pid tried". A `tcr` in
+    // another terminal, and `tcr login`, then recognize this proxy whatever program
+    // is hosting it — see [`crate::singleton`] for the silent token loss that
+    // depends on it.
+    //
+    // A write failure is NOT fatal. The claim is an optimisation over the
+    // command-line matcher for the CLI host, and refusing to serve because a cache
+    // directory is unwritable would be a worse outcome than the matcher we had
+    // before. It is loud, because for an EMBEDDED host the matcher recognizes
+    // nothing and this file is the only identity there is.
+    //
+    // A claim that could not be written is dropped from the handle: shutdown then
+    // has nothing to remove, rather than deleting a path this process never owned.
+    let owner_path = owner_path.and_then(|path| {
+        let owner = singleton::ProxyOwner {
+            pid: std::process::id(),
+            port: bound.port(),
+            sha: build_info::SHA.to_string(),
+            host,
+        };
+        match singleton::write_owner_file(&path, &owner) {
+            Ok(()) => {
+                tracing::info!(
+                    path = %path.display(),
+                    pid = owner.pid,
+                    port = owner.port,
+                    host = ?host,
+                    "proxy owner file written; this proxy is identifiable without its process name"
+                );
+                Some(path)
+            }
+            Err(err) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %err,
+                    host = ?host,
+                    "could not write the proxy owner file; identity falls back to command-line matching, which does NOT recognize an embedded proxy"
+                );
+                None
+            }
+        }
+    });
+
     let serve_manager = manager.clone();
     let mut stop = shutdown_tx.subscribe();
     let server = tokio::spawn(async move {
@@ -753,6 +847,7 @@ pub async fn serve(options: ServeOptions) -> anyhow::Result<ServeOutcome> {
         shutdown: shutdown_tx,
         manager,
         affinity_path,
+        owner_path,
         tasks_joined: 0,
         tasks_aborted: 0,
         server: Some(server),
@@ -828,6 +923,9 @@ mod tests {
             shutdown,
             manager,
             affinity_path,
+            // No claim: a hand-built handle in a unit test may not delete a file
+            // on shutdown, least of all one named after the live proxy's port.
+            owner_path: None,
             tasks_joined: 0,
             tasks_aborted: 0,
             server: Some(server),

--- a/src/server.rs
+++ b/src/server.rs
@@ -568,7 +568,7 @@ pub async fn serve(options: ServeOptions) -> anyhow::Result<ServeOutcome> {
     let takeover = match (port, incumbent.0) {
         (0, _) => singleton::Takeover::Proceed,
         (_, Signal::Never) => match singleton::live_proxy_server(port) {
-            Some(pid) => singleton::Takeover::IncumbentPresent(pid),
+            Some(incumbent) => singleton::Takeover::IncumbentPresent(incumbent.pid),
             None => singleton::Takeover::Proceed,
         },
         (_, Signal::LegacyJsOnly) => singleton::takeover_port(port, false),

--- a/src/server.rs
+++ b/src/server.rs
@@ -171,21 +171,32 @@ pub struct ServeOptions {
     /// that will then overwrite its fresh single-use refresh tokens.
     ///
     /// Recorded in the owner file, and only there — so it has no effect unless
-    /// [`Self::owner_path`] is set.
+    /// [`Self::owner_dir`] is set.
     pub host: singleton::ProxyHost,
-    /// Where to write `proxy-owner-<port>.json` claiming the port, or `None` to
-    /// write no claim at all.
+    /// The DIRECTORY to write the port claim in, or `None` to write no claim at
+    /// all. The file name inside it is not the caller's to choose: [`serve`]
+    /// derives it with [`singleton::owner_path_in`] from the port it actually
+    /// bound.
     ///
-    /// `None` is the default because the file is *shared state named after the
-    /// port*: a second process serving briefly would otherwise leave its own claim
-    /// where the live proxy's belongs. The binary passes
-    /// [`singleton::default_owner_path`]; a test points it somewhere disposable.
+    /// A directory rather than a path, because the NAME is a contract. Every
+    /// reader — [`singleton::live_proxy_server`], [`singleton::takeover_port`] —
+    /// looks the claim up as `proxy-owner-<port>.json`; a claim written under any
+    /// other name is consulted by nothing, with no error anywhere. Handing the
+    /// caller a free-form `owner_path` made that a one-typo failure, and worse, it
+    /// let the caller name the file after a port it did not bind: `port: Some(0)`
+    /// resolves to an ephemeral port at bind time, so the name and the contents
+    /// disagreed and the proxy stayed invisible while the write logged success.
+    ///
+    /// `None` is the default because the directory is *shared state*: a second
+    /// process serving briefly would otherwise leave its own claim where the live
+    /// proxy's belongs. The binary passes [`singleton::default_owner_dir`]; a test
+    /// points it somewhere disposable.
     ///
     /// Omitting it is safe, never silent: identity then falls back to the
     /// command-line matcher, which is what every `tcr` did before this file
     /// existed. It is only an *embedded* proxy that the matcher cannot see, and an
-    /// embedder must therefore pass a path.
-    pub owner_path: Option<PathBuf>,
+    /// embedder must therefore pass a directory.
+    pub owner_dir: Option<PathBuf>,
 }
 
 impl ServeOptions {
@@ -206,12 +217,12 @@ impl ServeOptions {
             incumbent: IncumbentPolicy::never_signal(),
             affinity_path: None,
             tls: TlsSetup::Load,
-            // Inert, like every other field here: with no owner path, `host` is
+            // Inert, like every other field here: with no owner dir, `host` is
             // recorded nowhere and this value cannot be read by anyone. A caller
             // that DOES claim the port must state its host, and both callers that
             // write a file spell the pair out together.
             host: singleton::ProxyHost::Cli,
-            owner_path: None,
+            owner_dir: None,
         }
     }
 }
@@ -550,7 +561,7 @@ pub async fn serve(options: ServeOptions) -> anyhow::Result<ServeOutcome> {
         affinity_path,
         tls,
         host,
-        owner_path,
+        owner_dir,
     } = options;
 
     if let Some(port) = port_override {
@@ -815,7 +826,15 @@ pub async fn serve(options: ServeOptions) -> anyhow::Result<ServeOutcome> {
     //
     // A claim that could not be written is dropped from the handle: shutdown then
     // has nothing to remove, rather than deleting a path this process never owned.
-    let owner_path = owner_path.and_then(|path| {
+    //
+    // The file NAME is derived here, from the port actually bound, and not taken
+    // from the caller: every reader looks a claim up as `proxy-owner-<port>.json`
+    // for the port it is resolving, so a name that does not match is a claim
+    // nothing consults. With `port: Some(0)` a caller cannot know the name in
+    // advance — the kernel picks the port during this function — which is why the
+    // caller supplies a directory and `serve` supplies the name.
+    let owner_path = owner_dir.and_then(|dir| {
+        let path = singleton::owner_path_in(&dir, bound.port());
         let owner = singleton::ProxyOwner {
             pid: std::process::id(),
             port: bound.port(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -226,6 +226,12 @@ pub struct StandDown {
     pub port: u16,
     /// The incumbent's pid, as `singleton` identified it.
     pub pid: u32,
+    /// WHICH proxy that pid is. Carried because it decides what a caller may tell
+    /// the operator to do about it: [`singleton::ProxyKind::TcrEmbedded`] means
+    /// the pid belongs to a host application, so neither a signal nor `--replace`
+    /// is an available recovery — advising either is advising the loss of the
+    /// app's shutdown and its final session→account pin write.
+    pub kind: singleton::ProxyKind,
     /// ONE probe of the incumbent: which build it runs, and whether it answers
     /// at all. Both halves are needed to pick an exit code.
     pub probe: cli::IncumbentProbe,
@@ -568,13 +574,13 @@ pub async fn serve(options: ServeOptions) -> anyhow::Result<ServeOutcome> {
     let takeover = match (port, incumbent.0) {
         (0, _) => singleton::Takeover::Proceed,
         (_, Signal::Never) => match singleton::live_proxy_server(port) {
-            Some(incumbent) => singleton::Takeover::IncumbentPresent(incumbent.pid),
+            Some(incumbent) => singleton::Takeover::IncumbentPresent(incumbent),
             None => singleton::Takeover::Proceed,
         },
         (_, Signal::LegacyJsOnly) => singleton::takeover_port(port, false),
         (_, Signal::Recognized) => singleton::takeover_port(port, true),
     };
-    if let singleton::Takeover::IncumbentPresent(pid) = takeover {
+    if let singleton::Takeover::IncumbentPresent(incumbent) = takeover {
         // ONE probe of the incumbent, answering two questions: which build it is
         // executing, and whether it is executing anything at all.
         let probe = cli::probe_incumbent(&config).await;
@@ -597,7 +603,8 @@ pub async fn serve(options: ServeOptions) -> anyhow::Result<ServeOutcome> {
         );
         return Ok(ServeOutcome::StoodDown(StandDown {
             port,
-            pid,
+            pid: incumbent.pid,
+            kind: incumbent.kind,
             probe,
             report,
         }));

--- a/src/server.rs
+++ b/src/server.rs
@@ -463,8 +463,13 @@ impl ServerHandle {
         // reason. Taken (not just read) so a re-issued `shutdown` does not try
         // again — and a leftover file is harmless anyway: `singleton` re-checks the
         // pid against the live listeners before believing any claim.
+        //
+        // Removed only if it still names US: the listener was freed at the top of
+        // this function while the joins below it can take hundreds of milliseconds,
+        // so a successor may already have bound the port and written its own claim
+        // to this same port-named path. See `singleton::remove_owner_file_if_owned`.
         if let Some(path) = self.owner_path.take() {
-            singleton::remove_owner_file(&path);
+            singleton::remove_owner_file_if_owned(&path, std::process::id(), self.addr.port());
         }
 
         self.manager.persist_now();

--- a/src/singleton.rs
+++ b/src/singleton.rs
@@ -25,10 +25,37 @@
 //!   actual `teamclaude`/`tcr` *server*. A non-proxy holder is left alone (the bind
 //!   then fails loudly with EADDRINUSE) rather than killed. This is what makes the
 //!   takeover safe against a reused PID or an unrelated process on the port.
+//!
+//! # Identity: the owner file, then the name matcher
+//!
+//! Recognition used to be *only* the name matcher — `argv[0]` ending in `/tcr`.
+//! That reads the HOST process, not the proxy: a proxy running inside another
+//! program (the menu-bar app) reports that program's path and matches nothing, so
+//! [`live_proxy_server`] returns `None`, `tcr login` stops refusing to run beside
+//! a live server, and the server's next `persist_tokens` writes its boot-time
+//! SINGLE-USE refresh tokens back over the fresh ones. That failure is silent
+//! until every account fails to refresh at the next boot.
+//!
+//! So a bound proxy now ADVERTISES itself: [`write_owner_file`] drops
+//! `proxy-owner-<port>.json` beside the affinity pin cache, and
+//! [`classify_port_owner`] is consulted BEFORE the name matcher. Identity becomes
+//! the proxy's own claim instead of an inference from someone else's `argv`.
+//!
+//! Two properties keep that from being a new way to get it wrong:
+//! - **A stale file proves nothing.** The pid it names must ALSO appear in
+//!   `port_listeners(port)` (and the port must match) or the claim is ignored
+//!   entirely — a crashed proxy, or anyone at all, can leave a file behind.
+//! - **The name matcher is RETAINED as the fallback**, so a `tcr` that predates
+//!   the owner file (including one serving right now) and a `LegacyJs` proxy —
+//!   which will never write one — are recognized exactly as before. Nothing has
+//!   to restart for this change to be safe.
 
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::thread::sleep;
 use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
 
 /// Which proxy a recognized incumbent is. The distinction is load-bearing for
 /// [`takeover_decision`], not cosmetic: a `tcr` peer is a program that is doing
@@ -36,10 +63,157 @@ use std::time::Duration;
 /// leftover JS `teamclaude` is the thing this module was written to displace.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProxyKind {
-    /// The Rust proxy — a peer of ours.
+    /// The Rust proxy running as its own process — a peer of ours.
     Tcr,
     /// The legacy JS proxy (`node …/teamclaude server`).
     LegacyJs,
+    /// The Rust proxy running **inside another program** (the menu-bar app),
+    /// which said so in its owner file ([`ProxyHost::Embedded`]).
+    ///
+    /// Never signalled, not even under `--replace`
+    /// ([`incumbents_to_signal`], [`takeover_decision`]). The pid on the port is
+    /// the HOST's, and `takeover_port` would SIGTERM it: AppKit installs no
+    /// SIGTERM handler, so the app dies without running
+    /// `applicationWillTerminate` — no graceful shutdown, no final session pin
+    /// write, and the operator's windows go with it. A CLI flag must not be able
+    /// to do that.
+    ///
+    /// This is not a new policy. `classify_proxy_server` already returns `None`
+    /// for `tcr run` (below), which is exactly why a proxy hosted inside a
+    /// `tcr run` process is never replaced either. Same shape, stronger reason.
+    /// Stopping an embedded proxy is the host application's job.
+    TcrEmbedded,
+}
+
+/// Which kind of process a proxy is running inside, as the proxy's **own claim**
+/// in its owner file — never sniffed from `argv[0]`.
+///
+/// [`crate::server::ServeOptions::host`] carries it, and each caller states it:
+/// the binary passes [`Self::Cli`], an in-process embedder passes
+/// [`Self::Embedded`]. The library does not guess, because guessing is the bug
+/// this whole mechanism replaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ProxyHost {
+    /// A standalone `tcr` process.
+    Cli,
+    /// A proxy served from inside a host application.
+    Embedded,
+}
+
+impl ProxyHost {
+    /// The incumbent kind a *verified* claim from this host means.
+    fn kind(self) -> ProxyKind {
+        match self {
+            ProxyHost::Cli => ProxyKind::Tcr,
+            ProxyHost::Embedded => ProxyKind::TcrEmbedded,
+        }
+    }
+}
+
+/// What a bound proxy writes to claim the port: `proxy-owner-<port>.json`.
+///
+/// Every field is load-bearing to a reader:
+/// - `pid` is what makes a stale file harmless — it must also be listening on
+///   `port` ([`verified_owner`]).
+/// - `port` guards against a file being read for the wrong port (a copied file,
+///   a caller passing a path that does not match its own port).
+/// - `sha` is which build is serving, so an operator reading the file gets the
+///   same fact the `server started` log line carries.
+/// - `host` is the whole point: it says whether SIGTERM is survivable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProxyOwner {
+    /// The pid holding the listener — the HOST process's pid when embedded.
+    pub pid: u32,
+    /// The port that pid bound.
+    pub port: u16,
+    /// The build the proxy is executing (`build_info::SHA`).
+    pub sha: String,
+    /// What is hosting the proxy.
+    pub host: ProxyHost,
+}
+
+/// `proxy-owner-<port>.json` inside `dir` — the file name is port-scoped so two
+/// proxies on two ports never overwrite each other's claim.
+pub fn owner_path_in(dir: &Path, port: u16) -> PathBuf {
+    dir.join(format!("proxy-owner-{port}.json"))
+}
+
+/// Where the binary keeps the claim: beside the session-affinity pin cache, so
+/// the proxy's two pieces of cross-boot state live in one directory.
+pub fn default_owner_path(port: u16) -> PathBuf {
+    let cache = crate::affinity::default_path();
+    let dir = cache
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+    owner_path_in(&dir, port)
+}
+
+/// Write the claim atomically (0600, temp + rename — the same
+/// [`crate::config::write_atomic`] every other state file uses, so a reader can
+/// never see a half-written claim).
+pub fn write_owner_file(path: &Path, owner: &ProxyOwner) -> Result<(), crate::config::ConfigError> {
+    crate::config::write_atomic(path, &serde_json::to_string_pretty(owner)?)
+}
+
+/// Drop the claim. Best-effort by design: a file left behind by a crash cannot
+/// produce a false positive ([`verified_owner`] re-checks the pid against the
+/// live listeners), so failing to remove one costs nothing.
+pub fn remove_owner_file(path: &Path) {
+    if let Err(err) = std::fs::remove_file(path) {
+        if err.kind() != std::io::ErrorKind::NotFound {
+            tracing::warn!(
+                path = %path.display(),
+                error = %err,
+                "could not remove the proxy owner file; a stale claim is harmless (its pid is re-checked against the live listeners)"
+            );
+        }
+    }
+}
+
+/// Read a claim, or `None` for absent/unreadable/unparseable. A malformed file is
+/// simply not a claim — the name matcher still gets its turn.
+fn read_owner_file(path: &Path) -> Option<ProxyOwner> {
+    let data = std::fs::read_to_string(path).ok()?;
+    match serde_json::from_str::<ProxyOwner>(&data) {
+        Ok(owner) => Some(owner),
+        Err(err) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %err,
+                "proxy owner file is unreadable; falling back to command-line recognition"
+            );
+            None
+        }
+    }
+}
+
+/// The claim's VERIFICATION, as a pure function: a claim counts only when it is
+/// for this `port` and its pid is one of the processes actually listening on it.
+///
+/// This is the check that makes the owner file safe to trust. Without it the file
+/// is a lie anyone can plant: any process could write `{"pid":<live proxy>,…}`
+/// and change what `tcr` does about the port, and every crashed proxy would leave
+/// behind a claim that outlives it and protects a pid the OS has since recycled
+/// onto something unrelated.
+fn verified_owner(owner: Option<&ProxyOwner>, port: u16, holders: &[u32]) -> Option<Incumbent> {
+    let owner = owner?;
+    (owner.port == port && holders.contains(&owner.pid)).then(|| Incumbent {
+        pid: owner.pid,
+        kind: owner.host.kind(),
+    })
+}
+
+/// The owner file at `owner_path`, verified against the processes actually
+/// holding `port`. `None` when there is no claim, the claim is for another port,
+/// or its pid is not listening — in every one of those cases the caller falls
+/// back to the name matcher.
+///
+/// `holders` and `owner_path` are parameters rather than read in here so this is
+/// testable against a real file without a real proxy.
+pub fn classify_port_owner(port: u16, holders: &[u32], owner_path: &Path) -> Option<Incumbent> {
+    verified_owner(read_owner_file(owner_path).as_ref(), port, holders)
 }
 
 /// A recognized, replaceable proxy holding the port.
@@ -121,16 +295,41 @@ fn port_listeners(port: u16) -> Vec<u32> {
 /// replaceable proxy incumbents, and which proxy is each? Excludes self and any
 /// non-proxy holder. Split out from the side-effecting kill so it is unit-testable
 /// with injected inputs.
+///
+/// Name matching only — [`replaceable_incumbents_with_owner`] is the version that
+/// takes a verified owner-file claim into account.
 pub fn replaceable_incumbents(
     holders: &[u32],
     self_pid: u32,
     command: impl Fn(u32) -> String,
 ) -> Vec<Incumbent> {
+    replaceable_incumbents_with_owner(holders, self_pid, command, None)
+}
+
+/// [`replaceable_incumbents`] with the port's **verified** owner-file claim
+/// (`classify_port_owner`) consulted FIRST.
+///
+/// Order matters: the claim is the proxy's own statement about what is hosting it,
+/// while the command line is an inference from the host process's `argv[0]` — and
+/// for an embedded proxy that inference is wrong in the dangerous direction (it
+/// recognizes nothing at all). Where both speak, the claim wins.
+///
+/// `owner` must already be verified against the live listeners; pass the result of
+/// [`classify_port_owner`], never a raw file read.
+pub fn replaceable_incumbents_with_owner(
+    holders: &[u32],
+    self_pid: u32,
+    command: impl Fn(u32) -> String,
+    owner: Option<Incumbent>,
+) -> Vec<Incumbent> {
     holders
         .iter()
         .copied()
         .filter(|&pid| pid != self_pid)
-        .filter_map(|pid| classify_proxy_server(&command(pid)).map(|kind| Incumbent { pid, kind }))
+        .filter_map(|pid| match owner.filter(|owner| owner.pid == pid) {
+            Some(claimed) => Some(claimed),
+            None => classify_proxy_server(&command(pid)).map(|kind| Incumbent { pid, kind }),
+        })
         .collect()
 }
 
@@ -144,7 +343,8 @@ pub fn replaceable_incumbents(
 /// port is free or held only by a non-proxy process.
 pub fn live_proxy_server(port: u16) -> Option<u32> {
     let holders = port_listeners(port);
-    replaceable_incumbents(&holders, std::process::id(), process_command)
+    let owner = classify_port_owner(port, &holders, &default_owner_path(port));
+    replaceable_incumbents_with_owner(&holders, std::process::id(), process_command, owner)
         .into_iter()
         .next()
         .map(|incumbent| incumbent.pid)
@@ -186,7 +386,18 @@ pub enum Takeover {
 /// the reason this module exists. Standing down for it would leave the JS proxy
 /// serving forever and make `tcr` unable to complete the migration it was
 /// installed for — and the two would token-war the moment tcr did bind elsewhere.
+///
+/// A [`ProxyKind::TcrEmbedded`] incumbent is checked BEFORE `replace`, and is the
+/// one kind `--replace` cannot override: the pid on the port belongs to the host
+/// application, so replacing it means SIGTERMing a GUI that installs no handler
+/// for it. See [`ProxyKind::TcrEmbedded`].
 pub fn takeover_decision(replaceable: &[Incumbent], replace: bool) -> Takeover {
+    if let Some(embedded) = replaceable
+        .iter()
+        .find(|incumbent| incumbent.kind == ProxyKind::TcrEmbedded)
+    {
+        return Takeover::IncumbentPresent(embedded.pid);
+    }
     if replace {
         return Takeover::Proceed;
     }
@@ -210,6 +421,12 @@ pub fn takeover_decision(replaceable: &[Incumbent], replace: bool) -> Takeover {
 ///
 /// Past that gate: with `--replace`, every incumbent. Without it, only the legacy
 /// JS proxy, which is the one case that reaches `Proceed` unasked.
+///
+/// A [`ProxyKind::TcrEmbedded`] incumbent is filtered out unconditionally, on top
+/// of the stand-down gate that already covers it. Both, deliberately: signalling
+/// one kills a host application without its `applicationWillTerminate`, so the
+/// guarantee is worth stating twice rather than resting on a `!= Proceed` that a
+/// future edit to [`takeover_decision`] could relax by accident.
 fn incumbents_to_signal(replaceable: &[Incumbent], replace: bool) -> Vec<Incumbent> {
     if takeover_decision(replaceable, replace) != Takeover::Proceed {
         return Vec::new();
@@ -217,6 +434,7 @@ fn incumbents_to_signal(replaceable: &[Incumbent], replace: bool) -> Vec<Incumbe
     replaceable
         .iter()
         .copied()
+        .filter(|incumbent| incumbent.kind != ProxyKind::TcrEmbedded)
         .filter(|incumbent| replace || incumbent.kind == ProxyKind::LegacyJs)
         .collect()
 }
@@ -251,6 +469,23 @@ fn stand_down_message(port: u16, pid: u32) -> String {
     )
 }
 
+/// The stand-down message for an EMBEDDED incumbent — the one case `--replace`
+/// does not override, so the message must not offer it.
+///
+/// Carries the same [`INCUMBENT_MARKER`] the CLI message does, because TcrBar's
+/// `incumbentMarkers` scan is what turns this into a reported incumbent instead of
+/// a bare `exited(0)`; only the instruction differs, and it names the host
+/// application, which is the one place that can actually stop this proxy.
+fn embedded_stand_down_message(port: u16, pid: u32) -> String {
+    format!(
+        "[tcr] {INCUMBENT_MARKER} :{port} (pid {pid}) and it is served from inside its host \
+         application — leaving it alone and exiting without binding. --replace cannot take this \
+         one over: the pid is the app's, and signalling it would kill the app without its normal \
+         shutdown, losing the session→account pin map. Quit the host application to stop this \
+         proxy."
+    )
+}
+
 /// Resolve `port` down to one proxy for this server.
 ///
 /// With `replace`, a recognized proxy incumbent is terminated (SIGTERM, then
@@ -262,7 +497,9 @@ fn stand_down_message(port: u16, pid: u32) -> String {
 #[must_use = "the caller must exit instead of binding on IncumbentPresent"]
 pub fn takeover_port(port: u16, replace: bool) -> Takeover {
     let holders = port_listeners(port);
-    let replaceable = replaceable_incumbents(&holders, std::process::id(), process_command);
+    let owner = classify_port_owner(port, &holders, &default_owner_path(port));
+    let replaceable =
+        replaceable_incumbents_with_owner(&holders, std::process::id(), process_command, owner);
 
     // Surface a non-proxy holder (we won't kill it; the bind will fail).
     for &pid in &holders {
@@ -280,12 +517,31 @@ pub fn takeover_port(port: u16, replace: bool) -> Takeover {
         // Only the pid and the instruction live here; `main` prints the build
         // comparison, because THAT is the part a user typing `tcr` after a rebuild
         // actually needs and it requires an async status read we must not do here.
-        eprintln!("{}", stand_down_message(port, pid));
+        let embedded = replaceable
+            .iter()
+            .any(|incumbent| incumbent.pid == pid && incumbent.kind == ProxyKind::TcrEmbedded);
+        if embedded {
+            eprintln!("{}", embedded_stand_down_message(port, pid));
+        } else {
+            eprintln!("{}", stand_down_message(port, pid));
+        }
         return Takeover::IncumbentPresent(pid);
     }
 
     for Incumbent { pid, kind } in incumbents_to_signal(&replaceable, replace) {
         match kind {
+            // Unreachable by construction — `incumbents_to_signal` filters this
+            // kind out twice. It is handled rather than `unreachable!()`d because
+            // the cost of being wrong is a SIGTERM to the operator's menu-bar app:
+            // skip and say so, never panic and never signal.
+            ProxyKind::TcrEmbedded => {
+                tracing::warn!(
+                    port,
+                    pid,
+                    "refusing to signal an embedded proxy: the pid belongs to its host application"
+                );
+                continue;
+            }
             ProxyKind::LegacyJs => eprintln!(
                 "[tcr] replacing the legacy JS teamclaude proxy on :{port} (pid {pid}) — migrating the port to tcr; leaving it running would token-war over the same single-use refresh tokens."
             ),
@@ -355,6 +611,297 @@ mod tests {
             pid,
             kind: ProxyKind::LegacyJs,
         }
+    }
+
+    fn embedded(pid: u32) -> Incumbent {
+        Incumbent {
+            pid,
+            kind: ProxyKind::TcrEmbedded,
+        }
+    }
+
+    /// A host application's command line: nothing in it matches the `tcr` name
+    /// matcher, which is the entire reason the owner file exists.
+    const HOST_APP_COMMAND: &str = "/Applications/TcrBar.app/Contents/MacOS/TcrBar";
+
+    /// A unique scratch dir for a claim file. Never [`default_owner_path`] — that
+    /// one is the live proxy's, and `tcr login` reads it.
+    fn scratch_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "tcr-owner-test-{}-{tag}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or_default()
+        ));
+        std::fs::create_dir_all(&dir).expect("a scratch dir under the temp dir is creatable");
+        dir
+    }
+
+    fn write_claim(dir: &Path, port: u16, pid: u32, host: ProxyHost) -> PathBuf {
+        let path = owner_path_in(dir, port);
+        write_owner_file(
+            &path,
+            &ProxyOwner {
+                pid,
+                port,
+                sha: "0000000".to_string(),
+                host,
+            },
+        )
+        .expect("the scratch claim is writable");
+        path
+    }
+
+    /// (a) THE FALSE-POSITIVE CONTROL, and the one that makes the whole mechanism
+    /// safe to trust: a claim whose pid is **not** listening on the port is
+    /// IGNORED.
+    ///
+    /// Without this check the file is a lie anyone can plant — any process could
+    /// write `{"pid":<some pid>,"host":"embedded"}` and make `tcr` treat that pid
+    /// as an unreplaceable proxy, and every crashed proxy would leave behind a
+    /// claim protecting a pid the OS has since recycled onto something unrelated.
+    /// The file is a *claim*; `port_listeners` is what settles it.
+    #[test]
+    fn a_claim_whose_pid_is_not_listening_is_ignored() {
+        let dir = scratch_dir("stale");
+        let path = write_claim(&dir, 4444, 4242, ProxyHost::Embedded);
+
+        // The file is real, parses, and is for the right port — the ONLY defect is
+        // that its pid holds nothing.
+        assert!(path.exists());
+        assert_eq!(
+            classify_port_owner(4444, &[], &path),
+            None,
+            "a claim with no live listener at all must be ignored"
+        );
+        assert_eq!(
+            classify_port_owner(4444, &[9999, 8888], &path),
+            None,
+            "a claim whose pid is not among the port's listeners must be ignored"
+        );
+        // And the positive control, so the assertions above cannot be passing for
+        // the boring reason that this function always returns None.
+        assert_eq!(
+            classify_port_owner(4444, &[9999, 4242], &path),
+            Some(embedded(4242)),
+            "a claim whose pid IS listening is the one case that counts"
+        );
+        // A claim for a different port is not this port's claim either.
+        assert_eq!(
+            classify_port_owner(4445, &[4242], &path),
+            None,
+            "the port in the file must match the port being resolved"
+        );
+
+        // A stale claim does not even suppress the fallback: the name matcher
+        // still gets its turn, so a `tcr` predating the owner file is recognized.
+        let command = |_pid: u32| "/x/tcr server".to_string();
+        let owner = classify_port_owner(4444, &[7777], &path);
+        assert_eq!(
+            replaceable_incumbents_with_owner(&[7777], 1, command, owner),
+            vec![tcr(7777)],
+            "ignoring a stale claim must fall through to command-line recognition"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The case the whole phase exists for: a proxy inside a host application is
+    /// invisible to the name matcher, and the claim is what makes it visible.
+    ///
+    /// The `assert!` on the matcher is not decoration — it is the bug being fixed,
+    /// stated as an executable fact. If it ever starts matching, `live_proxy_server`
+    /// stopped depending on the claim and this file's reason to exist changed.
+    #[test]
+    fn an_embedded_proxy_is_recognized_only_through_its_claim() {
+        assert_eq!(
+            classify_proxy_server(HOST_APP_COMMAND),
+            None,
+            "the name matcher cannot see a proxy hosted inside another program — \
+             that is the failure the claim file replaces"
+        );
+
+        let dir = scratch_dir("embedded");
+        let path = write_claim(&dir, 3456, 5150, ProxyHost::Embedded);
+        let owner = classify_port_owner(3456, &[5150], &path);
+        let command = |_pid: u32| HOST_APP_COMMAND.to_string();
+
+        assert_eq!(
+            replaceable_incumbents_with_owner(&[5150], 1, command, owner),
+            vec![embedded(5150)],
+            "the claim identifies the proxy the process name hides"
+        );
+        // Without the claim, the same holder is nothing at all — which is exactly
+        // what made `tcr login` stop refusing to run beside a live server.
+        assert!(replaceable_incumbents(&[5150], 1, command).is_empty());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// `host: "cli"` is a plain [`ProxyKind::Tcr`] — the claim adds identity, not a
+    /// new policy, for a proxy the matcher could already see.
+    #[test]
+    fn a_cli_claim_is_an_ordinary_tcr_peer() {
+        let dir = scratch_dir("cli");
+        let path = write_claim(&dir, 3456, 1234, ProxyHost::Cli);
+        assert_eq!(
+            classify_port_owner(3456, &[1234], &path),
+            Some(tcr(1234)),
+            "a CLI-hosted claim is the same kind the name matcher would produce"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// BACKWARD COMPATIBILITY, and the reason this phase needs no restart: the
+    /// proxy serving right now wrote no claim, and it must still be recognized.
+    ///
+    /// A missing file, an empty one and a corrupt one all mean "no claim", never
+    /// "not a proxy" — a claim that cannot be read must not be able to *hide* an
+    /// incumbent the matcher would have found.
+    #[test]
+    fn a_proxy_that_wrote_no_claim_is_still_recognized() {
+        let dir = scratch_dir("absent");
+        let command = |_pid: u32| "/x/tcr server".to_string();
+
+        for (label, path) in [
+            ("absent", owner_path_in(&dir, 3456)),
+            ("empty", {
+                let p = dir.join("empty.json");
+                std::fs::write(&p, b"").expect("scratch write");
+                p
+            }),
+            ("corrupt", {
+                let p = dir.join("corrupt.json");
+                std::fs::write(&p, b"{not json").expect("scratch write");
+                p
+            }),
+            ("wrong-shape", {
+                let p = dir.join("wrong-shape.json");
+                std::fs::write(&p, br#"{"pid":222}"#).expect("scratch write");
+                p
+            }),
+        ] {
+            let owner = classify_port_owner(3456, &[222], &path);
+            assert_eq!(owner, None, "{label} is not a claim");
+            assert_eq!(
+                replaceable_incumbents_with_owner(&[222], 1, command, owner),
+                vec![tcr(222)],
+                "{label}: the retained name matcher must still recognize a running \
+                 proxy that never wrote a claim"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// (b) An EMBEDDED incumbent stands the caller down even under `--replace`.
+    ///
+    /// The pid on the port belongs to the host application, and `takeover_port`
+    /// SIGTERMs it (see [`ProxyKind::TcrEmbedded`]): AppKit installs no SIGTERM
+    /// handler, so `--replace` would kill the app without its shutdown path — no
+    /// final session→account pin write, and the operator's app simply vanishes. A
+    /// CLI flag must not be able to do that.
+    #[test]
+    fn an_embedded_incumbent_stands_us_down_even_under_replace() {
+        for replace in [false, true] {
+            assert_eq!(
+                takeover_decision(&[embedded(777)], replace),
+                Takeover::IncumbentPresent(777),
+                "replace={replace} must not be able to take over an embedded proxy"
+            );
+        }
+        // And it wins over a legacy JS proxy sharing the port, in either order:
+        // proceeding for the JS proxy means SIGNALLING it, and this process would
+        // still refuse to bind afterwards.
+        for holders in [
+            vec![legacy_js(111), embedded(777)],
+            vec![embedded(777), legacy_js(111)],
+        ] {
+            assert_eq!(
+                takeover_decision(&holders, true),
+                Takeover::IncumbentPresent(777),
+                "{holders:?}"
+            );
+        }
+    }
+
+    /// (c) Nothing is ever signalled for an embedded incumbent — the assertion
+    /// that stands between `--replace` and SIGTERM to a GUI process.
+    #[test]
+    fn an_embedded_incumbent_is_never_signalled() {
+        for replace in [false, true] {
+            assert_eq!(
+                incumbents_to_signal(&[embedded(777)], replace),
+                vec![],
+                "replace={replace}: an embedded proxy must never be signalled"
+            );
+            assert_eq!(
+                incumbents_to_signal(&[embedded(777), legacy_js(111)], replace),
+                vec![],
+                "replace={replace}: nor its port-mates, since we stand down anyway"
+            );
+        }
+    }
+
+    /// The embedded stand-down still carries the marker TcrBar greps for, and does
+    /// NOT offer `--replace` — the one instruction that cannot work here.
+    #[test]
+    fn the_embedded_stand_down_message_reports_without_offering_replace() {
+        let message = embedded_stand_down_message(3456, 777);
+        assert!(
+            message.contains("another proxy holds"),
+            "apps/macos ServerController.incumbentMarkers greps for this: {message}"
+        );
+        assert!(message.contains("777"), "names the incumbent: {message}");
+        assert!(
+            !message.contains("--replace to"),
+            "must not offer an override that is refused for this kind: {message}"
+        );
+    }
+
+    /// The claim file is named after the PORT, so two proxies on two ports never
+    /// overwrite each other's identity, and it lives beside the pin cache rather
+    /// than anywhere a caller has to remember.
+    #[test]
+    fn the_claim_path_is_port_scoped_and_beside_the_pin_cache() {
+        assert_eq!(
+            owner_path_in(Path::new("/tmp/x"), 3456),
+            PathBuf::from("/tmp/x/proxy-owner-3456.json")
+        );
+        assert_ne!(
+            owner_path_in(Path::new("/tmp/x"), 3456),
+            owner_path_in(Path::new("/tmp/x"), 3457)
+        );
+        assert_eq!(
+            default_owner_path(3456).parent(),
+            crate::affinity::default_path().parent(),
+            "the claim belongs in the same directory as the pin cache"
+        );
+    }
+
+    /// The on-disk shape is a cross-process contract: the file a proxy writes is
+    /// read by a DIFFERENT `tcr` build, possibly older or newer. The key names are
+    /// spelled out here so a rename cannot happen silently.
+    #[test]
+    fn the_claim_is_the_documented_json_shape() {
+        let json = serde_json::to_string(&ProxyOwner {
+            pid: 42,
+            port: 3456,
+            sha: "abc1234".to_string(),
+            host: ProxyHost::Embedded,
+        })
+        .expect("a claim serializes");
+        assert_eq!(
+            json, r#"{"pid":42,"port":3456,"sha":"abc1234","host":"embedded"}"#,
+            "the claim's field names and the lowercase host values are read by \
+             other builds of tcr"
+        );
+        let parsed: ProxyOwner =
+            serde_json::from_str(r#"{"pid":7,"port":1,"sha":"s","host":"cli"}"#)
+                .expect("the documented shape parses");
+        assert_eq!(parsed.host, ProxyHost::Cli);
     }
 
     #[test]

--- a/src/singleton.rs
+++ b/src/singleton.rs
@@ -433,16 +433,22 @@ pub fn replaceable_incumbents_with_owner(
 /// [`takeover_port`] ([`replaceable_incumbents`]) but signals NOTHING — `tcr login` uses
 /// it to REFUSE to run beside a live server (the server reads config only at boot,
 /// and its next `persist_tokens` writes its boot-time TOKENS back over the file,
-/// clobbering the login's fresh ones). Returns the first replaceable proxy PID;
-/// `None` when the
-/// port is free or held only by a non-proxy process.
-pub fn live_proxy_server(port: u16) -> Option<u32> {
+/// clobbering the login's fresh ones). Returns the first replaceable
+/// [`Incumbent`]; `None` when the port is free or held only by a non-proxy
+/// process.
+///
+/// The KIND travels with the pid, and it has to. Since the owner file, this can
+/// return the pid of a HOST APPLICATION serving the proxy in-process, and a
+/// caller that renders "kill {pid}" would be telling the operator to SIGTERM a
+/// GUI that installs no handler for it — no `applicationWillTerminate`, no final
+/// session→account pin write. A bare `u32` cannot carry that distinction, so it
+/// is not returned as one; see `oauth::login_guard_refusal`.
+pub fn live_proxy_server(port: u16) -> Option<Incumbent> {
     let holders = port_listeners(port);
     let owner = classify_port_owner(port, &holders, &default_owner_path(port), process_command);
     replaceable_incumbents_with_owner(&holders, std::process::id(), process_command, owner)
         .into_iter()
         .next()
-        .map(|incumbent| incumbent.pid)
 }
 
 /// Is `pid` still alive? (`kill -0`.)

--- a/src/singleton.rs
+++ b/src/singleton.rs
@@ -471,7 +471,13 @@ pub enum Takeover {
     Proceed,
     /// A recognized proxy incumbent holds the port and was deliberately left
     /// running. The caller must NOT bind; it should exit 0.
-    IncumbentPresent(u32),
+    ///
+    /// Carries the whole [`Incumbent`], not just its pid. The KIND decides what a
+    /// caller may tell the operator to do about it — a `tcr` peer can be signalled
+    /// and an embedded one must only be quit — and a caller handed a bare `u32`
+    /// has to re-scan the incumbent list to recover a fact this function already
+    /// looked up, which is exactly the kind of parallel predicate that drifts.
+    IncumbentPresent(Incumbent),
 }
 
 /// The pure decision: given the replaceable incumbents on the port and whether
@@ -492,12 +498,16 @@ pub enum Takeover {
 /// one kind `--replace` cannot override: the pid on the port belongs to the host
 /// application, so replacing it means SIGTERMing a GUI that installs no handler
 /// for it. See [`ProxyKind::TcrEmbedded`].
+///
+/// That stand-down decides only whether WE bind. It says nothing about the OTHER
+/// incumbents on the port — see [`incumbents_to_signal`], which partitions them by
+/// kind rather than reading this one verdict as "touch nothing".
 pub fn takeover_decision(replaceable: &[Incumbent], replace: bool) -> Takeover {
     if let Some(embedded) = replaceable
         .iter()
         .find(|incumbent| incumbent.kind == ProxyKind::TcrEmbedded)
     {
-        return Takeover::IncumbentPresent(embedded.pid);
+        return Takeover::IncumbentPresent(*embedded);
     }
     if replace {
         return Takeover::Proceed;
@@ -506,7 +516,7 @@ pub fn takeover_decision(replaceable: &[Incumbent], replace: bool) -> Takeover {
         .iter()
         .find(|incumbent| incumbent.kind == ProxyKind::Tcr)
     {
-        Some(peer) => Takeover::IncumbentPresent(peer.pid),
+        Some(peer) => Takeover::IncumbentPresent(*peer),
         None => Takeover::Proceed,
     }
 }
@@ -528,8 +538,30 @@ pub fn takeover_decision(replaceable: &[Incumbent], replace: bool) -> Takeover {
 /// one kills a host application without its `applicationWillTerminate`, so the
 /// guarantee is worth stating twice rather than resting on a `!= Proceed` that a
 /// future edit to [`takeover_decision`] could relax by accident.
+///
+/// # The one stand-down that is not "touch nothing": `--replace` past an embedded
+///
+/// `port_listeners` filters by port, not by address, so a legacy JS
+/// `teamclaude server` on `[::1]:3456` and an embedded tcr on `127.0.0.1:3456`
+/// are both holders. Reading the embedded stand-down as "signal nothing" made
+/// that JS proxy undisplaceable on EVERY path — `--replace` included, since the
+/// embedded check precedes it — and the two proxies then token-war over the same
+/// single-use refresh tokens forever, which is the failure this module exists to
+/// end. So the kinds are partitioned rather than collapsed: the embedded
+/// incumbent is never signalled and still stands us down, while an explicit
+/// `--replace` still reaches the NON-embedded incumbents beside it. That is the
+/// escape hatch `takeover_decision`'s doc-comment promises for a `LegacyJs`
+/// incumbent, and it is the only way to honour both rules at once.
+///
+/// Without `--replace` a stand-down still signals nothing at all, embedded or
+/// not: the operator did not ask for a kill, and killing half the port's holders
+/// while refusing to bind is all cost and no benefit.
 fn incumbents_to_signal(replaceable: &[Incumbent], replace: bool) -> Vec<Incumbent> {
-    if takeover_decision(replaceable, replace) != Takeover::Proceed {
+    let embedded_present = replaceable
+        .iter()
+        .any(|incumbent| incumbent.kind == ProxyKind::TcrEmbedded);
+    let stood_down = takeover_decision(replaceable, replace) != Takeover::Proceed;
+    if stood_down && !(embedded_present && replace) {
         return Vec::new();
     }
     replaceable
@@ -614,21 +646,27 @@ pub fn takeover_port(port: u16, replace: bool) -> Takeover {
         }
     }
 
-    if let Takeover::IncumbentPresent(pid) = takeover_decision(&replaceable, replace) {
+    let decision = takeover_decision(&replaceable, replace);
+    if let Takeover::IncumbentPresent(incumbent) = decision {
         // Only the pid and the instruction live here; `main` prints the build
         // comparison, because THAT is the part a user typing `tcr` after a rebuild
         // actually needs and it requires an async status read we must not do here.
-        let embedded = replaceable
-            .iter()
-            .any(|incumbent| incumbent.pid == pid && incumbent.kind == ProxyKind::TcrEmbedded);
-        if embedded {
-            eprintln!("{}", embedded_stand_down_message(port, pid));
+        //
+        // The kind comes from the decision itself rather than a second scan of
+        // `replaceable` for the same predicate: two copies of "is this one
+        // embedded?" is how the generic message — which offers `--replace` — ends
+        // up printed for the one kind `--replace` cannot take over.
+        if incumbent.kind == ProxyKind::TcrEmbedded {
+            eprintln!("{}", embedded_stand_down_message(port, incumbent.pid));
         } else {
-            eprintln!("{}", stand_down_message(port, pid));
+            eprintln!("{}", stand_down_message(port, incumbent.pid));
         }
-        return Takeover::IncumbentPresent(pid);
     }
 
+    // Not `else`: standing down for an EMBEDDED incumbent still lets an explicit
+    // `--replace` displace the non-embedded proxies sharing the port. See
+    // `incumbents_to_signal`; without it a legacy JS proxy co-resident with an
+    // embedded tcr is undisplaceable on every path.
     for Incumbent { pid, kind } in incumbents_to_signal(&replaceable, replace) {
         match kind {
             // Unreachable by construction — `incumbents_to_signal` filters this
@@ -662,7 +700,7 @@ pub fn takeover_port(port: u16, replace: bool) -> Takeover {
             sleep(Duration::from_millis(300));
         }
     }
-    Takeover::Proceed
+    decision
 }
 
 #[cfg(test)]
@@ -969,7 +1007,7 @@ mod tests {
         for replace in [false, true] {
             assert_eq!(
                 takeover_decision(&[embedded(777)], replace),
-                Takeover::IncumbentPresent(777),
+                Takeover::IncumbentPresent(embedded(777)),
                 "replace={replace} must not be able to take over an embedded proxy"
             );
         }
@@ -982,14 +1020,14 @@ mod tests {
         ] {
             assert_eq!(
                 takeover_decision(&holders, true),
-                Takeover::IncumbentPresent(777),
+                Takeover::IncumbentPresent(embedded(777)),
                 "{holders:?}"
             );
         }
     }
 
-    /// (c) Nothing is ever signalled for an embedded incumbent — the assertion
-    /// that stands between `--replace` and SIGTERM to a GUI process.
+    /// (c) The embedded incumbent ITSELF is never signalled — the assertion that
+    /// stands between `--replace` and SIGTERM to a GUI process.
     #[test]
     fn an_embedded_incumbent_is_never_signalled() {
         for replace in [false, true] {
@@ -998,12 +1036,57 @@ mod tests {
                 vec![],
                 "replace={replace}: an embedded proxy must never be signalled"
             );
-            assert_eq!(
-                incumbents_to_signal(&[embedded(777), legacy_js(111)], replace),
-                vec![],
-                "replace={replace}: nor its port-mates, since we stand down anyway"
+            assert!(
+                !incumbents_to_signal(&[embedded(777), legacy_js(111)], replace)
+                    .iter()
+                    .any(|incumbent| incumbent.kind == ProxyKind::TcrEmbedded),
+                "replace={replace}: not even beside another incumbent on the port"
             );
         }
+        // Without --replace nothing at all is signalled: the operator asked for no
+        // kill, and half-killing while refusing to bind is all cost, no benefit.
+        assert_eq!(
+            incumbents_to_signal(&[embedded(777), legacy_js(111)], false),
+            vec![]
+        );
+    }
+
+    /// THE ESCAPE HATCH, and the reason the embedded stand-down is not read as
+    /// "touch nothing": a legacy JS proxy sharing the port with an embedded tcr
+    /// must still be displaceable with `--replace`.
+    ///
+    /// `port_listeners` filters by port and not by address, so `node …/teamclaude
+    /// server` on `[::1]:3456` and an embedded tcr on `127.0.0.1:3456` are both
+    /// holders. Collapsing that to one kind-blind stand-down left the JS proxy
+    /// serving forever on every path — and `takeover_decision`'s own doc-comment
+    /// says that outcome is unacceptable, because the two then token-war over the
+    /// same single-use refresh tokens with no way out.
+    #[test]
+    fn replace_still_displaces_a_legacy_js_proxy_beside_an_embedded_incumbent() {
+        for holders in [
+            vec![legacy_js(111), embedded(777)],
+            vec![embedded(777), legacy_js(111)],
+        ] {
+            assert_eq!(
+                incumbents_to_signal(&holders, true),
+                vec![legacy_js(111)],
+                "--replace must still reach the JS proxy, and ONLY it: {holders:?}"
+            );
+            // We still do not bind: the embedded proxy legitimately holds the port
+            // and the stand-down is unchanged. Ending the token war and taking the
+            // port over are two different questions.
+            assert_eq!(
+                takeover_decision(&holders, true),
+                Takeover::IncumbentPresent(embedded(777)),
+                "{holders:?}"
+            );
+        }
+        // A `tcr` peer beside an embedded proxy is likewise reachable by an
+        // explicit --replace, and the embedded one still is not.
+        assert_eq!(
+            incumbents_to_signal(&[embedded(777), tcr(222)], true),
+            vec![tcr(222)]
+        );
     }
 
     /// The embedded stand-down still carries the marker TcrBar greps for, and does
@@ -1155,7 +1238,7 @@ mod tests {
     fn a_healthy_tcr_peer_is_left_alone_by_default() {
         assert_eq!(
             takeover_decision(&[tcr(4242)], false),
-            Takeover::IncumbentPresent(4242)
+            Takeover::IncumbentPresent(tcr(4242))
         );
         assert_eq!(
             incumbents_to_signal(&[tcr(4242)], false),
@@ -1252,7 +1335,7 @@ mod tests {
         ] {
             assert_eq!(
                 takeover_decision(&holders, false),
-                Takeover::IncumbentPresent(222),
+                Takeover::IncumbentPresent(tcr(222)),
                 "the protected peer is the one named: {holders:?}"
             );
             assert_eq!(

--- a/src/singleton.rs
+++ b/src/singleton.rs
@@ -161,10 +161,50 @@ pub fn write_owner_file(path: &Path, owner: &ProxyOwner) -> Result<(), crate::co
     crate::config::write_atomic(path, &serde_json::to_string_pretty(owner)?)
 }
 
-/// Drop the claim. Best-effort by design: a file left behind by a crash cannot
-/// produce a false positive ([`verified_owner`] re-checks the pid against the
-/// live listeners), so failing to remove one costs nothing.
-pub fn remove_owner_file(path: &Path) {
+/// Withdraw the claim at `path` — but ONLY if it still names `pid` on `port`.
+///
+/// The check is the whole function. `proxy-owner-<port>.json` is shared state
+/// named after the PORT, not after the process, so a shutting-down proxy and its
+/// successor address the same file. A shutdown frees the listener first and then
+/// keeps joining background tasks (the affinity flusher does a blocking write, so
+/// hundreds of milliseconds); in that window a successor can bind the port and
+/// write its own claim. An unconditional unlink here would delete the SUCCESSOR's
+/// live claim, and for an embedded successor — whose command line identifies
+/// nothing — that means `live_proxy_server` returns `None`, `tcr login` stops
+/// refusing, and the boot-time single-use refresh tokens clobber the fresh ones.
+/// That is the exact failure the claim file exists to prevent, reintroduced by
+/// its own cleanup path.
+///
+/// Best-effort past the check: a claim left behind by a crash cannot produce a
+/// false positive ([`verified_owner`] re-checks the pid against the live
+/// listeners and the command line), so failing to remove one costs nothing.
+///
+/// A read-then-unlink still has a microsecond-wide TOCTOU window, which is not
+/// closable portably. It replaces a hundreds-of-milliseconds window with one
+/// bounded by two syscalls; the alternative — not checking — loses the file every
+/// time the race is entered at all.
+pub fn remove_owner_file_if_owned(path: &Path, pid: u32, port: u16) {
+    match read_owner_file(path) {
+        Some(owner) if owner.pid == pid && owner.port == port => {}
+        Some(owner) => {
+            tracing::info!(
+                path = %path.display(),
+                claim_pid = owner.pid,
+                claim_port = owner.port,
+                our_pid = pid,
+                our_port = port,
+                "not withdrawing the port claim: it names another proxy, so a successor \
+                 already took the port over"
+            );
+            return;
+        }
+        None => {
+            // Absent (already withdrawn) or unparseable — either way it is not
+            // this process's claim to delete, and a successor's write will
+            // replace it.
+            return;
+        }
+    }
     if let Err(err) = std::fs::remove_file(path) {
         if err.kind() != std::io::ErrorKind::NotFound {
             tracing::warn!(
@@ -974,6 +1014,52 @@ mod tests {
             !message.contains("--replace to"),
             "must not offer an override that is refused for this kind: {message}"
         );
+    }
+
+    /// THE SUCCESSOR'S CLAIM SURVIVES OUR SHUTDOWN. The claim path is named after
+    /// the port, so a proxy shutting down and the proxy that just replaced it
+    /// address the same file — and the shutdown frees the listener BEFORE it gets
+    /// here (`server::ServerHandle::shutdown_within` joins background tasks in
+    /// between, including a blocking affinity write). An unconditional unlink
+    /// deletes the live successor's claim: for an embedded successor the name
+    /// matcher then recognizes nothing, `tcr login` stops refusing, and the
+    /// boot-time single-use refresh tokens overwrite the fresh ones.
+    #[test]
+    fn a_withdrawal_deletes_only_a_claim_this_process_still_owns() {
+        let dir = scratch_dir("withdraw");
+
+        // (1) The successor's claim — different pid, same port, same path.
+        let path = write_claim(&dir, 3456, 777, ProxyHost::Embedded);
+        remove_owner_file_if_owned(&path, 5150, 3456);
+        assert!(
+            path.exists(),
+            "withdrawing must not delete a claim written by another pid: {}",
+            path.display()
+        );
+        assert_eq!(
+            read_owner_file(&path).map(|owner| owner.pid),
+            Some(777),
+            "and it must be left byte-for-byte the successor's"
+        );
+
+        // (2) A claim for another port at this path is not ours either.
+        remove_owner_file_if_owned(&path, 777, 3457);
+        assert!(path.exists(), "the port must match too: {}", path.display());
+
+        // (3) The positive control: our OWN claim is withdrawn, so a shutdown
+        // still stops advertising a port it no longer listens on.
+        let ours = write_claim(&dir, 3457, 5150, ProxyHost::Cli);
+        remove_owner_file_if_owned(&ours, 5150, 3457);
+        assert!(
+            !ours.exists(),
+            "a proxy must withdraw its own claim on shutdown: {}",
+            ours.display()
+        );
+
+        // (4) Withdrawing twice (a re-issued shutdown) is quiet and harmless.
+        remove_owner_file_if_owned(&ours, 5150, 3457);
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// The claim file is named after the PORT, so two proxies on two ports never

--- a/src/singleton.rs
+++ b/src/singleton.rs
@@ -103,6 +103,21 @@ pub enum ProxyHost {
     Cli,
     /// A proxy served from inside a host application.
     Embedded,
+    /// A host this build does not know about — a claim written by a NEWER `tcr`.
+    ///
+    /// The file is a cross-process, cross-BUILD contract: the `tcr` that reads it
+    /// may be older than the one that wrote it. Without this catch-all an unknown
+    /// `host` value fails the whole `ProxyOwner` parse, so a live proxy reads as
+    /// NO CLAIM AT ALL — the name matcher then sees the host program's `argv[0]`,
+    /// recognizes nothing, `tcr login` runs beside the live server and its fresh
+    /// single-use refresh tokens are overwritten, and `tcr server --replace`
+    /// SIGTERMs the process the claim existed to protect. Degrading to "a proxy is
+    /// there, do not signal it" is strictly safer than degrading to "nothing is
+    /// there", so this maps to [`ProxyKind::TcrEmbedded`].
+    ///
+    /// Only ever produced by DEserialization. Nothing in this crate writes it.
+    #[serde(other)]
+    Unknown,
 }
 
 impl ProxyHost {
@@ -110,7 +125,9 @@ impl ProxyHost {
     fn kind(self) -> ProxyKind {
         match self {
             ProxyHost::Cli => ProxyKind::Tcr,
-            ProxyHost::Embedded => ProxyKind::TcrEmbedded,
+            // An unrecognized host is treated as embedded: of the two, it is the
+            // kind that is never signalled. See [`ProxyHost::Unknown`].
+            ProxyHost::Embedded | ProxyHost::Unknown => ProxyKind::TcrEmbedded,
         }
     }
 }
@@ -143,15 +160,21 @@ pub fn owner_path_in(dir: &Path, port: u16) -> PathBuf {
     dir.join(format!("proxy-owner-{port}.json"))
 }
 
-/// Where the binary keeps the claim: beside the session-affinity pin cache, so
-/// the proxy's two pieces of cross-boot state live in one directory.
-pub fn default_owner_path(port: u16) -> PathBuf {
+/// The directory the binary keeps the claim in: beside the session-affinity pin
+/// cache, so the proxy's two pieces of cross-boot state live in one place.
+pub fn default_owner_dir() -> PathBuf {
     let cache = crate::affinity::default_path();
-    let dir = cache
+    cache
         .parent()
         .filter(|p| !p.as_os_str().is_empty())
-        .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
-    owner_path_in(&dir, port)
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf)
+}
+
+/// Where the binary keeps the claim for `port`. Every reader resolves the claim
+/// through this function, which is why a writer must never be handed a free-form
+/// path: see [`crate::server::ServeOptions::owner_dir`].
+pub fn default_owner_path(port: u16) -> PathBuf {
+    owner_path_in(&default_owner_dir(), port)
 }
 
 /// Write the claim atomically (0600, temp + rename — the same
@@ -218,8 +241,31 @@ pub fn remove_owner_file_if_owned(path: &Path, pid: u32, port: u16) {
 
 /// Read a claim, or `None` for absent/unreadable/unparseable. A malformed file is
 /// simply not a claim — the name matcher still gets its turn.
+///
+/// Every failure that is not "the file is absent" is LOGGED, the read errors as
+/// well as the parse errors. The claim is written 0600, so a proxy started under
+/// another uid (launchd, `sudo`) leaves one a client cannot read: the read fails
+/// EACCES, identity silently falls back to the matcher that by construction
+/// cannot see an embedded proxy, and `tcr login` proceeds beside a live server
+/// whose next persist overwrites the fresh single-use refresh tokens. An
+/// unreadable claim and an absent one lead to the same fallback but they are not
+/// the same fact, and the operator needs the difference on the record.
 fn read_owner_file(path: &Path) -> Option<ProxyOwner> {
-    let data = std::fs::read_to_string(path).ok()?;
+    let data = match std::fs::read_to_string(path) {
+        Ok(data) => data,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(err) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %err,
+                "the proxy owner file exists but could not be READ (permissions? it is written \
+                 0600, so a proxy running under another uid leaves one a client cannot open); \
+                 falling back to command-line recognition, which does NOT recognize an embedded \
+                 proxy"
+            );
+            return None;
+        }
+    };
     match serde_json::from_str::<ProxyOwner>(&data) {
         Ok(owner) => Some(owner),
         Err(err) => {
@@ -1169,6 +1215,46 @@ mod tests {
             crate::affinity::default_path().parent(),
             "the claim belongs in the same directory as the pin cache"
         );
+    }
+
+    /// FORWARD COMPATIBILITY. The claim is read by a different BUILD of `tcr` than
+    /// the one that wrote it — an older one, on any machine where a newer proxy is
+    /// serving. A host value this build does not know must degrade to "a proxy is
+    /// there, do not signal it", never to "no claim at all": the latter drops the
+    /// reader back to the name matcher, which cannot see an embedded proxy, so
+    /// `tcr login` proceeds beside a live server and `--replace` SIGTERMs the
+    /// process the file existed to protect.
+    #[test]
+    fn a_host_this_build_does_not_know_is_still_a_proxy_worth_protecting() {
+        let dir = scratch_dir("future-host");
+        let path = owner_path_in(&dir, 3456);
+        std::fs::write(
+            &path,
+            br#"{"pid":900,"port":3456,"sha":"0000000","host":"sidecar"}"#,
+        )
+        .expect("scratch write");
+
+        let parsed: ProxyOwner =
+            serde_json::from_str(&std::fs::read_to_string(&path).expect("scratch read"))
+                .expect("an unknown host must not fail the whole parse");
+        assert_eq!(parsed.host, ProxyHost::Unknown);
+        assert_eq!(parsed.pid, 900, "the rest of the claim still parses");
+
+        // And it lands on the kind that is never signalled, whatever the host
+        // program's command line says.
+        let command = |_pid: u32| HOST_APP_COMMAND.to_string();
+        assert_eq!(
+            classify_port_owner(3456, &[900], &path, command),
+            Some(embedded(900)),
+            "an unrecognized host degrades to the protected kind, not to nothing"
+        );
+        assert_eq!(
+            incumbents_to_signal(&[embedded(900)], true),
+            vec![],
+            "and --replace still cannot signal it"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// The on-disk shape is a cross-process contract: the file a proxy writes is

--- a/src/singleton.rs
+++ b/src/singleton.rs
@@ -41,10 +41,14 @@
 //! [`classify_port_owner`] is consulted BEFORE the name matcher. Identity becomes
 //! the proxy's own claim instead of an inference from someone else's `argv`.
 //!
-//! Two properties keep that from being a new way to get it wrong:
+//! Three properties keep that from being a new way to get it wrong:
 //! - **A stale file proves nothing.** The pid it names must ALSO appear in
 //!   `port_listeners(port)` (and the port must match) or the claim is ignored
 //!   entirely — a crashed proxy, or anyone at all, can leave a file behind.
+//! - **A claim SUPPLEMENTS the command check, it never replaces it.** A `cli`
+//!   claim is believed only when the command line ALSO says its pid is a proxy,
+//!   so "command-verified" above still holds on the claim path; a pid the OS
+//!   recycled onto an unrelated listener is not signalled. See [`verified_owner`].
 //! - **The name matcher is RETAINED as the fallback**, so a `tcr` that predates
 //!   the owner file (including one serving right now) and a `LegacyJs` proxy —
 //!   which will never write one — are recognized exactly as before. Nothing has
@@ -190,30 +194,78 @@ fn read_owner_file(path: &Path) -> Option<ProxyOwner> {
 }
 
 /// The claim's VERIFICATION, as a pure function: a claim counts only when it is
-/// for this `port` and its pid is one of the processes actually listening on it.
+/// for this `port`, its pid is one of the processes actually listening on it,
+/// AND — for a claim that says it is CLI-hosted — that pid's command line is
+/// still a proxy server.
 ///
 /// This is the check that makes the owner file safe to trust. Without it the file
 /// is a lie anyone can plant: any process could write `{"pid":<live proxy>,…}`
 /// and change what `tcr` does about the port, and every crashed proxy would leave
 /// behind a claim that outlives it and protects a pid the OS has since recycled
 /// onto something unrelated.
-fn verified_owner(owner: Option<&ProxyOwner>, port: u16, holders: &[u32]) -> Option<Incumbent> {
+///
+/// # A claim SUPPLEMENTS the command check; it never replaces it
+///
+/// The pid check alone is not enough, and the difference is a killed process. A
+/// crashed `tcr` leaves `{"pid":5150,"host":"cli"}` behind; months later pid 5150
+/// is someone's dev server listening on the same port. `pid ∈ holders` holds, so
+/// a claim-trusting reader calls it a `tcr` peer and `tcr --replace` SIGTERMs it,
+/// then SIGKILLs it 800ms later. The module's "command-verified" property (see the
+/// module doc) has to hold on the claim path too, so a `cli` claim is believed
+/// only when [`classify_proxy_server`] ALSO recognizes the pid. The claim's job is
+/// to say WHICH proxy it is and that it is ours; only the command line can say
+/// that the pid is still a proxy at all.
+///
+/// # The one asymmetry, and why it is safe
+///
+/// An `embedded` claim cannot be command-verified — by construction: the pid is
+/// the HOST application's and its `argv[0]` matches nothing, which is the entire
+/// reason this file exists. So an embedded claim is believed on the pid check
+/// alone, and that is deliberate: a false positive there can only ever make this
+/// process STAND DOWN (an embedded incumbent is never signalled, on any path —
+/// [`incumbents_to_signal`]), while a false positive on a CLI claim is a kill. The
+/// unverifiable case is the one whose worst outcome is refusing to act.
+fn verified_owner(
+    owner: Option<&ProxyOwner>,
+    port: u16,
+    holders: &[u32],
+    command: impl Fn(u32) -> String,
+) -> Option<Incumbent> {
     let owner = owner?;
-    (owner.port == port && holders.contains(&owner.pid)).then(|| Incumbent {
+    if owner.port != port || !holders.contains(&owner.pid) {
+        return None;
+    }
+    let kind = owner.host.kind();
+    if owner.host == ProxyHost::Cli && classify_proxy_server(&command(owner.pid)).is_none() {
+        tracing::warn!(
+            pid = owner.pid,
+            port,
+            "ignoring a cli-hosted port claim whose pid is not running a proxy: the claim is \
+             stale and the OS has recycled that pid onto something else"
+        );
+        return None;
+    }
+    Some(Incumbent {
         pid: owner.pid,
-        kind: owner.host.kind(),
+        kind,
     })
 }
 
 /// The owner file at `owner_path`, verified against the processes actually
-/// holding `port`. `None` when there is no claim, the claim is for another port,
-/// or its pid is not listening — in every one of those cases the caller falls
-/// back to the name matcher.
+/// holding `port` and against the claimed pid's command line. `None` when there is
+/// no claim, the claim is for another port, its pid is not listening, or a
+/// CLI-hosted claim names a pid that is not a proxy — in every one of those cases
+/// the caller falls back to the name matcher.
 ///
-/// `holders` and `owner_path` are parameters rather than read in here so this is
-/// testable against a real file without a real proxy.
-pub fn classify_port_owner(port: u16, holders: &[u32], owner_path: &Path) -> Option<Incumbent> {
-    verified_owner(read_owner_file(owner_path).as_ref(), port, holders)
+/// `holders`, `owner_path` and `command` are parameters rather than read in here
+/// so this is testable against a real file without a real proxy.
+pub fn classify_port_owner(
+    port: u16,
+    holders: &[u32],
+    owner_path: &Path,
+    command: impl Fn(u32) -> String,
+) -> Option<Incumbent> {
+    verified_owner(read_owner_file(owner_path).as_ref(), port, holders, command)
 }
 
 /// A recognized, replaceable proxy holding the port.
@@ -314,8 +366,11 @@ pub fn replaceable_incumbents(
 /// for an embedded proxy that inference is wrong in the dangerous direction (it
 /// recognizes nothing at all). Where both speak, the claim wins.
 ///
-/// `owner` must already be verified against the live listeners; pass the result of
-/// [`classify_port_owner`], never a raw file read.
+/// `owner` must already be verified against the live listeners AND (for a `cli`
+/// claim) against the pid's command line; pass the result of
+/// [`classify_port_owner`], never a raw file read. That is what keeps this
+/// short-circuit from being a way around the command check — by the time a claim
+/// arrives here, the command check has already had its say.
 pub fn replaceable_incumbents_with_owner(
     holders: &[u32],
     self_pid: u32,
@@ -343,7 +398,7 @@ pub fn replaceable_incumbents_with_owner(
 /// port is free or held only by a non-proxy process.
 pub fn live_proxy_server(port: u16) -> Option<u32> {
     let holders = port_listeners(port);
-    let owner = classify_port_owner(port, &holders, &default_owner_path(port));
+    let owner = classify_port_owner(port, &holders, &default_owner_path(port), process_command);
     replaceable_incumbents_with_owner(&holders, std::process::id(), process_command, owner)
         .into_iter()
         .next()
@@ -497,7 +552,7 @@ fn embedded_stand_down_message(port: u16, pid: u32) -> String {
 #[must_use = "the caller must exit instead of binding on IncumbentPresent"]
 pub fn takeover_port(port: u16, replace: bool) -> Takeover {
     let holders = port_listeners(port);
-    let owner = classify_port_owner(port, &holders, &default_owner_path(port));
+    let owner = classify_port_owner(port, &holders, &default_owner_path(port), process_command);
     let replaceable =
         replaceable_incumbents_with_owner(&holders, std::process::id(), process_command, owner);
 
@@ -624,6 +679,16 @@ mod tests {
     /// matcher, which is the entire reason the owner file exists.
     const HOST_APP_COMMAND: &str = "/Applications/TcrBar.app/Contents/MacOS/TcrBar";
 
+    /// An unrelated program listening on the port — what a recycled pid actually
+    /// runs. Not a proxy by any reading of its command line.
+    const DEV_SERVER_COMMAND: &str = "/usr/local/bin/node /srv/app/dev-server.js";
+
+    /// The command line of a real CLI-hosted proxy, for the tests that need the
+    /// claim's pid to survive the command check.
+    fn tcr_command(_pid: u32) -> String {
+        "/x/tcr server".to_string()
+    }
+
     /// A unique scratch dir for a claim file. Never [`default_owner_path`] — that
     /// one is the live proxy's, and `tcr login` reads it.
     fn scratch_dir(tag: &str) -> PathBuf {
@@ -672,25 +737,25 @@ mod tests {
         // that its pid holds nothing.
         assert!(path.exists());
         assert_eq!(
-            classify_port_owner(4444, &[], &path),
+            classify_port_owner(4444, &[], &path, tcr_command),
             None,
             "a claim with no live listener at all must be ignored"
         );
         assert_eq!(
-            classify_port_owner(4444, &[9999, 8888], &path),
+            classify_port_owner(4444, &[9999, 8888], &path, tcr_command),
             None,
             "a claim whose pid is not among the port's listeners must be ignored"
         );
         // And the positive control, so the assertions above cannot be passing for
         // the boring reason that this function always returns None.
         assert_eq!(
-            classify_port_owner(4444, &[9999, 4242], &path),
+            classify_port_owner(4444, &[9999, 4242], &path, tcr_command),
             Some(embedded(4242)),
             "a claim whose pid IS listening is the one case that counts"
         );
         // A claim for a different port is not this port's claim either.
         assert_eq!(
-            classify_port_owner(4445, &[4242], &path),
+            classify_port_owner(4445, &[4242], &path, tcr_command),
             None,
             "the port in the file must match the port being resolved"
         );
@@ -698,7 +763,7 @@ mod tests {
         // A stale claim does not even suppress the fallback: the name matcher
         // still gets its turn, so a `tcr` predating the owner file is recognized.
         let command = |_pid: u32| "/x/tcr server".to_string();
-        let owner = classify_port_owner(4444, &[7777], &path);
+        let owner = classify_port_owner(4444, &[7777], &path, command);
         assert_eq!(
             replaceable_incumbents_with_owner(&[7777], 1, command, owner),
             vec![tcr(7777)],
@@ -725,8 +790,8 @@ mod tests {
 
         let dir = scratch_dir("embedded");
         let path = write_claim(&dir, 3456, 5150, ProxyHost::Embedded);
-        let owner = classify_port_owner(3456, &[5150], &path);
         let command = |_pid: u32| HOST_APP_COMMAND.to_string();
+        let owner = classify_port_owner(3456, &[5150], &path, command);
 
         assert_eq!(
             replaceable_incumbents_with_owner(&[5150], 1, command, owner),
@@ -747,10 +812,60 @@ mod tests {
         let dir = scratch_dir("cli");
         let path = write_claim(&dir, 3456, 1234, ProxyHost::Cli);
         assert_eq!(
-            classify_port_owner(3456, &[1234], &path),
+            classify_port_owner(3456, &[1234], &path, tcr_command),
             Some(tcr(1234)),
             "a CLI-hosted claim is the same kind the name matcher would produce"
         );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// THE SECOND FALSE-POSITIVE CONTROL, and the one that stands between a stale
+    /// claim and a SIGKILL to an innocent process: the claimed pid IS listening on
+    /// the port — it is simply not a proxy.
+    ///
+    /// The stale-file test above only covers "the pid is not listening", which a
+    /// recycled pid passes trivially. The scenario that costs someone their unsaved
+    /// state is the other one: `tcr` is SIGKILLed leaving a `cli` claim behind,
+    /// months later that pid is a dev server on the same port, and a reader that
+    /// treats the claim as sufficient hands it to the kill loop. `verified_owner`
+    /// must ask `ps` before believing a `cli` claim, and the pid must then survive
+    /// to the very end of the chain unrecognized — `replaceable_incumbents_with_owner`
+    /// is what `takeover_port` iterates to choose whom to signal.
+    #[test]
+    fn a_cli_claim_whose_listening_pid_is_not_a_proxy_is_ignored() {
+        let dir = scratch_dir("recycled-pid");
+        let path = write_claim(&dir, 3456, 5150, ProxyHost::Cli);
+        let dev_server = |_pid: u32| DEV_SERVER_COMMAND.to_string();
+
+        assert_eq!(
+            classify_proxy_server(DEV_SERVER_COMMAND),
+            None,
+            "the fixture is only meaningful if the command line is genuinely not a proxy"
+        );
+        assert_eq!(
+            classify_port_owner(3456, &[5150], &path, dev_server),
+            None,
+            "a cli claim naming a pid that is not running a proxy is a stale claim on a \
+             recycled pid, not an incumbent"
+        );
+        // The positive control: the SAME claim, same pid, same holders — only the
+        // command line differs. So the None above is the command check, not the
+        // function refusing everything.
+        assert_eq!(
+            classify_port_owner(3456, &[5150], &path, tcr_command),
+            Some(tcr(5150)),
+            "the same claim IS believed when the pid is still running a proxy"
+        );
+
+        // End to end: the pid reaches the takeover chain as nothing at all, so
+        // there is no incumbent for --replace to SIGTERM.
+        let owner = classify_port_owner(3456, &[5150], &path, dev_server);
+        assert_eq!(
+            replaceable_incumbents_with_owner(&[5150], 1, dev_server, owner),
+            vec![],
+            "an unrelated listener on the port must never become a replaceable incumbent"
+        );
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -783,7 +898,7 @@ mod tests {
                 p
             }),
         ] {
-            let owner = classify_port_owner(3456, &[222], &path);
+            let owner = classify_port_owner(3456, &[222], &path, command);
             assert_eq!(owner, None, "{label} is not a claim");
             assert_eq!(
                 replaceable_incumbents_with_owner(&[222], 1, command, owner),

--- a/tests/serve_library_path.rs
+++ b/tests/serve_library_path.rs
@@ -62,11 +62,17 @@ fn scratch_affinity_path(tag: &str) -> std::path::PathBuf {
     std::env::temp_dir().join(unique).join("affinity.json")
 }
 
-/// A disposable path for the port claim, for the same reason as the pin cache
-/// above: the real claim is named after the live proxy's port and belongs to it,
-/// and `tcr login` reads it.
-fn scratch_owner_path(tag: &str) -> std::path::PathBuf {
-    scratch_affinity_path(tag).with_file_name("proxy-owner-scratch.json")
+/// A disposable DIRECTORY for the port claim, for the same reason as the pin
+/// cache above: the real claim lives beside the live proxy's pin cache, is named
+/// after its port, and `tcr login` reads it. The file name inside is `serve`'s to
+/// choose, never a caller's.
+fn scratch_owner_dir(tag: &str) -> std::path::PathBuf {
+    let dir = scratch_affinity_path(tag)
+        .parent()
+        .expect("the scratch affinity path has a parent directory")
+        .to_path_buf();
+    std::fs::create_dir_all(&dir).expect("a scratch dir under the temp dir is creatable");
+    dir
 }
 
 fn options(tag: &str) -> ServeOptions {
@@ -85,10 +91,10 @@ fn options(tag: &str) -> ServeOptions {
         // all this file exercises, so do not touch it.
         tls: TlsSetup::Disabled,
         // A library caller, so the host is stated as such — but with no claim
-        // path this is recorded nowhere. The one test that DOES write a claim
-        // overrides both fields together.
+        // directory this is recorded nowhere. The one test that DOES write a
+        // claim overrides both fields together.
         host: ProxyHost::Cli,
-        owner_path: None,
+        owner_dir: None,
     }
 }
 
@@ -293,9 +299,9 @@ fn the_convenience_constructor_touches_nothing_outside_the_process() {
         "ServeOptions::new must not be able to signal whatever holds the port"
     );
     assert_eq!(
-        options.owner_path, None,
-        "ServeOptions::new must not claim a port on disk; the real claim path is \
-         shared state named after the live proxy's port"
+        options.owner_dir, None,
+        "ServeOptions::new must not claim a port on disk; the real claim directory \
+         is shared state holding the live proxy's own claim"
     );
 }
 
@@ -316,15 +322,10 @@ fn the_convenience_constructor_touches_nothing_outside_the_process() {
 /// identity there is.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn serving_writes_the_port_claim_after_binding_and_withdraws_it_on_shutdown() {
-    let owner_path = scratch_owner_path("claim");
-    assert!(
-        !owner_path.exists(),
-        "the scratch claim path must start empty: {}",
-        owner_path.display()
-    );
+    let owner_dir = scratch_owner_dir("claim");
 
     let mut handle = serve(ServeOptions {
-        owner_path: Some(owner_path.clone()),
+        owner_dir: Some(owner_dir.clone()),
         host: ProxyHost::Embedded,
         ..options("claim")
     })
@@ -337,6 +338,18 @@ async fn serving_writes_the_port_claim_after_binding_and_withdraws_it_on_shutdow
         addr.port(),
         LIVE_PROXY_PORT,
         "a test must never bind the port a live proxy serves on"
+    );
+
+    // THE NAME IS THE CONTRACT, and this is the case that used to break it: the
+    // caller asked for port 0, so the port is only known after the bind. Every
+    // reader resolves `proxy-owner-<port>.json` for the port it is asking about,
+    // so a claim under any other name is consulted by nothing — silently. `serve`
+    // is handed a directory and derives the name from the port it bound.
+    let owner_path = teamclaude_rs::singleton::owner_path_in(&owner_dir, addr.port());
+    assert!(
+        owner_path.exists(),
+        "the claim must be named after the port actually bound: {}",
+        owner_path.display()
     );
 
     let written = std::fs::read_to_string(&owner_path).unwrap_or_else(|err| {

--- a/tests/serve_library_path.rs
+++ b/tests/serve_library_path.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 use teamclaude_rs::config::Config;
 use teamclaude_rs::proxy::STATUS_PATH;
 use teamclaude_rs::server::{serve, AffinityFlush, IncumbentPolicy, ServeOptions, TlsSetup};
+use teamclaude_rs::singleton::{ProxyHost, ProxyOwner};
 
 /// The port `tcr` uses by default. Named here so the assertion below says what
 /// it is protecting rather than showing a bare number.
@@ -61,6 +62,13 @@ fn scratch_affinity_path(tag: &str) -> std::path::PathBuf {
     std::env::temp_dir().join(unique).join("affinity.json")
 }
 
+/// A disposable path for the port claim, for the same reason as the pin cache
+/// above: the real claim is named after the live proxy's port and belongs to it,
+/// and `tcr login` reads it.
+fn scratch_owner_path(tag: &str) -> std::path::PathBuf {
+    scratch_affinity_path(tag).with_file_name("proxy-owner-scratch.json")
+}
+
 fn options(tag: &str) -> ServeOptions {
     ServeOptions {
         config: test_config(),
@@ -76,6 +84,11 @@ fn options(tag: &str) -> ServeOptions {
         // Loading the MITM material mints/reads a CA on disk. Base-URL mode is
         // all this file exercises, so do not touch it.
         tls: TlsSetup::Disabled,
+        // A library caller, so the host is stated as such — but with no claim
+        // path this is recorded nowhere. The one test that DOES write a claim
+        // overrides both fields together.
+        host: ProxyHost::Cli,
+        owner_path: None,
     }
 }
 
@@ -278,6 +291,85 @@ fn the_convenience_constructor_touches_nothing_outside_the_process() {
     assert!(
         !options.incumbent.signals_anything(),
         "ServeOptions::new must not be able to signal whatever holds the port"
+    );
+    assert_eq!(
+        options.owner_path, None,
+        "ServeOptions::new must not claim a port on disk; the real claim path is \
+         shared state named after the live proxy's port"
+    );
+}
+
+/// THE PHASE 1 GATE, the half a unit test cannot reach: a **real** `serve` writes
+/// its port claim after the bind and withdraws it on shutdown.
+///
+/// The claim is what makes a proxy identifiable when its process name is not
+/// `tcr` — `teamclaude_rs::singleton` documents the silent OAuth token loss that
+/// depends on it (`tcr login` stops refusing to run beside a live server, whose
+/// next persist writes its boot-time single-use refresh tokens back over the fresh
+/// ones). The file existing is therefore the behaviour, not an implementation
+/// detail, and its CONTENTS are asserted field by field: a claim carrying the
+/// wrong pid or port is ignored by every reader, which would look exactly like no
+/// claim at all.
+///
+/// `host: Embedded` is used deliberately — that is the host the command-line
+/// matcher cannot recognize, so it is the case where this file is the only
+/// identity there is.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn serving_writes_the_port_claim_after_binding_and_withdraws_it_on_shutdown() {
+    let owner_path = scratch_owner_path("claim");
+    assert!(
+        !owner_path.exists(),
+        "the scratch claim path must start empty: {}",
+        owner_path.display()
+    );
+
+    let mut handle = serve(ServeOptions {
+        owner_path: Some(owner_path.clone()),
+        host: ProxyHost::Embedded,
+        ..options("claim")
+    })
+    .await
+    .expect("binding an ephemeral port cannot fail")
+    .expect_started();
+
+    let addr = handle.addr();
+    assert_ne!(
+        addr.port(),
+        LIVE_PROXY_PORT,
+        "a test must never bind the port a live proxy serves on"
+    );
+
+    let written = std::fs::read_to_string(&owner_path).unwrap_or_else(|err| {
+        panic!(
+            "no port claim at {} after a successful bind: {err}",
+            owner_path.display()
+        )
+    });
+    let owner: ProxyOwner = serde_json::from_str(&written)
+        .unwrap_or_else(|err| panic!("the claim is not a readable ProxyOwner: {err}: {written}"));
+    assert_eq!(
+        owner,
+        ProxyOwner {
+            pid: std::process::id(),
+            port: addr.port(),
+            sha: teamclaude_rs::build_info::SHA.to_string(),
+            host: ProxyHost::Embedded,
+        },
+        "the claim must name THIS process, the port actually bound, this build and \
+         the host the caller stated — a reader verifies pid and port before \
+         believing any of it"
+    );
+
+    let report = tokio::time::timeout(Duration::from_secs(10), handle.shutdown())
+        .await
+        .expect("shutdown did not finish: a background task ignored the shutdown signal");
+    assert_eq!(report.tasks_aborted, 0, "clean shutdown");
+
+    assert!(
+        !owner_path.exists(),
+        "the claim must be withdrawn on shutdown; a proxy that has stopped \
+         listening must not still be advertising the port: {}",
+        owner_path.display()
     );
 }
 


### PR DESCRIPTION
Phase 1 of `docs/design/in-process-proxy-target-state.md`, and the **prerequisite** for embedding the proxy in TcrBar. Nothing else in that plan may ship before it.

## The silent failure this prevents

The proxy is identified by its process name: `classify_proxy_server` matches `argv[0]` with `is_tcr = |t| t == "tcr" || t.ends_with("/tcr")` (`src/singleton.rs:70`). A proxy running inside TcrBar reports `.../TcrBar`, matches nothing, and `live_proxy_server` returns `None`.

That function's own doc-comment says what breaks:

> `tcr login` uses it to REFUSE to run beside a live server (the server reads config only at boot, and its next `persist_tokens` writes its boot-time TOKENS back over the file, clobbering the login's fresh ones).

Anthropic's refresh tokens are **single-use**. So an embedded proxy makes that guard stop firing, `tcr login` runs alongside, the server overwrites the fresh tokens with its boot-time copies, and every account fails to refresh on the next boot — with no error at any point. Everything else in the in-process design fails loudly; this one does not.

## What changed

`ProxyOwner {pid, port, sha, host}` written by `serve()` after a successful bind — same placement and reasoning as the `server started` marker — and withdrawn in `shutdown_within`. Written atomically through the same `config::write_atomic` every other state file uses, port-scoped, beside the pin cache.

`classify_port_owner` is consulted **before** the name matcher, which is retained as fallback. `replaceable_incumbents` is now a thin delegate with `owner: None`, which is why every pre-existing recognition test is untouched.

`ProxyKind::TcrEmbedded` is checked *before* the `replace` gate and filtered out of `incumbents_to_signal`. Reason: SIGTERMing an embedded proxy kills the menu bar app **without** running `applicationWillTerminate`, so there is no graceful shutdown and no final pin write. This follows the existing precedent that a `tcr run`-hosted proxy is never replaced (`singleton.rs:87`).

`--port 0` writes no claim at all — the filename would say 0 while the contents said the ephemeral port, and nothing can look a claim up by a port that was never bound.

## A claim carries no authority on its own

`verified_owner` requires the recorded port to equal the port being resolved **and** the recorded pid to appear in the `port_listeners(port)` list the caller already had to obtain. A stale file from a crashed process proves nothing, and does not even suppress the name-matcher fallback.

The test writes a real, well-formed, correct-port claim whose only defect is a non-listening pid, asserts three negatives (no listeners, wrong listeners, wrong port), and includes a positive control so the negatives cannot be passing because the function always returns `None`.

## No restart required, and that is tested

The live proxy has written no claim, so the retained matcher must still recognise it. `a_proxy_that_wrote_no_claim_is_still_recognized` drives absent, empty, corrupt and wrong-shape files and asserts `Tcr` for each. And `an_embedded_proxy_is_recognized_only_through_its_claim` asserts `None` for a host-app command line — so the bug being fixed is itself an executable fact.

## Verification

`cargo fmt --check` 0 · `clippy -D warnings` 0 · `cargo test` 0 (516 + 10 + 5 + 11; `singleton::` 21, was 12) · `swift build` 0 · `swift test` 0 at 107 executed.

Six mutants, all compiling so none inconclusive. Harness byte-writes and bumps mtime explicitly (the preserved-mtime trap that makes cargo re-run a mutant against restored source), asserts each anchor appears exactly once, and uses a private `CARGO_TARGET_DIR` so no mutant artifact leaks into a shared target dir.

**One mutant killed nothing and is reported rather than dropped:** removing *only* the `TcrEmbedded` filter in `incumbents_to_signal` turns no test red, because that filter is defence-in-depth behind the stand-down gate and removing it alone changes no observable behaviour. The behaviour is still killed by a single-site mutation via the embedded-beside-legacy-JS case.

## Note

`ServeOptions` gained `owner_path: Option<PathBuf>` alongside `host`, defaulting to `None` — inert, matching every other field on `ServeOptions::new`. The integration test needs a temp claim path; it binds port 0 and writes only under unique temp dirs.