### PR TITLE
feat: auto-negotiate h1/h2 on the MITM connection builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,14 @@ path = "src/main.rs"
 # async runtime + HTTP
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "io-std", "sync", "time", "signal"] }
 axum = { version = "0.8", features = ["http2"] }
-hyper = { version = "1", features = ["server", "http1"] }
+hyper = { version = "1", features = ["server", "http1", "http2"] }
 # TokioIo: the only bridge from tokio AsyncRead/Write to hyper 1.x rt::Read/Write,
 # needed to serve the axum router over a raw/TLS stream in MITM mode. Already in
 # the tree transitively (via axum/reqwest); this just pins the glue we call directly.
-hyper-util = { version = "0.1", features = ["tokio"] }
+# "server-auto" pulls in the auto h1/h2-negotiating connection builder
+# (hyper_util::server::conn::auto::Builder) used in src/mitm.rs so base-URL/MITM
+# clients can negotiate h2 instead of being forced to h1.
+hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
 reqwest = { version = "0.12", default-features = false, features = ["stream", "json", "rustls-tls", "http2"] }
 tower = "0.5"
 bytes = "1"

--- a/src/mitm.rs
+++ b/src/mitm.rs
@@ -537,9 +537,12 @@ where
             // Infallible, so no `.unwrap()` sits on the request hot path.
             router.clone().oneshot(req.map(axum::body::Body::new))
         });
-    if let Err(err) = hyper::server::conn::http1::Builder::new()
-        .serve_connection(hyper_util::rt::TokioIo::new(io), service)
-        .await
+    // Auto-negotiating builder (h1 or h2 via ALPN/prior-knowledge detection) so
+    // base-URL clients that support h2 aren't forced down to h1.
+    if let Err(err) =
+        hyper_util::server::conn::auto::Builder::new(hyper_util::rt::TokioExecutor::new())
+            .serve_connection(hyper_util::rt::TokioIo::new(io), service)
+            .await
     {
         tracing::debug!(error = %err, "http connection error");
     }
@@ -729,5 +732,104 @@ mod tests {
         assert!(build_acceptor(&cert_path, &key_path).is_ok());
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A `Manager` with one never-expiring dummy account and no proxy api-key,
+    /// so a loopback GET on `/_tcr/status` is answered locally with no upstream
+    /// call and no auth gate — the cheapest real route through `serve_http`'s
+    /// router to observe which HTTP version `serve_connection` negotiated.
+    fn dummy_manager() -> Arc<Manager> {
+        let config = crate::config::Config {
+            proxy: crate::config::ProxyConfig {
+                port: 0,
+                api_key: None,
+                extra: serde_json::Map::new(),
+            },
+            upstream: "http://127.0.0.1:1".to_string(),
+            switch_threshold: 0.90,
+            pacing: crate::config::PacingConfig::default(),
+            throttle: crate::config::ThrottleConfig::default(),
+            lock_account: None,
+            accounts: vec![crate::config::Account {
+                name: "dummy".to_string(),
+                account_type: "oauth".to_string(),
+                account_uuid: None,
+                org_uuid: None,
+                org_name: None,
+                access_token: "at-dummy".to_string(),
+                refresh_token: Some("rt-dummy".to_string()),
+                expires_at: Some(crate::now_ms() + 3_600_000),
+                priority: Some(0),
+                switch_threshold: None,
+                disabled: None,
+                extra: serde_json::Map::new(),
+            }],
+            extra: serde_json::Map::new(),
+        };
+        Manager::new(
+            config,
+            Arc::new(crate::oauth::NoRefresh),
+            Arc::new(crate::probe::LiveUsageProber::new()),
+            Arc::new(crate::warmer::LiveWarmer::new()),
+            None,
+        )
+    }
+
+    /// Start a base-URL-mode listener (`handle_conn`'s non-CONNECT branch, i.e.
+    /// `serve_http` over a raw TCP stream — the exact path this change touches)
+    /// and return its address.
+    async fn spawn_base_url_listener() -> SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let manager = dummy_manager();
+        tokio::spawn(async move {
+            loop {
+                let Ok((stream, peer)) = listener.accept().await else {
+                    break;
+                };
+                let manager = manager.clone();
+                tokio::spawn(async move {
+                    let _ = handle_conn(stream, peer, manager, None).await;
+                });
+            }
+        });
+        addr
+    }
+
+    /// Discriminating control: an ordinary h1 client must still work after the
+    /// swap to the auto-negotiating builder. If this regresses, the h2 test
+    /// below is measuring a broken server, not a real negotiation.
+    #[tokio::test]
+    async fn base_url_mode_still_serves_http1() {
+        let addr = spawn_base_url_listener().await;
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let resp = client
+            .get(format!("http://{addr}/_tcr/status"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+        assert_eq!(resp.version(), reqwest::Version::HTTP_11);
+    }
+
+    /// The behavior this change exists to add: a base-URL client that speaks
+    /// h2 via cleartext prior knowledge (no ALPN/TLS involved — this is the
+    /// plain-TCP `serve_http` call site at `handle_conn`'s non-CONNECT branch)
+    /// negotiates HTTP/2 instead of being forced onto HTTP/1.1.
+    #[tokio::test]
+    async fn base_url_mode_negotiates_http2_prior_knowledge() {
+        let addr = spawn_base_url_listener().await;
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .http2_prior_knowledge()
+            .build()
+            .unwrap();
+        let resp = client
+            .get(format!("http://{addr}/_tcr/status"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+        assert_eq!(resp.version(), reqwest::Version::HTTP_2);
     }
 }


### PR DESCRIPTION
`mitm.rs` hard-coded `hyper::server::conn::http1::Builder`, so a client reaching the proxy by base URL could never negotiate HTTP/2. `hyper_util::server::conn::auto::Builder` negotiates h1 or h2 per connection — and `hyper-util` was **already a dependency**, so this costs no new crate.

Surfaced by the library audit as the genuinely valuable half of a lane that was otherwise rejected: adopting `axum::serve` would have been +27 lines and would have reintroduced an unbounded shutdown wait that two doc-comments explicitly warn against. The capability was reachable without any of that.

## The capability claim, stated narrowly on purpose

h2 is now reachable for **base-URL clients over cleartext prior-knowledge**. MITM-terminated CONNECT traffic **stays h1 in practice**, because the rustls `ServerConfig` at `mitm.rs:210` advertises no ALPN.

That distinction is presence-versus-wired, and it is in the commit body too. Adding ALPN is a live TLS-handshake change for intercepted traffic and deserves its own premortem, so it is written up as a follow-up candidate rather than smuggled in here.

## A CI-only failure mode this could have hit

CI runs `cargo clippy/test/build --locked`. This change enables `hyper/http2`, and that feature gates the `h2` crate — so if `h2` were not already in the lockfile, **CI would have failed on `--locked` while every local gate stayed green**.

Verified rather than assumed: `h2 0.4.15` is already in `Cargo.lock` via `reqwest`/`axum` http2, `Cargo.lock` is byte-unchanged against `origin/main`, and `cargo build --locked` was run directly and exits 0.

## Verification

`cargo fmt --check` 0 · `clippy -D warnings` 0 · `cargo test` 0 · `cargo build --locked` 0 · `swift build` 0 · `swift test` 0.

Test count **548 → 550**, exactly the two new tests. No suite lost a test — a dropping count would mean something stopped compiling into a binary.

Mutation: reverting to `http1::Builder` fails the h2 test with `BrokenPipe` on the h2 client preface — the expected failure class, not a compile error, which would have proven nothing. The h1 control passes before and after. Restore was done by edit rather than `mv`, so the preserved-mtime trap that makes cargo re-run a mutated binary could not apply.

## Known σ ceiling

**σ3, and the cap is a property of the constraint rather than a gap in the work.** The pass-criterion is a test authored alongside the change, so it cannot exceed σ3 without an independent oracle — a real client negotiating h2 against a running `tcr`. That cannot be run against the live proxy, so it stays capped until someone exercises it out of band.