### PR TITLE
refactor: adopt tempfile for the atomic config write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,6 +652,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,6 +2433,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.20",
  "time",
  "tokio",
@@ -2434,6 +2441,19 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ tokio-rustls = { version = "0.26.4", default-features = false, features = ["ring
 rustls = { version = "0.23.42", default-features = false, features = ["ring", "std", "tls12", "logging"] }
 rustls-pemfile = "2.2.0"
 rcgen = "0.14.8"
+tempfile = "3.27"
 
 [profile.release]
 opt-level = 3

--- a/src/config.rs
+++ b/src/config.rs
@@ -1156,6 +1156,7 @@ mod tests {
     /// A unique temp path per test — the suite runs tests in parallel threads of
     /// ONE process, so a pid-only name collides.
     fn tmp_path(tag: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
         static SEQ: AtomicU64 = AtomicU64::new(0);
         let seq = SEQ.fetch_add(1, Ordering::Relaxed);
         std::env::temp_dir().join(format!("tcr-{tag}-{}-{seq}.json", std::process::id()))

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,18 +5,13 @@
 //! `quotaProbeSeconds`, `warmupSeconds`, …). Every struct carries a flattened
 //! `extra` map so an unknown key survives a load→save round-trip untouched.
 
-use std::fs::{self, OpenOptions};
+use std::fs;
 use std::io::Write as _;
-use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
+use std::os::unix::fs::PermissionsExt as _;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-
-/// Monotonic counter making each [`save`] temp filename unique, so concurrent
-/// saves never collide on one temp path (finding #6).
-static SAVE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 /// Typed config-layer errors: I/O vs malformed JSON stay distinguishable so a
 /// caller can tell "no config yet" from "config is corrupt".
@@ -291,27 +286,25 @@ pub(crate) fn write_atomic(path: &Path, json: &str) -> Result<(), ConfigError> {
     // rotated refresh token. Fails loudly on a real perms error (finding #2).
     fs::create_dir_all(dir)?;
 
-    let file_name = path.file_name().map_or_else(
-        || "teamclaude.json".to_string(),
-        |f| f.to_string_lossy().into_owned(),
-    );
-    // A per-call unique temp name: two concurrent saves (e.g. `probe_all`
-    // refreshing several expired accounts at once) must not open and truncate the
-    // SAME temp file and interleave into a corrupt write (finding #6).
-    let seq = SAVE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-    let tmp = dir.join(format!(".{file_name}.{}.{seq}.tmp", std::process::id()));
-
-    let mut file = OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(&tmp)?;
+    // `tempfile_in`, never `NamedTempFile::new()`: the temp file MUST live in the
+    // destination's own directory. The system temp dir is routinely a different
+    // filesystem, and `rename(2)` across filesystems fails with `EXDEV` — which
+    // would silently cost us the atomic swap this function exists to provide.
+    //
+    // The unique temp name is now the crate's job (finding #6): it opens with
+    // `O_EXCL` and retries on collision, so two concurrent saves (e.g. `probe_all`
+    // refreshing several expired accounts at once) can never open and truncate the
+    // SAME temp file and interleave into a corrupt write. That is a stronger
+    // guarantee than the pid+counter name this replaced: exclusivity is enforced
+    // by the kernel at open time rather than by a naming scheme being right.
+    let mut file = tempfile::Builder::new().tempfile_in(dir)?;
     file.write_all(json.as_bytes())?;
-    file.sync_all()?;
-    drop(file);
+    // `persist` below is a bare `rename(2)` and NEVER fsyncs, so durability stays
+    // ours to enforce by hand. This file holds live OAuth tokens: a crash after
+    // the rename must not be able to expose it as empty or half-written.
+    file.as_file().sync_all()?;
 
-    fs::rename(&tmp, path)?;
+    file.persist(path).map_err(|e| e.error)?;
     // Re-assert perms after rename in case the destination pre-existed with a
     // looser mode (rename keeps the source inode, but be explicit).
     fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;


### PR DESCRIPTION
Lane 3 of the library-adoption campaign (`docs/design/library-adoption-audit.md`).

## The win is not the line count

`config.rs` loses 6 lines net, and about 14 of the 20 added are doc-comment — so that number understates the code reduction and overstates the file reduction. Counting statements, the bespoke sequence goes from ~16 to 4.

The change worth having is this: **exclusivity stopped depending on a hand-constructed name being unique and became a kernel-enforced `O_EXCL` at open time.** `SAVE_SEQUENCE` — a process-wide `AtomicU64` combined with the pid to build a temp name nobody else should pick — is deleted outright. `tempfile` asks the kernel instead. That is what prevents the next bug in this function; the line count is not.

`tempfile_in(dir)` is used rather than `NamedTempFile::new()`, so the temp file lands on the same filesystem as its destination. `new()` would place it in the system temp dir and `persist()` would fail with `EXDEV` across a filesystem boundary — silently destroying the atomicity this function exists to provide.

## Durability: one half proven by the compiler, one half honestly unproven

**ORDERING — PROVEN, σ4.** `NamedTempFile::persist(self)` takes `self` **by value** (`tempfile-3.27.0/src/file/mod.rs:767`), so `sync_all()` cannot be written after `persist` and still compile. A type-level guarantee that costs nothing, cannot rot, and cannot be deleted without the compiler objecting.

**PRESENCE — provable, deliberately not proven.** An interposer at the dynamic-linker boundary was built and shown to work (delete `sync_all`, watch it go red at exit 101), then **not adopted**: it costs ~100 lines of platform-specific C plus a re-exec harness and a shell-out to `cc`, inside a lane whose purpose is less hand-written code. It is proposed as its own lane instead.

No source-grep tripwire was shipped in its place — omitted rather than mislabelled. A grep for `sync_all` passes if it is called on the wrong handle or in a dead branch, and labelling that "the durability proof" is the only unacceptable option.

Two facts found on the way, both of which outlive this PR:

- **On Apple, `File::sync_all()` calls `fcntl(F_FULLFSYNC)`, never `fsync(2)`** (std `sys/fs/unix.rs:1395-1402`, verified locally). An interposer shimming `fsync` observes nothing on macOS and reports a clean pass forever.
- `tempfile`'s rename goes through `rustix`, whose `linux_raw` backend issues **direct syscalls bypassing libc**, so an `LD_PRELOAD` of `rename` is invisible on the ubuntu runner.

A durability gate built the obvious way would have been genuinely green on one CI platform and structurally blind on the other — worse than no gate, because the honest half lends credibility to the blind half.

## Verification

`fmt` 0 · `clippy -D warnings` 0 · **`cargo build --locked` 0** · `cargo test` 0 · `swift build` 0 · `swift test` 0 at 107 executed.

Per-binary counts, reported per-line rather than summed: `521/11/5/11/0` before and after — **five `test result:` lines both sides**, so no binary silently stopped compiling. A sum cannot see that; only the line count can.

**Mutation.** Changing the post-rename `set_permissions` to `0o644` — deliberately not the temp file's mode, since the re-assert would have masked it and the red would have proved nothing — compiles and fires **four** pre-existing tests: `save_writes_owner_only_permissions`, `save_tokens_writes_owner_only_permissions`, `save_disabled_writes_owner_only_permissions`, and `affinity::tests::save_writes_owner_only_permissions` ("mode was 644"). None were authored for this change, which puts the 0600 claim at σ4 rather than σ2.

## Worth knowing: the first gate run was red, and `cargo build` was green

Removing `SAVE_SEQUENCE` dropped the module-level `AtomicU64`/`Ordering` imports while a test helper still used them through `use super::*`. **`cargo build` passed; `cargo test` failed to compile.** A build-only gate would have shipped it.

It is also a live instance of the rule that deleting load-bearing infra means grepping every surface: the sweep covered `SAVE_SEQUENCE` and not `AtomicU64`. Fixed in `0a92880`.

## Contract held

`write_atomic`'s signature and semantics are unchanged, which matters because it has **five** callers — `save`, `save_tokens`, `save_disabled`, the proxy-owner claim in `singleton.rs`, and `affinity::save`, the last of which is the hot path writing `session-affinity.json` while the proxy runs. `singleton.rs`, `oauth.rs` and `affinity.rs` are untouched by this diff.