### PR TITLE
ci: block private names, home paths and real emails at commit time

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -31,6 +31,67 @@ else
   echo "pre-commit: gitleaks not installed — skipping secret scan (brew install gitleaks)." >&2
 fi
 
+# ── Public-repo disclosure gate ─────────────────────────────────────────────
+# The banner above says "do NOT commit ~/ paths". It was read past, and on
+# 2026-08-08 a design document naming a PRIVATE repository in a different org
+# was committed and pushed here — its structure, CI config, file line ranges and
+# the author's local paths. The tree was cleaned within minutes; removing it from
+# HISTORY needed a force-push to a protected branch, because a public repo's
+# history cannot be un-published. A reminder that can be read past is not a gate.
+#
+# Scans ADDED lines only, so pre-existing content can never block you.
+# Every grep is `|| true`: under `set -e` a no-match (exit 1) would otherwise
+# abort the hook, and `grep -q` in a pipe can invert on SIGPIPE. Both failure
+# modes report the wrong answer confidently, which is the defect this gate exists
+# to prevent, one level up.
+#
+# Deliberate exception:  git commit --no-verify
+added="$(git diff --cached -U0 --diff-filter=ACM -- . ':(exclude).githooks/private-names' \
+         | sed -n 's/^+//p' || true)"
+hits=""
+
+if [ -n "$added" ]; then
+  # 1. Private names — an editable list, so adding one needs no hook edit.
+  if [ -f .githooks/private-names ]; then
+    while IFS= read -r name || [ -n "$name" ]; do
+      case "$name" in ''|\#*) continue ;; esac
+      found="$(printf '%s\n' "$added" | grep -i -m3 -- "$name" || true)"
+      [ -n "$found" ] && hits="$hits
+  private name '$name':
+$(printf '%s\n' "$found" | sed 's/^/      /')"
+    done < .githooks/private-names
+  fi
+
+  # 2. Absolute home paths — they leak the machine layout and the operator's name.
+  #    Obviously-synthetic users are allowed so fixtures and docs still work.
+  found="$(printf '%s\n' "$added" \
+           | grep -E -m3 '/(Users|home)/[A-Za-z0-9._-]+/' \
+           | grep -v -E '/(Users|home)/(x|y|alice|bob|carol|test|example|runner|user)/' || true)"
+  [ -n "$found" ] && hits="$hits
+  absolute home path:
+$(printf '%s\n' "$found" | sed 's/^/      /')"
+
+  # 3. Real-looking email addresses (example.com and the GitHub noreply are fine).
+  found="$(printf '%s\n' "$added" \
+           | grep -E -o -m3 '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' \
+           | grep -v -E '@(example\.(com|org|net)|users\.noreply\.github\.com)$' || true)"
+  [ -n "$found" ] && hits="$hits
+  real-looking email address:
+$(printf '%s\n' "$found" | sed 's/^/      /')"
+fi
+
+if [ -n "$hits" ]; then
+  echo "" >&2
+  echo "pre-commit: BLOCKED — staged changes would publish private information." >&2
+  echo "$hits" >&2
+  echo "" >&2
+  echo "  This repository is PUBLIC. Once pushed, removing it requires rewriting" >&2
+  echo "  history on a protected branch, and forks keep their own copies." >&2
+  echo "  Fix the lines, add a name to .githooks/private-names, or if this is" >&2
+  echo "  genuinely fine:  git commit --no-verify" >&2
+  exit 1
+fi
+
 # ── Rust format gate ────────────────────────────────────────────────────────
 # Mirror CI's `cargo fmt --check` Format job so a formatting slip is caught here,
 # not after a push goes red. Only fires when the commit stages Rust files.

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,8 @@ Thumbs.db
 # ── macOS app (TcrBar) build output ───────────────────────────
 apps/macos/.build/
 apps/macos/build/
+
+# Local denylist for the pre-commit disclosure gate. NEVER tracked: a public
+# list of private names discloses the names it exists to protect. Each clone
+# keeps its own; the gate is inert without it and says so on install.
+.githooks/private-names


### PR DESCRIPTION
Turns the pre-commit banner into a gate.

The banner already said `do NOT commit ... ~/ paths`. Today it was read past: a design document naming a private repository in a different org was committed and pushed here, along with absolute home paths. The working tree was clean again within minutes, but clearing it from history took a force-push to a protected branch, and forks keep their own copies. A public repo's history cannot be un-published, so this belongs at commit time rather than in a paragraph a human is asked to remember.

## What it checks

Added lines only, so existing content can never block a commit.

1. Names from `.githooks/private-names` — **untracked and gitignored on purpose.** A public denylist of private names discloses the names it exists to protect. Each clone keeps its own; without the file the check is simply skipped.
2. Absolute `/Users/...` and `/home/...` paths, with obviously-synthetic users (`x`, `alice`, `runner`, ...) still allowed so fixtures and docs keep working.
3. Real-looking email addresses, exempting `example.com`/`.org`/`.net` and the GitHub noreply.

## Failure modes designed against

Every `grep` is guarded with `|| true`. Under `set -e` a no-match exits 1 and would abort the hook, and `grep -q` inside a pipe can invert on SIGPIPE. Both report the wrong answer confidently — the same defect class this gate exists to catch, one level up.

## Watched failing before landing

Ten fixtures: five that must block (private name, mixed case, `/Users` path, `/home` path, real email) and five that must not (ordinary code, `alice@example.com`, the GitHub noreply, `/Users/x/...`, the word `tempfile`), plus a control asserting it fires for the *right* reason rather than merely firing. 10/10.

Escape hatch is `git commit --no-verify`, which should feel deliberate.