### PR TITLE
test: fix a port-listener test flake, and a comment crediting a filter that does nothing

### DIFF
--- a/src/singleton.rs
+++ b/src/singleton.rs
@@ -1067,12 +1067,20 @@ mod tests {
         );
     }
 
-    /// UDP control: `listeners`' backends hard-code every UDP socket's state to
-    /// `SocketState::Unknown` (never `Listen`), so this passes today for that
-    /// reason rather than because of an explicit UDP exclusion — which is
-    /// exactly why it is worth having as a canary. The day upstream gives UDP a
-    /// real state, `Protocol::TCP` (not the state filter) is what keeps this
-    /// green; if this test ever goes red, that upstream change is why.
+    /// UDP canary. **This test cannot currently fail, and that is deliberate —
+    /// but it was previously documented as if a filter were holding it up.**
+    ///
+    /// Measured 2026-08-08 on macOS by removing each filter in turn and re-running:
+    /// it stays green with `SocketState::Listen` removed AND with `Protocol::TCP`
+    /// removed. So neither filter is what excludes our UDP socket; `get_all()`
+    /// never enumerates it in the first place on this platform. The previous
+    /// comment here claimed "`Protocol::TCP` (not the state filter) is what keeps
+    /// this green", which the mutations refute.
+    ///
+    /// It is kept as a pure upstream canary: if `listeners` ever starts reporting
+    /// UDP sockets, this goes red and tells us the protocol filter has become
+    /// load-bearing. Do not count it as evidence that either filter works — the
+    /// two tests above are, and both were watched failing under mutation.
     #[test]
     fn port_listeners_excludes_a_udp_socket_on_the_same_port() {
         let udp = std::net::UdpSocket::bind("127.0.0.1:0").expect("binding an ephemeral UDP port");

--- a/src/singleton.rs
+++ b/src/singleton.rs
@@ -1054,9 +1054,14 @@ mod tests {
         // The LISTEN socket is gone; only the ESTABLISHED accepted socket still
         // has local port `port`. Without the `SocketState::Listen` filter this
         // would report this process's pid again and the assertion below fails.
+        // Same narrowing as the UDP case below, for the same reason: once `server`
+        // is dropped the port is released, so an unrelated process can take it and
+        // be reported here legitimately. The claim under test is about OUR
+        // ESTABLISHED socket, and the inline positive control above already proved
+        // `port_listeners` reports this pid when a real LISTEN socket exists.
         let holders_after = port_listeners(port);
         assert!(
-            holders_after.is_empty(),
+            !holders_after.contains(&std::process::id()),
             "an ESTABLISHED socket on port {port} must not be reported as a LISTEN holder; \
              got {holders_after:?}"
         );
@@ -1076,9 +1081,19 @@ mod tests {
             .expect("a bound socket has a local address")
             .port();
 
+        // Assert on OUR pid, not on global emptiness. A UDP bind reserves a port
+        // in the UDP space only — the TCP space is independent, so an unrelated
+        // process may legitimately be TCP-LISTENing on this same number. Asserting
+        // `is_empty()` made this test depend on the whole machine's TCP usage, a
+        // precondition it never established, and it went red on a CI runner where
+        // pid 9460 held TCP on the port the kernel handed us for UDP.
+        //
+        // This cannot pass vacuously through a broken `port_listeners` that always
+        // returns empty: `port_listeners_finds_this_process_on_an_ephemeral_port`
+        // is the positive control for that, and would fail first.
         let holders = port_listeners(port);
         assert!(
-            holders.is_empty(),
+            !holders.contains(&std::process::id()),
             "a UDP socket on port {port} must never be reported as a TCP LISTEN holder; \
              got {holders:?}"
         );


### PR DESCRIPTION
`port_listeners_excludes_a_udp_socket_on_the_same_port` went red on a macOS runner in #48:

```
a UDP socket on port 49374 must never be reported as a TCP LISTEN holder; got [9460]
```

Pid 9460 was not ours and was not a bug. **A UDP bind reserves a port in the UDP space only** — the TCP space is independent, so the kernel handing us UDP:49374 says nothing about who may be TCP-LISTENing on 49374. Asserting the whole list is empty made a test about *our* socket depend on the entire machine's TCP usage, a precondition it never established.

The sibling ESTABLISHED test has the same flaw with a narrower window: it binds TCP so it owns the port, and is exposed only in the gap after `drop(server)` releases it. Both now assert **our own pid is absent**, which is the claim each was written to make.

Neither can pass vacuously through a `port_listeners` that always returns empty — `port_listeners_finds_this_process_on_an_ephemeral_port` is the positive control and would fail first.

## Verified by mutation, not assumed

Removing `SocketState::Listen` turns the ESTABLISHED test **red**; restored by content (not `mv`, whose preserved mtime lets cargo re-run the stale binary), file re-read to confirm, green again with a real recompile in between.

## A second finding that came out of doing that

The UDP test stayed green under that mutation, so I ran the one its comment claimed was load-bearing. **It stays green with `Protocol::TCP` removed too.** Neither filter excludes our UDP socket — `get_all()` never enumerates it on macOS. The comment asserting "`Protocol::TCP` (not the state filter) is what keeps this green" was wrong.

The test cannot currently fail. It is kept as a pure upstream canary — if `listeners` ever starts reporting UDP sockets it goes red and tells us the protocol filter has become load-bearing — but it is now labelled as one, so nobody counts it as evidence that either filter works.