### PR TITLE
ci: add swift-format gates to match the Rust format/lint parity

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -107,3 +107,43 @@ if git diff --cached --name-only --diff-filter=ACM | grep -q '\.rs$'; then
     echo "pre-commit: cargo not found — skipping rustfmt check." >&2
   fi
 fi
+
+# ── Swift format gate ───────────────────────────────────────────────────────
+# Mirror CI's `Format (swift)` step, the same way the block above mirrors
+# `cargo fmt --check`. Scoped to the staged .swift files rather than the whole
+# tree: a full-tree check on every commit is slow enough that people turn the
+# hook off, and a hook that is off gates nothing.
+#
+# The pathspec matches CI's scope exactly. Sources/TcrBar is excluded there
+# while a large change is in flight; if it were checked here but not there, the
+# hook would block commits that CI is happy with, which is how a local gate
+# earns a reputation for lying and gets bypassed.
+#
+# No pipe into `grep -q` here — see the note at the top of the disclosure gate:
+# `grep -q` exits on its first match, and under `pipefail` the SIGPIPE'd
+# producer turns the whole pipeline non-zero, silently skipping the check.
+staged_swift="$(git diff --cached --name-only --diff-filter=ACM \
+                -- 'apps/macos/Sources/TcrBarCore/*.swift' 'apps/macos/Tests/*.swift' || true)"
+if [ -n "$staged_swift" ]; then
+  # xcrun, not PATH: swift-format ships inside the Xcode toolchain and is not on
+  # a default PATH even on a machine that has it.
+  swift_format="$(xcrun --find swift-format 2>/dev/null || true)"
+  if [ -z "$swift_format" ] && command -v swift-format >/dev/null 2>&1; then
+    swift_format="$(command -v swift-format)"
+  fi
+  if [ -n "$swift_format" ]; then
+    # Word-splitting on the newline-separated list is intended here.
+    # shellcheck disable=SC2086
+    if ! "$swift_format" lint --strict $staged_swift >&2; then
+      echo "" >&2
+      echo "pre-commit: BLOCKED — swift-format lint failed; CI's Format (swift) step would go red." >&2
+      echo "  Fix it:  \$(xcrun --find swift-format) format -i $(printf '%s ' $staged_swift)" >&2
+      echo "  then re-stage and commit." >&2
+      exit 1
+    fi
+  else
+    # Warn only, for the same reason gitleaks does: a missing tool must not
+    # block every commit, and must not pretend the check passed either.
+    echo "pre-commit: swift-format not found — skipping Swift format check (install Xcode)." >&2
+  fi
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,24 @@ jobs:
       - name: Swift toolchain version
         run: swift --version
 
+      # The Swift half of the `Format` job above. It lives here and not in `ci`
+      # because swift-format ships inside the Xcode toolchain, which only the
+      # macOS runner has — that is exactly the "only what Linux cannot answer"
+      # rule in the comment above this job, not an exception to it.
+      #
+      # Resolved through xcrun rather than assumed on PATH: the toolchain binary
+      # is not on a bare runner's PATH, and a bare `swift-format` would resolve
+      # to whatever a future image happens to install instead.
+      #
+      # Scope is TcrBarCore + Tests, not all of Sources: Sources/TcrBar has a
+      # large change in flight and is swept in a follow-up, at which point this
+      # widens to `apps/macos/Sources`.
+      - name: Format (swift)
+        run: |
+          swift_format="$(xcrun --find swift-format)"
+          "$swift_format" --version
+          "$swift_format" lint --strict -r apps/macos/Sources/TcrBarCore apps/macos/Tests
+
       # No SwiftPM cache: the package declares zero external dependencies, so
       # there is nothing to fetch, and .build artifacts key on the toolchain
       # and every source file — it would miss on essentially every run.

--- a/apps/macos/.swift-format
+++ b/apps/macos/.swift-format
@@ -1,0 +1,79 @@
+{
+  "fileScopedDeclarationPrivacy": {
+    "accessLevel": "private"
+  },
+  "indentBlankLines": false,
+  "indentConditionalCompilationBlocks": true,
+  "indentSwitchCaseLabels": false,
+  "indentation": {
+    "spaces": 4
+  },
+  "lineBreakAroundMultilineExpressionChainComponents": false,
+  "lineBreakBeforeControlFlowKeywords": false,
+  "lineBreakBeforeEachArgument": false,
+  "lineBreakBeforeEachGenericRequirement": false,
+  "lineBreakBetweenDeclarationAttributes": false,
+  "lineLength": 110,
+  "maximumBlankLines": 1,
+  "multiElementCollectionTrailingCommas": true,
+  "noAssignmentInExpressions": {
+    "allowedFunctions": [
+      "XCTAssertNoThrow"
+    ]
+  },
+  "orderedImports": {
+    "includeConditionalImports": false
+  },
+  "prioritizeKeepingFunctionOutputTogether": false,
+  "reflowMultilineStringLiterals": "never",
+  "respectsExistingLineBreaks": true,
+  "rules": {
+    "AllPublicDeclarationsHaveDocumentation": false,
+    "AlwaysUseLiteralForEmptyCollectionInit": false,
+    "AlwaysUseLowerCamelCase": true,
+    "AmbiguousTrailingClosureOverload": true,
+    "AvoidRetroactiveConformances": true,
+    "BeginDocumentationCommentWithOneLineSummary": false,
+    "DoNotUseSemicolons": true,
+    "DontRepeatTypeInStaticProperties": true,
+    "FileScopedDeclarationPrivacy": true,
+    "FullyIndirectEnum": true,
+    "GroupNumericLiterals": true,
+    "IdentifiersMustBeASCII": true,
+    "NeverForceUnwrap": false,
+    "NeverUseForceTry": false,
+    "NeverUseImplicitlyUnwrappedOptionals": false,
+    "NoAccessLevelOnExtensionDeclaration": true,
+    "NoAssignmentInExpressions": true,
+    "NoBlockComments": true,
+    "NoCasesWithOnlyFallthrough": true,
+    "NoEmptyLinesOpeningClosingBraces": false,
+    "NoEmptyTrailingClosureParentheses": true,
+    "NoLabelsInCasePatterns": true,
+    "NoLeadingUnderscores": false,
+    "NoParensAroundConditions": true,
+    "NoPlaygroundLiterals": true,
+    "NoVoidReturnOnFunctionSignature": true,
+    "OmitExplicitReturns": false,
+    "OneCasePerLine": true,
+    "OneVariableDeclarationPerLine": true,
+    "OnlyOneTrailingClosureArgument": true,
+    "OrderedImports": true,
+    "ReplaceForEachWithForLoop": true,
+    "ReturnVoidInsteadOfEmptyTuple": true,
+    "TypeNamesShouldBeCapitalized": true,
+    "UseEarlyExits": false,
+    "UseExplicitNilCheckInConditions": true,
+    "UseLetInEveryBoundCaseVariable": true,
+    "UseShorthandTypeNames": true,
+    "UseSingleLinePropertyGetter": true,
+    "UseSynthesizedInitializer": true,
+    "UseTripleSlashForDocumentationComments": true,
+    "UseWhereClausesInForLoops": false,
+    "ValidateDocumentationComments": false
+  },
+  "spacesAroundRangeFormationOperators": false,
+  "spacesBeforeEndOfLineComments": 2,
+  "tabWidth": 8,
+  "version": 1
+}

--- a/apps/macos/Sources/TcrBarCore/StatusPoller.swift
+++ b/apps/macos/Sources/TcrBarCore/StatusPoller.swift
@@ -37,7 +37,8 @@ public enum PollState: Equatable {
             if n == 0, let unreadable = fleet.unreadableNotice {
                 return "no account decoded — \(unreadable)"
             }
-            let base = fleet.source.countersAreStructural
+            let base =
+                fleet.source.countersAreStructural
                 ? "\(n) \(noun) — offline read, counters are structurally zero"
                 : "\(n) \(noun) — live"
             guard let unreadable = fleet.unreadableNotice else { return base }

--- a/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
@@ -5,90 +5,90 @@ import XCTest
 /// Fixtures use obviously-fake account names only. Real account emails never
 /// enter this repository — see CLAUDE.md.
 private let liveFixture = """
-[
-  {
-    "source": "live",
-    "serverSha": "abc1234",
-    "serverDirty": false,
-    "name": "alice@example.com",
-    "priority": 1,
-    "status": "active",
-    "disabled": false,
-    "quota": 0.42,
-    "quotaState": "ok",
-    "fiveHour": 0.11,
-    "sevenDay": 0.42,
-    "sevenDayOi": 0.05,
-    "held": [],
-    "requests": 128,
-    "inputTokens": 4096,
-    "outputTokens": 512,
-    "cacheReadTokens": 2048,
-    "cacheHitRatio": 0.5,
-    "probeStatus": "ok",
-    "probeError": null,
-    "lastStreamError": null,
-    "streamErrorCount": 0
-  },
-  {
-    "source": "live",
-    "serverSha": "abc1234",
-    "serverDirty": false,
-    "name": "bob@example.com",
-    "priority": 2,
-    "status": "held",
-    "disabled": false,
-    "quota": 1.0,
-    "quotaState": "spent",
-    "fiveHour": 1.0,
-    "sevenDay": 1.0,
-    "sevenDayOi": 0.9,
-    "held": [
-      {"window": "7d", "minutesUntilReset": 1528, "resetAtMs": 1000000000000},
-      {"window": "5h", "minutesUntilReset": 93, "resetAtMs": 999000000000}
-    ],
-    "requests": 0,
-    "inputTokens": 0,
-    "outputTokens": 0,
-    "cacheReadTokens": 0,
-    "cacheHitRatio": null,
-    "probeStatus": "ok",
-    "probeError": null,
-    "lastStreamError": "overloaded_error",
-    "streamErrorCount": 3
-  }
-]
-"""
+    [
+      {
+        "source": "live",
+        "serverSha": "abc1234",
+        "serverDirty": false,
+        "name": "alice@example.com",
+        "priority": 1,
+        "status": "active",
+        "disabled": false,
+        "quota": 0.42,
+        "quotaState": "ok",
+        "fiveHour": 0.11,
+        "sevenDay": 0.42,
+        "sevenDayOi": 0.05,
+        "held": [],
+        "requests": 128,
+        "inputTokens": 4096,
+        "outputTokens": 512,
+        "cacheReadTokens": 2048,
+        "cacheHitRatio": 0.5,
+        "probeStatus": "ok",
+        "probeError": null,
+        "lastStreamError": null,
+        "streamErrorCount": 0
+      },
+      {
+        "source": "live",
+        "serverSha": "abc1234",
+        "serverDirty": false,
+        "name": "bob@example.com",
+        "priority": 2,
+        "status": "held",
+        "disabled": false,
+        "quota": 1.0,
+        "quotaState": "spent",
+        "fiveHour": 1.0,
+        "sevenDay": 1.0,
+        "sevenDayOi": 0.9,
+        "held": [
+          {"window": "7d", "minutesUntilReset": 1528, "resetAtMs": 1000000000000},
+          {"window": "5h", "minutesUntilReset": 93, "resetAtMs": 999000000000}
+        ],
+        "requests": 0,
+        "inputTokens": 0,
+        "outputTokens": 0,
+        "cacheReadTokens": 0,
+        "cacheHitRatio": null,
+        "probeStatus": "ok",
+        "probeError": null,
+        "lastStreamError": "overloaded_error",
+        "streamErrorCount": 3
+      }
+    ]
+    """
 
 /// Same shape, `source: offline` and a `quotaState` this build has never seen.
 private let offlineUnknownFixture = """
-[
-  {
-    "source": "offline",
-    "serverSha": null,
-    "serverDirty": null,
-    "name": "carol@example.com",
-    "priority": 3,
-    "status": "active",
-    "disabled": true,
-    "quota": 0.0,
-    "quotaState": "brand-new-variant",
-    "fiveHour": 0.0,
-    "sevenDay": 0.0,
-    "sevenDayOi": 0.0,
-    "held": [],
-    "requests": 0,
-    "inputTokens": 0,
-    "outputTokens": 0,
-    "cacheReadTokens": 0,
-    "cacheHitRatio": null,
-    "probeStatus": "skipped",
-    "probeError": "no server",
-    "lastStreamError": null,
-    "streamErrorCount": 0
-  }
-]
-"""
+    [
+      {
+        "source": "offline",
+        "serverSha": null,
+        "serverDirty": null,
+        "name": "carol@example.com",
+        "priority": 3,
+        "status": "active",
+        "disabled": true,
+        "quota": 0.0,
+        "quotaState": "brand-new-variant",
+        "fiveHour": 0.0,
+        "sevenDay": 0.0,
+        "sevenDayOi": 0.0,
+        "held": [],
+        "requests": 0,
+        "inputTokens": 0,
+        "outputTokens": 0,
+        "cacheReadTokens": 0,
+        "cacheHitRatio": null,
+        "probeStatus": "skipped",
+        "probeError": "no server",
+        "lastStreamError": null,
+        "streamErrorCount": 0
+      }
+    ]
+    """
 
 final class FleetStatusTests: XCTestCase {
     private func fleet(_ json: String) throws -> Fleet {
@@ -422,10 +422,11 @@ final class FleetCapacityGlyphTests: XCTestCase {
     }
 
     func testAnyReadyAccountIsGreenEvenBesideSpentOnes() {
-        let fleet = Fleet(accounts: [
-            account("ok1@example.com", state: .ok),
-            account("near1@example.com", state: .near, held: held(166)),
-        ] + (1...11).map { account("spent\($0)@example.com", state: .spent, held: held(6526)) })
+        let fleet = Fleet(
+            accounts: [
+                account("ok1@example.com", state: .ok),
+                account("near1@example.com", state: .near, held: held(166)),
+            ] + (1...11).map { account("spent\($0)@example.com", state: .spent, held: held(6526)) })
         XCTAssertEqual(fleet.readyCount, 1)
         XCTAssertEqual(fleet.capacityGlyphState, .ok, "one ready account is capacity")
     }
@@ -440,9 +441,10 @@ final class FleetCapacityGlyphTests: XCTestCase {
     }
 
     func testNoneReadyAndNoneNearIsRed() {
-        let fleet = Fleet(accounts: (1...3).map {
-            account("spent\($0)@example.com", state: .spent, held: held(6526))
-        })
+        let fleet = Fleet(
+            accounts: (1...3).map {
+                account("spent\($0)@example.com", state: .spent, held: held(6526))
+            })
         XCTAssertEqual(fleet.capacityGlyphState, .spent)
     }
 
@@ -467,9 +469,10 @@ final class FleetCapacityGlyphTests: XCTestCase {
     }
 
     func testAnAllDisabledFleetIsUnknownNotAnAlarm() {
-        let fleet = Fleet(accounts: (1...3).map {
-            account("off\($0)@example.com", state: .ok, disabled: true)
-        })
+        let fleet = Fleet(
+            accounts: (1...3).map {
+                account("off\($0)@example.com", state: .ok, disabled: true)
+            })
         XCTAssertTrue(fleet.enabledAccounts.isEmpty)
         XCTAssertEqual(fleet.capacityGlyphState, .unknown("empty"))
         XCTAssertEqual(fleet.capacityGlyphState, fleet.capacityState, "the two agree on an empty fleet")
@@ -645,7 +648,8 @@ final class ServerControllerTests: XCTestCase {
     }
 
     func testIncumbentIsSuccessNotFailure() {
-        let stderr = "[tcr] another proxy holds :3456 (pid 123) and --no-replace was set; "
+        let stderr =
+            "[tcr] another proxy holds :3456 (pid 123) and --no-replace was set; "
             + "two proxies refreshing the same single-use tokens will token-war. Not replacing."
         let state = ServerController.classifyExit(exitCode: 1, stderr: stderr)
         guard case .incumbentHoldsPort = state else {
@@ -660,20 +664,25 @@ final class ServerControllerTests: XCTestCase {
     /// cannot lean on a non-zero exit code: without a marker match this would
     /// render "the server exited cleanly" for a server that never bound.
     func testTheStandDownIsRecognisedEvenThoughItExitsZero() {
-        let stderr = "[tcr] another proxy holds :3456 (pid 123) and it is still listening — "
+        let stderr =
+            "[tcr] another proxy holds :3456 (pid 123) and it is still listening — "
             + "leaving it alone and exiting without binding. Replacing it would wipe its "
             + "session→account pin map and cold-start every live session's prompt cache, the "
             + "most expensive event in this system. Pass --replace to take the port over anyway."
-        guard case .incumbentHoldsPort = ServerController.classifyExit(
-            intent: .safeStart, exitCode: 0, stderr: stderr
-        ) else {
+        guard
+            case .incumbentHoldsPort = ServerController.classifyExit(
+                intent: .safeStart, exitCode: 0, stderr: stderr
+            )
+        else {
             return XCTFail("a stand-down must read as an incumbent, not as a clean exit")
         }
         // Same text on the takeover path is the opposite verdict: the user asked
         // for the port and did not get it.
-        guard case .takeoverRefused = ServerController.classifyExit(
-            intent: .takeover, exitCode: 0, stderr: stderr
-        ) else {
+        guard
+            case .takeoverRefused = ServerController.classifyExit(
+                intent: .takeover, exitCode: 0, stderr: stderr
+            )
+        else {
             return XCTFail("a takeover that stood down has failed, however it exited")
         }
     }

--- a/apps/macos/Tests/TcrBarTests/RealWorldDecodeTests.swift
+++ b/apps/macos/Tests/TcrBarTests/RealWorldDecodeTests.swift
@@ -23,87 +23,87 @@ final class RealWorldDecodeTests: XCTestCase {
     /// Three real shapes: a populated account, the never-probed account whose four
     /// quota fractions are all null, and one holding a `7d` window.
     private let realWorldFixture = #"""
-    [
-      {
-        "cacheHitRatio": 0.8434839920081313,
-        "cacheReadTokens": 7407414,
-        "disabled": false,
-        "fiveHour": 0.04,
-        "held": [],
-        "inputTokens": 8781926,
-        "lastStreamError": null,
-        "name": "alice@example.com",
-        "outputTokens": 31860,
-        "priority": 0,
-        "probeError": null,
-        "probeStatus": "ok",
-        "quota": 0.04,
-        "quotaState": "ok",
-        "requests": 102,
-        "serverDirty": false,
-        "serverSha": "bd60839",
-        "sevenDay": 0.01,
-        "sevenDayOi": 0.0,
-        "source": "live",
-        "status": "active",
-        "streamErrorCount": 0
-      },
-      {
-        "cacheHitRatio": null,
-        "cacheReadTokens": 0,
-        "disabled": true,
-        "fiveHour": null,
-        "held": [],
-        "inputTokens": 0,
-        "lastStreamError": null,
-        "name": "bob@example.com",
-        "outputTokens": 0,
-        "priority": 10,
-        "probeError": null,
-        "probeStatus": "never",
-        "quota": null,
-        "quotaState": "ok",
-        "requests": 0,
-        "serverDirty": false,
-        "serverSha": "bd60839",
-        "sevenDay": null,
-        "sevenDayOi": null,
-        "source": "live",
-        "status": "active",
-        "streamErrorCount": 0
-      },
-      {
-        "cacheHitRatio": null,
-        "cacheReadTokens": 0,
-        "disabled": false,
-        "fiveHour": 0.0,
-        "held": [
+        [
           {
-            "minutesUntilReset": 6498,
-            "resetAtMs": 1786406400224,
-            "window": "7d"
+            "cacheHitRatio": 0.8434839920081313,
+            "cacheReadTokens": 7407414,
+            "disabled": false,
+            "fiveHour": 0.04,
+            "held": [],
+            "inputTokens": 8781926,
+            "lastStreamError": null,
+            "name": "alice@example.com",
+            "outputTokens": 31860,
+            "priority": 0,
+            "probeError": null,
+            "probeStatus": "ok",
+            "quota": 0.04,
+            "quotaState": "ok",
+            "requests": 102,
+            "serverDirty": false,
+            "serverSha": "bd60839",
+            "sevenDay": 0.01,
+            "sevenDayOi": 0.0,
+            "source": "live",
+            "status": "active",
+            "streamErrorCount": 0
+          },
+          {
+            "cacheHitRatio": null,
+            "cacheReadTokens": 0,
+            "disabled": true,
+            "fiveHour": null,
+            "held": [],
+            "inputTokens": 0,
+            "lastStreamError": null,
+            "name": "bob@example.com",
+            "outputTokens": 0,
+            "priority": 10,
+            "probeError": null,
+            "probeStatus": "never",
+            "quota": null,
+            "quotaState": "ok",
+            "requests": 0,
+            "serverDirty": false,
+            "serverSha": "bd60839",
+            "sevenDay": null,
+            "sevenDayOi": null,
+            "source": "live",
+            "status": "active",
+            "streamErrorCount": 0
+          },
+          {
+            "cacheHitRatio": null,
+            "cacheReadTokens": 0,
+            "disabled": false,
+            "fiveHour": 0.0,
+            "held": [
+              {
+                "minutesUntilReset": 6498,
+                "resetAtMs": 1786406400224,
+                "window": "7d"
+              }
+            ],
+            "inputTokens": 0,
+            "lastStreamError": null,
+            "name": "carol@example.com",
+            "outputTokens": 0,
+            "priority": 0,
+            "probeError": null,
+            "probeStatus": "ok",
+            "quota": 0.99,
+            "quotaState": "near",
+            "requests": 0,
+            "serverDirty": false,
+            "serverSha": "bd60839",
+            "sevenDay": 0.99,
+            "sevenDayOi": 0.0,
+            "source": "live",
+            "status": "active",
+            "streamErrorCount": 0
           }
-        ],
-        "inputTokens": 0,
-        "lastStreamError": null,
-        "name": "carol@example.com",
-        "outputTokens": 0,
-        "priority": 0,
-        "probeError": null,
-        "probeStatus": "ok",
-        "quota": 0.99,
-        "quotaState": "near",
-        "requests": 0,
-        "serverDirty": false,
-        "serverSha": "bd60839",
-        "sevenDay": 0.99,
-        "sevenDayOi": 0.0,
-        "source": "live",
-        "status": "active",
-        "streamErrorCount": 0
-      }
-    ]
-    """#
+        ]
+        """#
 
     private func fleet() throws -> Fleet {
         try Fleet.decode(Data(realWorldFixture.utf8))
@@ -169,7 +169,8 @@ final class RealWorldDecodeTests: XCTestCase {
     /// The never-probed row with `disabled` flipped to `false` — the exact state the
     /// panel's enable button puts it in.
     private func enabledNeverProbedFleet() throws -> Fleet {
-        let json = realWorldFixture
+        let json =
+            realWorldFixture
             .replacingOccurrences(of: "\"disabled\": true", with: "\"disabled\": false")
         let all = try Fleet.decode(Data(json.utf8))
         let neverProbed = try XCTUnwrap(all.accounts.first { $0.probeStatus == .never })

--- a/apps/macos/Tests/TcrBarTests/TakeoverIntentTests.swift
+++ b/apps/macos/Tests/TcrBarTests/TakeoverIntentTests.swift
@@ -162,7 +162,8 @@ final class StandDownExitCodeTests: XCTestCase {
 
     /// Verbatim from `singleton::stand_down_message` — the line every stand-down
     /// prints, regardless of which of the three it is.
-    private let standDown = "[tcr] another proxy holds :3456 (pid 123) and it is still "
+    private let standDown =
+        "[tcr] another proxy holds :3456 (pid 123) and it is still "
         + "listening — leaving it alone and exiting without binding. Replacing it would wipe "
         + "its session→account pin map and cold-start every live session's prompt cache, the "
         + "most expensive event in this system. Pass --replace to take the port over anyway."
@@ -221,14 +222,18 @@ final class StandDownExitCodeTests: XCTestCase {
     /// panel's text actually comes from, against the same literals rather than
     /// through the constants.
     func testTheLiteralCodesReachTheStatesTheyAreDefinedFor() {
-        guard case .incumbentIsStale = ServerController.classifyExit(
-            intent: .safeStart, exitCode: 3, stderr: standDown
-        ) else {
+        guard
+            case .incumbentIsStale = ServerController.classifyExit(
+                intent: .safeStart, exitCode: 3, stderr: standDown
+            )
+        else {
             return XCTFail("literal 3 must classify as a stale incumbent")
         }
-        guard case .incumbentNotAnswering = ServerController.classifyExit(
-            intent: .safeStart, exitCode: 4, stderr: standDown
-        ) else {
+        guard
+            case .incumbentNotAnswering = ServerController.classifyExit(
+                intent: .safeStart, exitCode: 4, stderr: standDown
+            )
+        else {
             return XCTFail("literal 4 must classify as a wedged incumbent")
         }
     }
@@ -292,14 +297,18 @@ final class StandDownExitCodeTests: XCTestCase {
     /// That is not hypothetical — the pipe race this file also tests could drop
     /// the whole message, and a lost stand-down used to read as a clean exit.
     func testTheVerdictSurvivesAnEmptyStderr() {
-        guard case .incumbentNotAnswering = ServerController.classifyExit(
-            intent: .safeStart, exitCode: 4, stderr: ""
-        ) else {
+        guard
+            case .incumbentNotAnswering = ServerController.classifyExit(
+                intent: .safeStart, exitCode: 4, stderr: ""
+            )
+        else {
             return XCTFail("the exit code alone must carry a wedged incumbent")
         }
-        guard case .incumbentIsStale = ServerController.classifyExit(
-            intent: .safeStart, exitCode: 3, stderr: ""
-        ) else {
+        guard
+            case .incumbentIsStale = ServerController.classifyExit(
+                intent: .safeStart, exitCode: 3, stderr: ""
+            )
+        else {
             return XCTFail("the exit code alone must carry a stale incumbent")
         }
     }
@@ -324,14 +333,18 @@ final class StandDownExitCodeTests: XCTestCase {
     /// benign outcome on a safe start and a failure on a takeover, exactly as
     /// before the exit codes existed.
     func testAnAnsweringIncumbentKeepsTheOldBehaviourOnBothPaths() {
-        guard case .incumbentHoldsPort = ServerController.classifyExit(
-            intent: .safeStart, exitCode: 0, stderr: standDown
-        ) else {
+        guard
+            case .incumbentHoldsPort = ServerController.classifyExit(
+                intent: .safeStart, exitCode: 0, stderr: standDown
+            )
+        else {
             return XCTFail("exit 0 on a safe start is still the benign outcome")
         }
-        guard case .takeoverRefused = ServerController.classifyExit(
-            intent: .takeover, exitCode: 0, stderr: standDown
-        ) else {
+        guard
+            case .takeoverRefused = ServerController.classifyExit(
+                intent: .takeover, exitCode: 0, stderr: standDown
+            )
+        else {
             return XCTFail("exit 0 on a takeover is still a failure")
         }
     }
@@ -583,7 +596,8 @@ final class ChildStderrTests: XCTestCase {
     func testADroppedStandDownWouldReadAsACleanExit() throws {
         let pipe = Pipe()
         let stderr = ChildStderr(reading: pipe, installReadabilityHandler: false)
-        let standDown = "[tcr] another proxy holds :3456 (pid 123) and it is still listening — "
+        let standDown =
+            "[tcr] another proxy holds :3456 (pid 123) and it is still listening — "
             + "leaving it alone and exiting without binding."
         try pipe.fileHandleForWriting.write(contentsOf: Data(standDown.utf8))
         try pipe.fileHandleForWriting.close()


### PR DESCRIPTION
## The gap

The Rust code here has three gates. The Swift code had one, and it was a typecheck.

| | format | lint | typecheck | warnings-as-errors |
|---|---|---|---|---|
| Rust | `cargo fmt --all --check` — CI **and** pre-commit | `cargo clippy -- -D warnings` | `cargo build` | yes |
| Swift (before) | none | none | `swift build` | no |
| Swift (after) | `swift-format lint --strict` — CI **and** pre-commit | (same tool) | `swift build` | no — see below |

There was no `.swift-format`, no `.swiftlint.yml`, and the pre-commit hook did not look at `.swift`
files at all.

## What this does

1. **`apps/macos/.swift-format`** — the toolchain default with two overrides chosen to match the tree
   as it already is, not to impose a new style: 4-space indentation, and a 110-column line length
   (the longest existing line is exactly 110). The whole default rule set is written out rather than
   left implicit, so a toolchain bump cannot silently enable a new rule and turn CI red.
2. **A mechanical format sweep**, in its own commit, so the churn is reviewable apart from the policy.
   No behaviour change: the multiline JSON fixtures are re-indented together with their closing
   delimiter, so the parsed string values are byte-identical. 107 tests still pass.
3. **The gates** — a `Format (swift)` step in the existing `macos` job, and a matching pre-commit
   block.

`swift-format` is Apple's own and ships inside the Xcode toolchain, so this adds **no dependency**;
SwiftLint is deliberately not used. It is resolved through `xcrun --find swift-format` in both
places, because the toolchain binary is not on a default PATH.

The Swift check lives in the `macos` job and not in `ci`. That does not contradict the comment above
that job — swift-format only exists on a machine with Xcode, so it is precisely "only what Linux
cannot answer".

## Warnings-as-errors: measured, then deliberately NOT added

`swift build -c release` on a clean build emits **8 warning lines / 4 distinct warnings**:

- `Sources/TcrBar/RenderStates.swift:101,102,103` — `NSAppearance.current` deprecated in macOS 12.0
- `Sources/TcrBarCore/ServerController.swift:273` — `wait` unavailable from an async context; *this is
  an error in the Swift 6 language mode*

Since the count is not zero, `-Xswiftc -warnings-as-errors` is **not** in this PR. Flipping a soft
signal to a hard failure is a separate decision and it would need those four fixed first — the
`ServerController` one in particular is a real latent problem, not cosmetic, and deserves its own
change rather than being bundled into a formatting PR.

## Scope, and the follow-up

The sweep and both gates cover `Sources/TcrBarCore` and `Tests`. `Sources/TcrBar` is excluded **for
now** because it has a large change in flight (the Sparkle work) and reformatting under it would
conflict for no reason. It is 2 violations away from clean, both in `RenderStates.swift`.

The two scopes are identical on purpose. A pre-commit hook stricter than CI blocks commits that CI
would accept, and a local gate with a reputation for lying gets switched off.

**Merge order: this goes in after the Sparkle PR.** It will be rebased onto that merge and the sweep
re-run to pick up the new files, at which point the scope widens to `apps/macos/Sources`.

## Proof the gate fires

A green CI run proves nothing about what a gate catches, so the failure was constructed. A scratch
test file with a 2-space indent, staged:

```
$ swift-format lint --strict apps/macos/Tests/TcrBarTests/ScratchGateProbe.swift
ScratchGateProbe.swift:4:1: error: [Indentation] indent by 2 spaces
ScratchGateProbe.swift:6:1: error: [Indentation] indent by 2 spaces
lint-exit=1

$ git commit -m "test: scratch probe, must never land" -- <that file>
pre-commit: BLOCKED — swift-format lint failed; CI's Format (swift) step would go red.
  Fix it:  $(xcrun --find swift-format) format -i apps/macos/Tests/TcrBarTests/ScratchGateProbe.swift
  then re-stage and commit.
commit-exit=1
HEAD unchanged
```

Then the same file, formatted and re-staged: `lint-exit=0`, `pre-commit exit=0`. The probe file was
removed; the tree is clean and HEAD is unchanged.

## Gate results

| gate | exit |
|---|---|
| `swift-format lint --strict -r apps/macos/Sources/TcrBarCore apps/macos/Tests` | 0 |
| `swift build --package-path apps/macos` | 0 |
| `swift build --package-path apps/macos -c release` | 0 |
| `swift test --package-path apps/macos` (107 tests, 0 failures) | 0 |
| `bash -n .githooks/pre-commit` | 0 |
| `shellcheck .githooks/pre-commit` | 0 |

## One thing found while reading the hook

`.githooks/pre-commit:98` gates the rustfmt block with
`git diff --cached --name-only | grep -q '\.rs$'`. That is the pattern the disclosure gate's own
comment at `:44` warns about: `grep -q` exits on its first match, and under `set -o pipefail` the
SIGPIPE'd `git` makes the whole pipeline non-zero, so the `if` reads false and the rustfmt check is
**skipped**. It only bites when the file list is large enough that `git` is still writing when `grep`
exits, which is why it has not surfaced. Left alone here to keep this PR to one subject; the new
Swift block avoids the pattern by capturing to a variable first.
