### PR TITLE
feat: sign, notarize and publish TcrBar.app releases

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -1,0 +1,121 @@
+# Build, sign, notarize and publish TcrBar.app for a tagged release.
+#
+# This runs alongside `release.yml` (the dist-generated workflow that publishes
+# the `tcr` CLI tarballs) on the same tags. Two workflows rather than one
+# because the CLI is cross-platform and cheap, while this job needs a macOS
+# runner, an Apple certificate and a notarization round-trip.
+#
+# TAG-TRIGGERED ONLY, DELIBERATELY. This job holds a Developer ID private key,
+# an App Store Connect API key and Sparkle's update-signing key. A
+# `pull_request` trigger would hand all three to anyone who opens a PR from a
+# fork, and Sparkle's key in particular signs the payload every existing
+# install trusts. Do not add `pull_request` or `workflow_dispatch` with these
+# secrets in scope.
+name: Release app
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-app-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-app:
+    runs-on: macos-14
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # CFBundleVersion is `git rev-list --count HEAD`. A shallow clone
+          # reports 1, which macOS reads as a downgrade — build-tcrbar.sh
+          # aborts on a shallow repository rather than ship one.
+          fetch-depth: 0
+
+      - name: Install create-dmg
+        run: brew install create-dmg
+
+      - name: Import the Developer ID certificate into an ephemeral keychain
+        env:
+          MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          # A keychain created and destroyed inside this job, never the default
+          # login keychain: the runner is ephemeral in theory, and a signing key
+          # left in a shared keychain is a key any later step can use.
+          keychain="$RUNNER_TEMP/signing.keychain-db"
+          p12="$RUNNER_TEMP/cert.p12"
+          printf '%s' "$MACOS_CERT_P12_BASE64" | base64 --decode > "$p12"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$keychain"
+          security import "$p12" -P "$MACOS_CERT_PASSWORD" \
+            -f pkcs12 -t cert -k "$keychain" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          # Without this, codesign's request for the private key raises a UI
+          # prompt that no one can answer, so the job HANGS until the timeout
+          # instead of failing. It is the single most common CI signing defect.
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$keychain" >/dev/null
+          # Put it on the search list so `security find-identity` sees it.
+          security list-keychain -d user -s "$keychain" login.keychain-db
+          rm -f "$p12"
+          # Report the COUNT, never the identity: the identity string contains a
+          # human name and the team id, and this repository is public.
+          echo "codesigning identities available: $(security find-identity -v -p codesigning | grep -c 'Developer ID Application' || true)"
+
+      - name: Write the App Store Connect API key
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          set -euo pipefail
+          key="$RUNNER_TEMP/asc-key.p8"
+          umask 077
+          printf '%s' "$APPLE_API_KEY_P8" > "$key"
+          chmod 600 "$key"
+          echo "APPLE_API_KEY_PATH=$key" >> "$GITHUB_ENV"
+
+      - name: Build, sign, notarize and publish
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+          # The Sparkle PUBLIC key is not a secret — it goes into Info.plist so
+          # the installed app can verify what it downloads. It lives in a repo
+          # variable so it is reviewable.
+          TCRBAR_SPARKLE_PUBLIC_KEY: ${{ vars.TCRBAR_SPARKLE_PUBLIC_KEY }}
+          RELEASE_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TCRBAR_SPARKLE_PUBLIC_KEY:-}" ]; then
+            echo "ERROR: repository variable TCRBAR_SPARKLE_PUBLIC_KEY is unset." >&2
+            echo "ERROR: the app would ship unable to verify its own updates." >&2
+            echo "ERROR: See docs/RELEASING.md (generate_keys prints the public key)." >&2
+            exit 1
+          fi
+          apps/macos/scripts/release-tcrbar.sh --tag "$GITHUB_REF_NAME"
+
+      - name: Upload the DMG as a workflow artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: TcrBar-dmg
+          path: apps/macos/build/*.dmg
+          if-no-files-found: ignore
+
+      - name: Destroy the ephemeral keychain and the API key
+        if: always()
+        run: |
+          # `if: always()` so a failed build cannot leave a signing key or an
+          # App Store Connect key behind on the runner.
+          security delete-keychain "$RUNNER_TEMP/signing.keychain-db" || true
+          rm -f "$RUNNER_TEMP/asc-key.p8" "$RUNNER_TEMP/cert.p12" || true

--- a/apps/macos/scripts/release-tcrbar.sh
+++ b/apps/macos/scripts/release-tcrbar.sh
@@ -127,7 +127,7 @@ assert_developer_id() {
     echo "ERROR:   2. '+' -> Software -> 'Developer ID Application'"
     echo "ERROR:      NOT 'Developer ID Installer' (that signs .pkg, we ship a DMG)"
     echo "ERROR:      NOT 'Apple Distribution'     (Mac App Store only)"
-    echo "ERROR:      NOT 'Apple Development'      (what this machine has now)"
+    echo "ERROR:      NOT 'Apple Development'      (a local development cert)"
     echo "ERROR:   3. requires the Account Holder role on the Apple Developer team"
     echo "ERROR:   4. upload a CSR from Keychain Access ->"
     echo "ERROR:      Certificate Assistant -> Request a Certificate From a"
@@ -190,12 +190,20 @@ resign_hardened() {
 }
 
 assert_hardened_runtime() {
-  local bundle="$1"
+  local bundle="$1" desc
   codesign --verify --deep --strict --verbose=2 "$bundle" >/dev/null 2>&1 \
     || die "codesign --verify --deep --strict failed on $bundle."
-  codesign -dvv "$bundle" 2>&1 | grep -q 'flags=.*runtime' \
-    || die "$bundle is not signed with the hardened runtime (--options runtime)." \
-           "notarytool would reject it without naming this as the cause."
+  # Captured, then matched — NOT `codesign ... | grep -q`. Under `set -o
+  # pipefail` a `grep -q` that finds its match exits immediately, SIGPIPEs
+  # codesign, and the pipeline reports 141: the check fails precisely when it
+  # succeeds. This assert did exactly that on its first run against a correctly
+  # hardened bundle.
+  desc="$(codesign -dvv "$bundle" 2>&1)"
+  case "$desc" in
+    *"flags="*"runtime"*) ;;
+    *) die "$bundle is not signed with the hardened runtime (--options runtime)." \
+           "notarytool would reject it without naming this as the cause." ;;
+  esac
   note "hardened runtime: present, signature verifies --deep --strict"
 }
 
@@ -211,8 +219,10 @@ find_sign_update() {
   fi
   # Sparkle ships sign_update inside its SPM artifact bundle, which lands under
   # .build/artifacts once the package has been resolved and built.
+  # `|| true`: `head` closing the pipe SIGPIPEs `find`, and under pipefail that
+  # non-zero status would abort the script on the normal path.
   local found
-  found="$(find "$pkg_dir/.build/artifacts" -type f -name sign_update -perm -u+x 2>/dev/null | head -n 1)"
+  found="$(find "$pkg_dir/.build/artifacts" -type f -name sign_update -perm -u+x 2>/dev/null | head -n 1 || true)"
   [ -n "$found" ] || die \
     "could not find Sparkle's sign_update under $pkg_dir/.build/artifacts." \
     "It ships in the Sparkle SPM artifact bundle — build the package first," \
@@ -220,11 +230,20 @@ find_sign_update() {
   printf '%s\n' "$found"
 }
 
-# Prints `sparkle:edSignature="..." length="..."`, which is exactly the
-# attribute pair the appcast <enclosure> needs.
+# Sets `sparkle_sig_attrs` to `sparkle:edSignature="..." length="..."`, exactly
+# the attribute pair the appcast <enclosure> needs.
+#
+# It sets a variable instead of printing, and the caller must NOT wrap it in
+# `$(...)`. A `die` inside a command substitution exits only that subshell: the
+# first version of this printed its signing-tool-not-found error and then
+# carried straight on into the fallback branch, reporting a SECOND failure for a
+# stage that should already have aborted. An abort that does not abort is worse
+# than no check.
+sparkle_sig_attrs=""
 sparkle_sign() {
   local dmg="$1" tool sig keyfile
-  tool="$(find_sign_update)"
+  tool="$(find_sign_update)" || exit 1
+  [ -n "$tool" ] || exit 1
   if [ -n "${SPARKLE_ED_PRIVATE_KEY:-}" ]; then
     # A 0600 file, not `-s <key>`: process arguments are readable by every user
     # on the machine via `ps`, and a CI runner is a machine like any other.
@@ -242,7 +261,7 @@ sparkle_sign() {
              "or export it with: generate_keys -x -"
   fi
   [ -n "$sig" ] || die "sign_update produced an empty signature."
-  printf '%s\n' "$sig"
+  sparkle_sig_attrs="$sig"
 }
 
 # ---------------------------------------------------------------------------
@@ -399,8 +418,8 @@ main() {
 
   # ---- stage 7: Sparkle signature -----------------------------------------
   stage "stage 7/9  Sparkle EdDSA signature"
-  local sig_attrs
-  sig_attrs="$(sparkle_sign "$dmg")"
+  # Deliberately not `$(sparkle_sign ...)` — see the note on that function.
+  sparkle_sign "$dmg"
   note "sign_update: ok (signature withheld from this log)"
 
   # ---- stage 8: appcast ---------------------------------------------------
@@ -421,7 +440,7 @@ main() {
       <sparkle:shortVersionString>$version</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
       <pubDate>$pubdate</pubDate>
-      <enclosure url=\"$url\" type=\"application/octet-stream\" $sig_attrs />
+      <enclosure url=\"$url\" type=\"application/octet-stream\" $sparkle_sig_attrs />
     </item>"
   appcast_insert "$item"
   note "appcast: added $version ($build_number) -> $appcast_path"

--- a/apps/macos/scripts/release-tcrbar.sh
+++ b/apps/macos/scripts/release-tcrbar.sh
@@ -1,0 +1,448 @@
+#!/usr/bin/env bash
+# Cut a distributable TcrBar.app release: build → Developer ID signature →
+# hardened runtime → DMG → notarize → staple → Sparkle EdDSA signature →
+# appcast → GitHub Release.
+#
+# This is the DISTRIBUTION path. `build-tcrbar.sh` is the LOCAL path and stays
+# that way: it signs with whatever certificate happens to be on the machine and
+# says so, which is right for a developer build and wrong for something a
+# stranger downloads. This script calls it and then refuses to continue unless
+# the result is something Gatekeeper will actually open. It never reimplements
+# the build.
+#
+# NOTHING HERE PRINTS A SECRET. This repository is public, and the strings that
+# pass through this script — a certificate's common name, an App Store Connect
+# issuer id, a team id, a Sparkle private key — are either credentials or
+# personal data. Two consequences that look like paranoia and are not:
+#
+#   * The signing identity is never echoed. `codesign -dvv` reports it as
+#     `Authority=Developer ID Application: Some Human (TEAMID)`; only the part
+#     BEFORE the first `: ` (the certificate CLASS) is ever printed, because the
+#     part after it is a name, an email and a team id. Every assert below
+#     reports the class and swallows the rest.
+#   * Sparkle's private key is handed to `sign_update` through a 0600 file, not
+#     through `-s <key>`. Command-line arguments are world-readable in `ps`.
+#
+# `set -x` in this script would defeat both. Do not add it.
+#
+# Usage:
+#   release-tcrbar.sh [--dry-run] [--skip-notarize] [--tag vX.Y.Z]
+#   release-tcrbar.sh --verify-only /path/to/TcrBar.app
+#
+#   --dry-run       do everything except notarize and upload. This is how the
+#                   pipeline is exercised on a machine with no credentials.
+#   --skip-notarize skip notarization and stapling only. The DMG is still built
+#                   and signed; it will be Gatekeeper-quarantined on download.
+#   --tag           the release tag. Defaults to v<Cargo.toml version> and must
+#                   agree with it — two version numbers for one release is a bug
+#                   this script exists to prevent, not to tolerate.
+#   --verify-only   run the signature asserts (stages 2 and 3) against an
+#                   already-built bundle and exit. Builds nothing.
+#
+# Environment:
+#   APPLE_API_KEY_PATH    path to the App Store Connect .p8 private key
+#   APPLE_API_KEY_ID      the key id shown beside it
+#   APPLE_API_ISSUER_ID   the issuer id shown at the top of that page
+#   SPARKLE_ED_PRIVATE_KEY  Sparkle EdDSA private key (falls back to keychain)
+#   SPARKLE_SIGN_UPDATE   path to Sparkle's sign_update, if not discoverable
+#   RELEASE_REPO          owner/name for the GitHub Release (default: origin)
+#
+# See docs/RELEASING.md for how each of those is produced.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+pkg_dir="$(dirname "$here")"
+repo_root="$(cd "$pkg_dir/../.." && pwd)"
+
+app_name="TcrBar"
+build_dir="$pkg_dir/build"
+app_dir="$build_dir/$app_name.app"
+appcast_path="$pkg_dir/appcast.xml"
+
+# The one class of certificate that can sign a directly-downloaded Mac app.
+#
+# Not "Apple Development" (a development cert; Gatekeeper blocks it on every
+# machine except the ones in its provisioning profile), not "Apple
+# Distribution" (Mac App Store only), not "Developer ID Installer" (signs .pkg
+# installers, which we do not ship). See docs/RELEASING.md.
+readonly required_cert_class="Developer ID Application"
+
+die() { printf 'ERROR: %s\n' "$@" >&2; exit 1; }
+stage() { printf '\n==> %s\n' "$1"; }
+note() { printf '    %s\n' "$1"; }
+
+# ---------------------------------------------------------------------------
+# Stage 2 — the Developer ID assert
+# ---------------------------------------------------------------------------
+
+# Pure predicate: is this certificate CLASS one that Gatekeeper honours for a
+# direct download? Separated from the codesign call on purpose — it is the only
+# part of the assert that can be exercised without a certificate, and a check
+# that cannot be tested is a check nobody has tested.
+cert_class_is_distributable() {
+  [ "${1:-}" = "$required_cert_class" ]
+}
+
+# Read the signing certificate CLASS out of a bundle. Prints the class only
+# (e.g. `Developer ID Application`), never the holder's name/email/team id.
+# Prints `ad-hoc` for an ad-hoc signature and nothing at all when unsigned.
+bundle_cert_class() {
+  local bundle="$1" out authority
+  # codesign writes everything to stderr.
+  out="$(codesign -dvv "$bundle" 2>&1)" || return 1
+  authority="$(printf '%s\n' "$out" | grep -m1 '^Authority=' || true)"
+  if [ -z "$authority" ]; then
+    if printf '%s\n' "$out" | grep -q '^Signature=adhoc'; then
+      printf 'ad-hoc\n'
+    fi
+    return 0
+  fi
+  # `Authority=Developer ID Application: Some Human (TEAMID)` -> the class.
+  # No `: ` at all means a class-only authority; keep the whole thing.
+  authority="${authority#Authority=}"
+  printf '%s\n' "${authority%%: *}"
+}
+
+assert_developer_id() {
+  local bundle="$1" class
+  [ -d "$bundle" ] || die "no bundle at $bundle — did the build stage run?"
+  class="$(bundle_cert_class "$bundle")" \
+    || die "codesign could not read a signature from $bundle."
+
+  if cert_class_is_distributable "$class"; then
+    note "signature: $required_cert_class (holder withheld — this repo is public)"
+    return 0
+  fi
+
+  {
+    echo "ERROR: $bundle is signed with: ${class:-<unsigned>}"
+    echo "ERROR: a release MUST be signed with a '$required_cert_class'"
+    echo "ERROR: certificate. Anything else is Gatekeeper-blocked on every Mac"
+    echo "ERROR: except the ones this certificate was issued for, so shipping it"
+    echo "ERROR: would produce a download that silently refuses to open."
+    echo "ERROR:"
+    echo "ERROR: Create the certificate — this is the exact one, the names are"
+    echo "ERROR: close enough to pick the wrong one:"
+    echo "ERROR:   1. https://developer.apple.com/account/resources/certificates"
+    echo "ERROR:   2. '+' -> Software -> 'Developer ID Application'"
+    echo "ERROR:      NOT 'Developer ID Installer' (that signs .pkg, we ship a DMG)"
+    echo "ERROR:      NOT 'Apple Distribution'     (Mac App Store only)"
+    echo "ERROR:      NOT 'Apple Development'      (what this machine has now)"
+    echo "ERROR:   3. requires the Account Holder role on the Apple Developer team"
+    echo "ERROR:   4. upload a CSR from Keychain Access ->"
+    echo "ERROR:      Certificate Assistant -> Request a Certificate From a"
+    echo "ERROR:      Certificate Authority, then download and double-click the"
+    echo "ERROR:      resulting .cer to install it in the login keychain"
+    echo "ERROR:   5. confirm with: security find-identity -v -p codesigning"
+    echo "ERROR:      (a line reading \"$required_cert_class: ...\")"
+    echo "ERROR:"
+    echo "ERROR: build-tcrbar.sh will then pick it automatically — its signing"
+    echo "ERROR: ladder prefers $required_cert_class over Apple Development."
+  } >&2
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Stage 3 — hardened runtime
+# ---------------------------------------------------------------------------
+
+# Notarization requires the hardened runtime, and `notarytool` rejects a bundle
+# without it with a message that does not name the cause. build-tcrbar.sh signs
+# without it (correct for a local build — the hardened runtime blocks debugger
+# attach), so the release path re-signs. Nested Mach-O first: the outer
+# signature seals the bundle's contents, so re-signing the inner binary after
+# the outer one would invalidate the outer one.
+#
+# --timestamp is LOAD-BEARING here, not hygiene. It contacts Apple's timestamp
+# server and records when the signature was made. A timestamped signature stays
+# valid after the signing certificate expires; an untimestamped one becomes
+# invalid the moment the certificate does, retroactively, on every machine that
+# already downloaded it. Developer ID certificates issued for this project have
+# run as short as six months, so an untimestamped build would break well inside
+# the lifetime of an installed copy. Every codesign call in this file — nested
+# binary, bundle, DMG — carries it.
+
+# Prints the full signing identity string. Never log the result: it contains the
+# certificate holder's name and the team id.
+find_signing_identity() {
+  security find-identity -v -p codesigning 2>/dev/null \
+    | grep -F "\"$required_cert_class: " \
+    | head -n 1 \
+    | sed -E 's/^[^"]*"(.*)"[[:space:]]*$/\1/' || true
+}
+
+resign_hardened() {
+  local bundle="$1" identity
+  identity="$(find_signing_identity)"
+  [ -n "$identity" ] || die \
+    "no '$required_cert_class' identity in the keychain — cannot sign a release." \
+    "Check with: security find-identity -v -p codesigning" \
+    "Create it at https://developer.apple.com/account/resources/certificates" \
+    "('+' -> Software -> '$required_cert_class'; NOT Developer ID Installer," \
+    "NOT Apple Distribution, NOT Apple Development)."
+
+  codesign --force --options runtime --timestamp \
+    --sign "$identity" "$bundle/Contents/MacOS/tcr" >/dev/null 2>&1 \
+    || die "codesign failed on the nested tcr binary."
+  codesign --force --options runtime --timestamp \
+    --sign "$identity" "$bundle" >/dev/null 2>&1 \
+    || die "codesign failed on $bundle."
+}
+
+assert_hardened_runtime() {
+  local bundle="$1"
+  codesign --verify --deep --strict --verbose=2 "$bundle" >/dev/null 2>&1 \
+    || die "codesign --verify --deep --strict failed on $bundle."
+  codesign -dvv "$bundle" 2>&1 | grep -q 'flags=.*runtime' \
+    || die "$bundle is not signed with the hardened runtime (--options runtime)." \
+           "notarytool would reject it without naming this as the cause."
+  note "hardened runtime: present, signature verifies --deep --strict"
+}
+
+# ---------------------------------------------------------------------------
+# Sparkle
+# ---------------------------------------------------------------------------
+
+find_sign_update() {
+  if [ -n "${SPARKLE_SIGN_UPDATE:-}" ]; then
+    [ -x "$SPARKLE_SIGN_UPDATE" ] || die "SPARKLE_SIGN_UPDATE=$SPARKLE_SIGN_UPDATE is not executable."
+    printf '%s\n' "$SPARKLE_SIGN_UPDATE"
+    return 0
+  fi
+  # Sparkle ships sign_update inside its SPM artifact bundle, which lands under
+  # .build/artifacts once the package has been resolved and built.
+  local found
+  found="$(find "$pkg_dir/.build/artifacts" -type f -name sign_update -perm -u+x 2>/dev/null | head -n 1)"
+  [ -n "$found" ] || die \
+    "could not find Sparkle's sign_update under $pkg_dir/.build/artifacts." \
+    "It ships in the Sparkle SPM artifact bundle — build the package first," \
+    "or set SPARKLE_SIGN_UPDATE to its path."
+  printf '%s\n' "$found"
+}
+
+# Prints `sparkle:edSignature="..." length="..."`, which is exactly the
+# attribute pair the appcast <enclosure> needs.
+sparkle_sign() {
+  local dmg="$1" tool sig keyfile
+  tool="$(find_sign_update)"
+  if [ -n "${SPARKLE_ED_PRIVATE_KEY:-}" ]; then
+    # A 0600 file, not `-s <key>`: process arguments are readable by every user
+    # on the machine via `ps`, and a CI runner is a machine like any other.
+    keyfile="$(mktemp)"
+    chmod 600 "$keyfile"
+    printf '%s' "$SPARKLE_ED_PRIVATE_KEY" >"$keyfile"
+    sig="$("$tool" -f "$keyfile" "$dmg" 2>/dev/null)" || { rm -f "$keyfile"; die "sign_update failed."; }
+    rm -f "$keyfile"
+  else
+    # No env key: sign_update reads the private key from the login keychain,
+    # which is where `generate_keys` put it.
+    sig="$("$tool" "$dmg" 2>/dev/null)" \
+      || die "sign_update failed and SPARKLE_ED_PRIVATE_KEY is unset." \
+             "Either run on the machine holding the key in its login keychain," \
+             "or export it with: generate_keys -x -"
+  fi
+  [ -n "$sig" ] || die "sign_update produced an empty signature."
+  printf '%s\n' "$sig"
+}
+
+# ---------------------------------------------------------------------------
+# Appcast
+# ---------------------------------------------------------------------------
+
+readonly appcast_marker='<!-- release-tcrbar.sh inserts new items directly below this line -->'
+
+ensure_appcast() {
+  [ -f "$appcast_path" ] && return 0
+  cat >"$appcast_path" <<XML
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>TcrBar</title>
+    <description>Updates for TcrBar</description>
+    <language>en</language>
+    $appcast_marker
+  </channel>
+</rss>
+XML
+  note "appcast: created $appcast_path"
+}
+
+# Insert the item at a FIXED marker rather than "after <channel>" or "before
+# </channel>". Sparkle reads items newest-first, and an insertion point derived
+# by pattern-matching the surrounding XML silently moves the day someone
+# reformats the file. A missing marker aborts instead of guessing.
+appcast_insert() {
+  local item="$1" tmp
+  grep -qF "$appcast_marker" "$appcast_path" \
+    || die "$appcast_path has no insertion marker. Restore this line inside <channel>:" \
+           "  $appcast_marker"
+  tmp="$(mktemp)"
+  awk -v marker="$appcast_marker" -v item="$item" '
+    { print }
+    index($0, marker) && !done { print item; done = 1 }
+  ' "$appcast_path" >"$tmp"
+  mv "$tmp" "$appcast_path"
+}
+
+# ---------------------------------------------------------------------------
+
+usage() { sed -n '2,60p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+
+main() {
+  local dry_run=0 skip_notarize=0 tag="" verify_only=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --dry-run)       dry_run=1 ;;
+      --skip-notarize) skip_notarize=1 ;;
+      --tag)           tag="${2:-}"; shift ;;
+      --verify-only)   verify_only="${2:-}"; shift ;;
+      -h|--help)       usage; exit 0 ;;
+      *)               die "unknown argument: $1" ;;
+    esac
+    shift
+  done
+
+  if [ -n "$verify_only" ]; then
+    stage "verify-only: $verify_only"
+    assert_developer_id "$verify_only"
+    assert_hardened_runtime "$verify_only"
+    exit 0
+  fi
+
+  local version
+  version="$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([0-9][^"]*\)".*/\1/p' "$repo_root/Cargo.toml" | head -1)"
+  [ -n "$version" ] || die "could not read version from $repo_root/Cargo.toml."
+  if [ -z "$tag" ]; then
+    tag="v$version"
+  elif [ "$tag" != "v$version" ]; then
+    die "--tag $tag disagrees with Cargo.toml version $version." \
+        "One release must not carry two version numbers; bump Cargo.toml or fix the tag."
+  fi
+
+  local repo
+  repo="${RELEASE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)}"
+  [ -n "$repo" ] || die "could not determine the GitHub repository; set RELEASE_REPO=owner/name."
+
+  local dmg="$build_dir/$app_name-$version.dmg"
+
+  # ---- stage 1: build -----------------------------------------------------
+  stage "stage 1/9  build (apps/macos/scripts/build-tcrbar.sh)"
+  "$here/build-tcrbar.sh"
+
+  # ---- stage 2: Developer ID assert ---------------------------------------
+  stage "stage 2/9  assert the bundle is signed for distribution"
+  assert_developer_id "$app_dir"
+
+  # ---- stage 3: hardened runtime ------------------------------------------
+  stage "stage 3/9  re-sign with the hardened runtime and a secure timestamp"
+  resign_hardened "$app_dir"
+  assert_hardened_runtime "$app_dir"
+
+  # ---- stage 4: DMG -------------------------------------------------------
+  stage "stage 4/9  build the DMG"
+  command -v create-dmg >/dev/null 2>&1 \
+    || die "create-dmg is not installed. Install it with: brew install create-dmg"
+  rm -f "$dmg"
+  # create-dmg exits 2 when it built the image but could not set the window
+  # background; that is cosmetic and not a release failure.
+  create-dmg \
+    --volname "$app_name $version" \
+    --window-size 520 340 \
+    --icon-size 96 \
+    --icon "$app_name.app" 130 170 \
+    --app-drop-link 390 170 \
+    --hdiutil-quiet \
+    "$dmg" "$app_dir" || [ -f "$dmg" ] || die "create-dmg produced no image at $dmg."
+  note "dmg: $dmg"
+
+  # The DMG is signed too: an unsigned disk image gets its own Gatekeeper
+  # complaint even when the app inside it is perfectly signed. --timestamp for
+  # the reason given above the signing helpers — the signature has to outlive
+  # the certificate.
+  codesign --force --timestamp --sign "$(find_signing_identity)" "$dmg" >/dev/null 2>&1 \
+    || die "could not sign $dmg."
+
+  # ---- stage 5: notarize --------------------------------------------------
+  if [ "$dry_run" = 1 ] || [ "$skip_notarize" = 1 ]; then
+    stage "stage 5/9  notarize — SKIPPED"
+    note "the DMG is NOT notarized; macOS will refuse to open it after download."
+  else
+    stage "stage 5/9  notarize (xcrun notarytool submit --wait)"
+    : "${APPLE_API_KEY_PATH:?set APPLE_API_KEY_PATH to the App Store Connect .p8 file}"
+    : "${APPLE_API_KEY_ID:?set APPLE_API_KEY_ID}"
+    : "${APPLE_API_ISSUER_ID:?set APPLE_API_ISSUER_ID}"
+    [ -f "$APPLE_API_KEY_PATH" ] || die "APPLE_API_KEY_PATH does not point at a file."
+    # An API key, not an Apple ID + app-specific password: the password pair is
+    # tied to one human's account and stops working the moment they enable a
+    # different 2FA device, which is a release outage nobody can debug at 2am.
+    xcrun notarytool submit "$dmg" \
+      --key "$APPLE_API_KEY_PATH" \
+      --key-id "$APPLE_API_KEY_ID" \
+      --issuer "$APPLE_API_ISSUER_ID" \
+      --wait --timeout 30m \
+      || die "notarization failed. Get the detail with:" \
+             "  xcrun notarytool log <submission-id> --key ... --key-id ... --issuer ..."
+  fi
+
+  # ---- stage 6: staple ----------------------------------------------------
+  if [ "$dry_run" = 1 ] || [ "$skip_notarize" = 1 ]; then
+    stage "stage 6/9  staple — SKIPPED (nothing was notarized)"
+  else
+    stage "stage 6/9  staple the notarization ticket"
+    # Stapling is what makes the DMG open on a machine that is OFFLINE. Without
+    # it Gatekeeper has to ask Apple at open time, so a first launch without
+    # network fails for a release that was notarized perfectly well.
+    xcrun stapler staple "$dmg" || die "stapler staple failed on $dmg."
+    xcrun stapler validate "$dmg" || die "stapler validate failed on $dmg."
+    note "stapled and validated"
+  fi
+
+  # ---- stage 7: Sparkle signature -----------------------------------------
+  stage "stage 7/9  Sparkle EdDSA signature"
+  local sig_attrs
+  sig_attrs="$(sparkle_sign "$dmg")"
+  note "sign_update: ok (signature withheld from this log)"
+
+  # ---- stage 8: appcast ---------------------------------------------------
+  stage "stage 8/9  appcast entry"
+  local build_number pubdate item url
+  build_number="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$app_dir/Contents/Info.plist")"
+  pubdate="$(LC_ALL=C date -u '+%a, %d %b %Y %H:%M:%S +0000')"
+  url="https://github.com/$repo/releases/download/$tag/$(basename "$dmg")"
+  ensure_appcast
+  if grep -q "sparkle:shortVersionString=\"$version\"" "$appcast_path"; then
+    die "$appcast_path already has an item for version $version." \
+        "Bump the version in Cargo.toml rather than republishing one."
+  fi
+  item="    <item>
+      <title>$app_name $version</title>
+      <link>https://github.com/$repo/releases/tag/$tag</link>
+      <sparkle:version>$build_number</sparkle:version>
+      <sparkle:shortVersionString>$version</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>$pubdate</pubDate>
+      <enclosure url=\"$url\" type=\"application/octet-stream\" $sig_attrs />
+    </item>"
+  appcast_insert "$item"
+  note "appcast: added $version ($build_number) -> $appcast_path"
+
+  # ---- stage 9: publish ---------------------------------------------------
+  if [ "$dry_run" = 1 ]; then
+    stage "stage 9/9  publish — SKIPPED (--dry-run)"
+    note "would upload $(basename "$dmg") and appcast.xml to $repo release $tag"
+  else
+    stage "stage 9/9  publish to the GitHub Release"
+    # --clobber: the release already exists (the CLI workflow creates it from
+    # the same tag), and a re-run must replace its assets rather than fail.
+    gh release upload "$tag" "$dmg" "$appcast_path" --clobber --repo "$repo" \
+      || die "gh release upload failed for $tag."
+    note "uploaded to https://github.com/$repo/releases/tag/$tag"
+  fi
+
+  printf '\nrelease %s: done%s\n' "$tag" "$([ "$dry_run" = 1 ] && echo ' (dry run)' || echo '')"
+}
+
+# Guarded so the asserts above can be sourced and exercised in isolation.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,151 @@
+# Releasing TcrBar.app
+
+How a signed, notarized, self-updating `TcrBar.app` gets from this repository onto someone else's
+Mac. The CLI (`tcr`) is released separately by `.github/workflows/release.yml`, which cargo-dist
+generates; this document is only about the app.
+
+Everything below is executed by `apps/macos/scripts/release-tcrbar.sh`, either on a laptop or from
+`.github/workflows/release-app.yml`. Read the script if you want the detail — this is the operator's
+view.
+
+## The certificate
+
+**Developer ID Application.** That exact one. The names are close enough that picking the wrong one
+is the normal mistake, and the resulting artifact fails in a way that looks like something else:
+
+| certificate | what it is for | what happens if you use it here |
+|---|---|---|
+| **Developer ID Application** | apps distributed **outside** the Mac App Store | correct |
+| Developer ID Installer | signing `.pkg` installers | we ship a `.dmg`; notarization rejects the app |
+| Apple Distribution | Mac App Store submissions | cannot be used for a direct download |
+| Apple Development | local development builds | Gatekeeper blocks it on every Mac but yours |
+
+The last row is the dangerous one, because a development-signed build works perfectly on the machine
+that built it. `release-tcrbar.sh` asserts the class before doing anything else and aborts naming the
+certificate to create; that assert is the reason this failure cannot ship silently.
+
+### Creating it
+
+1. <https://developer.apple.com/account/resources/certificates> → **+**
+2. Software → **Developer ID Application**. Requires the **Account Holder** role on the team.
+3. Upload a CSR: Keychain Access → Certificate Assistant → *Request a Certificate From a Certificate
+   Authority* → "Saved to disk".
+4. Download the `.cer`, double-click it. It lands in the **login** keychain along with the private
+   key from step 3.
+5. Confirm: `security find-identity -v -p codesigning` shows a line reading
+   `"Developer ID Application: <name> (<team id>)"`.
+
+Team ID for this project is `UJQ3GQF56Y`. That is not a secret — it is embedded in every signature
+we ship. The private key, the `.p12` export and the account email are secrets and appear nowhere in
+this repository.
+
+Developer ID certificates are issued with a fixed expiry (the current one expires **2027-02-01**).
+Every `codesign` call in the release path passes `--timestamp` for that reason: a timestamped
+signature stays valid after its certificate expires, an untimestamped one is retroactively invalid
+on every machine that already installed the app.
+
+## Cutting a release from a laptop
+
+```sh
+# 1. bump the version — Cargo.toml is the single source of truth. The app's
+#    CFBundleShortVersionString, the tag and `tcr --version` all derive from it.
+$EDITOR Cargo.toml && cargo check          # refresh Cargo.lock
+
+# 2. rehearse. Builds, signs, hardens, makes the DMG, signs the appcast entry.
+#    Notarization and upload are skipped, so it needs no credentials beyond the
+#    certificate.
+apps/macos/scripts/release-tcrbar.sh --dry-run
+
+# 3. tag and push. Both release workflows fire on the tag.
+git tag v0.2.0 && git push origin v0.2.0
+```
+
+To do the whole thing locally instead of in CI, export the notarization variables (below) and run
+`release-tcrbar.sh` with no flags.
+
+Flags:
+
+- `--dry-run` — everything except `notarytool submit` and `gh release upload`.
+- `--skip-notarize` — build and sign the DMG but skip notarization and stapling. The result opens
+  only on machines that already trust it; useful for testing an update feed, never for a release.
+- `--tag vX.Y.Z` — must equal `v<Cargo.toml version>`. Mismatch aborts.
+- `--verify-only <path/to/TcrBar.app>` — run the signature asserts against an existing bundle.
+
+## What the pipeline does
+
+1. `build-tcrbar.sh` — Swift build, bundle assembly, `tcr` bundled alongside, local signature.
+2. **Assert Developer ID.** Reads the class out of `codesign -dvv` and aborts on anything else.
+3. **Re-sign with `--options runtime --timestamp`.** The hardened runtime is a notarization
+   prerequisite; without it `notarytool` rejects the submission with a message that does not say so.
+   Nested `Contents/MacOS/tcr` is signed *before* the bundle, because the bundle's seal covers it.
+4. **DMG** via `create-dmg` (`brew install create-dmg`), drag-to-Applications layout, then signed.
+5. **Notarize** — `xcrun notarytool submit --wait` with an App Store Connect **API key**. Not an
+   Apple ID plus app-specific password: that pair is tied to one person's account and breaks when
+   their 2FA setup changes.
+6. **Staple** — `xcrun stapler staple` then `stapler validate`. Stapling is what lets the DMG open
+   on a machine with no network; without it Gatekeeper has to ask Apple at open time.
+7. **Sparkle signature** — `sign_update` produces the EdDSA signature and byte length.
+8. **Appcast** — a new `<item>` is inserted at the marker comment in `apps/macos/appcast.xml`.
+9. **Publish** — `gh release upload` puts the DMG and `appcast.xml` on the release for the tag.
+
+## CI secrets
+
+`.github/workflows/release-app.yml` runs on `macos-14` and fires **only** on `v*` tags. It must
+never gain a `pull_request` trigger: it holds three private keys, and a fork PR would get all of
+them.
+
+| secret | how to produce it |
+|---|---|
+| `MACOS_CERT_P12_BASE64` | Keychain Access → login → My Certificates → the Developer ID Application entry → right-click → Export → `.p12` (**include the private key** — export the certificate row with its disclosure triangle, not the bare key). Then `base64 -i cert.p12 \| pbcopy`. |
+| `MACOS_CERT_PASSWORD` | the password chosen during that export |
+| `KEYCHAIN_PASSWORD` | any random string, e.g. `openssl rand -base64 24`. It only scopes the ephemeral keychain the job creates and deletes. |
+| `APPLE_API_KEY_P8` | App Store Connect → Users and Access → Integrations → App Store Connect API → **+**, role **Developer**. The `.p8` downloads **once and only once**; paste its whole contents, `-----BEGIN PRIVATE KEY-----` line included. |
+| `APPLE_API_KEY_ID` | the Key ID shown beside that key |
+| `APPLE_API_ISSUER_ID` | the Issuer ID shown at the top of that page |
+| `SPARKLE_ED_PRIVATE_KEY` | Sparkle's `generate_keys` stores the key in the **login keychain**, not in a file. Export it for CI with `generate_keys -x -` and paste the output. |
+
+Plus one repository **variable** (not a secret):
+
+| variable | value |
+|---|---|
+| `TCRBAR_SPARKLE_PUBLIC_KEY` | the public key `generate_keys` prints. It goes into `Info.plist` so an installed app can verify what it downloads. Publishing it is the point. |
+
+The workflow imports the `.p12` into a keychain it creates in `$RUNNER_TEMP` and deletes in an
+`if: always()` step — never the login keychain — and runs `security set-key-partition-list` so
+`codesign` can use the key without a UI prompt. Omitting that call is the most common CI signing
+defect: the job hangs until its timeout instead of failing.
+
+Nothing in the workflow echoes a secret. GitHub's log masking does not reliably cover base64
+fragments or substrings, so the certificate import step prints a *count* of matching identities
+rather than the identity, which contains a person's name and the team id.
+
+## Verifying a release actually installs
+
+Do this on a Mac that has never built the app, from the downloaded DMG — not from `build/`. A local
+build is trusted for reasons a stranger's Mac will not reproduce.
+
+```sh
+# 1. the notarization ticket is stapled (works offline; this is the real test)
+xcrun stapler validate ~/Downloads/TcrBar-0.2.0.dmg
+
+# 2. Gatekeeper's own verdict on the app inside
+spctl -a -vvv -t install /Volumes/TcrBar\ 0.2.0/TcrBar.app
+#    expect: accepted / source=Notarized Developer ID
+
+# 3. the signature is hardened, timestamped and chains to Apple
+codesign -dvv --verbose=4 /Volumes/TcrBar\ 0.2.0/TcrBar.app 2>&1 \
+  | grep -E 'flags|Timestamp|TeamIdentifier'
+#    expect: flags=0x10000(runtime), a Timestamp= line, TeamIdentifier=UJQ3GQF56Y
+```
+
+Then drag it to `/Applications`, launch it, and check that **Check for Updates** finds the appcast.
+A quarantined download that opens with no warning is the outcome all of the above exists to produce;
+if macOS says *"cannot be opened because the developer cannot be verified"*, the build was signed
+with the wrong certificate class and step 2 of the pipeline did not run.
+
+## Known-unverified
+
+Notarization and stapling (stages 5 and 6) have not been exercised — no App Store Connect API key
+exists for this project yet. They are written from Apple's documented interface, not from a
+successful run. The first real release is the first test of those two stages; run it with a
+throwaway patch version before announcing anything.


### PR DESCRIPTION
Adds the distribution path for the menu-bar app. `build-tcrbar.sh` is unchanged and stays the *local* path: it signs with whatever certificate happens to be on the machine and says so, which is right for a developer build and a silent Gatekeeper failure for anything a stranger downloads.

Three new files, nothing else touched:

- `apps/macos/scripts/release-tcrbar.sh` — build → assert Developer ID → hardened runtime + secure timestamp → DMG → notarize → staple → Sparkle EdDSA signature → appcast item → `gh release upload`. `--dry-run` stops short of notarize and upload; `--skip-notarize` and `--verify-only <bundle>` are also available.
- `.github/workflows/release-app.yml` — `macos-14`, fires on the same `v*` tags as the dist-generated CLI workflow. Tag-triggered only, deliberately: the job holds a Developer ID key, an App Store Connect key and Sparkle's update-signing key, and a `pull_request` trigger would hand all three to a fork.
- `docs/RELEASING.md` — the runbook: which certificate and why it is that one, the command that produces each CI secret, how to cut a release, how to verify one actually installs.

## What is verified

`--dry-run` reaches stage 7 on this machine:

- stages 1-4 pass: build, Developer ID assert, hardened-runtime re-sign, signed DMG.
- stages 5-6 skip (`--dry-run`).
- stage 7 aborts: Sparkle's `sign_update` is not present until the Sparkle dependency lands.

Every assert was mutation-tested rather than reasoned about — 20 checks, all constructed failures:

| mutation | result |
|---|---|
| ad-hoc signature | rejected, names the certificate to create |
| Apple Development signature (the dangerous near-miss) | rejected, reports the class |
| Developer ID but no hardened runtime | rejected, names `--options runtime` |
| no Developer ID identity in the keychain | aborts with the creation steps |
| appcast with no insertion marker | aborts instead of guessing a position |
| `--tag` disagreeing with `Cargo.toml` | aborts |

That found two real defects, both fixed in the second commit and both the same class — a check that reports success without checking:

1. The hardened-runtime assert was `codesign -dvv | grep -q`. Under `set -o pipefail` a `grep -q` that *finds* its match exits immediately, SIGPIPEs `codesign`, and the pipeline reports 141 — so the assert failed precisely when the bundle was correct. It rejected a properly hardened bundle on its first real run.
2. The Sparkle stage ran inside a command substitution, where `die` exits only the subshell. Its abort printed, then execution fell through to the fallback branch and failed a second time, for a stage that should already have stopped the release.

## What is NOT verified

**Notarization and stapling (stages 5 and 6) have never run.** No App Store Connect API key exists for this project yet, so those two stages are written from Apple's documented interface, not from a successful submission. `docs/RELEASING.md` says so in a "Known-unverified" section. The first real release is the first test of them; cut it with a throwaway patch version.

The CI workflow itself is unrun — it cannot execute before its secrets exist.

## Public-repo notes

No secret, `.p12`, `.p8`, issuer id or email appears in any of the three files. The signing identity string is never echoed anywhere: `codesign -dvv` reports it as `Authority=Developer ID Application: <name> (<team>)`, and every message prints only the part before the first `: `. The certificate-import step in CI prints a *count* of matching identities for the same reason. Sparkle's private key is passed to `sign_update` through a `0600` file rather than `-s <key>`, because command-line arguments are readable by any user via `ps`.

Team ID `UJQ3GQF56Y` is written down in the runbook. It is embedded in every signature we publish and is not a secret.