### PR TITLE
feat: self-update TcrBar via Sparkle

### DIFF
--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "79bc9e872948e47877e76f194cb0c8e0412b0b90",
+        "version" : "2.9.5"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -12,12 +12,29 @@ let package = Package(
     products: [
         .executable(name: "TcrBar", targets: ["TcrBar"])
     ],
+    dependencies: [
+        // Self-update. Deliberately a dependency of the EXECUTABLE only:
+        // `TcrBarCore` stays free of it so the test target keeps linking a
+        // framework-free library, and `swift test` never pulls in an updater.
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.5")
+    ],
     targets: [
         .target(name: "TcrBarCore", path: "Sources/TcrBarCore"),
         .executableTarget(
             name: "TcrBar",
-            dependencies: ["TcrBarCore"],
-            path: "Sources/TcrBar"
+            dependencies: [
+                "TcrBarCore",
+                .product(name: "Sparkle", package: "Sparkle"),
+            ],
+            path: "Sources/TcrBar",
+            // Sparkle links as `@rpath/Sparkle.framework/...`, and SPM only ever
+            // adds `@loader_path` — which resolves inside `.build`, not inside an
+            // assembled bundle. Without this the app builds and links cleanly and
+            // then fails to launch from `TcrBar.app` with a dyld "Library not
+            // loaded" the moment the framework moves to `Contents/Frameworks`.
+            linkerSettings: [
+                .unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "@executable_path/../Frameworks"])
+            ]
         ),
         .testTarget(
             name: "TcrBarTests",

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -13,6 +13,7 @@ struct FleetView: View {
     @ObservedObject var server: ServerController
     @ObservedObject var loginItem: LoginItem
     @ObservedObject var accounts: AccountController
+    @ObservedObject var updater: Updater
     /// Owned by the app so it survives the panel closing; bound here so the
     /// checkbox and the launch path can never disagree about its value.
     @Binding var startServerAtLaunch: Bool
@@ -238,6 +239,14 @@ struct FleetView: View {
                             + "refuses while a proxy is holding the port."
                     )
                 Spacer()
+                // Disabled rather than silently no-op while Sparkle already has
+                // a check in flight — the same rule "Take over port…" follows.
+                Button("Check for Updates…") { updater.checkForUpdates() }
+                    .disabled(!updater.canCheckForUpdates)
+                    .help(
+                        "Ask the release feed whether a newer TcrBar exists. "
+                            + "Also reachable as `tcrbar://check-for-updates`."
+                    )
                 Button("Quit") { NSApplication.shared.terminate(nil) }
             }
             .buttonStyle(.bordered)

--- a/apps/macos/Sources/TcrBar/RenderStates.swift
+++ b/apps/macos/Sources/TcrBar/RenderStates.swift
@@ -108,6 +108,10 @@ enum RenderStates {
                 server: ServerController(),
                 loginItem: LoginItem(),
                 accounts: AccountController(),
+                // `startingUpdater: false`: this process was asked for PNGs. A
+                // started updater schedules background checks and can put a
+                // window on screen, neither of which belongs in a render run.
+                updater: Updater(startingUpdater: false),
                 startServerAtLaunch: .constant(false),
                 snapshotMode: true
             )

--- a/apps/macos/Sources/TcrBar/TcrBarApp.swift
+++ b/apps/macos/Sources/TcrBar/TcrBarApp.swift
@@ -36,6 +36,7 @@ struct TcrBarApp: App {
     @StateObject private var server = ServerController()
     @StateObject private var loginItem = LoginItem()
     @StateObject private var accounts = AccountController()
+    @StateObject private var updater = Updater()
 
     /// Bring the proxy up when the app starts.
     ///
@@ -61,6 +62,7 @@ struct TcrBarApp: App {
                 server: server,
                 loginItem: loginItem,
                 accounts: accounts,
+                updater: updater,
                 startServerAtLaunch: $startServerAtLaunch
             )
             .onAppear {
@@ -76,21 +78,68 @@ struct TcrBarApp: App {
             }
         } label: {
             MenuBarLabel(state: poller.state)
+                // Deliberately on the LABEL, not on the panel content.
+                //
+                // The delegate is what receives `tcrbar://check-for-updates`,
+                // and the updater is owned by the app, so the delegate has to be
+                // handed a reference before any URL can arrive. The panel's
+                // `onAppear` fires only when someone opens the menu — a URL sent
+                // to an app whose panel has never been opened would then find a
+                // nil updater and do nothing. The label is drawn at launch,
+                // which is the moment the app becomes reachable at all.
+                .onAppear { delegate.updater = updater }
         }
         .menuBarExtraStyle(.window)
     }
 }
 
-/// Exists for one reason: a child process TcrBar spawned must not outlive it.
+/// Two jobs: a child process TcrBar spawned must not outlive it, and the app's
+/// `tcrbar://` URLs land here.
 ///
 /// `terminateSupervisedChildOnQuit()` is a no-op unless *this app* spawned the
 /// server — an incumbent proxy is never signalled.
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     var server: ServerController?
+    /// Handed over by `TcrBarApp` when the menu-bar label first appears, which is
+    /// at launch. Optional because the delegate is constructed by AppKit before
+    /// any SwiftUI scene exists, not because it is expected to stay nil.
+    var updater: Updater?
 
     func applicationWillTerminate(_ notification: Notification) {
         server?.terminateSupervisedChildOnQuit()
+    }
+
+    /// The URL contract with the `tcr` CLI: `tcrbar://check-for-updates` runs the
+    /// same user-initiated check the panel's button runs.
+    ///
+    /// The scheme is declared in `CFBundleURLTypes` by `scripts/build-tcrbar.sh`;
+    /// a bundle built any other way is not registered with LaunchServices and no
+    /// URL will ever reach this method. `LSUIElement` does not change that —
+    /// an accessory app is a perfectly ordinary URL handler.
+    ///
+    /// Host-based, not path-based: `URL(string:)` parses `tcrbar://check-for-updates`
+    /// with `host == "check-for-updates"` and an empty path. An unrecognised URL
+    /// is logged rather than silently dropped, because a typo'd scheme call that
+    /// does nothing is indistinguishable from a broken updater.
+    func application(_ application: NSApplication, open urls: [URL]) {
+        for url in urls {
+            guard url.scheme == "tcrbar" else {
+                NSLog("TcrBar: ignoring URL with unexpected scheme: %@", url.absoluteString)
+                continue
+            }
+            switch url.host {
+            case "check-for-updates":
+                NSLog("TcrBar: tcrbar://check-for-updates received")
+                guard let updater else {
+                    NSLog("TcrBar: no updater is available yet — check ignored")
+                    continue
+                }
+                updater.checkForUpdates()
+            default:
+                NSLog("TcrBar: unhandled tcrbar URL: %@", url.absoluteString)
+            }
+        }
     }
 }
 

--- a/apps/macos/Sources/TcrBar/TcrBarApp.swift
+++ b/apps/macos/Sources/TcrBar/TcrBarApp.swift
@@ -101,10 +101,24 @@ struct TcrBarApp: App {
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     var server: ServerController?
+
     /// Handed over by `TcrBarApp` when the menu-bar label first appears, which is
     /// at launch. Optional because the delegate is constructed by AppKit before
     /// any SwiftUI scene exists, not because it is expected to stay nil.
-    var updater: Updater?
+    ///
+    /// A URL that arrives before that hand-off is REMEMBERED rather than dropped:
+    /// launching the app *with* `tcrbar://check-for-updates` is the ordinary case
+    /// — that is what happens when the app was not already running — and the URL
+    /// event beats the first scene by a few milliseconds.
+    var updater: Updater? {
+        didSet {
+            guard checkIsPending, let updater else { return }
+            checkIsPending = false
+            NSLog("TcrBar: running the update check that arrived before launch finished")
+            updater.checkForUpdates()
+        }
+    }
+    private var checkIsPending = false
 
     func applicationWillTerminate(_ notification: Notification) {
         server?.terminateSupervisedChildOnQuit()
@@ -115,30 +129,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     ///
     /// The scheme is declared in `CFBundleURLTypes` by `scripts/build-tcrbar.sh`;
     /// a bundle built any other way is not registered with LaunchServices and no
-    /// URL will ever reach this method. `LSUIElement` does not change that —
-    /// an accessory app is a perfectly ordinary URL handler.
-    ///
-    /// Host-based, not path-based: `URL(string:)` parses `tcrbar://check-for-updates`
-    /// with `host == "check-for-updates"` and an empty path. An unrecognised URL
-    /// is logged rather than silently dropped, because a typo'd scheme call that
-    /// does nothing is indistinguishable from a broken updater.
+    /// URL will ever reach here. `LSUIElement` does not change that — an accessory
+    /// app is a perfectly ordinary URL handler.
     func application(_ application: NSApplication, open urls: [URL]) {
         for url in urls {
-            guard url.scheme == "tcrbar" else {
-                NSLog("TcrBar: ignoring URL with unexpected scheme: %@", url.absoluteString)
-                continue
+            handle(url)
+        }
+    }
+
+    /// Host-based, not path-based: `URL(string:)` parses `tcrbar://check-for-updates`
+    /// with `host == "check-for-updates"` and an empty path. An unrecognised URL is
+    /// logged rather than silently dropped, because a mistyped scheme call that
+    /// does nothing is indistinguishable from a broken updater.
+    private func handle(_ url: URL) {
+        guard url.scheme == "tcrbar" else {
+            NSLog("TcrBar: ignoring URL with unexpected scheme: %@", url.absoluteString)
+            return
+        }
+        switch url.host {
+        case "check-for-updates":
+            NSLog("TcrBar: tcrbar://check-for-updates received")
+            guard let updater else {
+                NSLog("TcrBar: no updater yet — the check is queued until launch completes")
+                checkIsPending = true
+                return
             }
-            switch url.host {
-            case "check-for-updates":
-                NSLog("TcrBar: tcrbar://check-for-updates received")
-                guard let updater else {
-                    NSLog("TcrBar: no updater is available yet — check ignored")
-                    continue
-                }
-                updater.checkForUpdates()
-            default:
-                NSLog("TcrBar: unhandled tcrbar URL: %@", url.absoluteString)
-            }
+            updater.checkForUpdates()
+        default:
+            NSLog("TcrBar: unhandled tcrbar URL: %@", url.absoluteString)
         }
     }
 }

--- a/apps/macos/Sources/TcrBar/Updater.swift
+++ b/apps/macos/Sources/TcrBar/Updater.swift
@@ -1,0 +1,53 @@
+import Combine
+import Sparkle
+import SwiftUI
+
+/// Self-update, owned by the app the same way `poller` / `server` / `loginItem` /
+/// `accounts` are: one instance created in `TcrBarApp` and handed down. Not a
+/// singleton — a singleton would start an updater in the PNG-render harness too,
+/// which is a process that only asked for bitmaps.
+///
+/// Sparkle's `SPUStandardUpdaterController` is the whole user-facing flow (check,
+/// download, install, relaunch) plus its own UI. It reads `SUFeedURL`,
+/// `SUPublicEDKey` and `SUEnableAutomaticChecks` out of the bundle's Info.plist,
+/// which `scripts/build-tcrbar.sh` writes — so this class configures nothing and
+/// hardcodes no URL. An unsigned or hand-assembled bundle simply has no feed and
+/// Sparkle reports that itself rather than being second-guessed here.
+///
+/// Sparkle orders releases on `CFBundleVersion`, which this project derives from
+/// the commit count. `build-tcrbar.sh` documents why a shallow clone is refused:
+/// it would make that number go backwards, and an updater comparing versions
+/// would conclude there is nothing to install.
+@MainActor
+final class Updater: ObservableObject {
+    /// Mirrors Sparkle's own gate. It is false while a check is already in
+    /// flight, so the button is disabled rather than silently no-op — the same
+    /// rule the rest of this panel follows.
+    @Published private(set) var canCheckForUpdates = false
+
+    private let controller: SPUStandardUpdaterController
+    private var observation: AnyCancellable?
+
+    /// `startingUpdater: false` exists for the render harness. Starting the
+    /// updater schedules background checks and can put UI on screen; a process
+    /// invoked with `--render-states` must do neither.
+    init(startingUpdater: Bool = true) {
+        controller = SPUStandardUpdaterController(
+            startingUpdater: startingUpdater,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+        observation = controller.updater.publisher(for: \.canCheckForUpdates)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] value in
+                MainActor.assumeIsolated { self?.canCheckForUpdates = value }
+            }
+    }
+
+    /// The user-initiated check. Sparkle drives every subsequent step, including
+    /// telling the user when there is nothing to install — which a background
+    /// check deliberately stays silent about.
+    func checkForUpdates() {
+        controller.updater.checkForUpdates()
+    }
+}

--- a/apps/macos/scripts/build-tcrbar.sh
+++ b/apps/macos/scripts/build-tcrbar.sh
@@ -2,9 +2,9 @@
 # Assemble TcrBar.app by hand — no Xcode project, no .xcodeproj to keep in sync.
 #
 # Output: apps/macos/build/TcrBar.app, signed with the best certificate present on
-# the machine (see the signing ladder below). Notarization, stapling, DMGs and
-# Sparkle are deliberately out of scope: this is a local operator tool, not a
-# distributed product.
+# the machine (see the signing ladder below), with Sparkle.framework embedded and
+# the update feed configured. Notarization, stapling and DMGs are still out of
+# scope here — the release pipeline owns those.
 set -euo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -16,6 +16,17 @@ bundle_id="com.github.dhkts1.tcrbar"
 build_dir="$pkg_dir/build"
 app_dir="$build_dir/$app_name.app"
 macos_dir="$app_dir/Contents/MacOS"
+frameworks_dir="$app_dir/Contents/Frameworks"
+
+# The one URL the app answers, and the CLI's half of the contract. `tcr` opens
+# this to ask a running TcrBar to check for updates; `AppDelegate.application(_:open:)`
+# handles it. Changing either string without the other silently breaks the hand-off,
+# so both live here beside the CFBundleURLTypes entry that registers the scheme.
+url_scheme="tcrbar"
+
+# Where the appcast lives. Sparkle reads this out of Info.plist at runtime, so it
+# is written once here rather than compiled into the app.
+feed_url="https://github.com/dhkts1/teamclaude-rs/releases/latest/download/appcast.xml"
 
 # Build stamp. A missing or unreadable .git must never fail the build.
 #
@@ -102,12 +113,35 @@ fi
 
 echo "==> swift build -c release --product $app_name"
 swift build --package-path "$pkg_dir" -c release --product "$app_name"
-binary="$(swift build --package-path "$pkg_dir" -c release --product "$app_name" --show-bin-path)/$app_name"
+bin_path="$(swift build --package-path "$pkg_dir" -c release --product "$app_name" --show-bin-path)"
+binary="$bin_path/$app_name"
 
 echo "==> assembling $app_dir"
 rm -rf "$app_dir"
 mkdir -p "$macos_dir"
 cp "$binary" "$macos_dir/$app_name"
+
+# Embed Sparkle.
+#
+# SPM builds Sparkle as a VERSIONED framework (Versions/B plus a Current symlink)
+# whose payload includes an Updater.app and two XPC services. `ditto` is used
+# rather than `cp -R` because it preserves the symlink layout and the extended
+# attributes a signed bundle carries; a framework whose Current symlink is
+# flattened into a copy is not a valid framework and `codesign --deep` says so.
+#
+# The executable finds it through an `@executable_path/../Frameworks` rpath that
+# `Package.swift` adds explicitly — SPM only emits `@loader_path`, which resolves
+# inside `.build` and not inside this bundle.
+sparkle_framework="$bin_path/Sparkle.framework"
+if [ ! -d "$sparkle_framework" ]; then
+  echo "ERROR: $sparkle_framework is missing — the app links Sparkle and would" >&2
+  echo "ERROR: fail to launch with a dyld 'Library not loaded' error." >&2
+  exit 1
+fi
+mkdir -p "$frameworks_dir"
+rm -rf "$frameworks_dir/Sparkle.framework"
+ditto "$sparkle_framework" "$frameworks_dir/Sparkle.framework"
+echo "    Sparkle: embedded from $sparkle_framework"
 
 # Bundle the `tcr` server binary alongside the app.
 #
@@ -176,6 +210,33 @@ else
 fi
 rm -rf "$(dirname "$iconset")"
 
+# Sparkle's EdDSA public key — OMITTED when unset, never a placeholder.
+#
+# Sparkle refuses any update whose signature does not verify against this key.
+# A placeholder or a stale key therefore rejects every real update, and the error
+# it produces reads like a corrupted download rather than a misconfigured build —
+# so a wrong key is strictly worse than no key. With the key absent Sparkle
+# reports that the update cannot be verified, which names the actual problem.
+#
+# It is read from the environment rather than written down because the private
+# half signs releases: only the release pipeline should have to know it, and this
+# repository is public.
+sparkle_public_key_entry=""
+if [ -n "${TCRBAR_SPARKLE_PUBLIC_KEY:-}" ]; then
+  sparkle_public_key_entry="	<key>SUPublicEDKey</key>
+	<string>$TCRBAR_SPARKLE_PUBLIC_KEY</string>"
+else
+  {
+    echo
+    echo "WARNING: TCRBAR_SPARKLE_PUBLIC_KEY is not set, so SUPublicEDKey is OMITTED."
+    echo "WARNING: this build can check the feed but cannot verify a downloaded"
+    echo "WARNING: update, so Sparkle will refuse to install one. That is deliberate:"
+    echo "WARNING: a placeholder key would fail the same way while looking configured."
+    echo "WARNING: Fix: export TCRBAR_SPARKLE_PUBLIC_KEY=<the EdDSA public key> and rebuild."
+    echo
+  } >&2
+fi
+
 cat >"$app_dir/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -203,6 +264,22 @@ cat >"$app_dir/Contents/Info.plist" <<PLIST
 	<true/>
 	<key>TcrGitSHA</key>
 	<string>$git_sha</string>
+	<key>SUFeedURL</key>
+	<string>$feed_url</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+$sparkle_public_key_entry
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>$bundle_id</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>$url_scheme</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>
 PLIST
@@ -247,15 +324,51 @@ done
 # `codesign -v --deep --strict` on the finished bundle is what proves the order
 # is right, and per the note above an invalid signature is not cosmetic: it
 # silently breaks "Launch at login" and every permission grant.
+#
+# Sparkle makes that ordering deeper rather than different. The framework is not
+# one Mach-O: it contains an Updater.app, an Autoupdate helper and two XPC
+# services, each of which is code in its own right. Code signs INSIDE-OUT, so the
+# order is xpc → Updater.app → Autoupdate → the framework version → the app's own
+# `tcr` → the bundle. Signing the framework after the bundle would invalidate the
+# bundle's seal, and signing the framework without its nested payload leaves the
+# framework's own seal invalid — `--deep --strict` catches both.
+#
+# `--preserve-metadata=entitlements` on the nested code is not optional: Sparkle's
+# installer XPC service ships entitlements it needs, and a plain re-sign drops
+# them silently.
 if [ -n "$sign_identity" ]; then
-  echo "==> codesign ($sign_tier)"
-  codesign -s "$sign_identity" --force "$macos_dir/tcr"
-  codesign -s "$sign_identity" --force "$app_dir"
+  sign_key="$sign_identity"
 else
   sign_tier="ad-hoc"
-  echo "==> codesign (ad-hoc)"
-  codesign -s - --force "$macos_dir/tcr"
-  codesign -s - --force "$app_dir"
+  sign_key="-"
+fi
+
+# Hardened runtime and a trusted timestamp are what notarization requires, and
+# they are only meaningful with a real certificate behind them — an ad-hoc or
+# development signature is never notarized, and `--timestamp` on one is a network
+# round trip that buys nothing. So this rides the Developer ID tier alone.
+codesign_flags="--force"
+if [ "$sign_tier" = "Developer ID Application" ]; then
+  codesign_flags="--force --options runtime --timestamp"
+fi
+
+echo "==> codesign ($sign_tier)"
+sparkle_version_dir="$frameworks_dir/Sparkle.framework/Versions/B"
+for nested in "$sparkle_version_dir/XPCServices/"*.xpc \
+  "$sparkle_version_dir/Updater.app" \
+  "$sparkle_version_dir/Autoupdate"; do
+  [ -e "$nested" ] || continue
+  # shellcheck disable=SC2086  # $codesign_flags is a deliberate word list.
+  codesign -s "$sign_key" $codesign_flags --preserve-metadata=entitlements "$nested"
+done
+# shellcheck disable=SC2086
+codesign -s "$sign_key" $codesign_flags "$sparkle_version_dir"
+# shellcheck disable=SC2086
+codesign -s "$sign_key" $codesign_flags "$macos_dir/tcr"
+# shellcheck disable=SC2086
+codesign -s "$sign_key" $codesign_flags "$app_dir"
+
+if [ -z "$sign_identity" ]; then
   {
     echo
     echo "WARNING: no codesigning certificate found — signed ad-hoc."


### PR DESCRIPTION
Wires Sparkle 2.9.5 into TcrBar so the menu-bar app can update itself from a signed appcast. Wiring only — signing/notarizing a release and the CLI side are separate lanes.

## What changed

- **`Package.swift`** — Sparkle 2.9.5 on the `TcrBar` executable target only, so `TcrBarCore` and the test target stay framework-free. Also adds an `@executable_path/../Frameworks` rpath: SPM emits only `@loader_path`, which resolves inside `.build` and not inside an assembled bundle, so without it the app links cleanly and then fails to launch.
- **`Sources/TcrBar/Updater.swift`** — an `@MainActor final class Updater: ObservableObject` owning an `SPUStandardUpdaterController`, publishing `canCheckForUpdates`. `startingUpdater:` is a parameter so the PNG render harness gets an inert one; a process asked for bitmaps should not schedule background update checks.
- **UI** — `Button("Check for Updates…")` in FleetView's footer beside Quit, disabled while a check is in flight. Threaded from `TcrBarApp` as a `@StateObject`, the same way `poller`/`server`/`loginItem`/`accounts` are.
- **URL scheme** — `tcrbar://check-for-updates`, handled in `AppDelegate.application(_:open:)`. A URL that arrives before the first SwiftUI scene (the ordinary case when the app was not already running) is queued rather than dropped.
- **`scripts/build-tcrbar.sh`** — embeds `Sparkle.framework` with `ditto`; writes `SUFeedURL`, `SUEnableAutomaticChecks` and `CFBundleURLTypes`; reads `SUPublicEDKey` from `TCRBAR_SPARKLE_PUBLIC_KEY` and **omits it with a loud warning when unset**, because a placeholder key rejects every real update with an error that reads like a corrupted download. Signing extends the existing inside-out ordering through Sparkle's nested payload (XPC services, `Updater.app`, `Autoupdate`, framework version) before the outer bundle, and adds `--options runtime --timestamp` on the Developer ID tier only.

## Gates

| gate | exit |
|---|---|
| `swift build -c release --product TcrBar` | 0 |
| `swift test` (107 tests) | 0 |
| `scripts/build-tcrbar.sh` | 0 |
| `codesign -v --deep --strict TcrBar.app` | 0 |
| `PlistBuddy -c 'Print :SUFeedURL'` | 0 |
| `shellcheck build-tcrbar.sh` | 0 |

The Developer ID tier was exercised, not just reachable:

```
Identifier=com.github.dhkts1.tcrbar
CodeDirectory v=20500 flags=0x10000(runtime)
Authority=Developer ID Application: (…)
Timestamp=9 Aug 2026 at 14:13:37
```

The same `flags=0x10000(runtime)` and a timestamp are present on the nested `Sparkle.framework/Versions/B`, which is what `--deep --strict` exiting 0 is evidence for: the framework and its payload were signed before the outer bundle sealed them.

`SUPublicEDKey` was checked in both directions — omitted plus a warning when the env var is unset, and written verbatim when it is set.

## What is NOT demonstrated

The `tcrbar://check-for-updates` round trip was **not** observed firing at runtime. Every instrument failed for a reason unrelated to the handler: `NSLog` from this app does not reach `log show`, and a directly-executed copy of the bundle exits within about a second. A control build of `origin/main` (pre-Sparkle) exits just as fast, so that short lifetime is not introduced here — but it also means the URL path is verified by construction and by the registered `CFBundleURLSchemes` entry, not by observation. Worth a second pair of eyes before the CLI side depends on it.