### PR TITLE
ci: skip the macOS signing job when its secrets are unset

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -95,19 +95,22 @@ jobs:
           fi
 
           {
-            echo "## Release app: SKIPPED — signing secrets are not set"
-            echo
-            echo "None of the seven macOS signing secrets exist on this"
-            echo "repository, so there is nothing to build with and the signing"
-            echo "job was skipped rather than failed."
-            echo
-            echo "This is the intended configuration: releases are cut LOCALLY"
-            echo 'with `apps/macos/scripts/release-tcrbar.sh`, and the Apple'
-            echo "signing key is deliberately not stored in GitHub."
-            echo
-            echo 'See `docs/RELEASING.md`. To sign in CI instead, set all of:'
-            echo
-            for name in "${missing[@]}"; do echo "- \`$name\`"; done
+            # A quoted heredoc so the backticks stay literal markdown.
+            cat <<'MD'
+          ## Release app: SKIPPED — signing secrets are not set
+
+          None of the seven macOS signing secrets exist on this repository, so
+          there is nothing to sign with and the signing job was skipped rather
+          than failed.
+
+          This is the intended configuration: releases are cut LOCALLY with
+          `apps/macos/scripts/release-tcrbar.sh`, and the Apple signing key is
+          deliberately not stored in GitHub.
+
+          See `docs/RELEASING.md`. To sign in CI instead, set all of:
+
+          MD
+            for name in "${missing[@]}"; do echo "- $name"; done
           } >> "$GITHUB_STEP_SUMMARY"
           echo "SKIPPING: no signing secrets are set on this repository."
           echo "Releases are cut locally with apps/macos/scripts/release-tcrbar.sh."

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -26,7 +26,96 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Releases are currently cut LOCALLY (see docs/RELEASING.md), so none of the
+  # signing secrets are set on this repository. Without this job every `v*` tag
+  # would start `release-app`, which would fail at the certificate import — a
+  # red release run on every tag, forever, for a repository that has
+  # deliberately not been given an Apple signing key.
+  #
+  # The check has to be a separate job because the `secrets` context is NOT
+  # available in a job-level `if:`. Per GitHub's context-availability table,
+  # `jobs.<job_id>.if` accepts only `github`, `needs`, `vars` and `inputs`;
+  # `secrets` is readable in a step `env:`, which is what this job does. It
+  # emits only the literal `true` or `false` — never the value, never a length.
+  check-signing-secrets:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      have-secrets: ${{ steps.probe.outputs.have-secrets }}
+    steps:
+      - name: Probe for the signing secrets without revealing them
+        id: probe
+        env:
+          MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+        run: |
+          # No `set -x` here, and nothing below prints a secret's value or its
+          # length: `[ -n ... ]` is the only thing ever done with one. Secret
+          # NAMES are not secret, so reporting which are missing is safe.
+          set -euo pipefail
+          missing=()
+          for name in \
+            MACOS_CERT_P12_BASE64 MACOS_CERT_PASSWORD KEYCHAIN_PASSWORD \
+            APPLE_API_KEY_P8 APPLE_API_KEY_ID APPLE_API_ISSUER_ID \
+            SPARKLE_ED_PRIVATE_KEY
+          do
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+
+          if [ "${#missing[@]}" -eq 0 ]; then
+            echo "have-secrets=true" >> "$GITHUB_OUTPUT"
+            echo "All signing secrets are set; the signing job will run."
+            exit 0
+          fi
+
+          echo "have-secrets=false" >> "$GITHUB_OUTPUT"
+
+          # A PARTIAL set is a misconfiguration, not a deliberate opt-out, and
+          # failing loudly beats silently shipping no app for a tag someone
+          # believed was signed. Only a completely empty set skips cleanly.
+          if [ "${#missing[@]}" -ne 7 ]; then
+            {
+              echo "## Release app: FAILED — signing secrets are incomplete"
+              echo
+              echo "Some signing secrets are set but these are missing:"
+              echo
+              for name in "${missing[@]}"; do echo "- \`$name\`"; done
+              echo
+              echo "Set the missing secrets, or unset them all to skip signing in CI."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "ERROR: incomplete signing secret set; missing: ${missing[*]}" >&2
+            exit 1
+          fi
+
+          {
+            echo "## Release app: SKIPPED — signing secrets are not set"
+            echo
+            echo "None of the seven macOS signing secrets exist on this"
+            echo "repository, so there is nothing to build with and the signing"
+            echo "job was skipped rather than failed."
+            echo
+            echo "This is the intended configuration: releases are cut LOCALLY"
+            echo 'with `apps/macos/scripts/release-tcrbar.sh`, and the Apple'
+            echo "signing key is deliberately not stored in GitHub."
+            echo
+            echo 'See `docs/RELEASING.md`. To sign in CI instead, set all of:'
+            echo
+            for name in "${missing[@]}"; do echo "- \`$name\`"; done
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "SKIPPING: no signing secrets are set on this repository."
+          echo "Releases are cut locally with apps/macos/scripts/release-tcrbar.sh."
+          echo "See docs/RELEASING.md."
+
   release-app:
+    needs: check-signing-secrets
+    if: needs.check-signing-secrets.outputs.have-secrets == 'true'
     runs-on: macos-14
     timeout-minutes: 60
     steps:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -94,6 +94,16 @@ Flags:
 never gain a `pull_request` trigger: it holds three private keys, and a fork PR would get all of
 them.
 
+**None of these secrets are set today, and that is deliberate** — the Apple signing key is not
+stored in GitHub, and releases are cut locally with `apps/macos/scripts/release-tcrbar.sh`. So a
+`v*` tag reaches a `check-signing-secrets` job which finds all seven unset, writes a job summary
+saying so, and the signing job is **skipped** rather than failed. Setting all seven turns CI
+signing on with no further change. Setting only *some* is treated as a misconfiguration and fails
+loudly, naming the missing ones — a half-configured release is likelier to be a mistake than an
+intent to skip. The check must be its own job because the `secrets` context is unavailable in a
+job-level `if:` (GitHub's context-availability table allows only `github`, `needs`, `vars` and
+`inputs` there).
+
 | secret | how to produce it |
 |---|---|
 | `MACOS_CERT_P12_BASE64` | Keychain Access → login → My Certificates → the Developer ID Application entry → right-click → Export → `.p12` (**include the private key** — export the certificate row with its disclosure triangle, not the bare key). Then `base64 -i cert.p12 \| pbcopy`. |


### PR DESCRIPTION
## Why

None of the seven macOS signing secrets exist on this repository, and that is deliberate: the Apple signing key is not stored in GitHub and releases are cut locally with `apps/macos/scripts/release-tcrbar.sh`. As it stands, `git tag v0.2.0 && git push --tags` starts `release-app`, which fails at the certificate import. That is a red release run on every tag, forever.

## What

A `check-signing-secrets` job reads the seven secrets into a step `env:`, tests each only for emptiness, and emits `have-secrets=true|false` on `$GITHUB_OUTPUT`. `release-app` gains `needs: check-signing-secrets` and `if: needs.check-signing-secrets.outputs.have-secrets == 'true'`, so it is **skipped** rather than failed. The skip is explained in the job summary, naming both the reason and the local release script.

The check has to be a separate job. Per GitHub's context-availability table, `jobs.<job_id>.if` accepts only `github`, `needs`, `vars` and `inputs` — the `secrets` context is not available there, so the obvious one-line `if: secrets.X != ''` is not valid.

A **partial** secret set fails loudly and names what is missing, rather than skipping. A half-configured release is far likelier to be a mistake than an intent to skip, and silently shipping no app for a tag someone believed was signed is the worse outcome. Setting all seven turns CI signing on with no further change.

## Not leaking anything

The probe never echoes a value, never prints a length, and never sets `-x`. `[ -n ... ]` is the only operation performed on a secret; the only things written are the literals `true`/`false` and secret **names**, which are not secret.

## Verification

`actionlint` is clean (exit 0). It was also clean on `origin/main` before this change, so the two SC2016 findings the first draft produced were mine, and they are fixed. Parsed triggers after the edit are still exactly `['push']` on `v[0-9]+.[0-9]+.[0-9]+*` — no `pull_request`, `pull_request_target` or `workflow_dispatch`.

The guard's logic was executed rather than reasoned about. The probe script is extracted from the parsed YAML, so the bytes under test are the bytes Actions will run, and it is run three ways with the unset secrets exported-but-empty exactly as Actions passes them.

| arm | secrets set | rc | `have-secrets` |
|---|---|---|---|
| none | 0/7 | 0 | `false` |
| all | 7/7 | 0 | `true` |
| partial | 3/7 | 1 | `false` |

The harness itself was then mutation-tested, since a check that has only ever passed proves nothing. Six mutations — inverting the emptiness test, deleting the local-release pointer from the summary, three different secret leaks (false branch, success branch, and into the summary rather than the log), and disabling the partial-set failure — each turned it red. The first leak mutation did *not*, which was correct: it leaked a variable that is empty on that branch, so there was nothing to leak. It was replaced with one that leaks a non-empty value, and the leak scan was widened to cover every arm's log, output and summary.

**Not verified end to end.** Nothing here proves the real behaviour on GitHub's runners short of pushing an actual `v*` tag, which this PR does not do. The claim is sigma-3: the guard's logic is directly executed and the YAML lints clean, but the `needs`/`if` gating itself is confirmed only against GitHub's documented context availability, not observed.
