### PR TITLE
fix: propagate an unreadable quota utilization as absent, not as zero

### DIFF
--- a/src/probe.rs
+++ b/src/probe.rs
@@ -125,6 +125,21 @@ pub fn normalize_usage_bucket(bucket: Option<&Value>) -> Option<UsageBucket> {
 /// Pull a per-model weekly limit out of the payload's `limits[]` array (where
 /// the endpoint now reports model-scoped quota as a `weekly` entry carrying
 /// `scope.model.display_name`). Returns a synthesized bucket-shaped value.
+///
+/// Note the endpoint's naming asymmetry, which is why this translation exists at
+/// all: a top-level bucket (`five_hour`, `seven_day`) reports its fraction under
+/// one of three candidate keys led by `used_percentage`, while a `limits[]` entry
+/// reports the same quantity only as `percent`. [`normalize_usage_bucket`] knows
+/// the former set, so the entry is re-keyed to `utilization` here.
+///
+/// A key whose source value is missing **or `null` is omitted, never emitted as
+/// null**. `serde_json::json!` renders an absent `entry.get(..)` as
+/// `Value::Null`, so building the object unconditionally produced
+/// `{"utilization": null}` — an object that is *present* and therefore passes
+/// [`normalize_usage_bucket`]'s absent-check, carrying a hole downstream disguised
+/// as a reading. The distinction is load-bearing in [`crate::quota::apply_bucket`]
+/// and only stays honest if "we did not read it" is expressed as absence at every
+/// hop.
 pub fn find_scoped_weekly_limit(data: &Value, needle: &str) -> Option<Value> {
     let needle = needle.to_lowercase();
     let entry = data.get("limits")?.as_array()?.iter().find(|l| {
@@ -135,10 +150,16 @@ pub fn find_scoped_weekly_limit(data: &Value, needle: &str) -> Option<Value> {
                 .and_then(Value::as_str)
                 .is_some_and(|name| name.to_lowercase().contains(&needle))
     })?;
-    Some(serde_json::json!({
-        "utilization": entry.get("percent"),
-        "resets_at": entry.get("resets_at"),
-    }))
+    let mut bucket = serde_json::Map::new();
+    for (src, dst) in [("percent", "utilization"), ("resets_at", "resets_at")] {
+        match entry.get(src) {
+            Some(v) if !v.is_null() => {
+                bucket.insert(dst.to_string(), v.clone());
+            }
+            _ => {}
+        }
+    }
+    Some(Value::Object(bucket))
 }
 
 /// Turn a parsed usage-endpoint payload into normalized buckets.
@@ -306,6 +327,68 @@ mod tests {
         let usage = usage_from_payload(&data);
         let oi = usage.seven_day_oi.unwrap();
         assert_eq!(oi.utilization, Some(0.55));
+    }
+
+    /// A `limits[]` entry with no `percent` must not be re-keyed into a
+    /// `{"utilization": null}` object. That object is *present*, so it sails past
+    /// `normalize_usage_bucket`'s absent-check and lands on `apply_bucket` looking
+    /// like a bucket that was read — which is how a hole became a `0.0`.
+    #[test]
+    fn scoped_weekly_limit_missing_percent_omits_the_key() {
+        let data = serde_json::json!({
+            "limits": [
+                { "group": "weekly", "scope": { "model": { "display_name": "Claude Fable 5" } }, "resets_at": 1_893_456_000 }
+            ]
+        });
+        let synthesized = find_scoped_weekly_limit(&data, "fable").expect("the entry matched");
+        assert!(
+            synthesized.get("utilization").is_none(),
+            "an unread percent must be omitted, not emitted as null: {synthesized}"
+        );
+        assert!(
+            synthesized.get("resets_at").is_some(),
+            "the reset it DID report is still carried"
+        );
+
+        // End to end: the hole stays a hole all the way into the tracked window.
+        let usage = usage_from_payload(&data);
+        assert_eq!(
+            usage.seven_day_oi.expect("bucket present").utilization,
+            None
+        );
+        let mut quota = crate::quota::Quota::default();
+        quota.apply_usage(&usage);
+        assert!(
+            quota.seven_day_oi.is_none(),
+            "an unreadable percent must reach the wire as absent, never as 0.0"
+        );
+    }
+
+    /// Today's live payload shape — every weekly entry carrying an integer
+    /// `percent` — must be completely unaffected by the omission rule above.
+    #[test]
+    fn scoped_weekly_limit_with_a_numeric_percent_is_unchanged() {
+        let data = serde_json::json!({
+            "limits": [
+                { "group": "weekly", "scope": { "model": { "display_name": "Claude Fable 5" } }, "percent": 0, "resets_at": 1_893_456_000 }
+            ]
+        });
+        let usage = usage_from_payload(&data);
+        let oi = usage.seven_day_oi.expect("bucket present");
+        assert_eq!(
+            oi.utilization,
+            Some(0.0),
+            "a reported 0 percent is a reading and stays one"
+        );
+        assert_eq!(oi.reset_at_ms, Some(1_893_456_000_000));
+
+        let mut quota = crate::quota::Quota::default();
+        quota.apply_usage(&usage);
+        assert_eq!(
+            quota.seven_day_oi.map(|w| w.utilization),
+            Some(0.0),
+            "a genuine 0% weekly still renders as a measured empty bar"
+        );
     }
 
     #[test]

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -268,8 +268,15 @@ impl Quota {
     }
 
     /// Fold a background probe's usage into the tracked windows. Only fields the
-    /// probe actually reported overwrite existing values (a `None` utilization or
-    /// reset leaves the prior value intact — matches the JS `applyUsageData`).
+    /// probe actually reported overwrite existing values. There are three cases,
+    /// and the third is the one an earlier `unwrap_or(0.0)` got wrong:
+    ///  - the probe reported a utilization → it overwrites the tracked one;
+    ///  - it reported `None` and a prior window exists → the prior utilization
+    ///    (and, via [`resolve_reset`], the prior reset) is left intact — this is
+    ///    the JS `applyUsageData` behaviour;
+    ///  - it reported `None` and there is NO prior → the window stays **absent**.
+    ///    "We could not read this" is not "this is at 0%", and a fabricated `0.0`
+    ///    is byte-identical to a genuine one. See [`apply_bucket`].
     pub fn apply_usage(&mut self, usage: &crate::probe::Usage) {
         apply_bucket(&mut self.five_hour, usage.five_hour, FIVE_HOUR);
         apply_bucket(&mut self.seven_day, usage.seven_day, SEVEN_DAY);
@@ -296,6 +303,44 @@ impl Quota {
 /// a live window — and it is invisible to routing, because
 /// [`QuotaWindow::effective`] returns `0.0` for a zero bucket under both the
 /// `Some(reset)` and `None` arms.
+///
+/// **Exception — an UNREADABLE utilization with no prior leaves the window
+/// absent.** The bucket being present says only that the endpoint mentioned this
+/// dimension; if its utilization did not parse (key missing, `null`, a
+/// non-numeric string) and no prior reading exists, we have no measurement. This
+/// used to `unwrap_or(0.0)` and commit `Some(QuotaWindow { utilization: 0.0 })`,
+/// byte-identical to a genuine 0%. Three things read that fabrication differently
+/// from an absent window — and because the bucket's reported reset rode along
+/// with it (see below), the first two need only that reset:
+///  - [`crate::manager::Manager::warm_targets`] reads
+///    `five_hour.live_reset(now).is_some()` as "already warm — skip", so a
+///    fabricated window carrying a reset suppresses keep-warm for an account we
+///    have measured nothing about. This is the strongest of the three;
+///  - [`Quota::governing_weekly_reset`] then answers `Some(reset)` rather than
+///    `None` on `seven_day`, and rotation ordering sorts a `None` first
+///    (`select.rs` maps it to `i128::MIN`, "unknown quota → probe it"), so the
+///    fabrication moves the account out of the probe-me-first position;
+///  - the rendered value is a confident `0%` bar instead of "unmeasured".
+///
+/// It does NOT bias utilization-based routing. [`Quota::max_utilization`] folds
+/// only over the windows that are present, starting from `0.0`, so `Some(0.0)`
+/// and an absent window are arithmetically identical there; and every gate built
+/// on it is `effective(now) >= threshold`, which a zero never trips.
+///
+/// Absent is the truthful state and the wire already carries it: `snapshot.rs`
+/// maps a `None` window to a `None` utilization, which survives `stats.rs` →
+/// `status.rs` → `cli.rs` as JSON `null` and renders in TcrBar as a dashed bar
+/// with an `unmeasured` pill.
+///
+/// The defect is **latent, not firing**. One read of the live payload showed a
+/// numeric percentage on every `limits[]` entry it returned — one payload at one
+/// moment, which is not a property of the endpoint.
+///
+/// The bucket's reported **reset is discarded** along with it. `QuotaWindow` has
+/// no representation for "a reset with no utilization" (`utilization` is a plain
+/// `f64`), and inventing one would be the same fabrication in the other field —
+/// the `warm_targets` suppression above, which is precisely the failure the
+/// zero-utilization exception was written for.
 fn apply_bucket(
     window: &mut Option<QuotaWindow>,
     bucket: Option<crate::probe::UsageBucket>,
@@ -306,10 +351,12 @@ fn apply_bucket(
     };
     let now = OffsetDateTime::now_utc();
     let prior = *window;
-    let utilization = bucket
-        .utilization
-        .or_else(|| prior.map(|w| w.utilization))
-        .unwrap_or(0.0);
+    let Some(utilization) = bucket.utilization.or_else(|| prior.map(|w| w.utilization)) else {
+        // No reading, and nothing prior to keep. Leave the window absent rather
+        // than fabricating a 0.0 — see the exception above. `prior` is `None` on
+        // this arm by construction, so this destroys nothing.
+        return;
+    };
     let reported = bucket
         .reset_at_ms
         .and_then(|ms| OffsetDateTime::from_unix_timestamp_nanos(ms as i128 * 1_000_000).ok());
@@ -563,6 +610,133 @@ mod tests {
         assert!(
             !quota.is_near(0.90, now + Duration::hours(6)),
             "clearing after one bounded window, never pinning forever"
+        );
+    }
+
+    /// A bucket the endpoint mentions but whose utilization does not parse, with
+    /// no prior reading, must stay ABSENT — not be committed as a fabricated
+    /// `0.0`. A fabricated zero carries the bucket's reset with it, which reads to
+    /// `warm_targets` as "already warm — skip" and to `governing_weekly_reset` as
+    /// a known window; and it renders as a confident `0%` bar. Absent reaches the
+    /// wire as `null` and renders as "unmeasured".
+    #[test]
+    fn unreadable_utilization_with_no_prior_stays_absent() {
+        let mut quota = Quota::default();
+        quota.apply_usage(&crate::probe::Usage {
+            five_hour: Some(crate::probe::UsageBucket {
+                utilization: None,
+                reset_at_ms: Some(crate::now_ms() + 3_600_000),
+            }),
+            ..Default::default()
+        });
+
+        assert!(
+            quota.five_hour.is_none(),
+            "an unreadable utilization with no prior must not fabricate a window"
+        );
+        // And the reported reset goes with it: a reset with no measurement behind
+        // it would read as "already warm" to `warm_targets` and suppress keep-warm.
+        let now = OffsetDateTime::now_utc();
+        assert_eq!(
+            quota.five_hour.and_then(|w| w.live_reset(now)),
+            None,
+            "no window means no live reset to suppress keep-warm with"
+        );
+        // Nothing to report upward — this is the `None` the snapshot maps to JSON
+        // `null`. `max_utilization` reads the same either way (an absent window and
+        // a `Some(0.0)` both leave the fold at `0.0`); the difference is on the
+        // wire and in the reset-derived signals asserted above.
+        assert_eq!(quota.max_utilization(now, false), 0.0);
+    }
+
+    /// The same unreadable bucket must still PRESERVE a prior reading — that half
+    /// of the merge (the JS `applyUsageData` behaviour) is not what was broken.
+    ///
+    /// The probe here reports a NEW reset alongside the unreadable utilization,
+    /// which is what makes this test able to fail: skipping the merge entirely on
+    /// an unreadable utilization would also preserve the prior utilization (by not
+    /// writing at all) and would be indistinguishable — except that the freshly
+    /// reported reset would be dropped on the floor.
+    #[test]
+    fn unreadable_utilization_preserves_a_prior_reading() {
+        let now = OffsetDateTime::now_utc();
+        let prior_reset = now + Duration::hours(3);
+        let reported_reset = now + Duration::hours(4);
+        let mut quota = Quota {
+            five_hour: Some(QuotaWindow {
+                utilization: 0.77,
+                reset: Some(prior_reset),
+            }),
+            ..Quota::default()
+        };
+        quota.apply_usage(&crate::probe::Usage {
+            five_hour: Some(crate::probe::UsageBucket {
+                utilization: None,
+                reset_at_ms: Some((reported_reset.unix_timestamp_nanos() / 1_000_000) as i64),
+            }),
+            ..Default::default()
+        });
+
+        let window = quota.five_hour.expect("the prior window must survive");
+        assert_eq!(window.utilization, 0.77, "prior utilization kept");
+        assert_eq!(
+            window.reset.map(|r| r.unix_timestamp()),
+            Some(reported_reset.unix_timestamp()),
+            "and the freshly reported reset is still adopted"
+        );
+        // With no reported reset the still-future prior reset is inherited instead.
+        let mut quota = Quota {
+            five_hour: Some(QuotaWindow {
+                utilization: 0.77,
+                reset: Some(prior_reset),
+            }),
+            ..Quota::default()
+        };
+        quota.apply_usage(&crate::probe::Usage {
+            five_hour: Some(crate::probe::UsageBucket {
+                utilization: None,
+                reset_at_ms: None,
+            }),
+            ..Default::default()
+        });
+        assert_eq!(
+            quota.five_hour.map(|w| (w.utilization, w.reset)),
+            Some((0.77, Some(prior_reset))),
+            "prior utilization and prior reset both intact"
+        );
+    }
+
+    /// The guard above must not swing the error the other way: a GENUINE numeric
+    /// zero is a reading, and must stay a present `0.0` window rather than
+    /// collapsing into "unmeasured". This is the test that pins the two apart.
+    #[test]
+    fn a_genuine_zero_utilization_is_a_reading_not_an_absence() {
+        let mut quota = Quota::default();
+        quota.apply_usage(&crate::probe::Usage {
+            five_hour: Some(crate::probe::UsageBucket {
+                utilization: Some(0.0),
+                reset_at_ms: None,
+            }),
+            ..Default::default()
+        });
+
+        let window = quota
+            .five_hour
+            .expect("a genuine 0% is a measurement — the window must be present");
+        assert_eq!(window.utilization, 0.0);
+        // A later unreadable probe then falls into the prior-preserving arm, so
+        // the measured zero survives instead of blanking the bar.
+        quota.apply_usage(&crate::probe::Usage {
+            five_hour: Some(crate::probe::UsageBucket {
+                utilization: None,
+                reset_at_ms: None,
+            }),
+            ..Default::default()
+        });
+        assert_eq!(
+            quota.five_hour.map(|w| w.utilization),
+            Some(0.0),
+            "a measured zero is not re-classified as unmeasured by later silence"
         );
     }
 


### PR DESCRIPTION
# fix: propagate an unreadable quota utilization as absent, not as zero

A missing quota reading was being committed as a fully-empty window. "0% used" and
"never measured" became byte-identical, with no third state and no flag.

## The defect

`src/quota.rs`, in `apply_bucket`:

```rust
let utilization = bucket
    .utilization
    .or_else(|| prior.map(|w| w.utilization))
    .unwrap_or(0.0);
```

followed by an unconditional `*window = Some(QuotaWindow { utilization, reset });`. So a
bucket that is present, whose utilization is unreadable, with no prior window, produced
`Some(QuotaWindow { utilization: 0.0 })` — a fabricated measurement.

The branch had **no test coverage**: `rg 'utilization: None' src/ tests/` returned nothing
before this change, and reading the pre-fix `probe.rs` and `quota.rs` test modules
confirms no test reached it by any other route either — `UsageBucket` derives `Default`,
so a test could have built one without that literal text, and none does.

The feeder made it reachable rather than theoretical. `find_scoped_weekly_limit`
synthesized the bucket with `serde_json::json!`, and the macro renders a missing key as
`Value::Null` — so an entry lacking its percentage still produced an object *with* a
`"utilization"` key holding null, which is exactly the shape that survives
`normalize_usage_bucket`'s absent-detection and lands on the collapse.

Worth recording: top-level buckets are read with three candidate keys, while `limits[]`
entries are read with only one. That asymmetry is why the re-keying exists at all, and it
is now stated in the doc-comment.

## Why it matters

The wire value is *utilization*, `gating_quota` reduces the windows with `f64::max`, and
the bar fills proportionally — so a fabricated `0.0` renders as an **empty** bar reading
0%: the most-headroom, freshest-looking state in the fleet, not an exhausted one.

The rest of the pipeline is scrupulous about this distinction. `Option<f64>` survives
every layer to the wire, and the macOS client renders nil as a dashed bar and an
"unmeasured" pill, precisely so that "never probed" is never drawn as a confident,
fully-fresh 0%. The collapse happened at the source, so no downstream care could recover
it.

## The fix

Three cases, now distinct: a reported utilization overwrites; `None` with a prior keeps
the prior utilization, while a freshly reported reset is still adopted; `None` with no
prior leaves the window absent, which reaches the wire as `null`.

The reset is discarded along with an absent utilization — `QuotaWindow.utilization` is a
plain `f64`, so "reset, but no reading" has no representation, and keeping the reset
would repeat the same fabrication in the other field, where `warm.rs:88` reads a live
reset as "already warm, skip".

`find_scoped_weekly_limit` now builds its object with `serde_json::Map` and omits any
source key that is missing or null, instead of emitting an explicit null.

## Not currently firing

This is preventive. A live read of the usage payload at the time of writing showed a
numeric `percent` on every `limits[]` entry it returned — one payload at one moment, from
one account, not a property of an endpoint this project does not own. What actually pins
today's shape is the committed test
`scoped_weekly_limit_with_a_numeric_percent_is_unchanged`.

If the shape ever does change, the failure is one-directional and legible rather than
silent: an affected bar becomes a dashed "unmeasured" instead of quietly reading 0%.

## Gates

`cargo fmt --all --check`, `cargo clippy --all-targets --locked -- -D warnings`, and
`cargo test --all --locked` (567 tests) all green.

Six mutants. Five died on the first attempt: restoring the `unwrap_or(0.0)`; treating a
genuine `0.0` as unreadable; restoring the `json!` macro; always omitting the percentage
key; and removing the re-keying entirely. The sixth — skipping the merge on an unreadable
reading — **survived**, because skipping also preserves a prior utilization by simply not
writing. That test was rewritten to report a *new reset* alongside the unreadable
utilization, the only observable that separates the two, and then watched failing.

The regression test pinning that a genuine reported zero is still a reading, not an
absence, is what stops this fix from swinging the error the other way.

One note on scope: this was the only `unwrap_or(0.0)` in the crate, but roughly three
dozen `unwrap_or(0)` / `unwrap_or_default()` calls exist elsewhere and `build_info.rs`
already carries a comment about one of them printing "a measured-looking zero". Same
class, not addressed here.
