### PR TITLE
feat: keep this Mac awake, and own the status item so the signal can carry colour

### DIFF
--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -90,22 +90,43 @@ is:
 
 ```sh
 BIN="$(swift build --package-path apps/macos --show-bin-path)/TcrBar"
-"$BIN" --keep-awake-probe 10 &
+
+# Positive control, started HERE so the gate generates its own: a bare
+# `caffeinate` holds exactly one assertion, PreventUserIdleSystemSleep.
+caffeinate -t 15 &
+CAFF=$!
+
+"$BIN" --keep-awake-probe 6 &
+PROBE=$!
+
 sleep 3
-pmset -g assertions | grep TcrBar        # PreventUserIdleSystemSleep, named
-pmset -g assertions | grep -ci caffeinate # positive control: the grep can see assertions
-wait
+pmset -g assertions | grep -c "pid $CAFF"   # control: 1 — the grep can see assertions
+pmset -g assertions | grep TcrBar           # held:    PreventUserIdleSystemSleep, named
+
+sleep 4                                      # past the release, inside the linger
+ps -p "$PROBE" >/dev/null && echo "probe still alive"
+pmset -g assertions | grep -c TcrBar        # released: 0, while the process still runs
+
+wait "$PROBE"; kill "$CAFF" 2>/dev/null
 ```
 
 The flag holds the assertion for the given number of seconds and exits; like
 `--render-states` it is handled before the app starts, so no menu-bar item
 appears and no `tcr` subprocess is spawned.
 
-It stays alive for three seconds *after* releasing, and that linger is the point
-of the gate rather than politeness: an assertion also disappears when its process
-dies, so a reading taken after the probe exits would pass whether or not the
-release ever happened. Sampling while the process is still running is what makes
-the result attributable.
+Both samples are load-bearing, and the second one is the reason the probe stays
+alive for three seconds *after* releasing. An assertion also disappears when its
+process dies, so a reading taken after the probe exits would pass whether or not
+`endActivity` ever ran — it would be consistent with the release working and
+with the kernel cleaning up after a probe that never released. Sampling while
+`ps` still shows the pid is what separates those two, so a gate that only ever
+samples the hold proves half of what the linger was built for.
+
+The control obeys the same rule. `pmset -g assertions | grep -ci caffeinate`
+looks like a check that the grep can see assertions, but on a machine with no
+`caffeinate` running it prints `0` and scrolls past looking like a result — its
+outcome depends on ambient state rather than on anything the snippet did. So the
+snippet starts one itself and greps for that pid.
 
 ## Build and run
 

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -61,6 +61,52 @@ A rotating pool is *supposed* to contain spent accounts — that is the mechanis
 working. A worst-account-wins glyph sat at its most alarming setting permanently
 and therefore meant nothing.
 
+## Keeping the Mac awake
+
+"Keep this Mac awake" in the panel holds an idle-system-sleep power assertion —
+the same thing `caffeinate -i` does — for as long as the box is ticked. While it
+is on, a second tinted mark appears beside the capacity gauge in the menu bar.
+
+Three things it deliberately does not do:
+
+- **It does not keep the display awake.** The job is "a long run keeps running",
+  and a dark screen does not stop a run. Holding the backlight on all night is a
+  cost nobody asked for.
+- **It does not survive closing the lid.** No assertion of this class does. The
+  panel says so while the mode is on, because an operator who believes otherwise
+  comes back to a dead run and blames the proxy.
+- **It does not persist across launches.** A Mac that silently never sleeps
+  because of a box ticked last week is a worse bug than having to tick it again;
+  the symptom (a laptop cooking in a bag) is nowhere near the cause.
+
+Untick it, or quit TcrBar, and the assertion is released.
+
+### Proving it, without a screenshot
+
+The control is a checkbox, and nothing on the machine can click it for you.
+`screencapture` needs Screen Recording, which a build machine or a headless
+agent may not have, so "look at the menu bar" is not available as a gate. This
+is:
+
+```sh
+BIN="$(swift build --package-path apps/macos --show-bin-path)/TcrBar"
+"$BIN" --keep-awake-probe 10 &
+sleep 3
+pmset -g assertions | grep TcrBar        # PreventUserIdleSystemSleep, named
+pmset -g assertions | grep -ci caffeinate # positive control: the grep can see assertions
+wait
+```
+
+The flag holds the assertion for the given number of seconds and exits; like
+`--render-states` it is handled before the app starts, so no menu-bar item
+appears and no `tcr` subprocess is spawned.
+
+It stays alive for three seconds *after* releasing, and that linger is the point
+of the gate rather than politeness: an assertion also disappears when its process
+dies, so a reading taken after the probe exits would pass whether or not the
+release ever happened. Sampling while the process is still running is what makes
+the result attributable.
+
 ## Build and run
 
 ```sh

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -194,10 +194,47 @@ Three states look similar and are not:
 Package.swift
 Sources/TcrBarCore/   FleetStatus.swift  StatusPoller.swift  ServerController.swift
                       AccountControl.swift  LoginItem.swift  TcrTool.swift
-Sources/TcrBar/       TcrBarApp.swift  FleetView.swift  Tokens.swift
+                      AwakeController.swift  KeepAwakeGlyph.swift  KeepAwakeProbe.swift
+                      MenuBarMark.swift  LaunchPreference.swift
+Sources/TcrBar/       TcrBarApp.swift  MenuBarShell.swift  ShellProbe.swift
+                      FleetView.swift  Tokens.swift  RenderStates.swift  AppIcon.swift
 Tests/TcrBarTests/    FleetStatusTests.swift
 scripts/build-tcrbar.sh
 ```
 
 The logic lives in the `TcrBarCore` library so it can be tested without linking a
-test bundle against an `@main` executable; `TcrBar` is the SwiftUI shell.
+test bundle against an `@main` executable; `TcrBar` is the shell.
+
+## Why the shell is AppKit and not `MenuBarExtra`
+
+It was a SwiftUI `MenuBarExtra`, and a `MenuBarExtra` renders its label
+**monochrome no matter what the image says**. Six label constructions were each
+hosted in a real one and rasterised off the real `NSStatusBarButton`:
+`Image(nsImage:)` with `isTemplate = false`, the same with
+`.renderingMode(.original)`, a coloured `Text("●")`, and a symbol pre-flattened
+to a plain bitmap all came back with **0 coloured pixels**; an emoji managed 14.
+Setting `button.image` directly on the button gave **533 of 533**.
+
+So the app owns an `NSStatusItem`, composes the menu-bar image itself
+(`MenuBarMark`), and hosts the same unchanged `FleetView` in an `NSPopover`.
+Three things `MenuBarExtra` did for free are now explicit, and each is a silent
+regression if it is dropped: the popover is told the panel's preferred size, the
+login-item bit is re-read on every open rather than only on the first, and the
+app is activated before the panel is shown so text selection works.
+
+### Proving the shell, without a screenshot
+
+```sh
+BIN="$(swift build --package-path apps/macos --show-bin-path)/TcrBar"
+"$BIN" --shell-probe        # one line per assertion, non-zero if any failed
+```
+
+It builds the real shell in-process and checks nine things, including that the
+ON mark rasterises to cyan pixels off the real status button **and** that the OFF
+mark rasterises to none — the negative control, without which the first
+assertion passes on a mark that is cyan in both states. Every one of the nine was
+broken on purpose and watched go red.
+
+What it does not cover: the window server's final composite of the menu bar, a
+real mouse click, and anything about a signed bundle. Those are still a human's
+eyes.

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -13,6 +13,10 @@ struct FleetView: View {
     @ObservedObject var server: ServerController
     @ObservedObject var loginItem: LoginItem
     @ObservedObject var accounts: AccountController
+    /// Owned by the app, for the same reason the poller is: this panel is torn
+    /// down every time the menu closes, and an assertion released at that moment
+    /// would be a keep-awake control that keeps nothing awake.
+    @ObservedObject var awake: AwakeController
     /// Owned by the app so it survives the panel closing; bound here so the
     /// checkbox and the launch path can never disagree about its value.
     @Binding var startServerAtLaunch: Bool
@@ -251,6 +255,7 @@ struct FleetView: View {
 
             launchAtLogin
             startServerToggle
+            keepAwakeToggle
 
             dangerZone
         }
@@ -276,6 +281,52 @@ struct FleetView: View {
                     .font(Tok.detailFont)
                     .foregroundStyle(Tok.near)
                     .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    /// Keep the Mac from idle-sleeping, for as long as the box is ticked.
+    ///
+    /// A checkbox rather than a fifth button: the button row above is already
+    /// four wide inside a 380pt panel, and this belongs with the other two
+    /// toggles anyway — all three are modes, not actions.
+    ///
+    /// The detail line is not decoration. "Keep this Mac awake" over-promises by
+    /// exactly the two cases an operator will hit, and hitting either means
+    /// coming back to a dead run and blaming the proxy. It carries `Tok.near`
+    /// because it is a caveat, the same as the other two toggles' detail lines.
+    ///
+    /// `.tint(Tok.awake)` asks for the mark to be the same token the menu bar
+    /// draws, so the two surfaces cannot disagree about what "on" looks like.
+    /// **That one line is unverified**, and it is the only thing here that is: a
+    /// `.checkbox` toggle is an AppKit control, `ImageRenderer` does not draw
+    /// those at all (`--render-states` shows a placeholder for this toggle and
+    /// for the two above it, all three the same), and reading the real control
+    /// back needs a screenshot. On macOS a checkbox may well follow the system
+    /// accent colour and ignore the tint outright. The state is carried by the
+    /// checkbox being *ticked*, which is not a colour, so nothing depends on it.
+    private var keepAwakeToggle: some View {
+        VStack(alignment: .leading, spacing: Tok.tightSpacing) {
+            Toggle(
+                "Keep this Mac awake",
+                isOn: Binding(get: { awake.isOn }, set: { awake.setOn($0) })
+            )
+            .toggleStyle(.checkbox)
+            .font(Tok.secondaryFont)
+            .tint(Tok.awake)
+            .help(
+                "Holds an idle-system-sleep power assertion for as long as this "
+                    + "is on — the same thing `caffeinate -i` does. Released when "
+                    + "you untick it or quit TcrBar."
+            )
+            if awake.isOn {
+                Text(
+                    "The display can still sleep, and closing the lid still sleeps "
+                        + "the Mac — no power assertion prevents that."
+                )
+                .font(Tok.detailFont)
+                .foregroundStyle(Tok.near)
+                .fixedSize(horizontal: false, vertical: true)
             }
         }
     }

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -498,10 +498,11 @@ struct AccountRow: View {
     /// This row used to render a pill only when `disabled` was true, so "in
     /// rotation" was signalled by the absence of anything — and the only nearby
     /// text was a button reading "Disable", which names what a click would DO.
-    /// That is not a null state, it is a legible one: Gil read the button as a
-    /// status and concluded the proxy was routing traffic to a disabled account.
-    /// It was not; `disabled` was false. A row that can be misread as its own
-    /// opposite is a defect regardless of which fact happens to be true.
+    /// That is not a null state, it is a legible one: the button's verb was read
+    /// as a status, and the reader concluded from it that the proxy was routing
+    /// traffic to a disabled account. It was not; `disabled` was false. A row
+    /// that can be misread as its own opposite is a defect regardless of which
+    /// fact happens to be true.
     ///
     /// "rotating" rather than "enabled" on purpose. The button's label is the
     /// verb (`tcr enable` / `tcr disable`, and it should stay a verb), so an
@@ -687,11 +688,12 @@ struct AccountRow: View {
 ///
 /// `fraction` is optional because a never-probed account has no reading at all.
 /// A nil renders as a DASHED outline rather than an unfilled bar: an unfilled bar
-/// is pixel-identical to `0`, so drawing one would make the panel assert
-/// "exhausted" about an account nothing has ever measured. Keeping unknown
-/// distinct from empty at the last rendering step is the whole point of the
-/// optional model — collapsing it here would undo it after the decoder,
-/// `readyCount` and the pill all took care to preserve it.
+/// is pixel-identical to `0`, and since the fraction is utilization, drawing one
+/// would make the panel assert "nothing spent, full headroom" about an account
+/// nothing has ever measured. Keeping unknown distinct from empty at the last
+/// rendering step is the whole point of the optional model — collapsing it here
+/// would undo it after the decoder, `readyCount` and the pill all took care to
+/// preserve it.
 struct QuotaBar: View {
     let fraction: Double?
     let tint: Color
@@ -706,7 +708,7 @@ struct QuotaBar: View {
     /// important number is invisible to VoiceOver — and worse, the nil-vs-zero
     /// distinction that the decoder, `readyCount` and the pill all take care to
     /// preserve would survive only as a dashed outline. "Never measured" and
-    /// "exhausted" would be identical again, which is the exact defect the
+    /// "nothing spent" would be identical again, which is the exact defect the
     /// optional model exists to prevent.
     private var spokenValue: String {
         guard let fraction else { return "not measured" }

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -13,9 +13,12 @@ struct FleetView: View {
     @ObservedObject var server: ServerController
     @ObservedObject var loginItem: LoginItem
     @ObservedObject var accounts: AccountController
-    /// Owned by the app, for the same reason the poller is: this panel is torn
-    /// down every time the menu closes, and an assertion released at that moment
-    /// would be a keep-awake control that keeps nothing awake.
+    /// Owned by the app, for the same reason the poller is: the panel is a view
+    /// and the mode is not, and an assertion released when the view went away
+    /// would be a keep-awake control that keeps nothing awake. Under
+    /// `MenuBarExtra` that teardown happened on every close; hosted in a popover
+    /// it need not — which changes when that bug would bite, not whether it
+    /// would.
     @ObservedObject var awake: AwakeController
     /// Owned by the app so it survives the panel closing; bound here so the
     /// checkbox and the launch path can never disagree about its value.
@@ -40,11 +43,16 @@ struct FleetView: View {
 
     /// Measured height of the account rows.
     ///
-    /// A `ScrollView` has a flexible ideal height, and the `MenuBarExtra` window
-    /// sizes itself to its content's *ideal* height — so a scroll view carrying
-    /// only a `maxHeight` collapses to roughly one row no matter how many
-    /// accounts the fleet has. Measuring the rows and giving the scroll view a
-    /// concrete height is what makes the panel grow with the fleet.
+    /// A `ScrollView` has a flexible ideal height, and the window this panel
+    /// lives in sizes itself to its content's *ideal* height — so a scroll view
+    /// carrying only a `maxHeight` collapses to roughly one row no matter how
+    /// many accounts the fleet has. Measuring the rows and giving the scroll
+    /// view a concrete height is what makes the panel grow with the fleet.
+    ///
+    /// That was true of the `MenuBarExtra` window this panel used to live in and
+    /// is equally true of the `NSPopover` it lives in now, whose hosting
+    /// controller is set to `sizingOptions = [.preferredContentSize]`
+    /// (`MenuBarShell.swift`) for exactly this reason.
     @State private var rowsHeight: CGFloat = 0
 
     var body: some View {

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -301,8 +301,15 @@ struct FleetView: View {
     ///
     /// The detail line is not decoration. "Keep this Mac awake" over-promises by
     /// exactly the two cases an operator will hit, and hitting either means
-    /// coming back to a dead run and blaming the proxy. It carries `Tok.near`
-    /// because it is a caveat, the same as the other two toggles' detail lines.
+    /// coming back to a dead run and blaming the proxy.
+    ///
+    /// It carries `Tok.awake`, NOT `Tok.near`. Amber is this palette's "close to
+    /// a gating limit", and it is what the login-item error directly above uses;
+    /// an informational note about a mode the operator just turned on is not
+    /// that, and rendering it in the alarm colour made a footer with one note
+    /// read as a footer with two problems. `Tok.awake` is the mode's own token —
+    /// the same one the menu-bar mark uses — so the line reads as belonging to
+    /// the thing that is on, which is what it is.
     ///
     /// `.tint(Tok.awake)` asks for the mark to be the same token the menu bar
     /// draws, so the two surfaces cannot disagree about what "on" looks like.
@@ -328,13 +335,10 @@ struct FleetView: View {
                     + "you untick it or quit TcrBar."
             )
             if awake.isOn {
-                Text(
-                    "The display can still sleep, and closing the lid still sleeps "
-                        + "the Mac — no power assertion prevents that."
-                )
-                .font(Tok.detailFont)
-                .foregroundStyle(Tok.near)
-                .fixedSize(horizontal: false, vertical: true)
+                Text("The display still sleeps, and closing the lid still sleeps the Mac.")
+                    .font(Tok.detailFont)
+                    .foregroundStyle(Tok.awake)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
     }
@@ -489,6 +493,38 @@ struct AccountRow: View {
         account.hasQuotaEvidence ? Tok.color(for: account.quotaState) : Tok.unmeasured
     }
 
+    /// Whether this account is in the rotation, said in BOTH directions.
+    ///
+    /// This row used to render a pill only when `disabled` was true, so "in
+    /// rotation" was signalled by the absence of anything — and the only nearby
+    /// text was a button reading "Disable", which names what a click would DO.
+    /// That is not a null state, it is a legible one: Gil read the button as a
+    /// status and concluded the proxy was routing traffic to a disabled account.
+    /// It was not; `disabled` was false. A row that can be misread as its own
+    /// opposite is a defect regardless of which fact happens to be true.
+    ///
+    /// "rotating" rather than "enabled" on purpose. The button's label is the
+    /// verb (`tcr enable` / `tcr disable`, and it should stay a verb), so an
+    /// "ENABLED" pill next to a "Disable" button puts two words with the same
+    /// stem beside each other and asks the reader to notice which is a state.
+    /// Rotation is the vocabulary nothing else in the row uses, and it names the
+    /// consequence the operator actually cares about: whether requests land here.
+    ///
+    /// The in-rotation case is drawn in `Tok.inkFaint` rather than a status hue:
+    /// it is the normal state of twelve of thirteen rows, and colouring the
+    /// unremarkable case would spend the panel's colour budget on it. Colour
+    /// stays with quota, which is the thing worth scanning for.
+    @ViewBuilder
+    private var rotationPill: some View {
+        if account.disabled {
+            StatusPill("parked", tint: Tok.disabled)
+                .help("Out of the rotation — `tcr` sends this account no traffic.")
+        } else {
+            StatusPill("rotating", tint: Tok.inkFaint)
+                .help("In the rotation — this account can be picked for traffic.")
+        }
+    }
+
     /// One utterance for the whole row.
     ///
     /// Without this, VoiceOver walks roughly eight separate elements per account
@@ -498,7 +534,10 @@ struct AccountRow: View {
     /// actionable.
     private var rowAccessibilityLabel: String {
         var parts = [account.name]
-        if account.disabled { parts.append("disabled") }
+        // Spoken in both directions, for the same reason the pill is drawn in
+        // both: silence is not a state, and a VoiceOver user has even less to
+        // infer it from than a sighted one.
+        parts.append(account.disabled ? "parked, out of rotation" : "rotating")
         parts.append(
             account.hasQuotaEvidence
                 ? "\(account.quotaState.token), \(QuotaFormat.percent(account.quota)) used"
@@ -536,7 +575,7 @@ struct AccountRow: View {
                     .help(account.name)
                     .textSelection(.enabled)
                 Spacer(minLength: Tok.tightSpacing)
-                if account.disabled { StatusPill("disabled", tint: Tok.disabled) }
+                rotationPill
                 // A never-probed account's `quotaState` is Rust's default, not a
                 // reading. Printing `ok` on it would be the panel asserting
                 // something nothing has ever checked.
@@ -561,10 +600,10 @@ struct AccountRow: View {
                 Spacer()
                 // `status` is the account's own field and it keeps saying
                 // "active" while `disabled` is true — verified against live
-                // output, not just a fixture. Printing it next to a DISABLED
-                // pill puts "disabled" and "active" in one line and makes the
-                // row argue with itself, so the pill speaks for a parked
-                // account and the raw status only shows when it can be true.
+                // output, not just a fixture. Printing it next to a PARKED pill
+                // puts "parked" and "active" in one line and makes the row argue
+                // with itself, so the pill speaks for a parked account and the
+                // raw status only shows when it can be true.
                 if !account.disabled {
                     Text(account.status)
                         .font(Tok.secondaryFont)

--- a/apps/macos/Sources/TcrBar/MenuBarShell.swift
+++ b/apps/macos/Sources/TcrBar/MenuBarShell.swift
@@ -1,0 +1,205 @@
+import AppKit
+import Combine
+import SwiftUI
+import TcrBarCore
+
+/// The menu bar item and the panel that hangs off it, owned by this app rather
+/// than by SwiftUI.
+///
+/// ## Why it is hand-managed
+///
+/// A `MenuBarExtra` renders its label monochrome whatever the image says —
+/// measured across six label constructions, table in ``MenuBarMark``. The only
+/// construction that carries an arbitrary colour is setting `button.image` on the
+/// real `NSStatusBarButton`, and a SwiftUI scene never lets you near it. Owning
+/// the status item is what makes the keep-awake mark able to be cyan.
+///
+/// `FleetView` is unchanged. What changed is who owns the window it lives in: an
+/// `NSPopover` with one long-lived `NSHostingController` instead of a panel that
+/// `MenuBarExtra` destroyed and rebuilt on every open. Three things came free
+/// with that rebuild-per-open and now have to be arranged for, each noted at the
+/// line that arranges it: the login-item re-read, the panel's size, and key
+/// focus.
+@MainActor
+final class MenuBarShell {
+    let poller: StatusPoller
+    let server: ServerController
+    let loginItem: LoginItem
+    let accounts: AccountController
+    /// Owned here, not by the panel: the panel is a view that can be torn down,
+    /// and an assertion that ended when the panel closed would be a keep-awake
+    /// control that keeps nothing awake.
+    let awake: AwakeController
+    let preference: LaunchPreference
+
+    let statusItem: NSStatusItem
+    let popover: NSPopover
+
+    private var marks: Set<AnyCancellable> = []
+
+    /// `nil` means "the real one". A default argument is evaluated in a
+    /// *nonisolated* context, and every controller here is `@MainActor`, so
+    /// `poller: StatusPoller = StatusPoller()` does not compile — the optionals
+    /// are what let the probe substitute a pinned poller and an inert keep-awake
+    /// while the app passes nothing at all.
+    init(
+        poller: StatusPoller? = nil,
+        server: ServerController? = nil,
+        loginItem: LoginItem? = nil,
+        accounts: AccountController? = nil,
+        awake: AwakeController? = nil,
+        preference: LaunchPreference? = nil
+    ) {
+        self.poller = poller ?? StatusPoller()
+        self.server = server ?? ServerController()
+        self.loginItem = loginItem ?? LoginItem()
+        self.accounts = accounts ?? AccountController()
+        self.awake = awake ?? AwakeController()
+        self.preference = preference ?? LaunchPreference()
+
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        popover = NSPopover()
+
+        let hosting = NSHostingController(
+            rootView: FleetPanel(
+                poller: self.poller, server: self.server, loginItem: self.loginItem,
+                accounts: self.accounts, awake: self.awake, preference: self.preference))
+        // Without this the popover takes a default size and the panel is clipped.
+        //
+        // This is the specific thing `MenuBarExtra` did for free. `FleetView`
+        // measures its own row height through a `GeometryReader` preference
+        // (`FleetView.swift:44-56, 178-189`), which exists precisely because a
+        // scroll view's ideal height collapses to about one row — so a shell
+        // that does not propagate the preferred size up to the popover
+        // reproduces that exact bug, and it looks like a SwiftUI layout problem
+        // rather than a missing line here. `--shell-probe` assertion 5 checks
+        // the resulting `contentSize` numerically.
+        hosting.sizingOptions = [.preferredContentSize]
+        popover.contentViewController = hosting
+        // What restores click-outside dismissal, which a menu had by nature.
+        popover.behavior = .transient
+
+        if let button = statusItem.button {
+            button.target = self
+            button.action = #selector(togglePanel(_:))
+        }
+
+        // Both publishers, combined, so the image is recomposed whenever either
+        // half of it changes.
+        //
+        // The values come from the publisher, never from re-reading the
+        // controllers. `@Published` fires in `willSet`, so `awake.isOn` inside
+        // this sink is still the OLD value — a mark composed from it would
+        // disagree with `AwakeController.isOn` for one edge in each direction,
+        // which is the same "three representations of one fact" failure that
+        // controller's own doc-comment is built to prevent.
+        self.poller.$state
+            .combineLatest(self.awake.$isOn)
+            .sink { [weak self] state, isOn in
+                self?.updateMark(state: state, awake: isOn)
+            }
+            .store(in: &marks)
+    }
+
+    // MARK: - The mark
+
+    /// Which gauge the capacity state draws. Fleet *capacity*, not the worst
+    /// account: in a rotating pool spent accounts are the mechanism working, so a
+    /// worst-wins glyph pinned itself to the alarm state whenever any one of
+    /// thirteen accounts was spent, which is nearly always. The mapping itself
+    /// lives in `Fleet.capacityGlyphState`; there is no logic here. A failed read
+    /// shows a warning glyph rather than a healthy-looking gauge.
+    static func gaugeSymbol(for state: PollState) -> String {
+        switch state {
+        case .loaded(let fleet):
+            return Tok.glyph(for: fleet.capacityGlyphState)
+        case .pending:
+            return "gauge.with.dots.needle.33percent"
+        case .toolMissing, .commandFailed, .undecodable:
+            return Tok.unreadableGlyph
+        }
+    }
+
+    /// One line for the tooltip. The menu bar has room for a glyph and nothing
+    /// else, so this is where the poll's own summary is reachable by a human who
+    /// has not opened the panel.
+    static func toolTip(state: PollState, awake: Bool) -> String {
+        awake ? "\(state.summary) · \(KeepAwakeGlyph.accessibilityDescription)" : state.summary
+    }
+
+    private func updateMark(state: PollState, awake isOn: Bool) {
+        guard let button = statusItem.button else { return }
+        if let mark = MenuBarMark.image(
+            gaugeSymbol: Self.gaugeSymbol(for: state), awake: isOn,
+            awakeTint: Tok.awakeNSColor)
+        {
+            button.image = mark
+            button.title = ""
+        } else if button.image == nil {
+            // Only reachable if an SF Symbol this build names has gone missing.
+            // A status item with neither image nor title is zero points wide and
+            // invisible, which reads as "the app did not launch" — so say
+            // something rather than disappear.
+            button.title = "tcr"
+        }
+        button.toolTip = Self.toolTip(state: state, awake: isOn)
+    }
+
+    // MARK: - The panel
+
+    @objc private func togglePanel(_ sender: Any?) {
+        if popover.isShown { closePanel() } else { openPanel() }
+    }
+
+    func openPanel() {
+        guard let button = statusItem.button else { return }
+        // macOS owns the login-item bit and the operator can revoke it in System
+        // Settings, so a cached value is a lie (`LoginItem.swift:5-12`). Under
+        // `MenuBarExtra` this rode on `FleetView`'s own `.onAppear`, which fired
+        // on every open because the panel was rebuilt every time. One popover
+        // keeps one hosting controller for the life of the app, so that
+        // `onAppear` now fires once and never again — losing this line is a
+        // silent regression, not a visible one.
+        loginItem.refresh()
+        // Without activation the panel opens without key focus, and
+        // `.textSelection(.enabled)` on the account name (`FleetView.swift:537`)
+        // stops working.
+        if #available(macOS 14.0, *) {
+            NSApp.activate()
+        } else {
+            NSApp.activate(ignoringOtherApps: true)
+        }
+        popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+    }
+
+    func closePanel() {
+        popover.performClose(nil)
+    }
+}
+
+/// Hosts `FleetView` and exists for one reason: to turn ``LaunchPreference`` into
+/// the `Binding<Bool>` that view already takes.
+///
+/// `FleetView` is deliberately untouched by the shell rewrite. Observing the
+/// preference *here* is what makes the checkbox move when it is clicked — a
+/// binding built straight over `UserDefaults` reads and writes correctly and
+/// publishes nothing, so the control would appear stuck.
+struct FleetPanel: View {
+    @ObservedObject var poller: StatusPoller
+    @ObservedObject var server: ServerController
+    @ObservedObject var loginItem: LoginItem
+    @ObservedObject var accounts: AccountController
+    @ObservedObject var awake: AwakeController
+    @ObservedObject var preference: LaunchPreference
+
+    var body: some View {
+        FleetView(
+            poller: poller,
+            server: server,
+            loginItem: loginItem,
+            accounts: accounts,
+            awake: awake,
+            startServerAtLaunch: $preference.startServerAtLaunch
+        )
+    }
+}

--- a/apps/macos/Sources/TcrBar/MenuBarShell.swift
+++ b/apps/macos/Sources/TcrBar/MenuBarShell.swift
@@ -58,6 +58,29 @@ final class MenuBarShell {
         self.preference = preference ?? LaunchPreference()
 
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        // An `NSStatusItem`'s visibility is *persisted*, and the app must never
+        // depend on the persisted value.
+        //
+        // AppKit stores it per status item in this app's defaults domain, under
+        // `"NSStatusItem VisibleCC Item-0"`. A single ⌘-drag of the icon out of
+        // the menu bar writes `0` there, and every status item this app creates
+        // afterwards is born hidden — permanently, silently, and across
+        // reinstalls, because the value outlives the binary. The symptom is not
+        // a crash or a log line: the app launches, polls, holds its assertions
+        // and draws nothing a human can see.
+        //
+        // Both `com.github.dhkts1.tcrbar` and `TcrBar` currently hold `0` in
+        // that key. How it got there is *not* established — it could predate
+        // this work or have been written during it — so nothing here claims a
+        // history. Setting it explicitly at creation is correct under either
+        // one, which is the point: the shipped behaviour must not be a function
+        // of what is in `defaults`.
+        //
+        // No `autosaveName`. It would only move the same persisted flag to a
+        // differently-named key with the identical failure mode; the
+        // unconditional assignment below is what makes the stored value
+        // irrelevant, and `--shell-probe` assertion 1 asserts the result.
+        statusItem.isVisible = true
         popover = NSPopover()
 
         let hosting = NSHostingController(

--- a/apps/macos/Sources/TcrBar/MenuBarShell.swift
+++ b/apps/macos/Sources/TcrBar/MenuBarShell.swift
@@ -69,12 +69,16 @@ final class MenuBarShell {
         // a crash or a log line: the app launches, polls, holds its assertions
         // and draws nothing a human can see.
         //
-        // Both `com.github.dhkts1.tcrbar` and `TcrBar` currently hold `0` in
-        // that key. How it got there is *not* established — it could predate
-        // this work or have been written during it — so nothing here claims a
-        // history. Setting it explicitly at creation is correct under either
-        // one, which is the point: the shipped behaviour must not be a function
-        // of what is in `defaults`.
+        // Both `com.github.dhkts1.tcrbar` (the bundled app) and `TcrBar` (what
+        // an unbundled `swift build` binary uses) were observed holding `0`.
+        // How it got there is *not* established — it could predate this work or
+        // have been written during it — so nothing here claims a history, and
+        // nothing here claims a current value either: AppKit writes the key
+        // back on every run, so it was measured flipping to `1` and back within
+        // minutes. That is the whole argument for this line. Setting it
+        // explicitly at creation is correct under every history and every
+        // stored value, which is the point: the shipped behaviour must not be a
+        // function of what is in `defaults`.
         //
         // No `autosaveName`. It would only move the same persisted flag to a
         // differently-named key with the identical failure mode; the

--- a/apps/macos/Sources/TcrBar/RenderStates.swift
+++ b/apps/macos/Sources/TcrBar/RenderStates.swift
@@ -38,19 +38,26 @@ enum RenderStates {
     }
 
     /// Every state worth looking at, with the name its PNG gets.
-    private static var scenes: [(name: String, state: PollState)] {
+    ///
+    /// `awake` is a per-scene flag rather than a twelfth state because it is
+    /// orthogonal to the poll: the mode can be on under any fleet at all. One
+    /// scene carries it, which is what makes the new control's ON appearance —
+    /// the tinted mark and the caveat line — reviewable, since the real menu bar
+    /// cannot be screenshotted here.
+    private static var scenes: [(name: String, state: PollState, awake: Bool)] {
         [
-            ("01-healthy", .loaded(fleet(healthyJSON))),
-            ("02-mixed-thirteen", .loaded(fleet(mixedJSON))),
-            ("03-zero-capacity", .loaded(fleet(exhaustedJSON))),
-            ("04-unmeasured-row", .loaded(fleet(unmeasuredJSON))),
-            ("05-unreadable-row", .loaded(partiallyUnreadableFleet())),
-            ("06-offline-source", .loaded(fleet(offlineJSON))),
-            ("07-empty-fleet", .loaded(fleet("[]"))),
-            ("08-tool-missing", .toolMissing(searched: ["/usr/local/bin/tcr", "/opt/homebrew/bin/tcr"])),
-            ("09-command-failed", .commandFailed(exitCode: 1, message: "connection refused")),
-            ("10-undecodable", .undecodable(message: "DecodingError.valueNotFound: quota")),
-            ("11-pending", .pending),
+            ("01-healthy", .loaded(fleet(healthyJSON)), false),
+            ("02-mixed-thirteen", .loaded(fleet(mixedJSON)), false),
+            ("03-zero-capacity", .loaded(fleet(exhaustedJSON)), false),
+            ("04-unmeasured-row", .loaded(fleet(unmeasuredJSON)), false),
+            ("05-unreadable-row", .loaded(partiallyUnreadableFleet()), false),
+            ("06-offline-source", .loaded(fleet(offlineJSON)), false),
+            ("07-empty-fleet", .loaded(fleet("[]")), false),
+            ("08-tool-missing", .toolMissing(searched: ["/usr/local/bin/tcr", "/opt/homebrew/bin/tcr"]), false),
+            ("09-command-failed", .commandFailed(exitCode: 1, message: "connection refused"), false),
+            ("10-undecodable", .undecodable(message: "DecodingError.valueNotFound: quota"), false),
+            ("11-pending", .pending, false),
+            ("12-keeping-awake", .loaded(fleet(healthyJSON)), true),
         ]
     }
 
@@ -91,7 +98,7 @@ enum RenderStates {
 
     @MainActor
     private static func render(
-        _ scene: (name: String, state: PollState),
+        _ scene: (name: String, state: PollState, awake: Bool),
         appearance: Appearance,
         into directory: URL
     ) -> Bool {
@@ -102,12 +109,20 @@ enum RenderStates {
         NSAppearance.current = appearance.nsAppearance
         defer { NSAppearance.current = previous }
 
+        // `.inert`, never the real activity: drawing a checkbox in its ON state
+        // must not actually stop this machine sleeping. A harness with a side
+        // effect on the operator's power settings would be a worse bug than
+        // anything it could catch.
+        let awake = AwakeController(activity: .inert)
+        awake.setOn(scene.awake)
+
         let view =
             FleetView(
                 poller: StatusPoller(pinnedState: scene.state, lastPollAt: referenceDate),
                 server: ServerController(),
                 loginItem: LoginItem(),
                 accounts: AccountController(),
+                awake: awake,
                 startServerAtLaunch: .constant(false),
                 snapshotMode: true
             )

--- a/apps/macos/Sources/TcrBar/RenderStates.swift
+++ b/apps/macos/Sources/TcrBar/RenderStates.swift
@@ -41,9 +41,25 @@ enum RenderStates {
     ///
     /// `awake` is a per-scene flag rather than a twelfth state because it is
     /// orthogonal to the poll: the mode can be on under any fleet at all. One
-    /// scene carries it, which is what makes the new control's ON appearance —
-    /// the tinted mark and the caveat line — reviewable, since the real menu bar
-    /// cannot be screenshotted here.
+    /// scene carries it, and what that scene reviews is narrower than "the ON
+    /// appearance" — it is the caveat line under the checkbox, and the footer
+    /// moving down to make room for it. Nothing more:
+    ///
+    ///  - The tinted mark is drawn on the status item (``MenuBarShell``), which
+    ///    is not part of this view, so no scene here renders it.
+    ///  - The tick is not rendered either. `ImageRenderer` draws a `.checkbox`
+    ///    toggle as the same placeholder in both states, which
+    ///    `FleetView.keepAwakeToggle` already says.
+    ///
+    /// Measured rather than assumed: a band diff of `01-healthy-dark` against
+    /// `12-keeping-awake-dark` (max channel delta > 8) differs on 85 of the 897
+    /// rows they share, in ONE contiguous band, `y=812..896` — the caveat line
+    /// and everything the extra line pushes down. Every row above `y=812`,
+    /// checkbox included, is pixel-identical. Scene 12 is also 34px taller,
+    /// which is that same line and nothing else.
+    ///
+    /// Those figures move whenever the footer's wording or spacing does; if they
+    /// look stale, re-measure rather than trusting them.
     private static var scenes: [(name: String, state: PollState, awake: Bool)] {
         [
             ("01-healthy", .loaded(fleet(healthyJSON)), false),

--- a/apps/macos/Sources/TcrBar/ShellProbe.swift
+++ b/apps/macos/Sources/TcrBar/ShellProbe.swift
@@ -1,0 +1,411 @@
+import AppKit
+import Combine
+import TcrBarCore
+
+/// `TcrBar --shell-probe` — build the real menu-bar shell in-process, exercise
+/// it, print one line per assertion, and exit non-zero if any of them failed.
+///
+/// ## Why a flag and not a test
+///
+/// The test target links `TcrBarCore` only, and none of what this checks is a
+/// fact about types. It is what AppKit actually draws once a real
+/// `NSStatusBarButton` has laid itself out and a real `NSPopover` has sized
+/// itself — the same class of thing that `--render-states` exists for, and the
+/// same class of thing that shipped every genuine bug this app has had.
+///
+/// The obvious alternative, looking at the menu bar, is not available:
+/// `screencapture` needs Screen Recording, which is not granted on the machine
+/// this was written on, and a build machine or a headless agent will not have it
+/// either.
+///
+/// ## What it does NOT cover — read this before trusting a green run
+///
+///  - It rasterises **the button**, via `bitmapImageRepForCachingDisplay` +
+///    `cacheDisplay`, not the window server's final composite of the menu bar.
+///    Anything the compositor does afterwards — a vibrancy pass, the highlight
+///    fill under an open panel, the menu bar's own reduced-transparency
+///    treatment — happens past this measurement.
+///  - It clicks nothing with a real mouse. It calls `openPanel()` — the same
+///    method the button's action calls — which is not the same as proving the
+///    target/action wiring survives a real click.
+///  - It says nothing about a *bundled* run: no `LSUIElement`, no code signature,
+///    no login item. `scripts/build-tcrbar.sh` and a human's eyes still own that.
+///
+/// It is not invisible while it runs: a status item appears in the real menu bar
+/// for a couple of seconds, and `openPanel()` activates the app and shows a real
+/// popover. It touches no server and holds no power assertion.
+///
+/// ## Every assertion here can fail, and that was checked
+///
+/// A check that cannot fail is worse than no check, and this project has shipped
+/// that exact class — which is why `KeepAwakeProbe` has a deliberate
+/// post-release linger. Each of the nine below was broken on purpose, watched go
+/// red, and restored. Assertion 4 is the negative control for assertion 3:
+/// without it, "the ON mark has cyan in it" passes just as happily on a mark
+/// that is cyan in both states, which would mean the two states look identical
+/// in the menu bar.
+enum ShellProbe {
+    static let flag = "--shell-probe"
+
+    static func requested(_ arguments: [String] = CommandLine.arguments) -> Bool {
+        arguments.contains(flag)
+    }
+
+    /// Nothing here should take a second. If the run loop wedges — a popover that
+    /// never opens, a status bar that never vends a button — the probe has to
+    /// fail rather than hang a CI step forever.
+    private static let deadline: TimeInterval = 30
+
+    @MainActor
+    static func run() -> Never {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.accessory)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + deadline) {
+            FileHandle.standardError.write(
+                Data("shell-probe: deadline after \(Int(deadline))s — nothing concluded\n".utf8))
+            exit(2)
+        }
+
+        Task { @MainActor in
+            await exercise()  // exits
+        }
+        app.run()
+        exit(2)
+    }
+
+    // MARK: - The run
+
+    @MainActor
+    private static func exercise() async -> Never {
+        // A pinned poller: no timer, no `tcr` subprocess, and a fleet big enough
+        // that a collapsed scroll view is numerically obvious. An inert
+        // keep-awake: rasterising a cup must not stop this machine sleeping.
+        let shell = MenuBarShell(
+            poller: StatusPoller(pinnedState: .loaded(probeFleet())),
+            awake: AwakeController(activity: .inert))
+
+        var checks: [Check] = []
+        await settle()
+
+        // 1 — the status item exists and its button does something when clicked.
+        //
+        //     Two obvious clauses are deliberately reported and NOT asserted,
+        //     because both were tried and neither can fail:
+        //
+        //      - **bounds.** `NSStatusBar.system.statusItem(...)` vends a
+        //        non-nil `NSStatusBarButton` with a live frame even at
+        //        `withLength: 0`, with `isVisible` false, and with no image or
+        //        title ever set — measured 32x29, 32x29 and 16x22 respectively.
+        //      - **`isVisible`.** It reads `false` for this probe in a normal,
+        //        working run, while the button rasterises 754 opaque pixels one
+        //        line later. Asserting on it fails a correct shell, which is
+        //        worse than not checking: the first version of this check did
+        //        exactly that.
+        //
+        //     What is left is what the shell genuinely owns: a status bar button
+        //     of the right class whose target/action pair points back here. An
+        //     unwired button is an item that ignores every click, which is the
+        //     one failure at this layer that a later assertion would not catch.
+        let button = shell.statusItem.button
+        let buttonClass = button.map { String(describing: type(of: $0)) } ?? "nil"
+        let bounds = button?.bounds ?? .zero
+        let wired = button.map { $0.target as AnyObject? === shell && $0.action != nil } ?? false
+        checks.append(
+            Check(
+                1, "status item vends an NSStatusBarButton wired to the shell",
+                passed: button != nil && buttonClass.contains("StatusBarButton") && wired,
+                detail: "class=\(buttonClass) wired=\(wired) "
+                    + "bounds=\(Int(bounds.width))x\(Int(bounds.height)) "
+                    + "(reported, not asserted: isVisible=\(shell.statusItem.isVisible))"))
+
+        guard let button else {
+            report(checks)
+            exit(1)
+        }
+
+        // 2 — OFF is a template image, so the menu bar keeps tinting it.
+        let offImage = button.image
+        checks.append(
+            Check(
+                2, "OFF: button.image is set and isTemplate == true",
+                passed: offImage != nil && offImage?.isTemplate == true,
+                detail: "image=\(offImage == nil ? "nil" : "set") isTemplate="
+                    + "\(offImage.map { String($0.isTemplate) } ?? "n/a")"))
+
+        // 4 — the negative control, run before its positive so a leftover ON
+        //     state cannot be what makes it pass.
+        let offScan = scan(button)
+        checks.append(
+            Check(
+                4, "OFF: rasterised button has 0 cyan pixels (negative control)",
+                passed: offScan != nil && offScan?.cyan == 0,
+                detail: offScan.map { "opaque=\($0.opaque) cyan=\($0.cyan)" } ?? "no bitmap"))
+
+        // 3 and 8 — the whole point of owning the button.
+        shell.awake.setOn(true)
+        await settle()
+        let onScan = scan(button)
+        checks.append(
+            Check(
+                3, "ON: rasterised button has > 0 cyan pixels",
+                passed: (onScan?.cyan ?? 0) > 0,
+                detail: onScan.map { "opaque=\($0.opaque) cyan=\($0.cyan)" } ?? "no bitmap"))
+        checks.append(
+            Check(
+                8, "ON: the gauge survived — > 0 opaque non-cyan pixels",
+                passed: (onScan.map { $0.opaque - $0.cyan } ?? 0) > 0,
+                detail: onScan.map { "nonCyan=\($0.opaque - $0.cyan)" } ?? "no bitmap"))
+        shell.awake.setOn(false)
+        await settle()
+
+        // 5 — go through the real `openPanel()` rather than `popover.show`, so
+        //     the things that used to ride on the panel being rebuilt per open
+        //     are exercised rather than assumed.
+        shell.openPanel()
+        _ = await waitUntil { shell.popover.isShown && shell.popover.contentSize.height > 300 }
+        let size = shell.popover.contentSize
+        checks.append(
+            Check(
+                5, "open: isShown, contentSize is \(Int(Tok.panelWidth))pt wide and > 300pt tall",
+                passed: shell.popover.isShown && abs(size.width - Tok.panelWidth) < 1
+                    && size.height > 300,
+                detail: "isShown=\(shell.popover.isShown) "
+                    + "contentSize=\(Int(size.width))x\(Int(size.height))"))
+
+        // 6 — and it closes again.
+        shell.closePanel()
+        _ = await waitUntil { !shell.popover.isShown }
+        checks.append(
+            Check(
+                6, "close: isShown == false",
+                passed: !shell.popover.isShown,
+                detail: "isShown=\(shell.popover.isShown)"))
+
+        // 9 — the login-item re-read, measured on the SECOND open, which is the
+        //     only place it means anything.
+        //
+        //     `@Published` fires on every assignment, equal or not, so emissions
+        //     of `loginItem.$status` are a faithful count of `refresh()` calls.
+        //     Counting them on the FIRST open proves nothing, and that was
+        //     measured rather than reasoned about: `FleetView` carries its own
+        //     `.onAppear { loginItem.refresh() }` (`FleetView.swift:388`), which
+        //     fires during the first show and kept this assertion green with the
+        //     shell's refresh deleted. It fires once, because one popover keeps
+        //     one hosting controller — which is precisely the regression this
+        //     assertion exists for, so the second open is where to look.
+        let loginReads = Counter()
+        let watch = shell.loginItem.$status.dropFirst().sink { _ in loginReads.value += 1 }
+        shell.openPanel()
+        _ = await waitUntil { shell.popover.isShown }
+        await settle(0.5)
+        let reopenReads = loginReads.value
+        watch.cancel()
+        checks.append(
+            Check(
+                9, "re-open: the login-item bit is read again (macOS owns it; a cache is a lie)",
+                passed: reopenReads > 0,
+                detail: "LoginItem.status emissions on the second open=\(reopenReads)"))
+        shell.closePanel()
+        _ = await waitUntil { !shell.popover.isShown }
+
+        // 7 — the claim the ON image rests on: `NSColor.labelColor` inside the
+        //     drawing handler resolves in the appearance current at DRAW time,
+        //     so the gauge is right in both while the cup stays cyan in both.
+        checks.append(appearanceCheck())
+
+        report(checks)
+        exit(checks.allSatisfy(\.passed) ? 0 : 1)
+    }
+
+    /// Let the run loop lay out what was just changed. A status item is
+    /// `.variableLength`, so its button resizes only after a layout pass, and the
+    /// popover's preferred content size arrives from SwiftUI a pass after the
+    /// view first appears.
+    private static func settle(_ seconds: Double = 0.4) async {
+        try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+    }
+
+    /// Poll a condition, returning as soon as it holds or when `timeout` passes.
+    ///
+    /// Not a "sleep until it goes green": a condition that is genuinely false
+    /// stays false and the assertion built on it still fails. It exists because
+    /// `NSPopover` animates, and the two waits it guards were measured to be
+    /// borderline against a fixed sleep — `performClose` left `isShown` true for
+    /// somewhere between 0.5s and 0.75s on this machine, so a 0.4s settle failed
+    /// assertion 6 on a popover that had in fact closed.
+    private static func waitUntil(
+        _ timeout: Double = 5, _ condition: () -> Bool
+    ) async -> Bool {
+        let step = 0.1
+        var waited = 0.0
+        while waited < timeout {
+            if condition() { return true }
+            await settle(step)
+            waited += step
+        }
+        return condition()
+    }
+
+    // MARK: - Assertion 7
+
+    @MainActor
+    private static func appearanceCheck() -> Check {
+        guard
+            let mark = MenuBarMark.image(
+                gaugeSymbol: "gauge.with.dots.needle.33percent", awake: true,
+                awakeTint: Tok.awakeNSColor),
+            let aqua = NSAppearance(named: .aqua),
+            let dark = NSAppearance(named: .darkAqua),
+            let light = rasterise(mark, in: aqua),
+            let night = rasterise(mark, in: dark)
+        else {
+            return Check(
+                7, "ON image re-resolves labelColor per appearance", passed: false,
+                detail: "could not compose or rasterise the mark")
+        }
+        // The gauge is whatever is NOT cyan; the cup is whatever is. Splitting
+        // by colour rather than by pixel column keeps this from silently
+        // measuring the wrong half if the composition ever changes its layout.
+        let gaugeMoved = abs(light.nonCyanLuma - night.nonCyanLuma) > 0.2
+        let cupHeld = light.cyan > 0 && night.cyan > 0
+        return Check(
+            7, "ON image: gauge differs between .aqua and .darkAqua, cup cyan in both",
+            passed: gaugeMoved && cupHeld,
+            detail: String(
+                format: "aqua gaugeLuma=%.3f cyan=%d · dark gaugeLuma=%.3f cyan=%d",
+                light.nonCyanLuma, light.cyan, night.nonCyanLuma, night.cyan))
+    }
+
+    // MARK: - Pixels
+
+    private struct PixelScan {
+        var opaque = 0
+        var cyan = 0
+        /// Mean relative luminance of the opaque pixels that are not cyan — i.e.
+        /// of the gauge.
+        var nonCyanLuma = 0.0
+    }
+
+    /// The technique that produced the 533/533 measurement in ``MenuBarMark``'s
+    /// table: ask the button for a bitmap rep of itself and have it draw into it.
+    @MainActor
+    private static func scan(_ button: NSStatusBarButton) -> PixelScan? {
+        let bounds = button.bounds
+        guard bounds.width > 0, bounds.height > 0,
+            let rep = button.bitmapImageRepForCachingDisplay(in: bounds)
+        else { return nil }
+        button.cacheDisplay(in: bounds, to: rep)
+        return count(rep)
+    }
+
+    @MainActor
+    private static func rasterise(_ image: NSImage, in appearance: NSAppearance) -> PixelScan? {
+        let scale = 2
+        let width = Int(image.size.width.rounded()) * scale
+        let height = Int(image.size.height.rounded()) * scale
+        guard width > 0, height > 0,
+            let rep = NSBitmapImageRep(
+                bitmapDataPlanes: nil, pixelsWide: width, pixelsHigh: height,
+                bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+                colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0)
+        else { return nil }
+        appearance.performAsCurrentDrawingAppearance {
+            NSGraphicsContext.saveGraphicsState()
+            let context = NSGraphicsContext(bitmapImageRep: rep)
+            NSGraphicsContext.current = context
+            context?.cgContext.scaleBy(x: CGFloat(scale), y: CGFloat(scale))
+            image.draw(
+                in: NSRect(origin: .zero, size: image.size), from: .zero,
+                operation: .sourceOver, fraction: 1)
+            NSGraphicsContext.restoreGraphicsState()
+        }
+        return count(rep)
+    }
+
+    /// `g - r > 0.15 && b - r > 0.15` is the same cyan predicate the six-variant
+    /// `MenuBarExtra` sweep used, kept verbatim so the numbers this prints are
+    /// comparable with the ones in ``MenuBarMark``'s table.
+    private static func count(_ rep: NSBitmapImageRep) -> PixelScan {
+        var out = PixelScan()
+        var lumaSum = 0.0
+        var lumaCount = 0
+        for x in 0..<rep.pixelsWide {
+            for y in 0..<rep.pixelsHigh {
+                guard let colour = rep.colorAt(x: x, y: y)?.usingColorSpace(.sRGB),
+                    colour.alphaComponent > 0.35
+                else { continue }
+                out.opaque += 1
+                let r = colour.redComponent, g = colour.greenComponent, b = colour.blueComponent
+                if g - r > 0.15 && b - r > 0.15 {
+                    out.cyan += 1
+                } else {
+                    lumaSum += 0.2126 * r + 0.7152 * g + 0.0722 * b
+                    lumaCount += 1
+                }
+            }
+        }
+        out.nonCyanLuma = lumaCount == 0 ? 0 : lumaSum / Double(lumaCount)
+        return out
+    }
+
+    // MARK: - Reporting
+
+    /// A box, so a Combine sink can add to something the enclosing scope can
+    /// still read afterwards.
+    @MainActor
+    private final class Counter {
+        var value = 0
+    }
+
+    private struct Check {
+        let number: Int
+        let name: String
+        let passed: Bool
+        let detail: String
+
+        init(_ number: Int, _ name: String, passed: Bool, detail: String) {
+            self.number = number
+            self.name = name
+            self.passed = passed
+            self.detail = detail
+        }
+    }
+
+    /// One line per assertion, and the verdict grep-able on its own line.
+    private static func report(_ checks: [Check]) {
+        for check in checks.sorted(by: { $0.number < $1.number }) {
+            print("shell-probe: \(check.passed ? "PASS" : "FAIL") \(check.number). "
+                + "\(check.name) — \(check.detail)")
+        }
+        let failed = checks.filter { !$0.passed }
+        print(
+            "shell-probe: \(checks.count - failed.count)/\(checks.count) passed"
+                + (failed.isEmpty ? "" : " — failed \(failed.map(\.number).sorted())"))
+        fflush(stdout)
+    }
+
+    // MARK: - Fixture
+    //
+    // Fake accounts only. This repository is public and real account addresses
+    // never enter it.
+
+    /// Thirteen rows, which is the shape that made the scroll view collapse. A
+    /// two-account fleet would let assertion 5 pass on a panel that is short for
+    /// an honest reason.
+    private static func probeFleet() -> Fleet {
+        let rows = (1...13).map { index in
+            """
+            {"name":"probe-\(index)@example.com","priority":0,"status":"active",
+             "disabled":false,"quota":0.\(index % 9 + 1),"quotaState":"ok",
+             "fiveHour":0.1,"sevenDay":0.1,"sevenDayOi":0.0,"held":[],
+             "requests":1,"inputTokens":1,"outputTokens":1,"cacheReadTokens":1,
+             "cacheHitRatio":0.5,"probeStatus":"ok","probeError":null,
+             "lastStreamError":null,"streamErrorCount":0,"source":"live",
+             "serverSha":"abc1234","serverDirty":false}
+            """
+        }
+        let json = "[\(rows.joined(separator: ","))]"
+        return (try? Fleet.decode(Data(json.utf8))) ?? Fleet(accounts: [])
+    }
+}

--- a/apps/macos/Sources/TcrBar/ShellProbe.swift
+++ b/apps/macos/Sources/TcrBar/ShellProbe.swift
@@ -30,6 +30,15 @@ import TcrBarCore
 ///    target/action wiring survives a real click.
 ///  - It says nothing about a *bundled* run: no `LSUIElement`, no code signature,
 ///    no login item. `scripts/build-tcrbar.sh` and a human's eyes still own that.
+///  - It does not exercise the **animated** dismissal. The probe sets
+///    `popover.animates = false` before it closes anything, for the reason given
+///    at that line, so the code path a human sees — the panel fading out — is
+///    reported and not asserted here.
+///
+/// What still needs human eyes, in the menu bar of a machine that is awake and
+/// unlocked: the icon is actually there and is the right colour in both states,
+/// a real click opens the panel, and **open the panel and watch it animate
+/// away** — that last one is the part this file deliberately stops measuring.
 ///
 /// It is not invisible while it runs: a status item appears in the real menu bar
 /// for a couple of seconds, and `openPanel()` activates the app and shows a real
@@ -54,7 +63,13 @@ enum ShellProbe {
     /// Nothing here should take a second. If the run loop wedges — a popover that
     /// never opens, a status bar that never vends a button — the probe has to
     /// fail rather than hang a CI step forever.
-    private static let deadline: TimeInterval = 30
+    ///
+    /// It has to clear the sum of everything below it, or a single failing
+    /// assertion is replaced by "nothing concluded", which is a strictly worse
+    /// diagnostic. Four `waitUntil` calls at 5s each is 20s of worst case, plus
+    /// about 2.5s of `settle`, so 30s left barely 7s of headroom and one more
+    /// waiting assertion would have eaten it.
+    private static let deadline: TimeInterval = 60
 
     @MainActor
     static func run() -> Never {
@@ -86,41 +101,56 @@ enum ShellProbe {
             awake: AwakeController(activity: .inert))
 
         var checks: [Check] = []
+        var notes: [String] = []
+        var occlusionAtOpen = "not reached"
         await settle()
 
-        // 1 — the status item exists and its button does something when clicked.
+        // 1 — the status item exists, is visible, and its button does something
+        //     when clicked.
         //
-        //     Two obvious clauses are deliberately reported and NOT asserted,
-        //     because both were tried and neither can fail:
+        //     **`isVisible` is asserted, and an earlier version of this comment
+        //     was wrong to excuse it.** It claimed the flag "reads false for this
+        //     probe in a normal, working run" and that asserting it "fails a
+        //     correct shell". It does not. `isVisible` is persisted per status
+        //     item in the app's defaults domain, and it read false here because
+        //     the domain held a stale `"NSStatusItem VisibleCC Item-0" = 0` —
+        //     which is the shipped bug, not probe noise. Control: five status
+        //     items created in the same locked session (bare, title-only,
+        //     template-image, image-set-after-a-run-loop-turn, and one built
+        //     exactly as `MenuBarShell` builds its own at 32x29) all read
+        //     `isVisible=true`, because they were in a domain without the key.
+        //     The de-assertion papered over a true positive, and a status item
+        //     that draws 754 opaque pixels into a bitmap while being hidden from
+        //     the menu bar is precisely the failure a human reports as "the app
+        //     did not launch". `MenuBarShell` now sets it at creation.
         //
-        //      - **bounds.** `NSStatusBar.system.statusItem(...)` vends a
-        //        non-nil `NSStatusBarButton` with a live frame even at
-        //        `withLength: 0`, with `isVisible` false, and with no image or
-        //        title ever set — measured 32x29, 32x29 and 16x22 respectively.
-        //      - **`isVisible`.** It reads `false` for this probe in a normal,
-        //        working run, while the button rasterises 754 opaque pixels one
-        //        line later. Asserting on it fails a correct shell, which is
-        //        worse than not checking: the first version of this check did
-        //        exactly that.
+        //     **bounds** stays reported and not asserted, because it genuinely
+        //     cannot fail: `NSStatusBar.system.statusItem(...)` vends a non-nil
+        //     `NSStatusBarButton` with a live frame even at `withLength: 0`,
+        //     with `isVisible` false, and with no image or title ever set —
+        //     measured 32x29, 32x29 and 16x22 respectively.
         //
-        //     What is left is what the shell genuinely owns: a status bar button
-        //     of the right class whose target/action pair points back here. An
+        //     The rest is what the shell genuinely owns: a status bar button of
+        //     the right class whose target/action pair points back here. An
         //     unwired button is an item that ignores every click, which is the
         //     one failure at this layer that a later assertion would not catch.
         let button = shell.statusItem.button
         let buttonClass = button.map { String(describing: type(of: $0)) } ?? "nil"
         let bounds = button?.bounds ?? .zero
         let wired = button.map { $0.target as AnyObject? === shell && $0.action != nil } ?? false
+        let visible = shell.statusItem.isVisible
         checks.append(
             Check(
-                1, "status item vends an NSStatusBarButton wired to the shell",
-                passed: button != nil && buttonClass.contains("StatusBarButton") && wired,
-                detail: "class=\(buttonClass) wired=\(wired) "
-                    + "bounds=\(Int(bounds.width))x\(Int(bounds.height)) "
-                    + "(reported, not asserted: isVisible=\(shell.statusItem.isVisible))"))
+                1, "status item is visible and vends an NSStatusBarButton wired to the shell",
+                passed: button != nil && buttonClass.contains("StatusBarButton") && wired
+                    && visible,
+                detail: "class=\(buttonClass) wired=\(wired) isVisible=\(visible) "
+                    + "(reported, not asserted: "
+                    + "bounds=\(Int(bounds.width))x\(Int(bounds.height)))"))
 
         guard let button else {
-            report(checks)
+            report(checks, environment: environment(shell, occlusionAtOpen: occlusionAtOpen),
+                notes: notes)
             exit(1)
         }
 
@@ -163,24 +193,59 @@ enum ShellProbe {
         //     the things that used to ride on the panel being rebuilt per open
         //     are exercised rather than assumed.
         shell.openPanel()
-        _ = await waitUntil { shell.popover.isShown && shell.popover.contentSize.height > 300 }
+        let opened = await waitUntil {
+            shell.popover.isShown && shell.popover.contentSize.height > 300
+        }
+        occlusionAtOpen = occlusion(of: shell)
         let size = shell.popover.contentSize
         checks.append(
             Check(
                 5, "open: isShown, contentSize is \(Int(Tok.panelWidth))pt wide and > 300pt tall",
                 passed: shell.popover.isShown && abs(size.width - Tok.panelWidth) < 1
                     && size.height > 300,
-                detail: "isShown=\(shell.popover.isShown) "
+                detail: "isShown=\(shell.popover.isShown) timedOut=\(!opened) "
                     + "contentSize=\(Int(size.width))x\(Int(size.height))"))
 
         // 6 — and it closes again.
+        //
+        //     `animates = false` first, and this is a substitution in the probe
+        //     rather than a change to the app, the same way the pinned poller
+        //     and the inert `AwakeController` above are. `popover` is a `let`,
+        //     so nothing in `MenuBarShell` moves. **Do not "fix" this assertion
+        //     by changing `closePanel()`** — `performClose(nil)` is correct.
+        //
+        //     Measured, 8 variants under a real `NSApplication.run()`: the sole
+        //     discriminator is `animates`. Every `animates = true` variant was
+        //     still `isShown == true` six seconds later — `performClose` *and*
+        //     `close()`, across `.transient`, `.semitransient` and
+        //     `.applicationDefined`, with and without `NSApp.activate()`. Both
+        //     `animates = false` variants closed in under 0.1s. A mechanism
+        //     probe in the same process narrowed it: an empty
+        //     `NSAnimationContext` group completes in 0.1s and a raw
+        //     `CATransaction` on the popover's layer in 0.3s, but an alpha
+        //     animation on the popover's `_NSPopoverWindow` — and on an ordinary
+        //     `NSWindow` — never completes in 3s. `NSPopover` flips `isShown`
+        //     inside that window-animation completion, so with nothing being
+        //     composited (screen locked, display asleep, `occlusionState`
+        //     without `.visible`) it never flips.
+        //
+        //     So the animated variant of this assertion is not a check that
+        //     cannot fail; it is the more dangerous inverse — one that goes red
+        //     on a correct app whenever the machine is not drawing, and whose
+        //     obvious fix is a regression. The environment line at the bottom of
+        //     the report is what makes that adjudicable next time.
+        shell.popover.animates = false
         shell.closePanel()
-        _ = await waitUntil { !shell.popover.isShown }
+        let closed = await waitUntil { !shell.popover.isShown }
         checks.append(
             Check(
                 6, "close: isShown == false",
                 passed: !shell.popover.isShown,
-                detail: "isShown=\(shell.popover.isShown)"))
+                detail: "isShown=\(shell.popover.isShown) timedOut=\(!closed)"))
+        notes.append(
+            "the animated dismissal was NOT exercised — `popover.animates` was set false before "
+                + "assertion 6, because the window animation it waits on does not complete when "
+                + "nothing is being composited. Open the panel and watch it animate away.")
 
         // 9 — the login-item re-read, measured on the SECOND open, which is the
         //     only place it means anything.
@@ -194,27 +259,40 @@ enum ShellProbe {
         //     shell's refresh deleted. It fires once, because one popover keeps
         //     one hosting controller — which is precisely the regression this
         //     assertion exists for, so the second open is where to look.
+        //
+        //     It is gated on assertion 6's close having actually happened, and
+        //     that gate is not decoration. `show(relativeTo:)` on a popover that
+        //     is already shown re-anchors it; it does not open it. So whenever
+        //     the close silently failed, the "SECOND open" this assertion is
+        //     named for never occurred — and it passed anyway, because
+        //     `openPanel()` calls `loginItem.refresh()` unconditionally and
+        //     `@Published` fires on every assignment. A green line that is green
+        //     for a different reason than its own comment gives is worse than a
+        //     red one, because the next reader believes the comment.
         let loginReads = Counter()
         let watch = shell.loginItem.$status.dropFirst().sink { _ in loginReads.value += 1 }
         shell.openPanel()
-        _ = await waitUntil { shell.popover.isShown }
+        let reopened = await waitUntil { shell.popover.isShown }
         await settle(0.5)
         let reopenReads = loginReads.value
         watch.cancel()
         checks.append(
             Check(
                 9, "re-open: the login-item bit is read again (macOS owns it; a cache is a lie)",
-                passed: reopenReads > 0,
-                detail: "LoginItem.status emissions on the second open=\(reopenReads)"))
+                passed: closed && reopenReads > 0,
+                detail: "LoginItem.status emissions on the second open=\(reopenReads) "
+                    + "precedingCloseSucceeded=\(closed) timedOut=\(!reopened)"))
         shell.closePanel()
-        _ = await waitUntil { !shell.popover.isShown }
+        let closedAgain = await waitUntil { !shell.popover.isShown }
+        notes.append("teardown close: isShown=\(shell.popover.isShown) timedOut=\(!closedAgain)")
 
         // 7 — the claim the ON image rests on: `NSColor.labelColor` inside the
         //     drawing handler resolves in the appearance current at DRAW time,
         //     so the gauge is right in both while the cup stays cyan in both.
         checks.append(appearanceCheck())
 
-        report(checks)
+        report(checks, environment: environment(shell, occlusionAtOpen: occlusionAtOpen),
+            notes: notes)
         exit(checks.allSatisfy(\.passed) ? 0 : 1)
     }
 
@@ -372,12 +450,49 @@ enum ShellProbe {
         }
     }
 
+    /// The state of the machine the run happened on, printed every run whether
+    /// or not anything failed.
+    ///
+    /// This file is otherwise scrupulous about what it measures, and the
+    /// environment was the one input it took on faith. That cost most of a day:
+    /// two runs of the same binary disagreed about assertion 6 and there was
+    /// nothing in either output to adjudicate between them. The three values
+    /// here are the ones that actually decide whether AppKit will run a window
+    /// animation to completion.
+    @MainActor
+    private static func environment(_ shell: MenuBarShell, occlusionAtOpen: String) -> String {
+        let session = CGSessionCopyCurrentDictionary() as? [String: Any]
+        let locked: String
+        switch session?["CGSSessionScreenIsLocked"] {
+        case let flag as Bool: locked = String(flag)
+        case let flag as Int: locked = String(flag != 0)
+        default: locked = "absent"
+        }
+        return "screenLocked=\(locked) appActive=\(NSApp.isActive) "
+            + "popoverWindowOcclusion(atOpen)=\(occlusionAtOpen) "
+            + "popoverWindowOcclusion(now)=\(occlusion(of: shell))"
+    }
+
+    /// `.visible` on the popover's own window. Sampled while the panel is open,
+    /// because the window goes away with it.
+    @MainActor
+    private static func occlusion(of shell: MenuBarShell) -> String {
+        guard let window = shell.popover.contentViewController?.view.window else {
+            return "no-window"
+        }
+        return window.occlusionState.contains(.visible) ? "visible" : "not-visible"
+    }
+
     /// One line per assertion, and the verdict grep-able on its own line.
-    private static func report(_ checks: [Check]) {
+    private static func report(_ checks: [Check], environment: String, notes: [String]) {
         for check in checks.sorted(by: { $0.number < $1.number }) {
             print("shell-probe: \(check.passed ? "PASS" : "FAIL") \(check.number). "
                 + "\(check.name) — \(check.detail)")
         }
+        for note in notes {
+            print("shell-probe: NOTE \(note)")
+        }
+        print("shell-probe: env \(environment)")
         let failed = checks.filter { !$0.passed }
         print(
             "shell-probe: \(checks.count - failed.count)/\(checks.count) passed"

--- a/apps/macos/Sources/TcrBar/TcrBarApp.swift
+++ b/apps/macos/Sources/TcrBar/TcrBarApp.swift
@@ -12,6 +12,11 @@ import TcrBarCore
 enum TcrBarEntry {
     @MainActor
     static func main() {
+        // First, and the only one of the three that needs no AppKit at all: it
+        // draws nothing, it holds a power assertion and prints.
+        if let probe = KeepAwakeProbe.request() {
+            KeepAwakeProbe.run(probe)  // exits
+        }
         if let directory = RenderStates.requestedDirectory() {
             // AppKit needs to exist before anything can be rasterised, but the
             // app is never activated and no window or status item is created.
@@ -36,6 +41,10 @@ struct TcrBarApp: App {
     @StateObject private var server = ServerController()
     @StateObject private var loginItem = LoginItem()
     @StateObject private var accounts = AccountController()
+    /// Owned here, not by the panel: the panel is destroyed and rebuilt every
+    /// time the menu closes, and an assertion that ended when the menu closed
+    /// would be a keep-awake control that keeps nothing awake.
+    @StateObject private var awake = AwakeController()
 
     /// Bring the proxy up when the app starts.
     ///
@@ -61,11 +70,13 @@ struct TcrBarApp: App {
                 server: server,
                 loginItem: loginItem,
                 accounts: accounts,
+                awake: awake,
                 startServerAtLaunch: $startServerAtLaunch
             )
             .onAppear {
                 poller.start()
                 delegate.server = server
+                delegate.awake = awake
                 // macOS owns the login-item bit; re-read it every time the
                 // panel opens so a revocation in System Settings shows up.
                 loginItem.refresh()
@@ -75,22 +86,36 @@ struct TcrBarApp: App {
                 }
             }
         } label: {
-            MenuBarLabel(state: poller.state)
+            MenuBarLabel(state: poller.state, awake: awake)
         }
         .menuBarExtraStyle(.window)
     }
 }
 
-/// Exists for one reason: a child process TcrBar spawned must not outlive it.
+/// Exists so that nothing TcrBar started outlives it — a child process, and a
+/// power assertion.
 ///
 /// `terminateSupervisedChildOnQuit()` is a no-op unless *this app* spawned the
 /// server — an incumbent proxy is never signalled.
+///
+/// Both references are handed over from `FleetView.onAppear`, which first runs
+/// when the panel is opened. Late, but never too late for either: a server can
+/// only be started from that panel or from `startServerAtLaunch` (whose spawn
+/// happens in the same `onAppear`), and the keep-awake activity can only be
+/// started from that panel too. A `nil` here therefore means there is nothing
+/// to release.
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     var server: ServerController?
+    var awake: AwakeController?
 
     func applicationWillTerminate(_ notification: Notification) {
         server?.terminateSupervisedChildOnQuit()
+        // The kernel drops every power assertion a process holds when it dies,
+        // so this line is not what lets the Mac sleep again. It is here so that
+        // "quitting TcrBar releases it" is something this app does rather than
+        // something it gets away with.
+        awake?.releaseOnQuit()
     }
 }
 
@@ -102,10 +127,36 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 /// one of thirteen accounts was spent, which is nearly always. The mapping lives
 /// in `Fleet.capacityGlyphState`; this view does no logic. A failed read shows a
 /// warning glyph rather than a healthy-looking gauge.
+///
+/// Keep-awake is a SECOND, independent mark beside it, and the two never merge.
+/// The gauge answers "can I work right now"; keep-awake answers "will this Mac
+/// stay up while I do", and recolouring the gauge to say the second thing would
+/// destroy the first.
+///
+/// The mode is signalled on two channels at once, deliberately:
+///
+///  - **Shape** — an extra glyph that is either there or not. This is the
+///    primary channel, because it is the only one that cannot be taken away: it
+///    survives greyscale, a red-green colour vision deficiency, and a status
+///    item that decides to template the image after all. `Tokens.swift` records
+///    this project already rejecting a palette where two states differed in hue
+///    alone.
+///  - **Colour** — what was actually asked for, and a genuine improvement when
+///    it works. It needs a non-template `NSImage`; see `KeepAwakeGlyph` for
+///    what was measured about that and what was not.
 struct MenuBarLabel: View {
     let state: PollState
+    @ObservedObject var awake: AwakeController
 
     var body: some View {
+        HStack(spacing: Tok.space1) {
+            capacityGauge
+            if awake.isOn { keepAwakeMark }
+        }
+    }
+
+    @ViewBuilder
+    private var capacityGauge: some View {
         switch state {
         case .loaded(let fleet):
             Image(systemName: Tok.glyph(for: fleet.capacityGlyphState))
@@ -113,6 +164,20 @@ struct MenuBarLabel: View {
             Image(systemName: "gauge.with.dots.needle.33percent")
         case .toolMissing, .commandFailed, .undecodable:
             Image(systemName: Tok.unreadableGlyph)
+        }
+    }
+
+    /// Falls back to the plain template symbol if the tinted image cannot be
+    /// built. Losing the tint costs one channel; drawing nothing would cost the
+    /// signal, and the shape is the channel that matters.
+    @ViewBuilder
+    private var keepAwakeMark: some View {
+        if let tinted = KeepAwakeGlyph.image(tint: Tok.awakeNSColor) {
+            Image(nsImage: tinted)
+                .accessibilityLabel(KeepAwakeGlyph.accessibilityDescription)
+        } else {
+            Image(systemName: KeepAwakeGlyph.symbolName)
+                .accessibilityLabel(KeepAwakeGlyph.accessibilityDescription)
         }
     }
 }

--- a/apps/macos/Sources/TcrBar/TcrBarApp.swift
+++ b/apps/macos/Sources/TcrBar/TcrBarApp.swift
@@ -1,18 +1,24 @@
 import AppKit
-import SwiftUI
 import TcrBarCore
 
 /// The real entry point.
 ///
-/// `TcrBarApp` cannot carry `@main` itself, because the render harness has to run
-/// and exit BEFORE SwiftUI installs a menu-bar item or the poller starts. Doing it
-/// from `applicationDidFinishLaunching` would flash an icon in the menu bar and
-/// fire a `tcr` subprocess on a machine that only asked for PNGs.
+/// Every harness flag runs and exits BEFORE any UI exists. Doing it from
+/// `applicationDidFinishLaunching` would flash an icon in the menu bar and fire a
+/// `tcr` subprocess on a machine that only asked for PNGs. That ordering is
+/// load-bearing: none of these four paths may create a status item, poll `tcr`,
+/// or spawn a server.
 @main
 enum TcrBarEntry {
+
+    /// `NSApplication.delegate` is a **weak** reference, so a delegate that only
+    /// exists as a local in ``main()`` is deallocated before the first callback
+    /// and the app comes up with no menu-bar item at all.
+    @MainActor private static var delegate: AppDelegate?
+
     @MainActor
     static func main() {
-        // First, and the only one of the three that needs no AppKit at all: it
+        // First, and the only one of the four that needs no AppKit at all: it
         // draws nothing, it holds a power assertion and prints.
         if let probe = KeepAwakeProbe.request() {
             KeepAwakeProbe.run(probe)  // exits
@@ -27,157 +33,67 @@ enum TcrBarEntry {
             _ = NSApplication.shared
             AppIcon.writeIconSet(to: directory)  // exits
         }
-        TcrBarApp.main()
-    }
-}
-
-/// TcrBar — a menu-bar accessory for the `tcr` rotating proxy.
-///
-/// `LSUIElement` is set in the bundle's Info.plist, so there is no Dock icon and
-/// no main window: the whole app is the `MenuBarExtra`.
-struct TcrBarApp: App {
-    @NSApplicationDelegateAdaptor(AppDelegate.self) private var delegate
-    @StateObject private var poller = StatusPoller()
-    @StateObject private var server = ServerController()
-    @StateObject private var loginItem = LoginItem()
-    @StateObject private var accounts = AccountController()
-    /// Owned here, not by the panel: the panel is destroyed and rebuilt every
-    /// time the menu closes, and an assertion that ended when the menu closed
-    /// would be a keep-awake control that keeps nothing awake.
-    @StateObject private var awake = AwakeController()
-
-    /// Bring the proxy up when the app starts.
-    ///
-    /// Opt-in, and deliberately not default-on. Paired with "Launch at login" it
-    /// means the proxy is simply always up — but it also makes Quit expensive,
-    /// because once TcrBar supervises the server, quitting stops it. Turning that
-    /// on should be a decision the operator made, not a surprise on first launch.
-    ///
-    /// Safe by construction: this is `start()`, which passes `--no-replace`, so a
-    /// proxy that is already serving is never disturbed. If one is, the spawn
-    /// reports "already running" and nothing happens.
-    @AppStorage("startServerAtLaunch") private var startServerAtLaunch = false
-
-    /// Fires once per process, not once per panel open. `onAppear` on the
-    /// `MenuBarExtra` content runs every time the menu is opened, so without this
-    /// the app would attempt a spawn on every click.
-    @State private var didAttemptLaunchStart = false
-
-    var body: some Scene {
-        MenuBarExtra {
-            FleetView(
-                poller: poller,
-                server: server,
-                loginItem: loginItem,
-                accounts: accounts,
-                awake: awake,
-                startServerAtLaunch: $startServerAtLaunch
-            )
-            .onAppear {
-                poller.start()
-                delegate.server = server
-                delegate.awake = awake
-                // macOS owns the login-item bit; re-read it every time the
-                // panel opens so a revocation in System Settings shows up.
-                loginItem.refresh()
-                if startServerAtLaunch, !didAttemptLaunchStart {
-                    didAttemptLaunchStart = true
-                    server.start()
-                }
-            }
-        } label: {
-            MenuBarLabel(state: poller.state, awake: awake)
+        // The one flag that does build a status item — it has to, it is the gate
+        // on the shell. It builds its own, from a pinned poller and an inert
+        // keep-awake, and never reaches the delegate below.
+        if ShellProbe.requested() {
+            ShellProbe.run()  // exits
         }
-        .menuBarExtraStyle(.window)
+
+        let app = NSApplication.shared
+        // The bundle already sets `LSUIElement`, so this matches what the app
+        // already is: no Dock icon, no main window, no menu bar of its own.
+        // Setting it here as well is what makes an unbundled `swift build`
+        // binary behave the same way.
+        app.setActivationPolicy(.accessory)
+        let delegate = AppDelegate()
+        Self.delegate = delegate
+        app.delegate = delegate
+        app.run()
+        exit(0)
     }
 }
 
-/// Exists so that nothing TcrBar started outlives it — a child process, and a
-/// power assertion.
+/// Owns the shell, and makes sure nothing TcrBar started outlives it — a child
+/// process, and a power assertion.
 ///
 /// `terminateSupervisedChildOnQuit()` is a no-op unless *this app* spawned the
-/// server — an incumbent proxy is never signalled.
-///
-/// Both references are handed over from `FleetView.onAppear`, which first runs
-/// when the panel is opened. Late, but never too late for either: a server can
-/// only be started from that panel or from `startServerAtLaunch` (whose spawn
-/// happens in the same `onAppear`), and the keep-awake activity can only be
-/// started from that panel too. A `nil` here therefore means there is nothing
-/// to release.
+/// server; an incumbent proxy is never signalled. Both controllers are owned
+/// outright now rather than handed over from the panel's `onAppear`, so there is
+/// no window in which a quit could find them nil.
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
-    var server: ServerController?
-    var awake: AwakeController?
+    private var shell: MenuBarShell?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        let shell = MenuBarShell()
+        self.shell = shell
+        // Was `FleetView.onAppear`, which under `MenuBarExtra` meant the fleet
+        // was not polled until the panel had been opened once — the menu-bar
+        // glyph sat at its `.pending` gauge until then.
+        shell.poller.start()
+        // One attempt, once per process.
+        //
+        // This used to need a `didAttemptLaunchStart` flag because `onAppear`
+        // fires on every panel open, so without it the app attempted a spawn on
+        // every click. `applicationDidFinishLaunching` fires exactly once, so
+        // the guard is now structural rather than a variable — the reasoning is
+        // kept here because deleting the flag would otherwise delete the reason
+        // it existed with it.
+        //
+        // Safe by construction either way: this is `start()`, which passes
+        // `--no-replace`, so a proxy that is already serving is never disturbed.
+        if shell.preference.startServerAtLaunch {
+            shell.server.start()
+        }
+    }
 
     func applicationWillTerminate(_ notification: Notification) {
-        server?.terminateSupervisedChildOnQuit()
+        shell?.server.terminateSupervisedChildOnQuit()
         // The kernel drops every power assertion a process holds when it dies,
         // so this line is not what lets the Mac sleep again. It is here so that
         // "quitting TcrBar releases it" is something this app does rather than
         // something it gets away with.
-        awake?.releaseOnQuit()
-    }
-}
-
-/// The glyph in the menu bar: fleet *capacity*, not the worst account.
-///
-/// It answers one question — can I work right now — and it is deliberately not
-/// worst-account-wins. In a rotating pool spent accounts are the mechanism
-/// working, so a worst-wins glyph pinned itself to the alarm state whenever any
-/// one of thirteen accounts was spent, which is nearly always. The mapping lives
-/// in `Fleet.capacityGlyphState`; this view does no logic. A failed read shows a
-/// warning glyph rather than a healthy-looking gauge.
-///
-/// Keep-awake is a SECOND, independent mark beside it, and the two never merge.
-/// The gauge answers "can I work right now"; keep-awake answers "will this Mac
-/// stay up while I do", and recolouring the gauge to say the second thing would
-/// destroy the first.
-///
-/// The mode is signalled on two channels at once, deliberately:
-///
-///  - **Shape** — an extra glyph that is either there or not. This is the
-///    primary channel, because it is the only one that cannot be taken away: it
-///    survives greyscale, a red-green colour vision deficiency, and a status
-///    item that decides to template the image after all. `Tokens.swift` records
-///    this project already rejecting a palette where two states differed in hue
-///    alone.
-///  - **Colour** — what was actually asked for, and a genuine improvement when
-///    it works. It needs a non-template `NSImage`; see `KeepAwakeGlyph` for
-///    what was measured about that and what was not.
-struct MenuBarLabel: View {
-    let state: PollState
-    @ObservedObject var awake: AwakeController
-
-    var body: some View {
-        HStack(spacing: Tok.space1) {
-            capacityGauge
-            if awake.isOn { keepAwakeMark }
-        }
-    }
-
-    @ViewBuilder
-    private var capacityGauge: some View {
-        switch state {
-        case .loaded(let fleet):
-            Image(systemName: Tok.glyph(for: fleet.capacityGlyphState))
-        case .pending:
-            Image(systemName: "gauge.with.dots.needle.33percent")
-        case .toolMissing, .commandFailed, .undecodable:
-            Image(systemName: Tok.unreadableGlyph)
-        }
-    }
-
-    /// Falls back to the plain template symbol if the tinted image cannot be
-    /// built. Losing the tint costs one channel; drawing nothing would cost the
-    /// signal, and the shape is the channel that matters.
-    @ViewBuilder
-    private var keepAwakeMark: some View {
-        if let tinted = KeepAwakeGlyph.image(tint: Tok.awakeNSColor) {
-            Image(nsImage: tinted)
-                .accessibilityLabel(KeepAwakeGlyph.accessibilityDescription)
-        } else {
-            Image(systemName: KeepAwakeGlyph.symbolName)
-                .accessibilityLabel(KeepAwakeGlyph.accessibilityDescription)
-        }
+        shell?.awake.releaseOnQuit()
     }
 }

--- a/apps/macos/Sources/TcrBar/Tokens.swift
+++ b/apps/macos/Sources/TcrBar/Tokens.swift
@@ -39,31 +39,44 @@ public enum Tok {
 
     /// A colour that answers to the current appearance *and* the Increased
     /// Contrast setting, the way a system semantic colour does.
+    ///
+    /// Split from ``dyn`` because one token is needed as an `NSColor` as well:
+    /// the menu-bar mark is built as an `NSImage` so it can opt out of template
+    /// rendering, and a symbol configuration takes `NSColor`. Deriving the
+    /// `Color` from the `NSColor` rather than writing the hexes twice is what
+    /// stops the panel and the menu bar drifting apart.
+    private static func dynNS(
+        dark: String,
+        light: String,
+        darkHC: String? = nil,
+        lightHC: String? = nil
+    ) -> NSColor {
+        NSColor(name: nil) { appearance in
+            let matched = appearance.bestMatch(from: [
+                .aqua, .darkAqua,
+                .accessibilityHighContrastAqua,
+                .accessibilityHighContrastDarkAqua,
+            ])
+            switch matched {
+            case .accessibilityHighContrastDarkAqua:
+                return NSColor(tokenHex: darkHC ?? dark)
+            case .accessibilityHighContrastAqua:
+                return NSColor(tokenHex: lightHC ?? light)
+            case .darkAqua:
+                return NSColor(tokenHex: dark)
+            default:
+                return NSColor(tokenHex: light)
+            }
+        }
+    }
+
     private static func dyn(
         dark: String,
         light: String,
         darkHC: String? = nil,
         lightHC: String? = nil
     ) -> Color {
-        Color(
-            nsColor: NSColor(name: nil) { appearance in
-                let matched = appearance.bestMatch(from: [
-                    .aqua, .darkAqua,
-                    .accessibilityHighContrastAqua,
-                    .accessibilityHighContrastDarkAqua,
-                ])
-                switch matched {
-                case .accessibilityHighContrastDarkAqua:
-                    return NSColor(tokenHex: darkHC ?? dark)
-                case .accessibilityHighContrastAqua:
-                    return NSColor(tokenHex: lightHC ?? light)
-                case .darkAqua:
-                    return NSColor(tokenHex: dark)
-                default:
-                    return NSColor(tokenHex: light)
-                }
-            }
-        )
+        Color(nsColor: dynNS(dark: dark, light: light, darkHC: darkHC, lightHC: lightHC))
     }
 
     // MARK: - Surfaces
@@ -131,6 +144,31 @@ public enum Tok {
     public static let unknown = dyn(dark: "#c69bdd", light: "#7d4d96")
     /// Numbers that are structurally zero rather than measured.
     public static let offline = inkFaint
+
+    /// Keep-awake mode is held.
+    ///
+    /// Its own hue, and specifically NOT `ok` / `near` / `spent`: those three
+    /// are quota semantics, so an amber menu-bar mark would read as "the fleet
+    /// is nearly exhausted" while actually meaning "this Mac will not idle
+    /// sleep". Cyan is the open slot — hue 195, between `ok` at 150 and
+    /// `unmeasured` at 230.
+    ///
+    /// Generated and gated like the rest of the palette
+    /// (`scripts/tcrbar-palette.py`): dark `oklch(0.830 0.120 195)` measures
+    /// **11.22:1** on the panel and **10.06:1** on a raised row; light
+    /// `oklch(0.500 0.085 195)` measures **5.20:1** and **4.75:1**. Both clear
+    /// their floor (4.5:1 dark, 3:1 light for a non-text element) and neither
+    /// clips the sRGB gamut. It is held **1.31:1** dark / **1.37:1** light apart
+    /// in luminance from `unmeasured`, the only other cool token, so the two do
+    /// not collapse in greyscale.
+    ///
+    /// Every one of those figures is measured **against the panel**. The
+    /// menu-bar mark is drawn on the wallpaper, where no contrast ratio can be
+    /// guaranteed against anything — which is exactly why the menu bar carries
+    /// this state as a glyph that is *present or absent* and uses colour only as
+    /// a second channel. See `KeepAwakeGlyph`.
+    public static let awakeNSColor = dynNS(dark: "#51dfdf", light: "#017272")
+    public static let awake = Color(nsColor: awakeNSColor)
 
     /// The tint behind a status pill, and the hairline around it.
     public static func wash(_ tint: Color) -> Color { tint.opacity(0.14) }

--- a/apps/macos/Sources/TcrBarCore/AwakeController.swift
+++ b/apps/macos/Sources/TcrBarCore/AwakeController.swift
@@ -14,10 +14,6 @@ import Foundation
 /// line from a shell, and it is the gate: this claim is checkable in about
 /// fifteen seconds and should be re-checked rather than believed.
 ///
-/// `caffeinate` with no flags actually holds *three* assertions
-/// (`PreventUserIdleSystemSleep`, `PreventSystemSleep`, `PreventDiskIdle`).
-/// This holds one, deliberately — the `-i` one.
-///
 /// ## Deliberate scope
 ///
 /// **Idle *system* sleep only, never display sleep.** The job is "a long run

--- a/apps/macos/Sources/TcrBarCore/AwakeController.swift
+++ b/apps/macos/Sources/TcrBarCore/AwakeController.swift
@@ -1,0 +1,152 @@
+import Combine
+import Foundation
+
+/// "Keep this Mac awake" — what `caffeinate -i` does, held for exactly as long
+/// as the control is on.
+///
+/// ## Mechanism, measured rather than assumed
+///
+/// `ProcessInfo.beginActivity(options:reason:)` with `.idleSystemSleepDisabled`
+/// (`NSActivityIdleSystemSleepDisabled`, "the computer must not idle sleep").
+/// With the activity held, `pmset -g assertions` lists the process by pid under
+/// `PreventUserIdleSystemSleep`, named with ``reason`` — the same assertion type
+/// `caffeinate` registers. ``KeepAwakeProbe`` is the flag that produces that
+/// line from a shell, and it is the gate: this claim is checkable in about
+/// fifteen seconds and should be re-checked rather than believed.
+///
+/// `caffeinate` with no flags actually holds *three* assertions
+/// (`PreventUserIdleSystemSleep`, `PreventSystemSleep`, `PreventDiskIdle`).
+/// This holds one, deliberately — the `-i` one.
+///
+/// ## Deliberate scope
+///
+/// **Idle *system* sleep only, never display sleep.** The job is "a long run
+/// keeps running", and the screen going dark does not stop a run. Holding the
+/// display awake all night is a real cost — backlight, burn-in, a bright room —
+/// that nobody asked for. `.idleDisplaySleepDisabled` exists and is not used.
+///
+/// **This does not survive closing the lid.** No assertion of this class does;
+/// a clamshell sleep still sleeps. The panel says so, because an operator who
+/// believes otherwise comes back to a dead run and blames the proxy.
+///
+/// **Not persisted across launches.** There is deliberately no `@AppStorage`
+/// here. A Mac that silently never sleeps because of a box ticked a week ago is
+/// a worse bug than having to tick it again — the symptom (a laptop that runs
+/// hot in a bag) is nowhere near the cause. Contrast `startServerAtLaunch`,
+/// which *is* persisted: being wrong about that one costs a spawn that stands
+/// down harmlessly.
+@MainActor
+public final class AwakeController: ObservableObject {
+
+    /// The begin/end pair, injected.
+    ///
+    /// Nothing in-process can observe another process's power assertions, so a
+    /// test against the real `ProcessInfo` could only prove that the calls did
+    /// not throw — while leaving the machine awake for as long as the suite ran.
+    /// Taking the pair as a dependency is what makes the property that actually
+    /// matters testable: that begin and end are called exactly once each, on the
+    /// same token. `LoginItem.classify` is the precedent — keep the part with a
+    /// decision in it separable from the part that talks to the system.
+    public struct Activity {
+        public let begin: (String) -> NSObjectProtocol
+        public let end: (NSObjectProtocol) -> Void
+
+        public init(
+            begin: @escaping (String) -> NSObjectProtocol,
+            end: @escaping (NSObjectProtocol) -> Void
+        ) {
+            self.begin = begin
+            self.end = end
+        }
+
+        /// The real one.
+        public static let processInfo = Activity(
+            begin: { reason in
+                ProcessInfo.processInfo.beginActivity(
+                    options: .idleSystemSleepDisabled, reason: reason)
+            },
+            end: { ProcessInfo.processInfo.endActivity($0) }
+        )
+
+        /// A pair that holds nothing.
+        ///
+        /// For the PNG harness, which has to draw the panel in its ON state and
+        /// must not stop the machine sleeping in order to do it. Rendering a
+        /// checkbox is not a reason to hold a power assertion.
+        public static let inert = Activity(begin: { _ in NSObject() }, end: { _ in })
+    }
+
+    /// The assertion's name in `pmset -g assertions`, and therefore the string a
+    /// human greps for when their Mac will not sleep and they want to know who
+    /// is holding it open.
+    ///
+    /// Stable and greppable on purpose: it contains "TcrBar", the gate in
+    /// `apps/macos/README.md` matches on that, and rewording it silently breaks
+    /// both the gate and the human's search.
+    public static let reason = "TcrBar is keeping this Mac awake"
+
+    /// Whether the activity is held. Read by the panel and the menu bar.
+    @Published public private(set) var isOn = false
+
+    /// The live token — the single source of truth, and the only thing that can
+    /// move ``isOn``.
+    ///
+    /// A separate `Bool` is the defect this shape exists to prevent: any path
+    /// that set the flag without moving the token (or the reverse) would leave
+    /// the panel reporting a state of the *machine* that is not true. Because
+    /// the mirror is maintained here and nowhere else, "the checkbox is ticked"
+    /// and "a token is held" cannot disagree.
+    private var token: NSObjectProtocol? {
+        didSet { isOn = token != nil }
+    }
+
+    private let activity: Activity
+
+    public init(activity: Activity = .processInfo) {
+        self.activity = activity
+    }
+
+    public func setOn(_ on: Bool) {
+        if on { begin() } else { end() }
+    }
+
+    public func toggle() {
+        setOn(!isOn)
+    }
+
+    /// Idempotent, and that is the whole point.
+    ///
+    /// A second `beginActivity` would return a second token, and this class can
+    /// only store one — so the first would leak, unreleasable for the lifetime
+    /// of the process. The panel would then show OFF while the Mac still refused
+    /// to sleep: a control that lies about the state of the machine, with no way
+    /// back short of quitting the app.
+    private func begin() {
+        guard token == nil else { return }
+        token = activity.begin(Self.reason)
+    }
+
+    /// Ends only a token this class began, and clears it as part of ending it.
+    ///
+    /// The clear happens *first* so there is no instant in which `token` names
+    /// an activity that has already been ended — which is the state from which
+    /// a double `endActivity` on the same token becomes possible.
+    private func end() {
+        guard let held = token else { return }
+        token = nil
+        activity.end(held)
+    }
+
+    /// Called from `applicationWillTerminate`.
+    ///
+    /// The kernel releases every power assertion a process holds when it dies,
+    /// so this is not what lets the Mac sleep again — that would happen anyway.
+    /// It is here because "quitting TcrBar releases the assertion" should be
+    /// something this app *does*, not something it gets away with. Foundation
+    /// makes the same promise from the other side: per `NSProcessInfo.h`, an
+    /// activity token deallocated before `endActivity:` ends its activity
+    /// automatically.
+    public func releaseOnQuit() {
+        end()
+    }
+}

--- a/apps/macos/Sources/TcrBarCore/FleetStatus.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetStatus.swift
@@ -205,8 +205,9 @@ public enum QuotaFormat {
     /// itself, so the rule that matters — a nil fraction is *never* the same
     /// drawing as `0.0` — is a property of the model and can be tested. A
     /// zero-width fill and an unmeasured account look identical on screen, and
-    /// they mean opposite things: one account is exhausted, the other has
-    /// simply never been asked.
+    /// they mean opposite things. The fraction is *utilization*, so a zero-width
+    /// fill is the most headroom there is — nothing spent — while the other
+    /// account has simply never been asked.
     public enum BarFill: Equatable, Sendable {
         /// A real reading, clamped to `0...1` for drawing. The numeric label
         /// beside the bar still shows the unclamped figure.

--- a/apps/macos/Sources/TcrBarCore/KeepAwakeGlyph.swift
+++ b/apps/macos/Sources/TcrBarCore/KeepAwakeGlyph.swift
@@ -1,0 +1,65 @@
+import AppKit
+
+/// The tinted mark that sits beside the capacity gauge while keep-awake is on.
+///
+/// ## Why an `NSImage` and not `Image(systemName:).foregroundStyle(…)`
+///
+/// A status item draws its image as a **template**: macOS re-renders it in the
+/// menu bar's own colour so that it reads on any wallpaper and in either
+/// appearance, which strips whatever tint the view asked for. `isTemplate =
+/// false` is the documented opt-out, and it is a property of `NSImage` — there
+/// is nowhere to set it on a SwiftUI `Image(systemName:)`. So the mark is built
+/// here and handed over as `Image(nsImage:)`.
+///
+/// ## What is measured, and what is not
+///
+/// `AwakeControllerTests` rasterises the returned image and asserts two facts
+/// about it: `isTemplate == false`, and that a pixel inside the glyph actually
+/// carries the tint that was asked for. That proves the image **this app hands
+/// to the status item** carries colour, which is the half that is checkable
+/// without a screen.
+///
+/// It does not prove the status item honours it, and nothing available here
+/// can: reading back the real menu bar needs `screencapture`, which needs
+/// Screen Recording, which is not granted on the machine this was written on.
+/// That last step is a human looking at their own menu bar.
+///
+/// Which is the reason colour is the *second* channel and not the only one —
+/// see `MenuBarLabel`. If the tint is lost, a glyph that is present or absent
+/// still says whether the mode is on.
+///
+/// ## Why it lives in `TcrBarCore`
+///
+/// The test target links `TcrBarCore` only (`Package.swift`), so an image
+/// builder sitting in `TcrBar` next to the tokens could not be tested at all.
+/// The tint is a parameter for the matching reason: `Tok` stays the one place a
+/// colour is written down, and this file stays out of the view layer.
+public enum KeepAwakeGlyph {
+    /// A cup. The one mark for "caffeinated" that needs no legend, and it is
+    /// nothing like a gauge — the two are told apart by silhouette before
+    /// colour is involved at all.
+    public static let symbolName = "cup.and.saucer.fill"
+
+    /// What VoiceOver says. The menu bar is the one surface with no room for a
+    /// label, so this is the only place the state is spoken.
+    public static let accessibilityDescription = "Keeping this Mac awake"
+
+    /// `nil` when the symbol cannot be created. Callers fall back to the plain
+    /// template glyph rather than drawing nothing: losing the tint costs one of
+    /// two channels, losing the glyph costs the signal.
+    public static func image(tint: NSColor) -> NSImage? {
+        guard
+            let symbol = NSImage(
+                systemSymbolName: symbolName,
+                accessibilityDescription: accessibilityDescription)
+        else { return nil }
+
+        let tinted = symbol.withSymbolConfiguration(
+            NSImage.SymbolConfiguration(paletteColors: [tint])) ?? symbol
+        tinted.isTemplate = false
+        // `withSymbolConfiguration` returns a new image; carry the description
+        // across rather than assuming it was copied.
+        tinted.accessibilityDescription = accessibilityDescription
+        return tinted
+    }
+}

--- a/apps/macos/Sources/TcrBarCore/KeepAwakeGlyph.swift
+++ b/apps/macos/Sources/TcrBarCore/KeepAwakeGlyph.swift
@@ -9,23 +9,31 @@ import AppKit
 /// appearance, which strips whatever tint the view asked for. `isTemplate =
 /// false` is the documented opt-out, and it is a property of `NSImage` — there
 /// is nowhere to set it on a SwiftUI `Image(systemName:)`. So the mark is built
-/// here and handed over as `Image(nsImage:)`.
+/// here.
+///
+/// Handing the result to SwiftUI was not enough, and that is measured: a
+/// `MenuBarExtra` flattens its label to monochrome whatever the image says, for
+/// every construction that was tried. ``MenuBarMark`` carries the table and is
+/// what composes this cup into the image the app now sets on the status button
+/// itself. It calls this function from inside its drawing handler, so a dynamic
+/// `tint` resolves against the appearance current at draw time.
 ///
 /// ## What is measured, and what is not
 ///
-/// `AwakeControllerTests` rasterises the returned image and asserts two facts
-/// about it: `isTemplate == false`, and that a pixel inside the glyph actually
-/// carries the tint that was asked for. That proves the image **this app hands
-/// to the status item** carries colour, which is the half that is checkable
-/// without a screen.
+/// `KeepAwakeGlyphTests` rasterises what this function returns and asserts that
+/// `isTemplate == false` and that a pixel inside the glyph really carries the
+/// tint. `MenuBarMarkTests` asserts the same of the composed image, with the OFF
+/// mark as its negative control. `TcrBar --shell-probe` goes one step further: it
+/// rasterises the real `NSStatusBarButton` and counts cyan pixels there, with
+/// the OFF state as a negative control.
 ///
-/// It does not prove the status item honours it, and nothing available here
-/// can: reading back the real menu bar needs `screencapture`, which needs
-/// Screen Recording, which is not granted on the machine this was written on.
-/// That last step is a human looking at their own menu bar.
+/// Neither reaches the window server's final composite of the menu bar —
+/// reading that back needs `screencapture`, which needs Screen Recording, which
+/// is not granted on the machine this was written on. That last step is a human
+/// looking at their own menu bar.
 ///
 /// Which is the reason colour is the *second* channel and not the only one —
-/// see `MenuBarLabel`. If the tint is lost, a glyph that is present or absent
+/// see ``MenuBarMark``. If the tint is lost, a glyph that is present or absent
 /// still says whether the mode is on.
 ///
 /// ## Why it lives in `TcrBarCore`

--- a/apps/macos/Sources/TcrBarCore/KeepAwakeProbe.swift
+++ b/apps/macos/Sources/TcrBarCore/KeepAwakeProbe.swift
@@ -19,7 +19,7 @@ import Foundation
 ///     pmset -g assertions | grep TcrBar     # PreventUserIdleSystemSleep
 ///
 /// Like `--render-states` and `--render-icon` it is handled in
-/// `TcrBarEntry.main()` and exits before `TcrBarApp.main()`, so no menu-bar item
+/// `TcrBarEntry.main()` and exits before the shell is built, so no menu-bar item
 /// appears and no `tcr` subprocess is spawned. Unlike those two it draws
 /// nothing, so it does not even need an `NSApplication`.
 public enum KeepAwakeProbe {

--- a/apps/macos/Sources/TcrBarCore/KeepAwakeProbe.swift
+++ b/apps/macos/Sources/TcrBarCore/KeepAwakeProbe.swift
@@ -91,14 +91,18 @@ public enum KeepAwakeProbe {
             let controller = AwakeController()
             controller.setOn(true)
 
-            // A probe that reports success without holding anything would be
-            // worse than no probe: every later `pmset` reading would be read as
-            // evidence about the mechanism when it was evidence about this bug.
-            guard controller.isOn else {
-                write(to: FileHandle.standardError, "TcrBar: the activity did not start\n")
-                exit(1)
-            }
-
+            // There is deliberately no `guard controller.isOn` here, and its
+            // absence is the honest shape.
+            //
+            // `beginActivity` returns a non-optional, so `begin()` always
+            // stores a token and `isOn` is always true on the next line. A
+            // guard there cannot fail: it would read as a check on whether the
+            // assertion was really taken while checking nothing at all, which
+            // is worse than no check, because the next reader trusts it. What
+            // it purported to catch — a probe reporting success while holding
+            // nothing — is not observable in this process at all; only `pmset`
+            // can see a power assertion, and that reading is the gate in
+            // `apps/macos/README.md`.
             let pid = ProcessInfo.processInfo.processIdentifier
             write(
                 to: FileHandle.standardOutput,

--- a/apps/macos/Sources/TcrBarCore/KeepAwakeProbe.swift
+++ b/apps/macos/Sources/TcrBarCore/KeepAwakeProbe.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+/// `TcrBar --keep-awake-probe <seconds>` — hold the keep-awake assertion for a
+/// fixed interval, from a shell, with no GUI.
+///
+/// ## Why this exists
+///
+/// The keep-awake control is a checkbox, and proving it does what `caffeinate`
+/// does means reading `pmset -g assertions` while it is on. Nothing on this
+/// machine can tick a checkbox for you, and "look at the menu bar" is not
+/// available as a gate either: `screencapture` needs Screen Recording, which a
+/// headless agent or a build machine may not have been granted.
+///
+/// So this flag is the oracle. It drives the same ``AwakeController`` the panel
+/// drives, prints its own pid, and holds for a stated number of seconds:
+///
+///     TcrBar --keep-awake-probe 10 &
+///     sleep 3
+///     pmset -g assertions | grep TcrBar     # PreventUserIdleSystemSleep
+///
+/// Like `--render-states` and `--render-icon` it is handled in
+/// `TcrBarEntry.main()` and exits before `TcrBarApp.main()`, so no menu-bar item
+/// appears and no `tcr` subprocess is spawned. Unlike those two it draws
+/// nothing, so it does not even need an `NSApplication`.
+public enum KeepAwakeProbe {
+    public static let flag = "--keep-awake-probe"
+
+    /// How long the process stays alive *after* releasing the activity.
+    ///
+    /// Without this window the gate cannot attribute the release. A power
+    /// assertion also disappears when its process dies, so a `pmset` reading
+    /// taken after the probe exits is equally consistent with "`endActivity`
+    /// released it" and with "it was never released and the kernel cleaned up" —
+    /// the check would pass either way, which makes it not a check.
+    ///
+    /// Sampling inside this window separates them, and that separation was
+    /// measured with a scratch build of exactly this shape: at t=3 one `pmset`
+    /// line named the pid; at t=10, with the release done and `ps` confirming
+    /// the process still running, zero.
+    public static let lingerAfterRelease: TimeInterval = 3
+
+    /// What the command line asked for. `nil` from ``request(_:)`` means the
+    /// flag is absent and the app should start normally.
+    public enum Request: Equatable {
+        case hold(seconds: Double)
+        /// The flag was given but its argument was not usable. Kept as a case
+        /// rather than folded into `nil` because those are opposite outcomes: a
+        /// missing flag means "start the app", a broken one means "the operator
+        /// meant to probe and got it wrong", and starting a menu-bar app in
+        /// answer to a typo hides the mistake behind an icon.
+        case usage(problem: String)
+    }
+
+    public static func request(_ arguments: [String] = CommandLine.arguments) -> Request? {
+        guard let i = arguments.firstIndex(of: flag) else { return nil }
+        guard i + 1 < arguments.count else {
+            return .usage(problem: "\(flag) needs a duration in seconds")
+        }
+        let raw = arguments[i + 1]
+        // `isFinite` is load-bearing, not defensive noise: `Double("inf")` and
+        // `Double("1e400")` both parse, and either would ask `Thread.sleep` to
+        // wait forever while holding the assertion — a probe that never releases
+        // is the exact failure this whole file exists to detect in the app.
+        guard let seconds = Double(raw), seconds.isFinite, seconds > 0 else {
+            return .usage(problem: "not a positive number of seconds: '\(raw)'")
+        }
+        return .hold(seconds: seconds)
+    }
+
+    @MainActor
+    public static func run(_ request: Request) -> Never {
+        switch request {
+        case .usage(let problem):
+            write(
+                to: FileHandle.standardError,
+                """
+                TcrBar: \(problem)
+
+                usage: TcrBar \(flag) <seconds>
+
+                Holds an idle-system-sleep assertion for <seconds>, releases it,
+                then lingers \(Int(lingerAfterRelease))s so the release is observable while this
+                process is still alive. Prove it with:
+
+                    pmset -g assertions | grep TcrBar
+
+                """)
+            exit(2)
+
+        case .hold(let seconds):
+            let controller = AwakeController()
+            controller.setOn(true)
+
+            // A probe that reports success without holding anything would be
+            // worse than no probe: every later `pmset` reading would be read as
+            // evidence about the mechanism when it was evidence about this bug.
+            guard controller.isOn else {
+                write(to: FileHandle.standardError, "TcrBar: the activity did not start\n")
+                exit(1)
+            }
+
+            let pid = ProcessInfo.processInfo.processIdentifier
+            write(
+                to: FileHandle.standardOutput,
+                """
+                holding  pid \(pid)  for \(seconds)s
+                assertion name: \(AwakeController.reason)
+                check it:  pmset -g assertions | grep 'pid \(pid)'
+
+                """)
+            Thread.sleep(forTimeInterval: seconds)
+
+            controller.setOn(false)
+            write(
+                to: FileHandle.standardOutput,
+                """
+                released pid \(pid)  (staying alive \(Int(lingerAfterRelease))s so the release is \
+                attributable to endActivity, not to this process exiting)
+
+                """)
+            Thread.sleep(forTimeInterval: lingerAfterRelease)
+            exit(0)
+        }
+    }
+
+    /// Writes and flushes.
+    ///
+    /// `print` to a pipe is block-buffered, and this probe is meant to be run
+    /// with `&` and its output captured — so the "holding" line would not appear
+    /// until the process exited, by which point it says nothing useful.
+    private static func write(to handle: FileHandle, _ text: String) {
+        handle.write(Data(text.utf8))
+    }
+}

--- a/apps/macos/Sources/TcrBarCore/LaunchPreference.swift
+++ b/apps/macos/Sources/TcrBarCore/LaunchPreference.swift
@@ -1,0 +1,49 @@
+import Combine
+import Foundation
+
+/// "Start server at launch", persisted in `UserDefaults`.
+///
+/// ## Why this type exists at all
+///
+/// It was `@AppStorage("startServerAtLaunch")` on a SwiftUI `App` struct. There
+/// is no `App` struct any more — the shell is a hand-managed `NSStatusItem` — and
+/// `@AppStorage` is a property wrapper for a `View` or an `App`, so the
+/// preference needs somewhere else to live. A plain `UserDefaults` read would not
+/// do: nothing would publish the change, so the checkbox in the panel would
+/// appear not to move when it was clicked.
+///
+/// ## The key string is load-bearing
+///
+/// ``startServerAtLaunchKey`` is exactly the string `@AppStorage` used, and
+/// renaming it does not fail anything — it silently resets a preference the
+/// operator chose, and does it quietly enough that the first symptom is a proxy
+/// that stopped coming up at login. `LaunchPreferenceTests` pins the literal.
+///
+/// The stored value is deliberately *not* validated or defaulted to anything but
+/// `false`: `UserDefaults.bool(forKey:)` returns `false` for an absent key, which
+/// is the same default the `@AppStorage` declaration carried, and this option is
+/// opt-in on purpose (see `FleetView.startServerToggle` — once TcrBar supervises
+/// the server, quitting TcrBar stops it).
+@MainActor
+public final class LaunchPreference: ObservableObject {
+
+    /// The `UserDefaults` key. Do not change it. See the type's doc-comment.
+    public static let startServerAtLaunchKey = "startServerAtLaunch"
+
+    private let defaults: UserDefaults
+
+    /// Written through to `UserDefaults` on every change, so the value the panel
+    /// shows and the value the next launch reads cannot disagree.
+    @Published public var startServerAtLaunch: Bool {
+        didSet { defaults.set(startServerAtLaunch, forKey: Self.startServerAtLaunchKey) }
+    }
+
+    /// - Parameter defaults: injected so a test can use a scratch suite rather
+    ///   than writing to the operator's real preferences.
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        // Property initialisation in `init` does not fire `didSet`, so reading
+        // the stored value here cannot write it straight back.
+        self.startServerAtLaunch = defaults.bool(forKey: Self.startServerAtLaunchKey)
+    }
+}

--- a/apps/macos/Sources/TcrBarCore/MenuBarMark.swift
+++ b/apps/macos/Sources/TcrBarCore/MenuBarMark.swift
@@ -1,0 +1,146 @@
+import AppKit
+
+/// The whole menu-bar image: the capacity gauge, and — while keep-awake is on —
+/// a tinted cup beside it, composed into ONE `NSImage` that this app draws
+/// itself.
+///
+/// ## Why the app composes this instead of handing SwiftUI two views
+///
+/// It was a `MenuBarExtra` label, and a `MenuBarExtra` renders its label
+/// **monochrome no matter what the image says**. Six label constructions were
+/// each hosted in a real `MenuBarExtra` and rasterised off the real
+/// `NSStatusBarButton` with `cacheDisplay(in:to:)`:
+///
+/// | label | opaque px | coloured px |
+/// |---|---|---|
+/// | `Image(nsImage:)`, `isTemplate = false` | 68 | 0 |
+/// | `Image(nsImage:).renderingMode(.original)` | 68 | 0 |
+/// | `Text("●").foregroundStyle(cyan)` | 158 | 0 |
+/// | symbol pre-rasterised to a plain bitmap, `isTemplate = false` | 68 | 0 |
+/// | `Text("☕")` (an emoji, i.e. a colour font) | 198 | 14 |
+/// | `button.image = <tinted NSImage>` set on the button | 533 | 533 |
+///
+/// Only the last one carries an arbitrary colour, and it is not reachable from a
+/// SwiftUI scene. So the app owns the `NSStatusItem`, and this type is what it
+/// puts in `button.image`.
+///
+/// ## Two channels, deliberately, and the shape one comes first
+///
+/// Keep-awake is a SECOND mark beside the gauge, and the two never merge. The
+/// gauge answers "can I work right now"; keep-awake answers "will this Mac stay
+/// up while I do", and recolouring the gauge to say the second thing would
+/// destroy the first.
+///
+///  - **Shape** — a glyph that is either there or not. The primary channel,
+///    because it is the only one that cannot be taken away: it survives
+///    greyscale, a red-green colour vision deficiency, and any future rendering
+///    decision that templates the image after all. `Tokens.swift` records this
+///    project already rejecting a palette where two states differed in hue alone.
+///  - **Colour** — a genuine improvement when it works, which is the point of
+///    owning the button.
+///
+/// ## The catch, and how the ON image dodges it
+///
+/// A non-template image is drawn exactly as authored, so the *gauge* half stops
+/// getting the system's automatic menu-bar tinting and would freeze at whatever
+/// colour was baked in — right in one appearance and wrong in the other. The
+/// gauge is therefore drawn with `NSColor.labelColor` **inside**
+/// `NSImage(size:flipped:drawingHandler:)`, whose handler runs at draw time, so
+/// the dynamic colour resolves in the appearance that is actually current.
+///
+/// Measured rather than assumed, on this machine, with one `NSImage` drawn twice
+/// under `performAsCurrentDrawingAppearance`: the handler ran both times (no
+/// cached raster), the gauge's mean luma came out **0.000 under `.aqua` and
+/// 0.847 under `.darkAqua`**, and the cup stayed **516/516 cyan** in both.
+/// `--shell-probe` assertion 7 is that measurement, kept as a gate.
+///
+/// What this still does not buy: a non-template image does not invert while the
+/// status button is highlighted (the popover open) the way a template one does,
+/// so the ON mark keeps its own colours against the selection fill. That is a
+/// cost of colour, it applies only while the panel is open, and it is why the
+/// OFF image below stays a template.
+public enum MenuBarMark {
+
+    /// Gap between the gauge and the cup, in points.
+    ///
+    /// Matches `Tok.space1`, which cannot be referenced here: `Tok` lives in the
+    /// app target and this type lives in the library so the tests can link it —
+    /// the same reason `KeepAwakeGlyph` takes its tint as a parameter.
+    public static let glyphSpacing: CGFloat = 2
+
+    /// What VoiceOver says about the menu-bar item. It is the one surface with no
+    /// room for a label, so this is the only place the state is spoken.
+    public static func accessibilityDescription(awake: Bool) -> String {
+        awake
+            ? "tcr fleet capacity. \(KeepAwakeGlyph.accessibilityDescription)."
+            : "tcr fleet capacity"
+    }
+
+    /// The image for `NSStatusBarButton.image`.
+    ///
+    /// - OFF: the gauge alone, `isTemplate = true`. Byte-for-byte what the app
+    ///   drew before it owned the button — the menu bar tints it, and it adapts
+    ///   to the appearance and to a light wallpaper for free. Do not regress this
+    ///   to a hand-tinted image to make the two branches look alike.
+    /// - ON: gauge and cup side by side in one non-template image.
+    ///
+    /// Composed at the symbols' natural height (the gauge is 15×15 and the cup
+    /// 20×15 on this machine, against a `NSFont.menuBarFont(ofSize: 0).pointSize`
+    /// of 13) rather than at an invented size.
+    ///
+    /// `nil` only when the gauge symbol itself cannot be created — that is a
+    /// missing SF Symbol, which the caller has to notice rather than paper over.
+    /// A missing *cup* degrades to the plain template gauge instead: losing the
+    /// second mark costs one signal, drawing nothing at all costs the item.
+    public static func image(
+        gaugeSymbol: String,
+        awake: Bool,
+        awakeTint: NSColor
+    ) -> NSImage? {
+        guard
+            let gauge = NSImage(
+                systemSymbolName: gaugeSymbol,
+                accessibilityDescription: accessibilityDescription(awake: false))
+        else { return nil }
+        // Set explicitly rather than relied on: it is what makes the OFF image
+        // follow the menu bar, and it is what makes `draw` lay the glyph down as
+        // a mask the tint below can fill.
+        gauge.isTemplate = true
+
+        guard awake, let cup = KeepAwakeGlyph.image(tint: awakeTint) else {
+            gauge.accessibilityDescription = accessibilityDescription(awake: false)
+            return gauge
+        }
+
+        let gaugeSize = gauge.size
+        let cupSize = cup.size
+        let size = NSSize(
+            width: gaugeSize.width + glyphSpacing + cupSize.width,
+            height: max(gaugeSize.height, cupSize.height))
+        let gaugeRect = NSRect(
+            x: 0, y: (size.height - gaugeSize.height) / 2,
+            width: gaugeSize.width, height: gaugeSize.height)
+        let cupRect = NSRect(
+            x: gaugeSize.width + glyphSpacing, y: (size.height - cupSize.height) / 2,
+            width: cupSize.width, height: cupSize.height)
+
+        let composed = NSImage(size: size, flipped: false) { _ in
+            gauge.draw(in: gaugeRect, from: .zero, operation: .sourceOver, fraction: 1)
+            // Resolved HERE, not above: this closure runs on every draw, so a
+            // dynamic colour picks up the appearance that is current at that
+            // moment instead of the one that happened to be current when the
+            // image was built.
+            NSColor.labelColor.set()
+            gaugeRect.fill(using: .sourceAtop)
+            // Rebuilt inside the handler for the same reason — `awakeTint` is a
+            // dynamic `NSColor` too, and a symbol configuration built once
+            // outside would bake whichever appearance composed the image.
+            KeepAwakeGlyph.image(tint: awakeTint)?
+                .draw(in: cupRect, from: .zero, operation: .sourceOver, fraction: 1)
+            return true
+        }
+        composed.isTemplate = false
+        composed.accessibilityDescription = accessibilityDescription(awake: true)
+        return composed
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/AwakeControllerTests.swift
+++ b/apps/macos/Tests/TcrBarTests/AwakeControllerTests.swift
@@ -1,0 +1,284 @@
+import AppKit
+import XCTest
+
+@testable import TcrBarCore
+
+/// Records every begin/end the controller performs, so the *pairing* can be
+/// asserted.
+///
+/// The pairing is the whole safety property. A leaked token cannot be released
+/// without quitting the app, and the panel would then read OFF while the Mac
+/// still refused to sleep — a control lying about the state of the machine.
+/// Nothing in-process can observe a real power assertion, so this fake is the
+/// only place that property is checkable at all.
+@MainActor
+final class RecordingActivity {
+    private(set) var begun: [NSObjectProtocol] = []
+    private(set) var ended: [NSObjectProtocol] = []
+    private(set) var reasons: [String] = []
+
+    /// Tokens still outstanding — begun and not ended. The number that must
+    /// never exceed one.
+    var live: [NSObjectProtocol] {
+        begun.filter { token in !ended.contains { $0 === token } }
+    }
+
+    var activity: AwakeController.Activity {
+        AwakeController.Activity(
+            begin: { [self] reason in
+                reasons.append(reason)
+                // A fresh object per call, so "ended the token it began" is a
+                // statement about identity and not about equality.
+                let token = NSObject()
+                begun.append(token)
+                return token
+            },
+            end: { [self] token in ended.append(token) }
+        )
+    }
+}
+
+@MainActor
+final class AwakeControllerTests: XCTestCase {
+
+    func testOffToOnBeginsExactlyOneActivity() {
+        let fake = RecordingActivity()
+        let controller = AwakeController(activity: fake.activity)
+
+        controller.setOn(true)
+
+        XCTAssertEqual(fake.begun.count, 1)
+        XCTAssertEqual(fake.ended.count, 0)
+        XCTAssertTrue(controller.isOn)
+    }
+
+    /// The leak case, and the reason ``AwakeController/begin()`` guards.
+    ///
+    /// A second `beginActivity` returns a second token that this class has
+    /// nowhere to put, so the first becomes unreleasable for the lifetime of the
+    /// process.
+    func testOnToOnDoesNotBeginASecondActivity() {
+        let fake = RecordingActivity()
+        let controller = AwakeController(activity: fake.activity)
+
+        controller.setOn(true)
+        controller.setOn(true)
+        controller.setOn(true)
+
+        XCTAssertEqual(fake.begun.count, 1, "a second token would be unreleasable")
+        XCTAssertEqual(fake.live.count, 1)
+        XCTAssertTrue(controller.isOn)
+    }
+
+    func testOnToOffEndsExactlyTheTokenThatWasBegun() {
+        let fake = RecordingActivity()
+        let controller = AwakeController(activity: fake.activity)
+
+        controller.setOn(true)
+        controller.setOn(false)
+
+        XCTAssertEqual(fake.ended.count, 1)
+        XCTAssertTrue(
+            fake.ended.first === fake.begun.first,
+            "must end the identical token, not merely an equal one")
+        XCTAssertTrue(fake.live.isEmpty)
+        XCTAssertFalse(controller.isOn)
+    }
+
+    /// Ending nothing is not the same as ending something. `endActivity` on a
+    /// token this app did not begin is undefined behaviour, and the simplest way
+    /// to reach it is a spurious off.
+    func testOffToOffEndsNothing() {
+        let fake = RecordingActivity()
+        let controller = AwakeController(activity: fake.activity)
+
+        controller.setOn(false)
+        controller.setOn(false)
+
+        XCTAssertEqual(fake.begun.count, 0)
+        XCTAssertEqual(fake.ended.count, 0)
+        XCTAssertFalse(controller.isOn)
+    }
+
+    /// `isOn` is a mirror of the live token, never an independent flag. Walked
+    /// across every transition, including the two no-ops, because a divergence
+    /// on any single one of them is a panel that reports a state of the machine
+    /// that is not true.
+    func testIsOnTracksTheLiveTokenAcrossEveryTransition() {
+        let fake = RecordingActivity()
+        let controller = AwakeController(activity: fake.activity)
+
+        for on in [false, true, true, false, false, true, false] {
+            controller.setOn(on)
+            XCTAssertEqual(
+                controller.isOn, !fake.live.isEmpty,
+                "isOn=\(controller.isOn) but \(fake.live.count) token(s) held")
+        }
+    }
+
+    func testToggleFlipsAndReleases() {
+        let fake = RecordingActivity()
+        let controller = AwakeController(activity: fake.activity)
+
+        controller.toggle()
+        XCTAssertTrue(controller.isOn)
+        controller.toggle()
+        XCTAssertFalse(controller.isOn)
+        XCTAssertTrue(fake.live.isEmpty)
+    }
+
+    func testReleaseOnQuitEndsAHeldActivityAndIsSafeWhenNoneIsHeld() {
+        let fake = RecordingActivity()
+        let controller = AwakeController(activity: fake.activity)
+
+        controller.releaseOnQuit()
+        XCTAssertEqual(fake.ended.count, 0, "nothing was held, so nothing may be ended")
+
+        controller.setOn(true)
+        controller.releaseOnQuit()
+        XCTAssertEqual(fake.ended.count, 1)
+        XCTAssertFalse(controller.isOn)
+
+        controller.releaseOnQuit()
+        XCTAssertEqual(fake.ended.count, 1, "a second quit must not double-end")
+    }
+
+    /// The reason string is what `pmset -g assertions` shows and what a human
+    /// greps for when their Mac will not sleep. Rewording it silently breaks
+    /// both that search and the README's gate.
+    func testReasonNamesTheAppSoItIsGreppable() {
+        let fake = RecordingActivity()
+        let controller = AwakeController(activity: fake.activity)
+
+        controller.setOn(true)
+
+        XCTAssertEqual(fake.reasons, [AwakeController.reason])
+        XCTAssertTrue(AwakeController.reason.contains("TcrBar"), AwakeController.reason)
+    }
+
+    /// The harness pair must hold nothing. If `.inert` ever became the real one,
+    /// rendering PNGs would stop the machine sleeping.
+    func testInertActivityIsSafeForTheRenderHarness() {
+        let controller = AwakeController(activity: .inert)
+        controller.setOn(true)
+        XCTAssertTrue(controller.isOn, "the harness still needs the ON appearance")
+        controller.setOn(false)
+        XCTAssertFalse(controller.isOn)
+    }
+}
+
+// MARK: - Probe argument parsing
+
+@MainActor
+final class KeepAwakeProbeTests: XCTestCase {
+
+    func testAbsentFlagLeavesTheAppToStartNormally() {
+        XCTAssertNil(KeepAwakeProbe.request(["TcrBar"]))
+        XCTAssertNil(KeepAwakeProbe.request(["TcrBar", "--render-states", "/tmp/x"]))
+    }
+
+    func testDurationIsParsed() {
+        XCTAssertEqual(
+            KeepAwakeProbe.request(["TcrBar", KeepAwakeProbe.flag, "10"]),
+            .hold(seconds: 10))
+        XCTAssertEqual(
+            KeepAwakeProbe.request(["TcrBar", KeepAwakeProbe.flag, "0.5"]),
+            .hold(seconds: 0.5))
+    }
+
+    /// A broken argument is NOT the same as an absent one. Falling back to `nil`
+    /// would launch a menu-bar app in answer to a typo, hiding the mistake
+    /// behind an icon.
+    func testBadDurationsAreUsageErrorsRatherThanASilentLaunch() {
+        for bad in ["", "0", "-5", "ten", "10s"] {
+            guard case .usage = KeepAwakeProbe.request(["TcrBar", KeepAwakeProbe.flag, bad])
+            else { return XCTFail("'\(bad)' should be a usage error, not a duration") }
+        }
+        guard case .usage = KeepAwakeProbe.request(["TcrBar", KeepAwakeProbe.flag])
+        else { return XCTFail("a missing duration should be a usage error") }
+    }
+
+    /// `Double("inf")` parses. A probe asked to hold for infinity would never
+    /// release — the exact failure the probe exists to detect, committed by the
+    /// probe itself.
+    func testInfinityIsRejected() {
+        for bad in ["inf", "-inf", "nan", "1e400"] {
+            guard case .usage = KeepAwakeProbe.request(["TcrBar", KeepAwakeProbe.flag, bad])
+            else { return XCTFail("'\(bad)' parses as a Double and must still be refused") }
+        }
+    }
+}
+
+// MARK: - The menu-bar mark
+
+@MainActor
+final class KeepAwakeGlyphTests: XCTestCase {
+
+    /// A status item renders a template image in the menu bar's own colour,
+    /// which strips the tint. `isTemplate = false` is the opt-out, and it is the
+    /// single line that makes the colour channel possible at all.
+    func testTheMarkIsNotATemplate() throws {
+        let image = try XCTUnwrap(KeepAwakeGlyph.image(tint: .systemRed))
+        XCTAssertFalse(image.isTemplate)
+    }
+
+    /// Proves the image THIS APP HANDS OVER carries colour: rasterise it and
+    /// find a pixel that is actually the tint.
+    ///
+    /// It does not prove the status item honours it. Nothing here can — reading
+    /// back the real menu bar needs Screen Recording, which is not granted on
+    /// the machine this was written on. That step is a human's eyes.
+    ///
+    /// The tint is pure saturated red rather than `Tok.awake` on purpose: the
+    /// assertion is about colour surviving, so it must not be able to pass on a
+    /// near-grey, and a token is free to change.
+    func testAPixelInsideTheMarkCarriesTheTint() throws {
+        let tint = NSColor(srgbRed: 1, green: 0, blue: 0, alpha: 1)
+        let image = try XCTUnwrap(KeepAwakeGlyph.image(tint: tint))
+
+        let side = 64
+        let rep = try XCTUnwrap(
+            NSBitmapImageRep(
+                bitmapDataPlanes: nil, pixelsWide: side, pixelsHigh: side,
+                bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+                colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0))
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
+        image.draw(
+            in: NSRect(x: 0, y: 0, width: side, height: side),
+            from: .zero, operation: .sourceOver, fraction: 1)
+        NSGraphicsContext.restoreGraphicsState()
+
+        var reddest: (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat)?
+        var opaquePixels = 0
+        for x in 0..<side {
+            for y in 0..<side {
+                guard let px = rep.colorAt(x: x, y: y),
+                    let srgb = px.usingColorSpace(.sRGB), srgb.alphaComponent > 0.5
+                else { continue }
+                opaquePixels += 1
+                let candidate = (
+                    srgb.redComponent, srgb.greenComponent, srgb.blueComponent,
+                    srgb.alphaComponent
+                )
+                if reddest == nil || candidate.0 > reddest!.r { reddest = candidate }
+            }
+        }
+
+        // A positive control on the probe itself: if nothing was drawn, the
+        // colour assertion below would be vacuous rather than failing.
+        XCTAssertGreaterThan(opaquePixels, 0, "nothing was rasterised — the scan proves nothing")
+
+        let hit = try XCTUnwrap(reddest, "no opaque pixel found")
+        XCTAssertGreaterThan(hit.r, 0.5, "no red in the mark — the tint was dropped")
+        XCTAssertLessThan(hit.g, 0.4, "the mark is not the tint it was given")
+        XCTAssertLessThan(hit.b, 0.4, "the mark is not the tint it was given")
+    }
+
+    /// The shape channel: the mark must not be the capacity gauge. They are told
+    /// apart by silhouette before colour is involved.
+    func testTheMarkIsNotAGauge() {
+        XCTAssertFalse(KeepAwakeGlyph.symbolName.contains("gauge"))
+        XCTAssertFalse(KeepAwakeGlyph.accessibilityDescription.isEmpty)
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/LaunchPreferenceTests.swift
+++ b/apps/macos/Tests/TcrBarTests/LaunchPreferenceTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+
+@testable import TcrBarCore
+
+/// "Start server at launch" moved out of `@AppStorage` when the SwiftUI `App`
+/// struct went away. The value is the operator's, and it is already set on at
+/// least one machine, so the thing worth testing is that nothing about how it is
+/// stored changed.
+@MainActor
+final class LaunchPreferenceTests: XCTestCase {
+
+    private var suiteName = ""
+    private var defaults = UserDefaults.standard
+
+    override func setUp() {
+        super.setUp()
+        // A scratch suite, never `.standard`: a test that writes the real key
+        // would silently change whether the operator's proxy comes up at login.
+        suiteName = "tcrbar.tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName) ?? .standard
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    /// The literal, pinned.
+    ///
+    /// Renaming it fails nothing and breaks something: the stored value is
+    /// orphaned, the preference silently reverts to off, and the first symptom is
+    /// a proxy that stopped coming up at login — a long way from the cause.
+    func testTheDefaultsKeyIsTheOneAppStorageUsed() {
+        XCTAssertEqual(LaunchPreference.startServerAtLaunchKey, "startServerAtLaunch")
+    }
+
+    /// Same default as the `@AppStorage` declaration carried. Opt-in on purpose:
+    /// once TcrBar supervises the server, quitting TcrBar stops it.
+    func testAnAbsentKeyReadsAsOff() {
+        XCTAssertFalse(LaunchPreference(defaults: defaults).startServerAtLaunch)
+    }
+
+    func testAStoredValueIsRead() {
+        defaults.set(true, forKey: LaunchPreference.startServerAtLaunchKey)
+        XCTAssertTrue(LaunchPreference(defaults: defaults).startServerAtLaunch)
+    }
+
+    /// Written through immediately, not on quit. The panel and the next launch
+    /// read the same fact, so they cannot disagree about it.
+    func testSettingItWritesThroughAndSurvivesANewInstance() {
+        let preference = LaunchPreference(defaults: defaults)
+        preference.startServerAtLaunch = true
+
+        XCTAssertTrue(defaults.bool(forKey: LaunchPreference.startServerAtLaunchKey))
+        XCTAssertTrue(LaunchPreference(defaults: defaults).startServerAtLaunch)
+
+        preference.startServerAtLaunch = false
+        XCTAssertFalse(defaults.bool(forKey: LaunchPreference.startServerAtLaunchKey))
+        XCTAssertFalse(LaunchPreference(defaults: defaults).startServerAtLaunch)
+    }
+
+    /// Reading the stored value in `init` must not write it back — a property
+    /// initialised in `init` does not fire `didSet`, and this is the test that
+    /// says so out loud.
+    func testConstructingItDoesNotWriteTheKey() {
+        _ = LaunchPreference(defaults: defaults)
+        XCTAssertNil(defaults.object(forKey: LaunchPreference.startServerAtLaunchKey))
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/MenuBarMarkTests.swift
+++ b/apps/macos/Tests/TcrBarTests/MenuBarMarkTests.swift
@@ -1,0 +1,183 @@
+import AppKit
+import XCTest
+
+@testable import TcrBarCore
+
+/// The menu-bar image, checked at the level a unit test can reach: the `NSImage`
+/// this app hands to the status button.
+///
+/// What it cannot reach is whether the *button* honours what the image says —
+/// that needs a real `NSStatusItem` and a rasterisation off it, which is what
+/// `TcrBar --shell-probe` is for. These tests are the cheap half that runs in
+/// `swift test`; the probe is the gate.
+@MainActor
+final class MenuBarMarkTests: XCTestCase {
+
+    private let gauge = "gauge.with.dots.needle.33percent"
+    /// Pure saturated red rather than `Tok.awake`: the assertions below are about
+    /// colour surviving at all, so they must not be able to pass on a near-grey,
+    /// and a palette token is free to change.
+    private let loudTint = NSColor(srgbRed: 1, green: 0, blue: 0, alpha: 1)
+
+    /// The OFF mark stays a template, which is what buys the menu bar's automatic
+    /// tinting — correct in both appearances and over a light wallpaper, for
+    /// free. Hand-tinting it to match the ON branch would throw that away.
+    func testOffMarkIsATemplate() throws {
+        let image = try XCTUnwrap(
+            MenuBarMark.image(gaugeSymbol: gauge, awake: false, awakeTint: loudTint))
+        XCTAssertTrue(image.isTemplate)
+    }
+
+    /// A template image is re-rendered in the menu bar's own colour, which strips
+    /// the tint. `isTemplate = false` is the documented opt-out and the single
+    /// property that makes the colour channel possible.
+    func testOnMarkIsNotATemplate() throws {
+        let image = try XCTUnwrap(
+            MenuBarMark.image(gaugeSymbol: gauge, awake: true, awakeTint: loudTint))
+        XCTAssertFalse(image.isTemplate)
+    }
+
+    /// Two glyphs, not one recoloured glyph. The shape channel is the one that
+    /// survives greyscale and a red-green colour vision deficiency, so the ON
+    /// mark has to be *wider*, not merely different in hue.
+    func testOnMarkIsWiderThanOffBecauseItCarriesASecondGlyph() throws {
+        let off = try XCTUnwrap(
+            MenuBarMark.image(gaugeSymbol: gauge, awake: false, awakeTint: loudTint))
+        let on = try XCTUnwrap(
+            MenuBarMark.image(gaugeSymbol: gauge, awake: true, awakeTint: loudTint))
+        XCTAssertGreaterThan(on.size.width, off.size.width)
+        XCTAssertEqual(on.size.height, off.size.height, accuracy: 0.5)
+    }
+
+    /// The point of the whole rebuild: the composed image really carries colour.
+    func testAPixelInTheOnMarkCarriesTheTint() throws {
+        let image = try XCTUnwrap(
+            MenuBarMark.image(gaugeSymbol: gauge, awake: true, awakeTint: loudTint))
+        let scan = try XCTUnwrap(rasterise(image, in: XCTUnwrap(NSAppearance(named: .darkAqua))))
+
+        // A positive control on the probe itself: with nothing rasterised the
+        // colour assertion below would be vacuous rather than failing.
+        XCTAssertGreaterThan(scan.opaque, 0, "nothing was rasterised — the scan proves nothing")
+        XCTAssertGreaterThan(scan.tinted, 0, "no red in the mark — the tint was dropped")
+    }
+
+    /// And the OFF mark does not, which is the negative control. Without it the
+    /// test above passes just as happily on a mark that is red in both states —
+    /// i.e. on a menu bar that cannot tell the two modes apart.
+    func testTheOffMarkCarriesNoTint() throws {
+        let image = try XCTUnwrap(
+            MenuBarMark.image(gaugeSymbol: gauge, awake: false, awakeTint: loudTint))
+        let scan = try XCTUnwrap(rasterise(image, in: XCTUnwrap(NSAppearance(named: .darkAqua))))
+
+        XCTAssertGreaterThan(scan.opaque, 0, "nothing was rasterised — the scan proves nothing")
+        XCTAssertEqual(scan.tinted, 0, "the OFF mark is tinted, so both modes look alike")
+    }
+
+    /// The claim the ON branch rests on: a non-template image is drawn exactly as
+    /// authored, so the *gauge* half would freeze at one colour and be wrong in
+    /// the other appearance — unless the dynamic colour is resolved inside the
+    /// drawing handler, which runs at draw time.
+    ///
+    /// Asserted on one image drawn twice, not on two images: that is the stronger
+    /// statement, and it is the one that fails if `NSImage` ever caches the first
+    /// raster.
+    func testTheGaugeReResolvesLabelColourPerAppearanceWhileTheTintHolds() throws {
+        let image = try XCTUnwrap(
+            MenuBarMark.image(gaugeSymbol: gauge, awake: true, awakeTint: loudTint))
+        let light = try XCTUnwrap(rasterise(image, in: XCTUnwrap(NSAppearance(named: .aqua))))
+        let dark = try XCTUnwrap(rasterise(image, in: XCTUnwrap(NSAppearance(named: .darkAqua))))
+
+        XCTAssertGreaterThan(
+            abs(light.untintedLuma - dark.untintedLuma), 0.2,
+            "the gauge is the same brightness in both appearances, so labelColor was baked in")
+        XCTAssertGreaterThan(light.tinted, 0, "the tint was lost in the light appearance")
+        XCTAssertGreaterThan(dark.tinted, 0, "the tint was lost in the dark appearance")
+    }
+
+    /// `nil` rather than a blank image, so a caller notices. A missing SF Symbol
+    /// is a fact about this build, not something to paper over with an empty
+    /// status item.
+    func testAMissingSymbolIsNilRatherThanABlankImage() {
+        XCTAssertNil(
+            MenuBarMark.image(
+                gaugeSymbol: "not.a.real.sf.symbol.name", awake: false, awakeTint: loudTint))
+    }
+
+    /// The menu bar has no room for a label, so this string is the only place the
+    /// state is spoken. Both states have to say something, and they have to say
+    /// different things.
+    func testBothStatesAreSpokenAndTheyDiffer() throws {
+        let off = MenuBarMark.accessibilityDescription(awake: false)
+        let on = MenuBarMark.accessibilityDescription(awake: true)
+        XCTAssertFalse(off.isEmpty)
+        XCTAssertNotEqual(off, on)
+        XCTAssertTrue(
+            on.contains(KeepAwakeGlyph.accessibilityDescription),
+            "the ON description must name the mode: \(on)")
+
+        let image = try XCTUnwrap(
+            MenuBarMark.image(gaugeSymbol: gauge, awake: true, awakeTint: loudTint))
+        XCTAssertEqual(image.accessibilityDescription, on)
+    }
+
+    // MARK: - Rasterising
+
+    private struct Scan {
+        var opaque = 0
+        /// Pixels that carry the tint — i.e. the cup.
+        var tinted = 0
+        /// Mean relative luminance of the opaque pixels that are NOT the tint —
+        /// i.e. the gauge.
+        var untintedLuma = 0.0
+    }
+
+    /// Draw at 2x under a chosen appearance and count. `performAsCurrentDrawingAppearance`
+    /// is what makes the dynamic colours inside the drawing handler resolve
+    /// against that appearance rather than the process's default.
+    private func rasterise(_ image: NSImage, in appearance: NSAppearance) -> Scan? {
+        let scale = 2
+        let width = Int(image.size.width.rounded()) * scale
+        let height = Int(image.size.height.rounded()) * scale
+        guard width > 0, height > 0,
+            let rep = NSBitmapImageRep(
+                bitmapDataPlanes: nil, pixelsWide: width, pixelsHigh: height,
+                bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+                colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0)
+        else { return nil }
+
+        appearance.performAsCurrentDrawingAppearance {
+            NSGraphicsContext.saveGraphicsState()
+            let context = NSGraphicsContext(bitmapImageRep: rep)
+            NSGraphicsContext.current = context
+            context?.cgContext.scaleBy(x: CGFloat(scale), y: CGFloat(scale))
+            image.draw(
+                in: NSRect(origin: .zero, size: image.size), from: .zero,
+                operation: .sourceOver, fraction: 1)
+            NSGraphicsContext.restoreGraphicsState()
+        }
+
+        var scan = Scan()
+        var lumaSum = 0.0
+        var lumaCount = 0
+        for x in 0..<rep.pixelsWide {
+            for y in 0..<rep.pixelsHigh {
+                guard let colour = rep.colorAt(x: x, y: y)?.usingColorSpace(.sRGB),
+                    colour.alphaComponent > 0.35
+                else { continue }
+                scan.opaque += 1
+                let r = colour.redComponent, g = colour.greenComponent, b = colour.blueComponent
+                // `loudTint` is pure red, so "carries the tint" is "much more red
+                // than green or blue" — a predicate a grey or a white cannot
+                // satisfy however bright it is.
+                if r - g > 0.15 && r - b > 0.15 {
+                    scan.tinted += 1
+                } else {
+                    lumaSum += 0.2126 * r + 0.7152 * g + 0.0722 * b
+                    lumaCount += 1
+                }
+            }
+        }
+        scan.untintedLuma = lumaCount == 0 ? 0 : lumaSum / Double(lumaCount)
+        return scan
+    }
+}

--- a/scripts/tcrbar-palette.py
+++ b/scripts/tcrbar-palette.py
@@ -159,13 +159,28 @@ LIGHT_STATUS = {
 # "nearly exhausted" when it means "this Mac will not idle sleep". Hue 195 is
 # the open slot between ready (150) and unmeasured (230).
 #
-# Both values came out of a search over this file's own constraint set rather
-# than off a colour picker: highest chroma that stays in the sRGB gamut, clears
-# the contrast floor on BOTH the panel and a raised row, and holds >= 1.25:1
-# luminance separation from `unmeasured` -- the one other cool token, and so the
-# only one it could be confused with in greyscale.
+# The constraint set both values were searched against is this file's own:
+# stay in the sRGB gamut, clear the contrast floor on BOTH the panel and a
+# raised row, and hold >= 1.25:1 luminance separation from `unmeasured` -- the
+# one other cool token, and so the only one it could be confused with in
+# greyscale. The two values sit differently against it, and saying so matters
+# more than a tidier sentence would:
 #
-# Two things that search taught, both of which are in the numbers above:
+#  - LIGHT, oklch(0.500 0.085 195) -> #017272, is the constrained maximum. At
+#    L=0.500 the gamut runs out at C=0.085, so the shipped value is the most
+#    chroma the constraint set allows at that lightness, to the digit.
+#  - DARK, oklch(0.830 0.120 195) -> #51dfdf, is NOT. Nothing gated here binds
+#    at C=0.120: at L=0.830 every constraint above still passes at C=0.141
+#    (#12e3e3, 11.31:1 on panel, 1.32:1 from `unmeasured`), and letting L move
+#    too reaches oklch(0.905 0.150 195). The shipped value was chosen BELOW
+#    that ceiling for restraint, not derived: at C=0.120 `awake` is the least
+#    chromatic of the four coloured tokens (near 0.130, ready 0.150, spent
+#    0.180), so a mode indicator never out-shouts a quota status beside it.
+#    That is a taste judgement and this script does not measure it -- what is
+#    gated is the floor the colour clears, never the ceiling it declines. Do
+#    not "fix" the value to the maximum; it is deliberate.
+#
+# Two things the search taught, both of which are in the numbers above:
 #
 #  - Maximising chroma alone is the wrong objective. Unconstrained, it returns
 #    oklch(0.665 0.295 330) -> #ed17e6, a neon magenta at twice the chroma of

--- a/scripts/tcrbar-palette.py
+++ b/scripts/tcrbar-palette.py
@@ -97,6 +97,7 @@ STATUS = {
     "spent":      (0.655, 0.180,  25),   # red    - exhausted
     "unmeasured": (0.760, 0.070, 230),   # slate  - never probed, NOT zero
     "disabled":   (0.660, 0.004, 255),   # grey   - operator parked it
+    "awake":      (0.830, 0.120, 195),   # cyan   - keep-awake mode is held
 }
 
 WASH_ALPHA, LINE_ALPHA = 0.14, 0.34
@@ -150,7 +151,39 @@ LIGHT_STATUS = {
     "spent":      (0.510, 0.205,  25),
     "unmeasured": (0.580, 0.070, 230),
     "disabled":   (0.600, 0.004, 255),
+    "awake":      (0.500, 0.085, 195),
 }
+
+# `awake` -- keep-awake mode is held -- is NOT on the traffic-light scale, and
+# that is the point: reusing ready/near/spent would make the menu bar say
+# "nearly exhausted" when it means "this Mac will not idle sleep". Hue 195 is
+# the open slot between ready (150) and unmeasured (230).
+#
+# Both values came out of a search over this file's own constraint set rather
+# than off a colour picker: highest chroma that stays in the sRGB gamut, clears
+# the contrast floor on BOTH the panel and a raised row, and holds >= 1.25:1
+# luminance separation from `unmeasured` -- the one other cool token, and so the
+# only one it could be confused with in greyscale.
+#
+# Two things that search taught, both of which are in the numbers above:
+#
+#  - Maximising chroma alone is the wrong objective. Unconstrained, it returns
+#    oklch(0.665 0.295 330) -> #ed17e6, a neon magenta at twice the chroma of
+#    any shipped token, which also collides with `unknown` (#c69bdd).
+#  - Requiring separation from ALL FIVE existing statuses returns nothing at
+#    all in this hue range -- and that constraint is not this palette's: the
+#    shipped tokens do not meet it either (unmeasured vs ready is 1.02:1,
+#    disabled vs spent is 1.00:1). What is gated here is four NAMED pairs, and
+#    tokens off the traffic-light scale are separated by hue and by context.
+#
+# Known gap, deliberately not closed here: `unknown` (Tokens.swift, #c69bdd /
+# #7d4d96) is shipped but absent from this file, so it is the one token nothing
+# measures. It was left out rather than added because its dark value does not
+# round-trip -- the nearest OKLCH, (0.752 0.103 314), emits #c69bdc, one bit of
+# blue off what the app draws. Adding it would make this script authoritative
+# for a colour it does not actually reproduce, which is worse than the gap:
+# silent drift beats a known hole. Closing it properly means re-deriving that
+# token and changing what the app draws, which is its own change.
 
 # Increased Contrast: ink goes to the extremes, status hues gain lightness
 # separation from the panel.
@@ -242,6 +275,9 @@ def main():
         ("ready", "near"),
         ("near", "spent"),
         ("unmeasured", "disabled"),
+        # Both cool, both off the traffic-light scale: the pair that would
+        # collapse in greyscale if either drifted.
+        ("awake", "unmeasured"),
     ]
     for a, b in pairs:
         r = contrast(STATUS[a], STATUS[b])
@@ -263,7 +299,8 @@ def main():
               LIGHT_SURFACES, HC_LIGHT_INK, {}, failures, min_ratio=7.0)
 
     print("\nLIGHT-MODE DISCRIMINATION (the CVD pair must hold in both appearances)")
-    for a, b in [("ready", "spent"), ("ready", "near"), ("near", "spent")]:
+    for a, b in [("ready", "spent"), ("ready", "near"), ("near", "spent"),
+                 ("awake", "unmeasured")]:
         r = contrast(LIGHT_STATUS[a], LIGHT_STATUS[b])
         ok = r >= 1.25
         if not ok:


### PR DESCRIPTION
# feat: keep this Mac awake, and own the status item so the signal can carry colour

Adds a "Keep this Mac awake" control to TcrBar — the equivalent of `caffeinate -i`,
held for exactly as long as the checkbox is ticked — and a menu-bar mark that shows
when it is on. Replaces `MenuBarExtra` with a hand-managed `NSStatusItem` plus an
`NSPopover`, because the colour could not be delivered through the SwiftUI label.

## Why the shell was replaced

The obvious implementation is a tinted `Image` in the `MenuBarExtra` label. It does not
work. Six label constructions were each hosted in a real `MenuBarExtra` and the real
`NSStatusBarButton` rasterised with `cacheDisplay(in:to:)`:

| label construction | opaque px | coloured px |
|---|---|---|
| `Image(nsImage:)` with `isTemplate = false` | 68 | 0 |
| `Image(nsImage:).renderingMode(.original)` | 68 | 0 |
| `Text("●").foregroundStyle(cyan)` | 158 | 0 |
| SF Symbol pre-rasterised to a plain bitmap | 68 | 0 |
| an emoji (a colour font) | 198 | 14 |
| `button.image` set directly on the status button | 533 | 533 |

Every construction that routes through an `Image` returned zero coloured pixels. Only a
colour font got any colour through at all, and only 14 px of 198. Setting `button.image`
directly was the one construction of the six that carried an arbitrary colour.

Three caveats on that table, because it is the justification for a large diff:

- It was a **one-off measurement**; the sweep harness is not committed, so the rows
  cannot be regenerated from this repo. `ShellProbe` reuses the cyan predicate verbatim
  so its numbers are comparable, but it does not reproduce the sweep.
- `cacheDisplay` rasterises the view's own drawing. It never asks the window server to
  composite, so the table shows what SwiftUI *draws*, not what the menu bar *displays*.
- Opaque counts are not comparable between rows — the constructions differ in glyph and
  in button size. In particular the last row is a fully-tinted probe image, **not** the
  shipped mark; the shipped composed mark measures `opaque=188 cyan=128`.

## What the mode does, and deliberately does not

- Holds one `NSProcessInfo` activity with `.idleSystemSleepDisabled` — the same
  assertion `caffeinate -i` takes. Verified against `pmset -g assertions`: listed by pid
  and by name while held, and gone while the process is **still running**, so the release
  is attributable to `endActivity` rather than to process exit.
- **Idle system sleep only, never display sleep.** A dark screen does not stop a run, and
  holding the display awake all night is a cost nobody asked for.
- **Not persisted across launches.** A Mac that silently never sleeps because of a box
  ticked last week is a worse bug than having to tick it again.
- **Closing the lid still sleeps the Mac.** Clamshell sleep is not idle sleep and this
  assertion class does not cover it — reasoned from the assertion's definition, not
  measured here. The panel says so in the UI.
- One token is the only state. A second `beginActivity` would leak a token that cannot be
  released without quitting, leaving the panel reading OFF while the machine still
  refused to sleep.

## Signalled on two channels

Shape is primary and colour is second. The design rationale for that ordering — a mark
that is present or absent should survive greyscale, a red-green colour vision deficiency,
and any future decision to template the image — is rationale, not a tested claim; none of
the three was measured.

The capacity gauge is untouched and still means capacity; the two marks never merge. The
gauge stays a template image in the OFF state so it keeps following the menu bar's own
tint, and the composed ON image draws it through `NSImage(size:flipped:drawingHandler:)`
with `NSColor.labelColor`, which re-resolves at draw time. Measured: gauge mean luma
`0.000` under `.aqua` and `0.847` under `.darkAqua`, cup cyan in both.

## Also in this PR

- **The status item now owns its visibility.** Both defaults domains were observed
  holding `"NSStatusItem VisibleCC Item-0" = 0`. AppKit rewrites that key on its own — it
  was watched flipping to `1` and back within minutes — and how it came to be `0` is not
  established; it could predate this work or have been written during it. Nothing here
  claims a history. `MenuBarShell` sets `isVisible` unconditionally at creation, so the
  shipped behaviour no longer depends on the stored value under any history. An
  `autosaveName` was considered and declined: it moves the same flag to a differently
  named key with the identical failure mode.
- Account rows state whether an account is **`ROTATING`** or **`PARKED`**. Previously the
  enabled state was signalled by nothing at all, and the only nearby text was a button
  reading "Disable" — which was read as a status, leading to a false conclusion that the
  proxy was routing traffic to a disabled account. The button keeps naming the action,
  matching the CLI verbs.
- The keep-awake caveat is drawn in `Tok.awake`, not the amber `Tok.near` used by the
  login-item error directly above it: it is a note, not an alarm, and two amber lines read
  as two problems. (Both the control and the caveat are new here — this is a decision, not
  a change to anything on `main`.)
- A new `awake` token, generated and gated by `scripts/tcrbar-palette.py`: 11.22:1 on the
  dark panel, 5.20:1 on light, in gamut, 1.31:1 clear of `unmeasured`. Off the
  traffic-light scale on purpose — `ok`/`near`/`spent` mean quota, so an amber menu bar
  would read as "nearly exhausted" while the fleet was fine.

## Gates

`swift build` and `swift test` green: **136 tests, 107 on `main`**. `swift-format lint
--strict` clean against the config `main` added.

Two new headless harness flags, because `screencapture` needs a permission a build
machine may not have — and, as it turned out, a screen that is not locked:

```
shell-probe: 9/9 passed
  PASS 3. ON:  opaque=188 cyan=128
  PASS 4. OFF: opaque=68  cyan=0          (negative control)
  PASS 7. aqua gaugeLuma=0.000 cyan=516 · dark gaugeLuma=0.847 cyan=516
  env screenLocked=true appActive=false popoverWindowOcclusion=not-visible

keep-awake-probe: pid …(TcrBar) PreventUserIdleSystemSleep named:
                  "TcrBar is keeping this Mac awake"
                  released → 0 assertions, with `ps` confirming the probe still alive
```

Every assertion in both probes was broken deliberately and watched go red. Of those, one
(`--shell-probe` assertion 9) could not fail as first written and was rewritten until it
could; two clauses were demoted to reported-not-asserted, one unreachable guard was
deleted, and one assertion had been wrongly de-asserted and was restored. Assertion 6 is
the inverse case: it went red on a correct app whenever nothing was being composited, so
the probe now disables the popover animation and says so in its own output.

## Integrating with the Sparkle updater

`main` gained a Sparkle self-updater while this branch was open, wired into the SwiftUI
scene this branch removes. The updater is now owned by `MenuBarShell` as `let updater:
Updater`, alongside `poller` / `server` / `awake` — the same ownership lifetime the
`@StateObject` gave it, since `AppDelegate` builds the shell once in
`applicationDidFinishLaunching` and holds it for the process. Its user-facing entry point
did not move: still "Check for Updates…" in the panel footer.

The `tcrbar://` ordering guard — a check that arrives before the updater exists — moved
from the updater's `didSet` to the shell's. It is covered by a harness that extracts the
three shipped fragments from `TcrBarApp.swift` and runs them against a stub, over four
arms: a pre-launch URL drains exactly once, a post-launch URL fires without
double-firing, unrecognised hosts and foreign schemes queue nothing, and two pre-launch
URLs drain as one. The harness was then mutation-tested — neutering the drain reddens
arms 1 and 4, dropping the `checkIsPending` conjunct reddens 2, 3 and 5 — with
abort-failures distinguished from assertion-failures so a harness that died early cannot
read as a pass.

That caps at σ2: the oracle is self-authored. What it does not prove is AppKit's own
ordering — that `application(_:open:)` can precede `applicationDidFinishLaunching` — which
is inherited from `4423ab3` and from `src/update.rs` shipping `open -g
tcrbar://check-for-updates` against a not-running app. Falsifying that needs a registered
bundle.

## What a human still has to check

Nothing here reaches the window server's final composite of the menu bar, and the machine
this was built on had its screen locked throughout. Unverified, and stated as such in the
code:

- how the cyan reads against a light wallpaper, and while the button is highlighted with
  the panel open — a non-template image does not invert under the selection fill the way a
  template one does;
- whether clicking the icon dismisses the panel or flickers and re-opens, a known
  `NSStatusItem` + transient `NSPopover` ordering hazard. Nothing here clicks with a real
  mouse, so the first click's target/action is unproven too;
- the animated dismissal itself, which `--shell-probe` deliberately disables;
- `.tint(Tok.awake)` on the AppKit checkbox — `ImageRenderer` does not draw `.checkbox`
  at all, and the control may follow the system accent and ignore the tint outright;
- anything about a signed bundle: `LSUIElement`, the code signature, login-item
  registration. `scripts/build-tcrbar.sh` was not run.
