### PR TITLE
fix: survive a hidden menu-bar icon instead of quitting

### DIFF
--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -131,6 +131,40 @@ TCR_BIN=/path/to/tcr open build/TcrBar.app     # env override, shell launches
 If nothing is found the panel says so and names how many locations it searched —
 the bundle path included — it never shows an empty list.
 
+## A hidden menu-bar icon does not quit the app
+
+The whole UI is one `MenuBarExtra`, so the app declares exactly one scene. When
+Control Center hides the status item, SwiftUI tears that scene down — and a
+SwiftUI `App` left with zero scenes terminates itself. AppKit's default answer to
+`applicationShouldTerminate` is *yes*, so the app agreed: every launch exited 0
+within seconds, with no output and no crash report, which reads as a broken build
+rather than a quit. It cost a full day of no menu-bar app on 2026-08-09.
+
+`AppDelegate.applicationShouldTerminate` now REFUSES any termination nobody
+asked for, and `TerminationPolicy` holds the list of things that legitimately
+ask: the panel's Quit button, a logout or shutdown, Sparkle relaunching into a
+new version, and any quit request that arrives as an Apple event (`osascript`,
+the Dock, Cmd-Q). The status-item teardown matches none of them. The item is also
+bound through `MenuBarExtra(isInserted:)`, so a hide becomes observable state
+rather than a scene that vanishes.
+
+If the icon is hidden and the panel is therefore unclickable, `tcr ui` brings it
+back: that runs `open -b <bundle id>`, which reaches
+`applicationShouldHandleReopen` and re-inserts the item. The hidden state is
+never persisted, so relaunching also restores it.
+
+Reproduce the failure with:
+
+```sh
+defaults write com.github.dhkts1.tcrbar.dev TcrHideMenuBarItemForTesting -bool true
+```
+
+The app then removes its own menu-bar item three seconds after launch, which is
+the same teardown Control Center causes. This key exists because the real trigger
+cannot be scripted: Control Center owns the visibility in memory and ignores
+`defaults write com.apple.controlcenter "NSStatusItem Visible Item-0"` entirely —
+measured, the app mirrored `1` straight back over a `0` written seconds earlier.
+
 ## Reading the panel honestly
 
 Three states look similar and are not:
@@ -148,7 +182,8 @@ Three states look similar and are not:
 Package.swift
 Sources/TcrBarCore/   FleetStatus.swift  StatusPoller.swift  ServerController.swift
                       AccountControl.swift  LoginItem.swift  TcrTool.swift
-Sources/TcrBar/       TcrBarApp.swift  FleetView.swift  Tokens.swift
+                      TerminationPolicy.swift
+Sources/TcrBar/       TcrBarApp.swift  FleetView.swift  Tokens.swift  Updater.swift
 Tests/TcrBarTests/    FleetStatusTests.swift
 scripts/build-tcrbar.sh
 ```

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -153,17 +153,36 @@ back: that runs `open -b <bundle id>`, which reaches
 `applicationShouldHandleReopen` and re-inserts the item. The hidden state is
 never persisted, so relaunching also restores it.
 
-Reproduce the failure with:
+Both halves were measured separately rather than assumed. Against a reproduction
+that kills the unfixed app instantly, a build carrying only the delegate survived
+60s, and so did a build carrying only the `isInserted:` binding — each prevents
+the death on its own. The redundancy is kept deliberately: they fail for
+different reasons, since the binding relies on SwiftUI keeping a
+declared-but-absent scene alive, which is undocumented, while the delegate relies
+only on AppKit asking before it quits.
+
+To reproduce the failure, run the executable directly instead of through `open`:
+
+```sh
+apps/macos/build/TcrBar.app/Contents/MacOS/TcrBar; echo "exit=$?"
+```
+
+A build without the fix exits 0 within a second with no output — the reported
+signature exactly. A fixed build stays up. Launching this way denies the process
+a status item for the same reason a hidden icon does, so it reaches the same
+teardown without involving Control Center.
+
+`TcrHideMenuBarItemForTesting` is the other reproduction, driving the teardown
+from inside a normally launched app:
 
 ```sh
 defaults write com.github.dhkts1.tcrbar.dev TcrHideMenuBarItemForTesting -bool true
 ```
 
-The app then removes its own menu-bar item three seconds after launch, which is
-the same teardown Control Center causes. This key exists because the real trigger
-cannot be scripted: Control Center owns the visibility in memory and ignores
-`defaults write com.apple.controlcenter "NSStatusItem Visible Item-0"` entirely —
-measured, the app mirrored `1` straight back over a `0` written seconds earlier.
+Neither goes through Control Center itself, because that cannot be scripted: it
+owns the visibility in memory and ignores `defaults write
+com.apple.controlcenter "NSStatusItem Visible Item-0"` entirely — measured, the
+app mirrored `1` straight back over a `0` written seconds earlier.
 
 ## Reading the panel honestly
 

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -247,7 +247,15 @@ struct FleetView: View {
                         "Ask the release feed whether a newer TcrBar exists. "
                             + "Also reachable as `tcrbar://check-for-updates`."
                     )
-                Button("Quit") { NSApplication.shared.terminate(nil) }
+                // The authorization is not optional and not decoration.
+                // `applicationShouldTerminate` refuses every termination nobody
+                // asked for — that is what keeps a hidden menu-bar icon from
+                // quitting the app — so Quit has to say that it is the one asking
+                // BEFORE it terminates, or this button silently does nothing.
+                Button("Quit") {
+                    TerminationPolicy.shared.authorize(.userChoseQuit)
+                    NSApplication.shared.terminate(nil)
+                }
             }
             .buttonStyle(.bordered)
 

--- a/apps/macos/Sources/TcrBar/TcrBarApp.swift
+++ b/apps/macos/Sources/TcrBar/TcrBarApp.swift
@@ -104,6 +104,22 @@ struct TcrBarApp: App {
                 .onAppear { delegate.updater = updater }
         }
         .menuBarExtraStyle(.window)
+        // Cmd-Q has to authorize too.
+        //
+        // The standard termination command sends a bare `terminate:`, which
+        // `applicationShouldTerminate` now refuses — so leaving it in place would
+        // ship a keyboard shortcut that silently does nothing. Replacing it keeps
+        // the shortcut and the menu item exactly where a user expects them, and
+        // routes them through the one door that is allowed to open.
+        .commands {
+            CommandGroup(replacing: .appTermination) {
+                Button("Quit TcrBar") {
+                    TerminationPolicy.shared.authorize(.userChoseQuit)
+                    NSApplication.shared.terminate(nil)
+                }
+                .keyboardShortcut("q")
+            }
+        }
     }
 }
 
@@ -120,7 +136,7 @@ final class MenuBarPresence: ObservableObject {
 
     @Published var isInserted = true
 
-    /// Reproduce a hidden menu-bar icon on demand.
+    /// Replay a Control Center hide on demand.
     ///
     ///     defaults write com.github.dhkts1.tcrbar.dev \
     ///       TcrHideMenuBarItemForTesting -bool true
@@ -130,29 +146,50 @@ final class MenuBarPresence: ObservableObject {
     /// `com.apple.controlcenter "NSStatusItem Visible Item-0"` is simply ignored
     /// by the running process — measured 2026-08-09, the launched app mirrored
     /// `1` straight back over a `0` written seconds earlier. Only the Control
-    /// Center UI, or restarting it, moves that state. So without this key the fix
-    /// could only ever be argued for, never demonstrated: the failure it prevents
-    /// would have no reproduction, and a fix with no reproduction is a claim.
+    /// Center UI, or restarting it, moves that state. Without this key the fix
+    /// could only be argued for, never demonstrated, and a fix with no
+    /// reproduction is a claim.
     ///
-    /// It reproduces the TEARDOWN specifically, which is what the unified-log
-    /// trace shows — the scene is created and then destroyed a moment later —
-    /// rather than starting with no item, so the code path under test is the one
-    /// that actually fired. A defaults key rather than an environment variable
-    /// because `open` does not forward the environment to the app it launches,
-    /// and this project already overrides behaviour that way (`TcrExecutablePath`).
+    /// It replays BOTH steps of the traced sequence, in order, because the first
+    /// one alone turned out to be survivable:
+    ///
+    ///  1. the status item is removed — the `NSStatusItemChangeVisibilityAction`
+    ///     and the scene teardown behind it;
+    ///  2. an unrequested in-process `terminate:` with no Apple event behind it —
+    ///     the very next line in the log, and the thing that actually killed the
+    ///     app, because AppKit's default reply to it is YES.
+    ///
+    /// Step 1 on its own is not the failure: measured, a build carrying step 1 and
+    /// NO `applicationShouldTerminate` survived 60 s, because binding
+    /// `isInserted:` keeps the scene declared and nothing ever asks to terminate.
+    /// A harness that stopped there would have gone green against a build with the
+    /// fix removed — a probe that cannot fail, proving nothing.
+    ///
+    /// A defaults key rather than an environment variable because `open` does not
+    /// forward the environment to the app it launches, and this project already
+    /// overrides behaviour that way (`TcrExecutablePath`).
     static let hideForTestingDefaultsKey = "TcrHideMenuBarItemForTesting"
 
-    private init() {
+    /// Called from `applicationDidFinishLaunching`, and that timing is not
+    /// incidental. Scheduling this from `init` instead does not work: the
+    /// singleton is built while the `App` struct's properties initialize, which is
+    /// before `NSApplication` runs, and a `Task { @MainActor in … }` enqueued at
+    /// that point never resumes — measured, the "is set" line below printed and
+    /// neither replay step ever did, 30 s later. `DispatchQueue.main.asyncAfter`
+    /// from a launch callback is serviced by the run loop that is by then running.
+    func beginHideReplayIfRequested() {
         guard UserDefaults.standard.bool(forKey: Self.hideForTestingDefaultsKey) else { return }
         NSLog(
-            "TcrBar: %@ is set — the menu-bar item will be removed shortly to "
-                + "simulate Control Center hiding it.",
+            "TcrBar: %@ is set — replaying a Control Center hide shortly.",
             Self.hideForTestingDefaultsKey
         )
-        Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 3_000_000_000)
-            NSLog("TcrBar: simulating a Control Center hide — removing the menu-bar item")
-            self.isInserted = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [self] in
+            NSLog("TcrBar: replay step 1 — removing the menu-bar item")
+            isInserted = false
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                NSLog("TcrBar: replay step 2 — unrequested terminate: (nothing authorized this)")
+                NSApplication.shared.terminate(nil)
+            }
         }
     }
 
@@ -209,12 +246,48 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         ) { _ in
             TerminationPolicy.shared.authorize(.systemIsPoweringOff)
         }
+        // Take over the quit Apple event from AppKit.
+        //
+        // AppKit's own handler calls `terminate:` without telling us anything, and
+        // by the time `applicationShouldTerminate` runs the event is no longer
+        // "current" — measured, `currentAppleEvent` was nil for an
+        // `osascript -e 'quit app id "…"'`, so the refusal stood and the quit
+        // timed out after 25 s with the app still alive. Handling the event here
+        // authorizes FIRST and then terminates, which cannot race that timing.
+        // This is the path a logout's quit takes too.
+        NSAppleEventManager.shared().setEventHandler(
+            self,
+            andSelector: #selector(handleQuitAppleEvent(_:withReplyEvent:)),
+            forEventClass: AEEventClass(kCoreEventClass),
+            andEventID: AEEventID(kAEQuitApplication)
+        )
+
+        MenuBarPresence.shared.beginHideReplayIfRequested()
     }
 
-    /// The whole fix. AppKit's default answer is YES, and that default is what
-    /// turned a hidden menu-bar icon into an app that could not be launched — see
-    /// `TerminationPolicy` for the trace. Termination is now refused unless
-    /// something identifiable asked for it.
+    @objc private func handleQuitAppleEvent(
+        _ event: NSAppleEventDescriptor,
+        withReplyEvent reply: NSAppleEventDescriptor
+    ) {
+        NSLog("TcrBar: quit Apple event received — terminating")
+        TerminationPolicy.shared.authorize(.quitEventReceived)
+        NSApplication.shared.terminate(nil)
+    }
+
+    /// Half the fix, and measured to be sufficient on its own. AppKit's default
+    /// answer is YES, and that default is what turned a hidden menu-bar icon into
+    /// an app that could not be launched — see `TerminationPolicy` for the trace.
+    /// Termination is now refused unless something identifiable asked for it.
+    ///
+    /// The other half is binding `MenuBarExtra(isInserted:)`, and the two were
+    /// separated and measured rather than assumed. Against a reproduction that
+    /// kills the unfixed app instantly (exit 0, empty output), a build carrying
+    /// ONLY this method survived 60 s, and so did a build carrying only the
+    /// binding. Each prevents the death by itself; neither is dead weight, and
+    /// the redundancy is deliberate because they fail for different reasons — the
+    /// binding depends on SwiftUI keeping a declared-but-absent scene alive, which
+    /// is undocumented behaviour, while this depends only on AppKit asking before
+    /// it quits.
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         let external = Self.currentEventIsAQuitRequest()
         guard TerminationPolicy.shared.allowsTermination(externalQuitRequest: external) else {

--- a/apps/macos/Sources/TcrBar/TcrBarApp.swift
+++ b/apps/macos/Sources/TcrBar/TcrBarApp.swift
@@ -55,8 +55,22 @@ struct TcrBarApp: App {
     /// the app would attempt a spawn on every click.
     @State private var didAttemptLaunchStart = false
 
+    /// Whether the status item is in the menu bar right now.
+    ///
+    /// Binding this turns a hide into OBSERVABLE STATE instead of a scene
+    /// teardown: with `isInserted:` bound, SwiftUI writes `false` here when
+    /// Control Center hides the item, and the scene stays declared. Unbound, the
+    /// scene is simply removed — and an `App` with no scenes left terminates
+    /// itself, which is the bug (`TerminationPolicy`).
+    ///
+    /// Deliberately NOT persisted. An `@AppStorage`-backed value would remember
+    /// "hidden" across launches, so the next launch would come up with no icon and
+    /// no panel — a running app that looks dead, which is worse than the failure
+    /// being fixed. Starting at `true` every launch makes relaunch the recovery.
+    @StateObject private var presence = MenuBarPresence.shared
+
     var body: some Scene {
-        MenuBarExtra {
+        MenuBarExtra(isInserted: $presence.isInserted) {
             FleetView(
                 poller: poller,
                 server: server,
@@ -93,8 +107,68 @@ struct TcrBarApp: App {
     }
 }
 
-/// Two jobs: a child process TcrBar spawned must not outlive it, and the app's
-/// `tcrbar://` URLs land here.
+/// Is the status item in the menu bar? Owned here rather than by the `App` struct
+/// because `AppDelegate` has to reach it, and the delegate exists before any scene
+/// does — a hand-off through a view's `onAppear` would never happen on the launch
+/// that matters, the one where the icon is hidden and no view ever appears.
+///
+/// A singleton for that reason alone. Unlike `Updater`, holding one `Bool` starts
+/// nothing, so the render harness pays nothing for it.
+@MainActor
+final class MenuBarPresence: ObservableObject {
+    static let shared = MenuBarPresence()
+
+    @Published var isInserted = true
+
+    /// Reproduce a hidden menu-bar icon on demand.
+    ///
+    ///     defaults write com.github.dhkts1.tcrbar.dev \
+    ///       TcrHideMenuBarItemForTesting -bool true
+    ///
+    /// This exists because the real trigger cannot be driven from a script.
+    /// Control Center owns the visibility and holds it in memory: writing
+    /// `com.apple.controlcenter "NSStatusItem Visible Item-0"` is simply ignored
+    /// by the running process — measured 2026-08-09, the launched app mirrored
+    /// `1` straight back over a `0` written seconds earlier. Only the Control
+    /// Center UI, or restarting it, moves that state. So without this key the fix
+    /// could only ever be argued for, never demonstrated: the failure it prevents
+    /// would have no reproduction, and a fix with no reproduction is a claim.
+    ///
+    /// It reproduces the TEARDOWN specifically, which is what the unified-log
+    /// trace shows — the scene is created and then destroyed a moment later —
+    /// rather than starting with no item, so the code path under test is the one
+    /// that actually fired. A defaults key rather than an environment variable
+    /// because `open` does not forward the environment to the app it launches,
+    /// and this project already overrides behaviour that way (`TcrExecutablePath`).
+    static let hideForTestingDefaultsKey = "TcrHideMenuBarItemForTesting"
+
+    private init() {
+        guard UserDefaults.standard.bool(forKey: Self.hideForTestingDefaultsKey) else { return }
+        NSLog(
+            "TcrBar: %@ is set — the menu-bar item will be removed shortly to "
+                + "simulate Control Center hiding it.",
+            Self.hideForTestingDefaultsKey
+        )
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            NSLog("TcrBar: simulating a Control Center hide — removing the menu-bar item")
+            self.isInserted = false
+        }
+    }
+
+    /// Put the icon back. Reachable from `applicationShouldHandleReopen`, so
+    /// `open -b <bundle id>` — which is exactly what `tcr ui` runs — is the
+    /// recovery when the icon is hidden and the panel cannot be clicked.
+    func show() {
+        guard !isInserted else { return }
+        NSLog("TcrBar: re-inserting the menu-bar item after a reopen request")
+        isInserted = true
+    }
+}
+
+/// Three jobs: a child process TcrBar spawned must not outlive it, the app's
+/// `tcrbar://` URLs land here, and — the reason the app survives a hidden icon at
+/// all — every termination request is adjudicated here.
 ///
 /// `terminateSupervisedChildOnQuit()` is a no-op unless *this app* spawned the
 /// server — an incumbent proxy is never signalled.
@@ -119,6 +193,67 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
     private var checkIsPending = false
+
+    /// A logout, restart or shutdown must not be blocked by an accessory app.
+    ///
+    /// `applicationShouldTerminate` refuses anything unaccounted for, and macOS
+    /// asks every app before powering off — so without this the first shutdown
+    /// after the fix would stall on a menu-bar utility and blame the user for it.
+    /// `willPowerOffNotification` is delivered before those terminate requests go
+    /// out, which is what makes recording it here sufficient.
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.willPowerOffNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            TerminationPolicy.shared.authorize(.systemIsPoweringOff)
+        }
+    }
+
+    /// The whole fix. AppKit's default answer is YES, and that default is what
+    /// turned a hidden menu-bar icon into an app that could not be launched — see
+    /// `TerminationPolicy` for the trace. Termination is now refused unless
+    /// something identifiable asked for it.
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        let external = Self.currentEventIsAQuitRequest()
+        guard TerminationPolicy.shared.allowsTermination(externalQuitRequest: external) else {
+            NSLog(
+                "TcrBar: refusing a termination nobody requested — this is what a hidden "
+                    + "menu-bar icon looks like. The app stays running; re-show the icon in "
+                    + "Control Center, or run `tcr ui` to put it back."
+            )
+            return .terminateCancel
+        }
+        let reason = TerminationPolicy.shared.authorization?.rawValue ?? "externalQuitRequest"
+        NSLog("TcrBar: terminating (%@)", reason)
+        return .terminateNow
+    }
+
+    /// Did the terminate currently being handled arrive as a quit Apple event?
+    ///
+    /// This is the discriminator, and it is what makes the fix safe. Every quit
+    /// request from OUTSIDE the process carries one — `osascript -e 'quit app …'`,
+    /// the Dock's Quit, Cmd-Q through the standard menu — and none of them run any
+    /// of our code first, so none of them could have called `authorize(_:)`. The
+    /// status-item teardown carries no Apple event: it is a bare in-process
+    /// `terminate:`, so it is the one case that falls through to a refusal.
+    private static func currentEventIsAQuitRequest() -> Bool {
+        guard let event = NSAppleEventManager.shared().currentAppleEvent else { return false }
+        return event.eventClass == AEEventClass(kCoreEventClass)
+            && event.eventID == AEEventID(kAEQuitApplication)
+    }
+
+    /// `open -b com.github.dhkts1.tcrbar` on an already-running copy — which is
+    /// what `tcr ui` does — arrives here. Putting the icon back makes that the
+    /// recovery from a hide, without having to kill a perfectly healthy app.
+    func applicationShouldHandleReopen(
+        _ sender: NSApplication,
+        hasVisibleWindows: Bool
+    ) -> Bool {
+        MenuBarPresence.shared.show()
+        return true
+    }
 
     func applicationWillTerminate(_ notification: Notification) {
         server?.terminateSupervisedChildOnQuit()

--- a/apps/macos/Sources/TcrBar/Updater.swift
+++ b/apps/macos/Sources/TcrBar/Updater.swift
@@ -1,6 +1,29 @@
 import Combine
 import Sparkle
 import SwiftUI
+import TcrBarCore
+
+/// Tells the app that the termination Sparkle is about to perform was asked for.
+///
+/// Installing an update ends with Sparkle terminating this process and relaunching
+/// the new one. `applicationShouldTerminate` refuses terminations nobody asked for
+/// — which is what makes the app survive a hidden menu-bar icon — so without this
+/// hook that refusal would land on Sparkle and updates would silently never
+/// install. Both hooks are implemented because Sparkle can install on quit as well
+/// as install-and-relaunch, and only one of the two fires in each case.
+///
+/// Not `@MainActor`: Sparkle may call these from its own thread and terminates
+/// immediately afterwards, so the authorization has to be recorded before the call
+/// returns. `TerminationPolicy` is lock-guarded for exactly this.
+private final class UpdaterTerminationDelegate: NSObject, SPUUpdaterDelegate {
+    func updaterWillRelaunchApplication(_ updater: SPUUpdater) {
+        TerminationPolicy.shared.authorize(.updateWillRelaunch)
+    }
+
+    func updater(_ updater: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
+        TerminationPolicy.shared.authorize(.updateWillRelaunch)
+    }
+}
 
 /// Self-update, owned by the app the same way `poller` / `server` / `loginItem` /
 /// `accounts` are: one instance created in `TcrBarApp` and handed down. Not a
@@ -28,13 +51,22 @@ final class Updater: ObservableObject {
     private let controller: SPUStandardUpdaterController
     private var observation: AnyCancellable?
 
+    /// Sparkle holds its delegate WEAKLY, so this reference is what keeps the
+    /// object alive. Dropped, the update-authorization hooks above would simply
+    /// never fire and an update would be refused termination with no error.
+    private let terminationDelegate: UpdaterTerminationDelegate
+
     /// `startingUpdater: false` exists for the render harness. Starting the
     /// updater schedules background checks and can put UI on screen; a process
     /// invoked with `--render-states` must do neither.
     init(startingUpdater: Bool = true) {
+        // Built locally first: `self` is not usable as an argument until every
+        // stored property is initialized, and `controller` is one of them.
+        let terminationDelegate = UpdaterTerminationDelegate()
+        self.terminationDelegate = terminationDelegate
         controller = SPUStandardUpdaterController(
             startingUpdater: startingUpdater,
-            updaterDelegate: nil,
+            updaterDelegate: terminationDelegate,
             userDriverDelegate: nil
         )
         observation = controller.updater.publisher(for: \.canCheckForUpdates)

--- a/apps/macos/Sources/TcrBarCore/TerminationPolicy.swift
+++ b/apps/macos/Sources/TcrBarCore/TerminationPolicy.swift
@@ -28,18 +28,27 @@ import Foundation
 /// disease, because an app that cannot be quit is a worse bug than one that quits
 /// too easily. There are two ways in:
 ///
-///  * `authorize(_:)`, called by the code that is *about* to terminate the app —
-///    the panel's Quit button, the power-off notification (a logout or shutdown
-///    must not be blocked by an accessory app), and Sparkle immediately before it
-///    relaunches into a new version.
+///  * `authorize(_:)`, called by the code that is *about* to terminate the app.
+///    Every deliberate quit runs one of these first, by construction: the panel's
+///    Quit button, the `Cmd-Q` menu command (which the app replaces with its own),
+///    the app's own `kAEQuitApplication` handler (which likewise replaces
+///    AppKit's, and covers `osascript -e 'quit app id "…"'` and a logout's quit),
+///    the power-off notification, and Sparkle before it relaunches.
 ///  * `externalQuitRequest`, passed by `AppDelegate` when the terminate arrived
-///    as a `kAEQuitApplication` Apple event. That covers every quit request from
-///    *outside* the process — `osascript -e 'quit app id "…"'`, the Dock, Cmd-Q
-///    routed through the standard menu — none of which run any of our code first
-///    and so cannot have called `authorize(_:)`.
+///    as a `kAEQuitApplication` Apple event.
 ///
-/// The scene teardown above matches neither: it is an in-process `terminate:` with
-/// no Apple event behind it, which is exactly the signal that separates it from
+/// That second one is a BELT, not the mechanism, and it is documented here
+/// because it was measured FAILING. Reading
+/// `NSAppleEventManager.shared().currentAppleEvent` from inside
+/// `applicationShouldTerminate` yielded no event for an
+/// `osascript -e 'quit app id "…"'`: the refusal stood, the quit timed out after
+/// 25 s, and the app was still running — an app that cannot be quit, which is
+/// exactly the failure mode that is worse than the bug. AppKit does not still
+/// consider the quit event current by the time it asks. Hence the handlers above,
+/// which do not depend on that timing.
+///
+/// The scene teardown matches none of them: it is an in-process `terminate:` that
+/// runs no quit handler and authorizes nothing, which is what separates it from
 /// every deliberate quit.
 ///
 /// # Thread safety
@@ -60,6 +69,9 @@ public final class TerminationPolicy: @unchecked Sendable {
         case systemIsPoweringOff
         /// Sparkle is about to install an update and relaunch.
         case updateWillRelaunch
+        /// A `kAEQuitApplication` Apple event reached our own handler: an
+        /// `osascript -e 'quit app …'`, a logout's quit, the Dock's Quit.
+        case quitEventReceived
     }
 
     /// One process, one answer to "may I exit". A singleton because the question

--- a/apps/macos/Sources/TcrBarCore/TerminationPolicy.swift
+++ b/apps/macos/Sources/TcrBarCore/TerminationPolicy.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// Whether this process is allowed to exit.
+///
+/// # The bug this exists to prevent
+///
+/// TcrBar's entire UI is one `MenuBarExtra`, so `TcrBarApp.body` declares exactly
+/// one scene. When Control Center reports the status item hidden, SwiftUI tears
+/// that scene down — and a SwiftUI `App` left with zero scenes terminates itself.
+/// Traced live on 2026-08-09 from a real launch:
+///
+///     FrontBoard  Request for <FBSScene …-NSStatusItemView> complete!
+///     FrontBoard  Received action(s): NSStatusItemChangeVisibilityAction
+///     AppKit:Application  terminate:                        <- 1 ms later
+///     AppKit:Application  replyToApplicationShouldTerminate:YES
+///
+/// The app was not crashing. It was *agreeing to quit*: `AppDelegate` implemented
+/// no `applicationShouldTerminate(_:)`, so AppKit's default `YES` is what that
+/// last line records. Every launch exited 0 within 0.1–12 s with empty output and
+/// no crash report, which is why it read as a launch failure rather than a quit.
+/// A hidden icon therefore made the app unlaunchable for a whole day.
+///
+/// # The rule
+///
+/// Termination is REFUSED by default and allowed only when something identifiable
+/// asked for it. That inverts AppKit's default, so the interesting part is the
+/// list of things that legitimately ask — miss one and the cure is worse than the
+/// disease, because an app that cannot be quit is a worse bug than one that quits
+/// too easily. There are two ways in:
+///
+///  * `authorize(_:)`, called by the code that is *about* to terminate the app —
+///    the panel's Quit button, the power-off notification (a logout or shutdown
+///    must not be blocked by an accessory app), and Sparkle immediately before it
+///    relaunches into a new version.
+///  * `externalQuitRequest`, passed by `AppDelegate` when the terminate arrived
+///    as a `kAEQuitApplication` Apple event. That covers every quit request from
+///    *outside* the process — `osascript -e 'quit app id "…"'`, the Dock, Cmd-Q
+///    routed through the standard menu — none of which run any of our code first
+///    and so cannot have called `authorize(_:)`.
+///
+/// The scene teardown above matches neither: it is an in-process `terminate:` with
+/// no Apple event behind it, which is exactly the signal that separates it from
+/// every deliberate quit.
+///
+/// # Thread safety
+///
+/// Deliberately lock-guarded rather than `@MainActor`. Sparkle calls
+/// `updaterWillRelaunchApplication` and then terminates; hopping to the main actor
+/// to record the authorization would race that termination and could lose it, and
+/// a lost authorization here means a refused update. A lock makes the write land
+/// before the call returns, whichever thread it arrives on.
+public final class TerminationPolicy: @unchecked Sendable {
+    /// Who asked. Recorded rather than reduced to a flag so the log line names the
+    /// reason — "TcrBar refused to quit" is only debuggable if the accepted cases
+    /// are equally legible.
+    public enum Authorization: String, Sendable {
+        /// The Quit button in the panel.
+        case userChoseQuit
+        /// `NSWorkspace.willPowerOffNotification` — a logout, restart or shutdown.
+        case systemIsPoweringOff
+        /// Sparkle is about to install an update and relaunch.
+        case updateWillRelaunch
+    }
+
+    /// One process, one answer to "may I exit". A singleton because the question
+    /// is genuinely process-global: the Quit button, the delegate and Sparkle's
+    /// delegate all have to agree, and none of them can see the others' state.
+    public static let shared = TerminationPolicy()
+
+    /// Public so tests can exercise the policy without touching process state.
+    public init() {}
+
+    private let lock = NSLock()
+    private var storedAuthorization: Authorization?
+
+    /// The reason termination was authorized, or `nil` if it never was.
+    public var authorization: Authorization? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedAuthorization
+    }
+
+    /// Record that a termination is expected.
+    ///
+    /// First writer wins. The reasons are not ranked and it is never revoked: once
+    /// something legitimate has asked the app to go away, a later caller must not
+    /// be able to turn that back into a refusal, or a Quit pressed during a
+    /// Sparkle relaunch could wedge the app open.
+    public func authorize(_ reason: Authorization) {
+        lock.lock()
+        defer { lock.unlock() }
+        if storedAuthorization == nil {
+            storedAuthorization = reason
+        }
+    }
+
+    /// The decision itself, kept pure so it can be tested without an `NSApplication`.
+    ///
+    /// - Parameter externalQuitRequest: true when the terminate currently being
+    ///   handled arrived as a `kAEQuitApplication` Apple event.
+    public func allowsTermination(externalQuitRequest: Bool) -> Bool {
+        externalQuitRequest || authorization != nil
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/TerminationPolicyTests.swift
+++ b/apps/macos/Tests/TcrBarTests/TerminationPolicyTests.swift
@@ -49,10 +49,23 @@ final class TerminationPolicyTests: XCTestCase {
         XCTAssertTrue(policy.allowsTermination(externalQuitRequest: false))
     }
 
-    /// Every quit request from OUTSIDE the process — `osascript`, the Dock, Cmd-Q
-    /// through the standard menu — arrives as a `kAEQuitApplication` Apple event
-    /// and runs none of our code first, so it can never have authorized itself.
-    /// It is allowed on the strength of the event alone.
+    /// `osascript -e 'quit app id "…"'` and a logout's quit both arrive as a
+    /// `kAEQuitApplication` Apple event, which the app handles itself and
+    /// authorizes before terminating.
+    ///
+    /// This case is the one that was measured BROKEN. The first version relied on
+    /// reading `NSAppleEventManager.currentAppleEvent` inside
+    /// `applicationShouldTerminate`; it returned no event, the refusal stood, and
+    /// the quit timed out after 25 s with the app still running. Authorizing from
+    /// the app's own quit handler does not depend on that timing.
+    func testAQuitAppleEventIsAllowed() {
+        let policy = TerminationPolicy()
+        policy.authorize(.quitEventReceived)
+        XCTAssertTrue(policy.allowsTermination(externalQuitRequest: false))
+    }
+
+    /// The belt that survived that measurement: if AppKit ever does report the
+    /// quit event as current, that alone is enough, with no prior authorization.
     func testAnExternalQuitRequestIsAllowedWithoutPriorAuthorization() {
         let policy = TerminationPolicy()
         XCTAssertNil(policy.authorization)

--- a/apps/macos/Tests/TcrBarTests/TerminationPolicyTests.swift
+++ b/apps/macos/Tests/TcrBarTests/TerminationPolicyTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+
+@testable import TcrBarCore
+
+/// Regression test for an app that could not be launched.
+///
+/// TcrBar's whole UI is one `MenuBarExtra`. Hiding the status item tore that scene
+/// down, a SwiftUI `App` with zero scenes terminates itself, and AppKit's default
+/// `applicationShouldTerminate` answer — YES — meant the app agreed. Every launch
+/// exited 0 within seconds with no output and no crash report, so it read as a
+/// broken build rather than a quit. That cost a day of no menu-bar app.
+///
+/// The fix inverts the default: refuse, unless something identifiable asked. The
+/// danger in that inversion is the opposite bug — an app that cannot be quit — so
+/// what these tests actually guard is the ACCEPT list. Each case below is a way
+/// the app legitimately has to be able to exit, and dropping any one of them
+/// ships something worse than the failure being fixed.
+final class TerminationPolicyTests: XCTestCase {
+
+    /// The scene teardown itself: an in-process `terminate:` with no Apple event
+    /// and nothing having authorized it. The one case that must be refused.
+    func testAnUnrequestedTerminationIsRefused() {
+        let policy = TerminationPolicy()
+        XCTAssertNil(policy.authorization)
+        XCTAssertFalse(policy.allowsTermination(externalQuitRequest: false))
+    }
+
+    /// The panel's Quit button. It authorizes and then terminates.
+    func testTheQuitButtonIsAllowed() {
+        let policy = TerminationPolicy()
+        policy.authorize(.userChoseQuit)
+        XCTAssertTrue(policy.allowsTermination(externalQuitRequest: false))
+        XCTAssertEqual(policy.authorization, .userChoseQuit)
+    }
+
+    /// A logout, restart or shutdown. An accessory app that refuses these blocks
+    /// the whole power-off and gets blamed for it.
+    func testPowerOffIsAllowed() {
+        let policy = TerminationPolicy()
+        policy.authorize(.systemIsPoweringOff)
+        XCTAssertTrue(policy.allowsTermination(externalQuitRequest: false))
+    }
+
+    /// Sparkle terminating to install and relaunch. Refused, updates would
+    /// silently never install.
+    func testASparkleRelaunchIsAllowed() {
+        let policy = TerminationPolicy()
+        policy.authorize(.updateWillRelaunch)
+        XCTAssertTrue(policy.allowsTermination(externalQuitRequest: false))
+    }
+
+    /// Every quit request from OUTSIDE the process — `osascript`, the Dock, Cmd-Q
+    /// through the standard menu — arrives as a `kAEQuitApplication` Apple event
+    /// and runs none of our code first, so it can never have authorized itself.
+    /// It is allowed on the strength of the event alone.
+    func testAnExternalQuitRequestIsAllowedWithoutPriorAuthorization() {
+        let policy = TerminationPolicy()
+        XCTAssertNil(policy.authorization)
+        XCTAssertTrue(policy.allowsTermination(externalQuitRequest: true))
+    }
+
+    /// First writer wins, and it is never revoked. A Quit pressed while Sparkle is
+    /// mid-relaunch must not be able to turn an authorized termination back into a
+    /// refusal and wedge the app open.
+    func testAuthorizationIsNeverRevokedOrOverwritten() {
+        let policy = TerminationPolicy()
+        policy.authorize(.updateWillRelaunch)
+        policy.authorize(.userChoseQuit)
+        XCTAssertEqual(policy.authorization, .updateWillRelaunch)
+        XCTAssertTrue(policy.allowsTermination(externalQuitRequest: false))
+    }
+
+    /// Sparkle calls its delegate off the main thread and terminates immediately
+    /// afterwards, which is why this type is lock-guarded rather than
+    /// `@MainActor` — an authorization that lands after the terminate is a
+    /// refused update. Concurrent writers must not corrupt or lose the answer.
+    func testAuthorizingFromManyThreadsIsSafe() {
+        let policy = TerminationPolicy()
+        DispatchQueue.concurrentPerform(iterations: 64) { index in
+            policy.authorize(index.isMultiple(of: 2) ? .userChoseQuit : .updateWillRelaunch)
+        }
+        XCTAssertNotNil(policy.authorization)
+        XCTAssertTrue(policy.allowsTermination(externalQuitRequest: false))
+    }
+
+    /// The shared instance is what the app actually consults; asserting it exists
+    /// and starts refusing keeps the singleton from drifting away from the type
+    /// the rest of these tests exercise.
+    @MainActor
+    func testTheSharedPolicyStartsOutRefusing() {
+        // Nothing in this test bundle authorizes it, and the app is not running.
+        XCTAssertFalse(TerminationPolicy.shared.allowsTermination(externalQuitRequest: false))
+    }
+}

--- a/apps/macos/scripts/build-tcrbar.sh
+++ b/apps/macos/scripts/build-tcrbar.sh
@@ -12,7 +12,46 @@ pkg_dir="$(dirname "$here")"
 repo_root="$(cd "$pkg_dir/../.." && pwd)"
 
 app_name="TcrBar"
-bundle_id="com.github.dhkts1.tcrbar"
+
+# A DEV BUILD MUST NOT SHARE THE INSTALLED APP'S IDENTITY.
+#
+# The bundle id is not just a name. macOS keys four separate pieces of durable,
+# per-user state off it, and every one of them is state the installed app in
+# /Applications depends on:
+#
+#   1. The preferences domain — `~/Library/Preferences/<id>.plist`. That is where
+#      `@AppStorage` lives (startServerAtLaunch, TcrExecutablePath) AND where
+#      Sparkle records its update state (last check date, skipped version).
+#   2. Sparkle's update bookkeeping, per the above.
+#   3. Control Center's menu-bar autosave slot, which is what decides whether the
+#      status item is shown or hidden.
+#   4. The LaunchServices record — what `open -b <id>` and `tcrbar://` resolve to.
+#
+# With one shared id, every checkout, every worktree, every DMG copy and every
+# throwaway debug build is the SAME app as far as macOS is concerned. That is not
+# hypothetical: on 2026-08-09 a worker's debug build wrote Sparkle keys straight
+# into the installed app's preferences, and `open -b` became a coin flip over
+# which bundle LaunchServices had seen last.
+#
+# So non-shipping builds get their own id and their own display name, and are
+# thereby unable to touch any of the four. The SHIPPING id is unchanged and
+# exact — changing it would orphan every existing install and break Sparkle,
+# which matches updates against the id it already published.
+#
+# Opt IN, never opt out: the default is the safe one. `install.sh` and
+# `release-tcrbar.sh` — the two scripts that produce an artifact a user actually
+# runs — set TCRBAR_SHIPPING_BUILD=1 themselves.
+release_bundle_id="com.github.dhkts1.tcrbar"
+if [ "${TCRBAR_SHIPPING_BUILD:-0}" = "1" ]; then
+  bundle_id="$release_bundle_id"
+  bundle_name="$app_name"
+  build_channel="shipping"
+else
+  bundle_id="$release_bundle_id.dev"
+  bundle_name="$app_name (dev)"
+  build_channel="dev"
+fi
+
 build_dir="$pkg_dir/build"
 app_dir="$build_dir/$app_name.app"
 macos_dir="$app_dir/Contents/MacOS"
@@ -251,7 +290,7 @@ cat >"$app_dir/Contents/Info.plist" <<PLIST
 	<key>CFBundleIconName</key>
 	<string>AppIcon</string>
 	<key>CFBundleName</key>
-	<string>$app_name</string>
+	<string>$bundle_name</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
@@ -386,3 +425,9 @@ if [ -z "$sign_identity" ]; then
 fi
 
 echo "built $app_dir  version=$short_version build=$build_number sha=$git_sha signing=$sign_tier"
+echo "  channel=$build_channel  bundle id=$bundle_id"
+if [ "$build_channel" = "dev" ]; then
+  echo "  (a dev build: its preferences, Sparkle state, menu-bar slot and"
+  echo "   LaunchServices record are its own. Set TCRBAR_SHIPPING_BUILD=1 to"
+  echo "   build with the shipping identity — install.sh and release-tcrbar.sh do.)"
+fi

--- a/apps/macos/scripts/install.sh
+++ b/apps/macos/scripts/install.sh
@@ -58,7 +58,13 @@ SRC="$MACOS_DIR/build/${APP_NAME}.app"
 DEST="/Applications/${APP_NAME}.app"
 
 echo "==> Building ${APP_NAME}…"
-bash "$MACOS_DIR/scripts/build-tcrbar.sh"
+# This is a SHIPPING build: it lands in /Applications and becomes *the* installed
+# TcrBar, so it must carry the published bundle id. `build-tcrbar.sh` defaults to
+# a `.dev` id precisely so that an ordinary local build cannot write into this
+# app's preferences, Sparkle state or menu-bar slot; installing is the one local
+# path where the real identity is correct. See the comment beside `bundle_id`
+# there for what the four pieces of shared state are.
+TCRBAR_SHIPPING_BUILD=1 bash "$MACOS_DIR/scripts/build-tcrbar.sh"
 
 [ -d "$SRC" ] || { echo "build produced no bundle at $SRC" >&2; exit 1; }
 

--- a/apps/macos/scripts/release-tcrbar.sh
+++ b/apps/macos/scripts/release-tcrbar.sh
@@ -67,9 +67,35 @@ appcast_path="$pkg_dir/appcast.xml"
 # installers, which we do not ship). See docs/RELEASING.md.
 readonly required_cert_class="Developer ID Application"
 
+# The PUBLISHED bundle id, and the one thing about a release that can never
+# change. Sparkle matches an update against the id the installed copy already
+# carries, and LaunchServices resolves `open -b` and `tcrbar://` through it, so a
+# release shipping any other id would silently orphan every existing install.
+#
+# `build-tcrbar.sh` deliberately defaults to `<id>.dev` so that an ordinary local
+# build cannot write into an installed app's preferences, Sparkle state or
+# menu-bar slot. A release opts back in with TCRBAR_SHIPPING_BUILD=1 — and then
+# this value is asserted against what actually landed, because an env var that
+# failed to take effect must not be discoverable only by users.
+readonly release_bundle_id="com.github.dhkts1.tcrbar"
+
 die() { printf 'ERROR: %s\n' "$@" >&2; exit 1; }
 stage() { printf '\n==> %s\n' "$1"; }
 note() { printf '    %s\n' "$1"; }
+
+# Assert the built bundle carries the published identity.
+assert_release_bundle_id() {
+  local bundle="$1" id
+  [ -d "$bundle" ] || die "no bundle at $bundle — did the build stage run?"
+  id="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' \
+    "$bundle/Contents/Info.plist" 2>/dev/null || true)"
+  [ "$id" = "$release_bundle_id" ] || die \
+    "$bundle declares CFBundleIdentifier '${id:-<unreadable>}', not '$release_bundle_id'." \
+    "A release under any other id orphans every existing install: Sparkle would" \
+    "never offer it as an update and 'open -b' would not resolve to it." \
+    "This usually means TCRBAR_SHIPPING_BUILD=1 did not reach build-tcrbar.sh."
+  note "bundle id: $release_bundle_id"
+}
 
 # ---------------------------------------------------------------------------
 # Stage 2 — the Developer ID assert
@@ -346,7 +372,14 @@ main() {
 
   # ---- stage 1: build -----------------------------------------------------
   stage "stage 1/9  build (apps/macos/scripts/build-tcrbar.sh)"
-  "$here/build-tcrbar.sh"
+  # The DISTRIBUTION identity, and it must be exact. `build-tcrbar.sh` defaults to
+  # a `.dev` bundle id so a local build cannot poison an installed app's
+  # preferences, Sparkle state or menu-bar slot; a release is the case that has to
+  # opt back in. Shipping the `.dev` id would orphan every existing install and
+  # break Sparkle, which matches updates against the id already published — so
+  # the id that actually LANDED is asserted below rather than this line trusted.
+  TCRBAR_SHIPPING_BUILD=1 "$here/build-tcrbar.sh"
+  assert_release_bundle_id "$app_dir"
 
   # ---- stage 2: Developer ID assert ---------------------------------------
   stage "stage 2/9  assert the bundle is signed for distribution"


### PR DESCRIPTION
## The failure

`TcrBarApp.body` declares exactly one scene, a `MenuBarExtra`. When Control Center hides the status item, SwiftUI tears that scene down, and a SwiftUI `App` left with zero scenes terminates itself. AppKit's default answer to `applicationShouldTerminate` is *yes* and `AppDelegate` implemented no override, so the app agreed to quit:

```
FrontBoard  Request for <FBSScene …-NSStatusItemView> complete!
FrontBoard  Received action(s): NSStatusItemChangeVisibilityAction
AppKit:Application  terminate:                        <- 1 ms later
AppKit:Application  replyToApplicationShouldTerminate:YES
```

Every launch exited 0 within a second with empty output and no crash report, which reads as a broken build rather than a quit. It cost a day of no menu-bar app.

## The fix

Termination is refused by default. `TerminationPolicy` (in `TcrBarCore`, so it is testable) holds the list of things that legitimately ask, and each entry has a test, because getting that accept-list wrong ships an app that cannot be quit — a worse bug than the one being fixed:

- the panel's **Quit** button;
- **Cmd-Q**, whose standard command is replaced with one that authorizes first;
- the app's own **`kAEQuitApplication` handler**, covering `osascript -e 'quit app id "…"'` and a logout's quit;
- **power-off** (`NSWorkspace.willPowerOffNotification`), so an accessory app never blocks a shutdown;
- **Sparkle**, immediately before it relaunches into a new version.

The status item is also bound through `MenuBarExtra(isInserted:)`, making a hide observable state rather than a vanishing scene. It is never persisted — a remembered "hidden" would launch a running app that looks dead — and `applicationShouldHandleReopen` re-inserts it, so `tcr ui` is the recovery when the icon is gone and the panel cannot be clicked.

## Evidence

Control Center cannot be scripted: it holds visibility in memory and ignores a `defaults write` to `com.apple.controlcenter` outright, mirroring `1` back over a `0` written seconds earlier. Two probes built on that reproduced nothing, and a probe that cannot fail proves nothing. Running the executable **directly** rather than through `open` does reproduce it, with the reported signature exactly.

Against that reproduction, 60s each:

| build | result |
|---|---|
| `origin/main` code | **DIED** instantly, exit 0, empty output |
| delegate only, no `isInserted` binding | SURVIVED |
| `isInserted` binding only, no delegate | SURVIVED |
| both (what ships) | SURVIVED, and 90s in a second run |

Each half prevents the death on its own. Both are kept deliberately: the binding relies on SwiftUI keeping a declared-but-absent scene alive, which is undocumented, while the delegate relies only on AppKit asking before it quits.

Quit was measured **broken** by the first attempt at this fix — deciding intent by reading `NSAppleEventManager.currentAppleEvent` inside `applicationShouldTerminate` found no event, so an `osascript` quit timed out after 25s with the app still running. That is what the dedicated quit handler and the replaced Cmd-Q command exist for. Re-measured after the change: `osascript` quit returns 0 and the process is gone within seconds.

## Bundle identity

macOS keys the preferences domain, Sparkle's update state, Control Center's autosave slot and the LaunchServices record off the bundle id, so one shared id made every worktree, DMG copy and debug build the *same app* — which is how a debug build wrote Sparkle keys into the installed app's preferences. `build-tcrbar.sh` now defaults to `com.github.dhkts1.tcrbar.dev` with display name `TcrBar (dev)`; `install.sh` and `release-tcrbar.sh` opt back in with `TCRBAR_SHIPPING_BUILD=1`.

The shipped id is unchanged and exact — anything else would orphan every existing install and break Sparkle — and the release now **asserts the id that actually landed** rather than trusting the variable. Both directions were exercised: the assert fails on a dev bundle and passes on a shipping one, and a shipping build was confirmed to produce `com.github.dhkts1.tcrbar` / `TcrBar`.

## Gates

| gate | exit |
|---|---|
| `swift build -c release --product TcrBar` | 0 |
| `swift test` (116 tests) | 0 |
| `swift-format lint --strict` (CI's gate) | 0 |
| `shellcheck` on the three modified scripts | 0 |
| `apps/macos/scripts/build-tcrbar.sh` | 0 |
| `codesign -v --deep --strict` | 0 |

Not installed to `/Applications` — build and verification only.