### PR TITLE
fix: sign the app's code before executing it to render the icon

### DIFF
--- a/apps/macos/scripts/build-tcrbar.sh
+++ b/apps/macos/scripts/build-tcrbar.sh
@@ -185,31 +185,6 @@ else
   exit 1
 fi
 
-# The icon is DRAWN BY THE APP, not committed as a binary asset.
-#
-# `AppIcon.swift` renders it from the same `Tok` values the panel uses, so the
-# mark cannot drift from the palette the way a checked-in .icns silently does.
-# That is why this runs after the binary is copied: the binary is the generator.
-#
-# Non-fatal on purpose. A missing icon costs a generic placeholder in Finder; it
-# is not worth failing a build that is otherwise fine, and a hard failure here
-# would block `swift build` working on a machine without `iconutil`.
-iconset="$(mktemp -d)/AppIcon.iconset"
-if "$macos_dir/$app_name" --render-icon "$iconset" >/dev/null 2>&1 \
-    && command -v iconutil >/dev/null 2>&1 \
-    && iconutil -c icns "$iconset" -o "$app_dir/Contents/Resources/AppIcon.icns" 2>/dev/null; then
-  echo "    icon: generated"
-else
-  mkdir -p "$app_dir/Contents/Resources"
-  if "$macos_dir/$app_name" --render-icon "$iconset" >/dev/null 2>&1 \
-      && iconutil -c icns "$iconset" -o "$app_dir/Contents/Resources/AppIcon.icns" 2>/dev/null; then
-    echo "    icon: generated"
-  else
-    echo "    WARNING: could not generate the app icon — Finder will show a placeholder." >&2
-  fi
-fi
-rm -rf "$(dirname "$iconset")"
-
 # Sparkle's EdDSA public key — OMITTED when unset, never a placeholder.
 #
 # Sparkle refuses any update whose signature does not verify against this key.
@@ -329,13 +304,28 @@ done
 # one Mach-O: it contains an Updater.app, an Autoupdate helper and two XPC
 # services, each of which is code in its own right. Code signs INSIDE-OUT, so the
 # order is xpc → Updater.app → Autoupdate → the framework version → the app's own
-# `tcr` → the bundle. Signing the framework after the bundle would invalidate the
-# bundle's seal, and signing the framework without its nested payload leaves the
-# framework's own seal invalid — `--deep --strict` catches both.
+# `tcr` → its own executable → the bundle. Signing the framework after the bundle
+# would invalidate the bundle's seal, and signing the framework without its nested
+# payload leaves the framework's own seal invalid — `--deep --strict` catches both.
 #
 # `--preserve-metadata=entitlements` on the nested code is not optional: Sparkle's
 # installer XPC service ships entitlements it needs, and a plain re-sign drops
 # them silently.
+#
+# The icon step sits INSIDE this section, between the nested signatures and the
+# bundle's, and that placement is the whole point. The icon is rendered by
+# EXECUTING the app's own binary, and it used to run before any signing at all:
+# the kernel saw a main executable with no CMS blob and an ad-hoc Sparkle, and
+# refused to load them — `AMFI: ... has no CMS blob?` / `Sparkle ... is adhoc
+# signed`. It appeared to work only because a developer-tool exemption let the
+# process run anyway, and the icon fallback is deliberately non-fatal, so on a
+# machine without that exemption the build silently shipped a placeholder icon
+# and still reported success.
+#
+# So the order is: sign every nested binary AND the app's own executable, then
+# render the icon, then seal the bundle. The seal has to come last because it
+# covers `Contents/Resources/AppIcon.icns` — writing the icon after signing the
+# bundle would invalidate the signature that was just applied.
 if [ -n "$sign_identity" ]; then
   sign_key="$sign_identity"
 else
@@ -365,6 +355,41 @@ done
 codesign -s "$sign_key" $codesign_flags "$sparkle_version_dir"
 # shellcheck disable=SC2086
 codesign -s "$sign_key" $codesign_flags "$macos_dir/tcr"
+# The app's own executable is signed HERE, as a plain Mach-O, because the icon
+# step below runs it. The bundle signature further down re-signs it in place with
+# the same key and flags, which is what gives it the bundle identity; this earlier
+# pass exists only so the kernel will load it at all.
+# shellcheck disable=SC2086
+codesign -s "$sign_key" $codesign_flags "$macos_dir/$app_name"
+
+# The icon is DRAWN BY THE APP, not committed as a binary asset.
+#
+# `AppIcon.swift` renders it from the same `Tok` values the panel uses, so the
+# mark cannot drift from the palette the way a checked-in .icns silently does.
+# That is why this runs after the binary is copied and signed: the binary is the
+# generator, and an unsigned generator is one the kernel refuses to execute.
+#
+# Non-fatal on purpose. A missing icon costs a generic placeholder in Finder; it
+# is not worth failing a build that is otherwise fine, and a hard failure here
+# would block `swift build` working on a machine without `iconutil`.
+iconset="$(mktemp -d)/AppIcon.iconset"
+if "$macos_dir/$app_name" --render-icon "$iconset" >/dev/null 2>&1 \
+    && command -v iconutil >/dev/null 2>&1 \
+    && iconutil -c icns "$iconset" -o "$app_dir/Contents/Resources/AppIcon.icns" 2>/dev/null; then
+  echo "    icon: generated"
+else
+  mkdir -p "$app_dir/Contents/Resources"
+  if "$macos_dir/$app_name" --render-icon "$iconset" >/dev/null 2>&1 \
+      && iconutil -c icns "$iconset" -o "$app_dir/Contents/Resources/AppIcon.icns" 2>/dev/null; then
+    echo "    icon: generated"
+  else
+    echo "    WARNING: could not generate the app icon — Finder will show a placeholder." >&2
+  fi
+fi
+rm -rf "$(dirname "$iconset")"
+
+# The bundle is sealed LAST — after AppIcon.icns has been written into
+# Contents/Resources, which this signature covers.
 # shellcheck disable=SC2086
 codesign -s "$sign_key" $codesign_flags "$app_dir"
 


### PR DESCRIPTION
## The defect

`build-tcrbar.sh` renders the app icon by **executing the freshly-built binary**, and that
invocation sat ahead of the entire codesign section:

| line (before) | step |
|---|---|
| 143 | `ditto` Sparkle.framework — ad-hoc, as SPM ships it |
| 198 | `"$macos_dir/TcrBar" --render-icon` — **runs the unsigned binary** |
| 355 | `echo "==> codesign"` — signing starts here |

At line 198 the main executable had no signature at all and Sparkle still carried SPM's ad-hoc
one, so the kernel refused to load them. From a real build of the pre-fix ordering:

```
AMFI: '…/TcrBar.app/Contents/MacOS/TcrBar' has no CMS blob?
AMFI: '…/TcrBar.app/Contents/MacOS/TcrBar': Unrecoverable CT signature issue, bailing out.
AMFI: '…/Sparkle.framework/Versions/B/Sparkle' is adhoc signed.
amfid: …/Sparkle not valid: Error Domain=AppleMobileFileIntegrityError Code=-423
```

It ran anyway only because of a **developer-tool environment exemption**. The icon step is
deliberately non-fatal, so on a machine without that exemption the render fails, the build ships a
placeholder icon, and still reports success. The silent degradation is the bug; the log noise is
the symptom.

## The fix

Reorder so nothing unsigned is executed, while keeping the outer seal last — it covers
`Contents/Resources/AppIcon.icns`, so sealing before the icon is written would invalidate it:

```
sign XPC services → Updater.app → Autoupdate → Sparkle Versions/B → tcr
  → sign Contents/MacOS/TcrBar   (new: it is the icon generator)
  → render icon, write AppIcon.icns
  → seal the bundle
```

The app's own executable is signed as a plain Mach-O before the render; the bundle signature
re-signs it in place with the same key and flags. Every existing flag is preserved (`--force`,
`--options runtime --timestamp` on the Developer ID tier, `--preserve-metadata=entitlements` on
nested code), as is the signing ladder (Developer ID → Apple Development → ad-hoc with the
warning). The ordering doc-comment is updated so its reasoning still matches the code.

## Verification

The AMFI probe was **positive-controlled first**: built with the old ordering, queried the unified
log for the build path, and confirmed the complaint lines are present — so an empty result after
the fix means absence, not a broken grep.

| probe | old ordering | this branch |
|---|---|---|
| `has no CMS blob` / `CT signature issue` / `is adhoc signed` / `not valid: AppleMobileFileIntegrity` | **4 lines** | **0** |

The only remaining `amfid` lines after the fix are neutral `Entering OSX path for …` evaluation
records, with no rejection following them.

| gate | rc |
|---|---|
| `apps/macos/scripts/build-tcrbar.sh` | 0 |
| `codesign -v --deep --strict apps/macos/build/TcrBar.app` | 0 |
| `shellcheck apps/macos/scripts/build-tcrbar.sh` | 0 |
| `bash -n apps/macos/scripts/build-tcrbar.sh` | 0 |

Icon: **generated, not the fallback** — the build printed `icon: generated`, and
`AppIcon.icns` is 158054 bytes, `Mac OS X icon … "ic12" type`. The fallback path leaves the file
absent entirely.

This is unrelated to the missing menu-bar icon, which is a separate open issue and is untouched here.
