### PR TITLE
fix: move TcrBar to a new bundle id after ControlCenter blocked the old one

### DIFF
--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -191,7 +191,7 @@ whatever happens to be on `PATH`, or bundling buys nothing. Override explicitly
 with either:
 
 ```sh
-defaults write com.github.dhkts1.tcrbar TcrExecutablePath /path/to/tcr
+defaults write io.github.dhkts1.tcrbar TcrExecutablePath /path/to/tcr
 TCR_BIN=/path/to/tcr open build/TcrBar.app     # env override, shell launches
 ```
 

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -138,7 +138,7 @@ struct FleetView: View {
                 icon: Tok.unreadableGlyph,
                 title: "tcr is not on PATH",
                 detail: "Searched \(searched.count) locations. Set it with "
-                    + "`defaults write com.github.dhkts1.tcrbar \(TcrTool.overrideDefaultsKey) <path>`.",
+                    + "`defaults write io.github.dhkts1.tcrbar \(TcrTool.overrideDefaultsKey) <path>`.",
                 tint: Tok.spent
             )
         case .commandFailed(let code, let message):

--- a/apps/macos/Sources/TcrBar/MenuBarShell.swift
+++ b/apps/macos/Sources/TcrBar/MenuBarShell.swift
@@ -76,7 +76,7 @@ final class MenuBarShell {
         // a crash or a log line: the app launches, polls, holds its assertions
         // and draws nothing a human can see.
         //
-        // Both `com.github.dhkts1.tcrbar` (the bundled app) and `TcrBar` (what
+        // Both `io.github.dhkts1.tcrbar` (the bundled app) and `TcrBar` (what
         // an unbundled `swift build` binary uses) were observed holding `0`.
         // How it got there is *not* established — it could predate this work or
         // have been written during it — so nothing here claims a history, and

--- a/apps/macos/Sources/TcrBarCore/TcrTool.swift
+++ b/apps/macos/Sources/TcrBarCore/TcrTool.swift
@@ -9,7 +9,7 @@ import Foundation
 /// also never reads the tcr config file.
 public enum TcrTool {
     /// User-facing override, e.g.
-    /// `defaults write com.github.dhkts1.tcrbar TcrExecutablePath <path>`.
+    /// `defaults write io.github.dhkts1.tcrbar TcrExecutablePath <path>`.
     public static let overrideDefaultsKey = "TcrExecutablePath"
     /// Environment override, useful when launched from a shell.
     public static let overrideEnvKey = "TCR_BIN"

--- a/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
@@ -780,7 +780,7 @@ final class TcrToolTests: XCTestCase {
         let bundle = URL(fileURLWithPath: "/nonexistent-bundle", isDirectory: true)
         let result = TcrTool.resolve(
             environment: ["PATH": "/nonexistent-dir"],
-            defaults: UserDefaults(suiteName: "com.github.dhkts1.tcrbar.tests")!,
+            defaults: UserDefaults(suiteName: "io.github.dhkts1.tcrbar.tests")!,
             home: URL(fileURLWithPath: "/nonexistent-home", isDirectory: true),
             bundle: bundle
         )
@@ -809,7 +809,7 @@ final class TcrToolTests: XCTestCase {
     }
 
     private var scratchDefaults: UserDefaults {
-        let defaults = UserDefaults(suiteName: "com.github.dhkts1.tcrbar.tests")!
+        let defaults = UserDefaults(suiteName: "io.github.dhkts1.tcrbar.tests")!
         defaults.removeObject(forKey: TcrTool.overrideDefaultsKey)
         return defaults
     }

--- a/apps/macos/scripts/build-tcrbar.sh
+++ b/apps/macos/scripts/build-tcrbar.sh
@@ -12,7 +12,27 @@ pkg_dir="$(dirname "$here")"
 repo_root="$(cd "$pkg_dir/../.." && pwd)"
 
 app_name="TcrBar"
-bundle_id="com.github.dhkts1.tcrbar"
+
+# The bundle id, and why it is not the obvious one.
+#
+# macOS ControlCenter draws every third-party menu bar icon, and it keeps a
+# runtime blocked list keyed on BUNDLE ID. On 2026-08-09 at 14:02:53 two TcrBar
+# processes registered the same status item slot at the same instant and
+# `com.github.dhkts1.tcrbar` landed on that list. Every launch afterwards was
+# blocked ~12ms after registering: the app ran, polled and held its assertions,
+# and drew nothing clickable. The block survives relaunch, `killall
+# ControlCenter` and a reboot, and renaming the status item's `autosaveName`
+# does NOT clear it — measured; the key follows the bundle id. The only exit was
+# a new identity, which is why this reads `io.` and not `com.`.
+#
+# TCRBAR_DEV_BUILD=1 gives a non-shipping build its own identity so it can never
+# be the second process in that race again. Unset means the shipping id: a dev
+# bundle must be an explicit choice, and the build echoes which one it used.
+bundle_id="io.github.dhkts1.tcrbar"
+if [ "${TCRBAR_DEV_BUILD:-0}" = "1" ]; then
+  bundle_id="$bundle_id.dev"
+fi
+
 build_dir="$pkg_dir/build"
 app_dir="$build_dir/$app_name.app"
 macos_dir="$app_dir/Contents/MacOS"
@@ -109,6 +129,12 @@ if [ "$(git -C "$repo_root" rev-parse --is-shallow-repository 2>/dev/null || ech
     echo "ERROR: Fix:  git -C \"\$repo_root\" fetch --unshallow"
   } >&2
   exit 1
+fi
+
+if [ "${TCRBAR_DEV_BUILD:-0}" = "1" ]; then
+  echo "==> bundle id: $bundle_id  (DEV build — will not replace the installed app)"
+else
+  echo "==> bundle id: $bundle_id  (shipping identity)"
 fi
 
 echo "==> swift build -c release --product $app_name"

--- a/apps/macos/scripts/uninstall.sh
+++ b/apps/macos/scripts/uninstall.sh
@@ -8,7 +8,14 @@
 set -euo pipefail
 
 APP_NAME="TcrBar"
-BUNDLE_ID="com.github.dhkts1.tcrbar"
+BUNDLE_ID="io.github.dhkts1.tcrbar"
+# The id TcrBar shipped under until 2026-08-09, when ControlCenter's runtime
+# blocked list — keyed on bundle id — swallowed it and forced a new identity.
+# An uninstall that leaves the old prefs domain and the old LaunchServices
+# registration behind is not an uninstall: `open -b` can still resolve a stale
+# copy, and the abandoned domain keeps the hidden-status-item defaults alive
+# across a reinstall.
+LEGACY_BUNDLE_ID="com.github.dhkts1.tcrbar"
 DEST="/Applications/${APP_NAME}.app"
 
 if pgrep -f "${APP_NAME}.app/Contents/MacOS/${APP_NAME}" >/dev/null 2>&1; then
@@ -31,6 +38,29 @@ if [ -d "$DEST" ]; then
   rm -rf "$DEST"
 else
   echo "==> Nothing installed at ${DEST}."
+fi
+
+# Legacy identity cleanup. Unregister by PATH, because `lsregister` takes a
+# bundle path and not an id — so ask Spotlight which bundles still claim the old
+# id first. A machine that never ran the old build finds nothing and prints
+# nothing, which is the intended no-op.
+legacy_copies="$(/usr/bin/mdfind "kMDItemCFBundleIdentifier == '${LEGACY_BUNDLE_ID}'" 2>/dev/null || true)"
+if [ -n "$legacy_copies" ]; then
+  echo "==> Unregistering copies still claiming ${LEGACY_BUNDLE_ID}…"
+  echo "$legacy_copies" | while IFS= read -r legacy_app; do
+    [ -n "$legacy_app" ] || continue
+    echo "    $legacy_app"
+    /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister \
+      -u "$legacy_app" >/dev/null 2>&1 || true
+  done
+fi
+
+# The old domain is unconditionally dead — no build will ever read it again —
+# so unlike the current one it is deleted rather than merely reported. Leaving
+# it behind is how a hidden-status-item default outlives a reinstall.
+if /usr/bin/defaults read "${LEGACY_BUNDLE_ID}" >/dev/null 2>&1; then
+  echo "==> Removing stale preferences for ${LEGACY_BUNDLE_ID}…"
+  /usr/bin/defaults delete "${LEGACY_BUNDLE_ID}" >/dev/null 2>&1 || true
 fi
 
 echo

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,7 +282,7 @@ fn run_ui() -> anyhow::Result<()> {
     use anyhow::Context;
 
     let status = std::process::Command::new("open")
-        .args(["-b", "com.github.dhkts1.tcrbar"])
+        .args(["-b", "io.github.dhkts1.tcrbar"])
         .status()
         .context("failed to run `open`")?;
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -683,7 +683,7 @@ fn update_installed(force: bool) -> anyhow::Result<()> {
 /// resolves a URL scheme to whatever app claims it, so a bundle that is not
 /// TcrBar gets the instructional message instead of a request we cannot reason
 /// about.
-const TCRBAR_BUNDLE_ID: &str = "com.github.dhkts1.tcrbar";
+const TCRBAR_BUNDLE_ID: &str = "io.github.dhkts1.tcrbar";
 
 /// The URL TcrBar registers for "check for updates now". Fixed contract; the
 /// URL carries no arguments.
@@ -1293,7 +1293,7 @@ mod tests {
     #[test]
     fn the_handoff_contract_matches_the_app() {
         assert_eq!(TCRBAR_UPDATE_URL, "tcrbar://check-for-updates");
-        assert_eq!(TCRBAR_BUNDLE_ID, "com.github.dhkts1.tcrbar");
+        assert_eq!(TCRBAR_BUNDLE_ID, "io.github.dhkts1.tcrbar");
         // `-g` first: the request must not steal focus from the terminal.
         assert_eq!(open_handoff_argv(), ["-g", "tcrbar://check-for-updates"]);
     }
@@ -1377,6 +1377,13 @@ mod tests {
             AppBundleAction::Instruct(HandoffRefusal::UnreadableIdentity)
         );
         for foreign in [
+            // The id TcrBar shipped under before the 2026-08-09 ControlCenter
+            // block forced a new identity. A stale copy still installed under it
+            // is somebody else's bundle now, and must not receive the handoff.
+            "com.github.dhkts1.tcrbar",
+            // A suffix extension of the *live* id is the near miss that matters
+            // now that the id changed; the `com.` one below guards the old one.
+            "io.github.dhkts1.tcrbar.helper",
             "com.github.dhkts1.tcrbar.helper",
             "com.github.dhkts1.TcrBar",
             "com.example.tcrbar",


### PR DESCRIPTION
## The bug

The menu bar icon disappeared: invisible and unclickable, surviving app relaunch, `killall ControlCenter`, and a full reboot.

Since Big Sur an app does not draw its own menu bar icon. It registers an `NSStatusItemView` scene with **ControlCenter**, which draws it. ControlCenter keeps a runtime **blocked list keyed on bundle id**, and `com.github.dhkts1.tcrbar` is on it:

```
14:02:53  Moving host to blocked list; (bid:com.github.dhkts1.tcrbar-Item-0-18363)
14:02:53  Moving host to blocked list; (bid:com.github.dhkts1.tcrbar-Item-0-88376)
14:02:53  Requesting blocked host to not be visible; (bid:...)
```

Two processes sharing the one bundle id registered the same status item slot at the same instant, and ControlCenter blacklisted the id. Three launches minutes earlier — 13:58:48, 14:01:16, 14:02:27 — were tracked normally, so this is datable to the second.

Every launch since ends `Starting to track host` → `Created ephemaral instance` → `Moving host to blocked list` about 12ms later.

`Requesting blocked host to not be visible` is also how `"NSStatusItem VisibleCC Item-0" = 0` reaches the app's own defaults domain. That pref is a symptom, not the cause, which is why writing it back never fixed anything.

## What does not clear it

Measured, all negative: relaunch; `killall ControlCenter`; a full reboot; freeing menu bar slots by quitting other status-bar apps; `defaults write` in either the app's domain or `com.apple.controlcenter`; `statusItem.isVisible = true` (the log shows `clientRequestsVisibility: true` being overruled); and **setting an `autosaveName`** — `...tcrbar-TcrBarProbeSlot` was blocked identically, because the key follows the bundle id, not the slot name.

Also falsified along the way: menu bar overflow behind the notch, launch path, SF Symbol resolution, and notarization (the same unnotarized build worked fine at 14:02:27).

## The fix

New bundle id, `io.github.dhkts1.tcrbar`. Verified before committing: a byte-identical bundle re-signed under the new id produced `Starting to track host` with **no block line**, and the icon rendered.

`TCRBAR_DEV_BUILD=1` gives a non-shipping build `io.github.dhkts1.tcrbar.dev`, so a dev, worktree or probe build can never again collide with the installed app. The build echoes which identity it used.

`decide_app_bundle_handoff` now treats the old id as **foreign** — a stale copy under `com.github.dhkts1.tcrbar` must not be mistaken for ours. That assertion was mutation-tested: reverting the constant fails it with `Instruct(ForeignBundle("com.github.dhkts1.tcrbar"))`, the expected failure identity rather than an incidental one.

`uninstall.sh` deletes the legacy prefs domain rather than reporting it, since a surviving `NSStatusItem VisibleCC` default there is exactly what outlives a reinstall.

## Cost

The new identity resets everything keyed to the old one: Sparkle update state, app preferences, and the login item. **An existing install under the old id will not self-update to this build** — it needs a manual replacement once.

## Gates

`cargo build --release`, `cargo test --lib update::`, `swift build`, `cargo fmt --check`, and `shellcheck` on both scripts all exit 0. The remaining `com.github.dhkts1.tcrbar` hits in the tree are intentional: the foreign-id test entries, the `LEGACY_BUNDLE_ID` constant in `uninstall.sh`, and the incident comment in `build-tcrbar.sh`.
