### PR TITLE
chore: release v0.2.0 and move release signing off GitHub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaude-rs"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "Lean single-user rotating Anthropic proxy with a live TUI — a Rust replacement for the personal teamclaude proxy"

--- a/apps/macos/scripts/release-local.sh
+++ b/apps/macos/scripts/release-local.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Cut a signed, notarized TcrBar release from a laptop, with the credentials
+# pulled from 1Password at run time.
+#
+#   apps/macos/scripts/release-local.sh v0.2.0 [--dry-run] [--skip-notarize]
+#
+# This is a thin credential wrapper. It builds nothing and signs nothing —
+# `release-tcrbar.sh` does all of that and stays the single implementation of
+# the pipeline. What this script owns is the part that must not be written
+# down: getting an App Store Connect API key into the environment and taking it
+# back out again.
+#
+# WHY THIS EXISTS AT ALL. The seven signing secrets were deliberately removed
+# from GitHub on 2026-08-09. This repository is public and non-admin
+# collaborators hold push; a tag-triggered workflow runs the workflow file as it
+# exists on the tagged commit, and Sparkle's private key signs the payload that
+# every installed copy auto-trusts. Nothing stored is nothing stolen, so the
+# keys live on one Mac and releases are cut from it. See docs/RELEASING.md.
+#
+# NOTHING HERE PRINTS A SECRET, and nothing here hardcodes a person, a path or
+# an account — same rule as release-tcrbar.sh, for the same reason: this file is
+# world-readable. The key id and the issuer id are credentials, not labels, so
+# the progress line says that credentials loaded, not which ones.
+#
+# What it needs:
+#   - 1Password CLI signed in (1Password app -> Settings -> Developer)
+#   - the item named by TCRBAR_OP_ITEM, with the fields read below
+#   - Developer ID Application certificate in the login keychain
+#   - Sparkle private key in the login keychain (1Password holds the backup)
+#
+# The certificate and the Sparkle key are read from the keychain by
+# `release-tcrbar.sh` itself. What 1Password supplies here is the App Store
+# Connect API key, which notarization needs and which exists nowhere else —
+# Apple allows exactly one download of the .p8.
+#
+# Environment:
+#   TCRBAR_OP_ITEM   1Password item reference holding the signing fields
+set -euo pipefail
+
+tag="${1:-}"
+if [ -z "$tag" ]; then
+  echo "usage: $(basename "$0") vX.Y.Z [--dry-run] [--skip-notarize]" >&2
+  echo "  the tag must match the version in Cargo.toml" >&2
+  exit 2
+fi
+shift || true
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/../../.." && pwd)"
+item="${TCRBAR_OP_ITEM:-op://Employee/TcrBar Release Signing}"
+
+command -v op >/dev/null || { echo "ERROR: 1Password CLI (op) not found." >&2; exit 1; }
+op whoami >/dev/null 2>&1 || {
+  echo "ERROR: 1Password CLI is not signed in." >&2
+  echo "       1Password app -> Settings -> Developer -> Integrate with 1Password CLI" >&2
+  exit 1
+}
+
+# The .p8 has to exist as a FILE because `notarytool` takes --key <path>; there
+# is no form of the flag that accepts the key material as a value. So it is
+# written 0600 into a private temp dir and removed however this script exits.
+# Cleanup is on a trap rather than at the end of the happy path because the
+# failure path is the one that matters: a build that aborts halfway is exactly
+# when a private key would otherwise be left behind in /tmp.
+keydir="$(mktemp -d)"
+chmod 700 "$keydir"
+cleanup() { rm -rf "$keydir"; }
+trap cleanup EXIT INT TERM
+
+keyfile="$keydir/AuthKey.p8"
+(umask 077; op read "$item/APPLE_API_KEY_P8" > "$keyfile")
+[ -s "$keyfile" ] || { echo "ERROR: the .p8 read back empty from 1Password." >&2; exit 1; }
+
+APPLE_API_KEY_PATH="$keyfile"
+APPLE_API_KEY_ID="$(op read "$item/APPLE_API_KEY_ID")"
+APPLE_API_ISSUER_ID="$(op read "$item/APPLE_API_ISSUER_ID")"
+TCRBAR_SPARKLE_PUBLIC_KEY="$(op read "$item/SPARKLE_ED_PUBLIC_KEY")"
+export APPLE_API_KEY_PATH APPLE_API_KEY_ID APPLE_API_ISSUER_ID TCRBAR_SPARKLE_PUBLIC_KEY
+
+# Check every field here rather than three minutes into a build. `op read` on a
+# missing field is an error, but a field that exists and is empty is not, and
+# that one surfaces as an opaque notarization rejection much later.
+for v in APPLE_API_KEY_ID APPLE_API_ISSUER_ID TCRBAR_SPARKLE_PUBLIC_KEY; do
+  [ -n "${!v}" ] || { echo "ERROR: $v came back empty from 1Password." >&2; exit 1; }
+done
+
+echo "==> credentials loaded from 1Password"
+echo "==> releasing $tag from $repo_root"
+exec "$repo_root/apps/macos/scripts/release-tcrbar.sh" --tag "$tag" "$@"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -4,9 +4,9 @@ How a signed, notarized, self-updating `TcrBar.app` gets from this repository on
 Mac. The CLI (`tcr`) is released separately by `.github/workflows/release.yml`, which cargo-dist
 generates; this document is only about the app.
 
-Everything below is executed by `apps/macos/scripts/release-tcrbar.sh`, either on a laptop or from
-`.github/workflows/release-app.yml`. Read the script if you want the detail — this is the operator's
-view.
+Everything below is executed by `apps/macos/scripts/release-tcrbar.sh`. **Releases are cut locally,
+from the Mac that holds the signing keys** — not from CI. Read the script if you want the detail;
+this is the operator's view.
 
 ## The certificate
 
@@ -44,7 +44,22 @@ Every `codesign` call in the release path passes `--timestamp` for that reason: 
 signature stays valid after its certificate expires, an untimestamped one is retroactively invalid
 on every machine that already installed the app.
 
-## Cutting a release from a laptop
+## Cutting a release
+
+One command, from the Mac that holds the keys:
+
+```sh
+apps/macos/scripts/release-local.sh v0.2.0
+```
+
+`release-local.sh` is a credential wrapper and nothing else. It reads the App Store Connect API key
+out of 1Password, materialises the `.p8` as a 0600 file in a private temp dir — `notarytool` takes
+`--key <path>`, there is no form of the flag that accepts the key material as a value — removes it
+on a `trap` so an aborted build does not leave a private key in `/tmp`, and then `exec`s
+`release-tcrbar.sh --tag`. The certificate and the Sparkle private key it does *not* pass: those are
+read straight from the login keychain by `release-tcrbar.sh`.
+
+Before that, in order:
 
 ```sh
 # 1. bump the version — Cargo.toml is the single source of truth. The app's
@@ -56,12 +71,17 @@ $EDITOR Cargo.toml && cargo check          # refresh Cargo.lock
 #    certificate.
 apps/macos/scripts/release-tcrbar.sh --dry-run
 
-# 3. tag and push. Both release workflows fire on the tag.
+# 3. tag and push. `--tag` must agree with Cargo.toml or the release aborts.
 git tag v0.2.0 && git push origin v0.2.0
 ```
 
-To do the whole thing locally instead of in CI, export the notarization variables (below) and run
-`release-tcrbar.sh` with no flags.
+The tag push is a separate, deliberate step: a repository ruleset named **"Protect release tags"**
+restricts creating, updating and deleting `v*` tags to admins. A collaborator with push cannot
+mint a version tag, which is the point — see below.
+
+`TCRBAR_OP_ITEM` overrides the 1Password item reference (default
+`op://Employee/TcrBar Release Signing`); extra arguments after the tag are passed through to
+`release-tcrbar.sh`, so `release-local.sh v0.2.0 --dry-run` works.
 
 Flags:
 
@@ -88,46 +108,76 @@ Flags:
 8. **Appcast** — a new `<item>` is inserted at the marker comment in `apps/macos/appcast.xml`.
 9. **Publish** — `gh release upload` puts the DMG and `appcast.xml` on the release for the tag.
 
-## CI secrets
+## Why there are no signing secrets in GitHub
 
-`.github/workflows/release-app.yml` runs on `macos-14` and fires **only** on `v*` tags. It must
-never gain a `pull_request` trigger: it holds three private keys, and a fork PR would get all of
-them.
+**All seven signing secrets were removed from this repository on 2026-08-09, deliberately.** Not as
+cleanup, and not pending a fix — the release path is local and is meant to stay local. Three facts
+compose into the reason:
 
-**None of these secrets are set today, and that is deliberate** — the Apple signing key is not
-stored in GitHub, and releases are cut locally with `apps/macos/scripts/release-tcrbar.sh`. So a
-`v*` tag reaches a `check-signing-secrets` job which finds all seven unset, writes a job summary
-saying so, and the signing job is **skipped** rather than failed. Setting all seven turns CI
-signing on with no further change. Setting only *some* is treated as a misconfiguration and fails
-loudly, naming the missing ones — a half-configured release is likelier to be a mistake than an
-intent to skip. The check must be its own job because the `secrets` context is unavailable in a
-job-level `if:` (GitHub's context-availability table allows only `github`, `needs`, `vars` and
-`inputs` there).
+- the repository is **public**, and non-admin collaborators hold **push**;
+- a tag-triggered workflow executes **the workflow file as it exists on the tagged commit**, so
+  whoever can reach a `v*` tag chooses the code that runs with the secrets attached;
+- Sparkle's private key signs the payload that **every existing install auto-trusts**. It is not a
+  key that protects a build artifact; it is the key that decides what already-installed copies will
+  execute.
 
-| secret | how to produce it |
-|---|---|
-| `MACOS_CERT_P12_BASE64` | Keychain Access → login → My Certificates → the Developer ID Application entry → right-click → Export → `.p12` (**include the private key** — export the certificate row with its disclosure triangle, not the bare key). Then `base64 -i cert.p12 \| pbcopy`. |
-| `MACOS_CERT_PASSWORD` | the password chosen during that export |
-| `KEYCHAIN_PASSWORD` | any random string, e.g. `openssl rand -base64 24`. It only scopes the ephemeral keychain the job creates and deletes. |
-| `APPLE_API_KEY_P8` | App Store Connect → Users and Access → Integrations → App Store Connect API → **+**, role **Developer**. The `.p8` downloads **once and only once**; paste its whole contents, `-----BEGIN PRIVATE KEY-----` line included. |
-| `APPLE_API_KEY_ID` | the Key ID shown beside that key |
-| `APPLE_API_ISSUER_ID` | the Issuer ID shown at the top of that page |
-| `SPARKLE_ED_PRIVATE_KEY` | Sparkle's `generate_keys` stores the key in the **login keychain**, not in a file. Export it for CI with `generate_keys -x -` and paste the output. |
+Nothing stored is nothing stolen. The keys exist on one Mac and in one 1Password item, so a GitHub
+compromise — a leaked token, a mis-scoped collaborator, a workflow edited on a branch — reaches no
+signing material at all.
 
-Plus one repository **variable** (not a secret):
+The tag itself is defended separately, because the argument above turns on who can create one: a
+repository ruleset named **"Protect release tags"** restricts creating, updating and deleting `v*`
+tags to admins. A collaborator with push can land code; they cannot mint the tag that would make CI
+sign it.
+
+### Where each credential lives now
+
+1Password, vault **Employee**, item **TcrBar Release Signing**:
+
+| field | also in the login keychain? | notes |
+|---|---|---|
+| `APPLE_API_KEY_P8` | no | **1Password is the only copy.** Apple lets you download the `.p8` exactly once; it cannot be re-downloaded, only revoked and reissued. |
+| `APPLE_API_KEY_ID` | no | the Key ID shown beside that key |
+| `APPLE_API_ISSUER_ID` | no | the Issuer ID at the top of the App Store Connect API page |
+| `APPLE_TEAM_ID` | — | not a secret; embedded in every signature we ship |
+| `SPARKLE_ED_PRIVATE_KEY` | yes | `generate_keys` stores it in the login keychain and that is what signs. **1Password is the only backup**; lose both and no future build can update an installed copy. |
+| `SPARKLE_ED_PUBLIC_KEY` | — | public by design, see below |
+| `MACOS_CERT_P12_BASE64` | yes (as the cert + key) | `.p12` export of the Developer ID Application identity |
+| `MACOS_CERT_PASSWORD` | — | the password chosen during that export |
+
+The Developer ID certificate and the Sparkle key are used **from the login keychain** during a
+local release; the 1Password copies are backups and the machine-rebuild path. The two that have no
+other home — the `.p8` and the Sparkle private key — are the ones worth checking are still readable
+before you need them.
+
+One repository **variable** (not a secret) remains set, and should:
 
 | variable | value |
 |---|---|
-| `TCRBAR_SPARKLE_PUBLIC_KEY` | the public key `generate_keys` prints. It goes into `Info.plist` so an installed app can verify what it downloads. Publishing it is the point. |
+| `TCRBAR_SPARKLE_PUBLIC_KEY` | `1WZWEwzSEijRarey7qE0a+n4AO/+7e4Fj/nW8Y8ZKMM=` — the public key `generate_keys` prints. It goes into `Info.plist` so an installed app can verify what it downloads. Publishing it is the point. |
 
-The workflow imports the `.p12` into a keychain it creates in `$RUNNER_TEMP` and deletes in an
-`if: always()` step — never the login keychain — and runs `security set-key-partition-list` so
-`codesign` can use the key without a UI prompt. Omitting that call is the most common CI signing
-defect: the job hangs until its timeout instead of failing.
+### The workflow still exists, and a tag run is not broken
 
-Nothing in the workflow echoes a secret. GitHub's log masking does not reliably cover base64
-fragments or substrings, so the certificate import step prints a *count* of matching identities
-rather than the identity, which contains a person's name and the team id.
+`.github/workflows/release-app.yml` runs on `macos-14` and still fires on `v*` tags. **Do not
+"fix" it when a tag run shows a skipped signing job — that is the designed outcome.** A tag reaches
+a `check-signing-secrets` job, which finds all seven unset, writes a job summary saying so, and the
+signing job is **skipped** rather than failed. Setting only *some* of the seven is treated as a
+misconfiguration and fails loudly, naming the missing ones: a half-configured release is likelier
+to be a mistake than an intent to skip. The check must be its own job because the `secrets` context
+is unavailable in a job-level `if:` (GitHub's context-availability table allows only `github`,
+`needs`, `vars` and `inputs` there).
+
+Restoring CI signing would mean setting all seven again, which re-creates exactly the exposure
+described above. It must never gain a `pull_request` trigger for the same reason — it would hand
+three private keys to a fork PR.
+
+Two defences in the workflow are worth keeping if it is ever re-enabled. It imports the `.p12` into
+a keychain it creates in `$RUNNER_TEMP` and deletes in an `if: always()` step — never the login
+keychain — and runs `security set-key-partition-list` so `codesign` can use the key without a UI
+prompt; omitting that call is the most common CI signing defect, and the job hangs until its
+timeout instead of failing. And nothing in it echoes a secret: GitHub's log masking does not
+reliably cover base64 fragments or substrings, so the certificate import step prints a *count* of
+matching identities rather than the identity, which contains a person's name and the team id.
 
 ## Verifying a release actually installs
 
@@ -155,7 +205,8 @@ with the wrong certificate class and step 2 of the pipeline did not run.
 
 ## Known-unverified
 
-Notarization and stapling (stages 5 and 6) have not been exercised — no App Store Connect API key
-exists for this project yet. They are written from Apple's documented interface, not from a
-successful run. The first real release is the first test of those two stages; run it with a
-throwaway patch version before announcing anything.
+An App Store Connect API key now exists (2026-08-09) and `release-local.sh` supplies it, so the
+blocker on stages 5 and 6 is gone. What has **not** happened is a completed notarized run: those two
+stages are still written from Apple's documented interface rather than from a success. The first
+real release is the first test of them. Run it with `--dry-run` first, and verify the result with
+the section above from the downloaded DMG rather than from `build/`.


### PR DESCRIPTION
Two things, both prerequisites for the first real app release.

## Version 0.2.0

`release-tcrbar.sh` refuses to build when `--tag` disagrees with the `Cargo.toml` version — one release must not carry two version numbers. Tag `v0.2.0` is already pushed, so the version bumps to match.

`v0.1.0` is the CLI-only cargo-dist release: no app bundle, no DMG, no appcast. `v0.2.0` is the first release to contain `TcrBar.app`.

## Release signing moves off GitHub

Seven signing secrets were loaded into repository secrets and then deliberately removed the same day. The reasoning, and why this is not a step backwards:

- the repository is public, and two collaborators hold `push`
- tag-triggered workflows execute the workflow file **as it exists on the tagged commit**, so anyone who can push a tag can run their own workflow with every secret in scope
- `main` branch protection does not cover tags
- Sparkle's key signs the payload every existing install auto-trusts, and it cannot be rotated without stranding every install on a manual reinstall

Nothing stored is nothing stolen. Credentials now live in 1Password and the login keychain, and releases are cut locally.

Mitigation that remains: a repository ruleset, **"Protect release tags"**, restricting creation, update and deletion of `v*` tags to admins.

`.github/workflows/release-app.yml` is unchanged and still triggers on `v*` tags. With no secrets set, its `check-signing-secrets` job skips signing rather than failing — the design already anticipated local releases. Documented so nobody "fixes" a run that is behaving correctly.

## `apps/macos/scripts/release-local.sh`

One command:

```
apps/macos/scripts/release-local.sh v0.2.0        # --dry-run to rehearse
```

Reads the App Store Connect key from 1Password, materialises it as a `0600` temp file — `notarytool` takes a path, not a value — and removes it via `trap` on any exit, including failure. The Developer ID certificate and the Sparkle key are read from the login keychain by the release script itself.

Repo root is derived from the script's own location; the 1Password item is overridable via `TCRBAR_OP_ITEM`. No paths, credentials or key material are baked in.

## Verification

`cargo check --offline`, `shellcheck` and `bash -n` all exit 0, and the no-argument usage guard exits 2.

The `trap` cleanup has a real control rather than an assumed one. The first check counted leftover temp files under `TMPDIR` and found none — but a control run with the `trap` line deleted **also** found none, which exposed the probe rather than the code: BSD `mktemp -d` with no template ignores `TMPDIR` and uses the Darwin per-user temp directory, so the check was watching a directory the script never touches. Re-probed at the real location, baseline-differenced and keyed on the `AuthKey.p8` filename so concurrent temp directories cannot contaminate the signal: with the trap, 0 leftovers; without it, 1.

Each of the three input guards was mutation-tested and fails distinguishably — empty key id, empty `.p8`, and `op` not signed in each abort naming their own cause.

Still unverified, and documented as such: **no notarization has ever completed.** The App Store Connect key is well-formed and stored, but Apple has never accepted it. The first release is the first real test of that credential.
