### PR TITLE
fix: require TCRBAR_OP_ITEM and probe 1Password by reading the item

### DIFF
--- a/apps/macos/scripts/release-local.sh
+++ b/apps/macos/scripts/release-local.sh
@@ -34,7 +34,11 @@
 # Apple allows exactly one download of the .p8.
 #
 # Environment:
-#   TCRBAR_OP_ITEM   1Password item reference holding the signing fields
+#   TCRBAR_OP_ITEM   REQUIRED. 1Password item reference holding the signing
+#                    fields, in the form op://<vault>/<item>. There is no
+#                    default on purpose: a default would name someone's private
+#                    vault layout in a world-readable file. Export it from a
+#                    shell profile or a local config outside this repository.
 set -euo pipefail
 
 tag="${1:-}"
@@ -47,14 +51,40 @@ shift || true
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$here/../../.." && pwd)"
-item="${TCRBAR_OP_ITEM:-op://Employee/TcrBar Release Signing}"
+item="${TCRBAR_OP_ITEM:-}"
+if [ -z "$item" ]; then
+  echo "ERROR: TCRBAR_OP_ITEM is not set." >&2
+  echo "       Set it to your own 1Password item reference, e.g." >&2
+  echo "         export TCRBAR_OP_ITEM='op://<vault>/<item>'" >&2
+  echo "       The item must hold the fields APPLE_API_KEY_P8, APPLE_API_KEY_ID," >&2
+  echo "       APPLE_API_ISSUER_ID and SPARKLE_ED_PUBLIC_KEY." >&2
+  echo "       There is no default: this file is world-readable and a default" >&2
+  echo "       would publish someone's private vault layout." >&2
+  exit 1
+fi
 
 command -v op >/dev/null || { echo "ERROR: 1Password CLI (op) not found." >&2; exit 1; }
-op whoami >/dev/null 2>&1 || {
-  echo "ERROR: 1Password CLI is not signed in." >&2
-  echo "       1Password app -> Settings -> Developer -> Integrate with 1Password CLI" >&2
+
+# Probe by READING the item, not with `op whoami`.
+#
+# `op whoami` reports "account is not signed in" on a completely working setup:
+# with the 1Password desktop app integration there is no CLI session token for
+# it to find, while `op read` authorises on demand through the app. Measured on
+# this project's release Mac 2026-08-09, seconds apart in one shell — `op
+# whoami` exited 1 while `op read "$item/APPLE_API_KEY_ID"` exited 0 with the
+# right value. A `whoami` precondition therefore refuses every release on a
+# machine where releasing works perfectly. Do not restore it.
+#
+# Reading the item also proves the thing `whoami` never could: that THIS item
+# is readable, which is what the rest of the script depends on. The field
+# probed is the Sparkle PUBLIC key, so a failure prints nothing sensitive.
+if ! op read "$item/SPARKLE_ED_PUBLIC_KEY" >/dev/null 2>&1; then
+  echo "ERROR: cannot read $item from 1Password." >&2
+  echo "       Check TCRBAR_OP_ITEM names a real item, the 1Password app is" >&2
+  echo "       unlocked, and CLI integration is on:" >&2
+  echo "       Settings -> Developer -> Integrate with 1Password CLI" >&2
   exit 1
-}
+fi
 
 # The .p8 has to exist as a FILE because `notarytool` takes --key <path>; there
 # is no form of the flag that accepts the key material as a value. So it is

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -79,9 +79,17 @@ The tag push is a separate, deliberate step: a repository ruleset named **"Prote
 restricts creating, updating and deleting `v*` tags to admins. A collaborator with push cannot
 mint a version tag, which is the point — see below.
 
-`TCRBAR_OP_ITEM` overrides the 1Password item reference (default
-`op://Employee/TcrBar Release Signing`); extra arguments after the tag are passed through to
-`release-tcrbar.sh`, so `release-local.sh v0.2.0 --dry-run` works.
+`TCRBAR_OP_ITEM` is **required** and names the 1Password item holding the signing fields, in the
+form `op://<vault>/<item>`. There is deliberately no default: this repository is public, and a
+default would publish an operator's private vault layout. Set it to your own reference from a shell
+profile or a local config kept outside the repository —
+
+```sh
+export TCRBAR_OP_ITEM='op://<vault>/<item>'
+```
+
+— and `release-local.sh` exits non-zero naming the variable if it is unset. Extra arguments after
+the tag are passed through to `release-tcrbar.sh`, so `release-local.sh v0.2.0 --dry-run` works.
 
 Flags:
 
@@ -132,7 +140,8 @@ sign it.
 
 ### Where each credential lives now
 
-1Password, vault **Employee**, item **TcrBar Release Signing**:
+One 1Password item, named by `TCRBAR_OP_ITEM` (`op://<vault>/<item>` — the operator picks it; the
+repository does not record which vault or item any particular person uses), holding these fields:
 
 | field | also in the login keychain? | notes |
 |---|---|---|


### PR DESCRIPTION
Two fixes to the local release wrapper.

## `TCRBAR_OP_ITEM` is now required, with no default

The previous default named a private 1Password vault and item in a public repository. It is now required and unset means a non-zero exit naming the variable, with `op://<vault>/<item>` as the placeholder. `docs/RELEASING.md` describes the field contract the item must satisfy — field names carry no private information — but describes nobody's vault layout.

## `op whoami` was a gate that fails on a correct system

The wrapper guarded on `op whoami`, which would have refused every release on a working machine.

Measured 2026-08-09, seconds apart in one shell:

```
op whoami   -> exit 1, "account is not signed in"
op read ... -> exit 0, correct value
```

With the 1Password desktop app integration there is no CLI session token for `whoami` to find, while `op read` authorises on demand through the app. Replaced with a read of the item's **public** key field, which proves both that the CLI can authorise and that this specific item is readable — neither of which `whoami` established — and prints nothing sensitive on failure.

Probed live rather than reasoned about: with `TCRBAR_OP_ITEM='op://NoSuchVault/NoSuchItem'` the script exits 1 naming the unreadable item, so the guard fires rather than passing vacuously.