### PR TITLE
fix: insert the appcast item through a file, not awk -v

### DIFF
--- a/apps/macos/scripts/release-tcrbar.sh
+++ b/apps/macos/scripts/release-tcrbar.sh
@@ -290,16 +290,36 @@ XML
 # </channel>". Sparkle reads items newest-first, and an insertion point derived
 # by pattern-matching the surrounding XML silently moves the day someone
 # reformats the file. A missing marker aborts instead of guessing.
+#
+# The item arrives through a FILE, not `awk -v item=...`. BSD awk (the one on
+# macOS) rejects a literal newline inside a -v assignment — `awk: newline in
+# string` — and the item is a multi-line <item> block, so -v aborted awk before
+# it read a single input line. That wrote an EMPTY tmp file over the appcast:
+# exit status 0, a feed with no items and no marker, and Sparkle telling every
+# user they are up to date forever. Hence also the post-insert assert below: a
+# silent, well-formed, wrong result is the failure mode this function has.
 appcast_insert() {
-  local item="$1" tmp
+  local item="$1" tmp itemfile before after
   grep -qF "$appcast_marker" "$appcast_path" \
     || die "$appcast_path has no insertion marker. Restore this line inside <channel>:" \
            "  $appcast_marker"
+  before="$(grep -c '<item>' "$appcast_path" || true)"
   tmp="$(mktemp)"
-  awk -v marker="$appcast_marker" -v item="$item" '
+  itemfile="$(mktemp)"
+  printf '%s\n' "$item" >"$itemfile"
+  awk -v marker="$appcast_marker" -v itemfile="$itemfile" '
     { print }
-    index($0, marker) && !done { print item; done = 1 }
-  ' "$appcast_path" >"$tmp"
+    index($0, marker) && !done {
+      while ((getline line < itemfile) > 0) print line
+      close(itemfile)
+      done = 1
+    }
+  ' "$appcast_path" >"$tmp" || { rm -f "$tmp" "$itemfile"; die "appcast: awk failed to insert the item."; }
+  rm -f "$itemfile"
+  after="$(grep -c '<item>' "$tmp" || true)"
+  [ "$after" -eq $((before + 1)) ] \
+    || { rm -f "$tmp"; die "appcast: insert produced $after <item> elements, expected $((before + 1))." \
+                           "Refusing to publish a feed that lost or duplicated a release."; }
   mv "$tmp" "$appcast_path"
 }
 


### PR DESCRIPTION
## The bug

`appcast_insert()` passed a multi-line `<item>` block through `awk -v item="$item"`. BSD awk — the awk on macOS, where releases are cut — cannot take a literal newline in a `-v` assignment and aborts **while parsing the assignment, before reading any input**.

The consequences compound:

1. awk emits nothing, but `>"$tmp"` has already created the file
2. the unconditional `mv` copies that empty file over the appcast
3. `appcast_insert` still returns 0
4. the insertion marker is destroyed along with the content

So the first release publishes a feed with no update in it — well-formed, parses fine, silently advertising nothing — and the *second* release fails at the missing-marker check, an error two releases downstream of its cause.

Observed on a real dry run:

```
awk: newline in string     <item>\n      <ti... at source line 1   (x3)
insert1 rc=0  items=0
insert2 -> ERROR: appcast.xml has no insertion marker
```

GNU awk accepts the same input, so this reproduces only on macOS. A test of this code on `ubuntu-latest` would pass.

## The fix

The item goes through a temp file read with `getline`. Two guards were added, because a zero-exit well-formed wrong file is this function's characteristic failure:

- awk's exit status is checked, so a failed insert never reaches the `mv`
- the `<item>` count is asserted to have grown by exactly one before the `mv`

Temp files are removed on both the success and failure paths. The fixed-marker insertion strategy and its rationale are unchanged, and the doc-comment now names the awk constraint so nobody reintroduces `-v`.

## Verification

Reproduced first, then fixed — the repo's own rule about watching a test fail before trusting it.

Both guards were mutation-tested, since a guard that has never fired is not a guard:

| arm | result | appcast after |
|---|---|---|
| regress to `-v item=` | `ERROR: awk failed to insert the item.` rc=1 | intact, marker preserved |
| awk exits 0 inserting nothing | `ERROR: insert produced 0 <item> elements, expected 1.` rc=1 | intact |
| unmutated control | rc=0 | 1 item |

The first arm is the original bug, and it now aborts without destroying the file.

Double insertion verified: two items land, newest-first order preserved, both below the marker. `xmllint --noout` clean. `shellcheck` and `bash -n` both 0.