### PR TITLE
chore: track the appcast so releases append rather than restart

### DIFF
--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>TcrBar</title>
+    <description>Updates for TcrBar</description>
+    <language>en</language>
+    <!-- release-tcrbar.sh inserts new items directly below this line -->
+    <item>
+      <title>TcrBar 0.2.0</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.0</link>
+      <sparkle:version>248</sparkle:version>
+      <sparkle:shortVersionString>0.2.0</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Sun, 09 Aug 2026 19:13:02 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.0/TcrBar-0.2.0.dmg" type="application/octet-stream" sparkle:edSignature="JgBcTRrgdeEp3AhN5W7yabpqhihspg05r1ZLgsSkd2pKxtv4TaknKgtjAySDiAw+A8jgWfvhpTmriWe4xlasBw==" length="5871135" />
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
`release-tcrbar.sh` inserts each new `<item>` at a fixed marker in `apps/macos/appcast.xml`. Left untracked, every release starts from a fresh skeleton and publishes a single-item feed, dropping every prior version.

This is the file published as the `v0.2.0` release asset — the feed `SUFeedURL` resolves to. Verified live: `/releases/latest/download/appcast.xml` returns 200, one item, `sparkle:version` 248, an 88-character EdDSA signature, and an enclosure length matching the published DMG byte-for-byte.