### PR TITLE
fix: unreadable panel buttons, and a gate against shipping a released version

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -147,3 +147,80 @@ if [ -n "$staged_swift" ]; then
     echo "pre-commit: swift-format not found — skipping Swift format check (install Xcode)." >&2
   fi
 fi
+
+# ── Release-version gate ────────────────────────────────────────────────────
+# Refuse a commit that ships code under a version that has ALREADY been released.
+#
+# The incident (2026-08-09): v0.2.0 was tagged and published, then six further
+# commits landed on main with `version = "0.2.0"` still in Cargo.toml. The tree
+# had moved past the release while continuing to call itself the release. Two
+# separate things broke off that one fact:
+#
+#   - A SECOND GitHub release was created for the same v0.2.0 tag (one
+#     published, one left as a draft). `releases/latest/download/<asset>` then
+#     resolved to the wrong release, so TcrBar's Sparkle feed 404'd. Self-update
+#     was dead, and the only place that said so was a log line nobody reads.
+#   - `build-tcrbar.sh` reads CFBundleShortVersionString straight out of
+#     Cargo.toml, so every one of those builds called itself 0.2.0. Only
+#     CFBundleVersion (the commit count) kept moving. The builds stayed
+#     orderable by macOS and became indistinguishable to a human, which is the
+#     worse half.
+#
+# The rule is deliberately SELF-CLEARING: it fires on the first commit after a
+# release and goes quiet the moment the version is bumped. It is not a
+# bump-on-every-commit tax, and it needs no state of its own — the git tags
+# already are the state.
+#
+# This is a VALIDATING hook, never a mutating one. `build-tcrbar.sh:94-98`
+# rejects the pre-push variant that EDITS a version file, because git resolves
+# the refs to push before pre-push runs, so that edit can never land in the push
+# it fired for. Checking a number a human already set has no such ordering
+# problem, which is why this gate can exist where that one could not.
+#
+# Documentation-only commits are exempt: they change nothing a user installs.
+#
+# Deliberate exception:  git commit --no-verify
+staged_shippable="$(git diff --cached --name-only --diff-filter=ACMR -- . \
+                    ':(exclude)*.md' \
+                    ':(exclude)docs/**' \
+                    ':(exclude)assets/**' \
+                    ':(exclude).github/**' || true)"
+
+if [ -n "$staged_shippable" ]; then
+  # Read the INDEX (`:Cargo.toml`), not the working tree: that is what this
+  # commit will actually contain, and it falls back to HEAD's copy when
+  # Cargo.toml is not staged — which is precisely the case this gate catches.
+  #
+  # The sed is character-for-character the one in `build-tcrbar.sh:98`. Two
+  # copies of one expression is a real cost, but the alternative is this hook
+  # and the build script disagreeing about what the version IS, and a gate that
+  # reads a different number than the thing it guards is worse than no gate.
+  staged_version="$(git show :Cargo.toml 2>/dev/null \
+                    | sed -n 's/^version[[:space:]]*=[[:space:]]*"\([0-9][^"]*\)".*/\1/p' \
+                    | head -1 || true)"
+
+  if [ -z "$staged_version" ]; then
+    # Say so rather than pass silently. A gate that cannot read its input has
+    # not checked anything, and must not look like it did.
+    echo "pre-commit: could not read a version from the staged Cargo.toml — release-version gate SKIPPED." >&2
+  elif git rev-parse -q --verify "refs/tags/v$staged_version" >/dev/null 2>&1; then
+    echo "" >&2
+    echo "pre-commit: BLOCKED — v$staged_version is already a released tag." >&2
+    echo "" >&2
+    echo "  This commit changes shipped files but leaves Cargo.toml at $staged_version," >&2
+    echo "  a version that has already been tagged and published. Everything built" >&2
+    echo "  from here would claim to be $staged_version while not being it." >&2
+    echo "" >&2
+    echo "  Bump the version in Cargo.toml, stage it, and commit again:" >&2
+    echo "" >&2
+    echo "      \$EDITOR Cargo.toml    # version = \"$staged_version\"  ->  the next one" >&2
+    echo "      git add Cargo.toml" >&2
+    echo "" >&2
+    echo "  Staged files that triggered this:" >&2
+    printf '%s\n' "$staged_shippable" | sed 's/^/      /' >&2
+    echo "" >&2
+    echo "  Documentation-only commits (*.md, docs/, assets/, .github/) are exempt." >&2
+    echo "  If this genuinely should ship under $staged_version:  git commit --no-verify" >&2
+    exit 1
+  fi
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,22 @@ Assume every line you commit is world-readable, because it is.
 
 A `tcr` server may be serving real traffic on `127.0.0.1:3456`, with client sessions pointing at it.
 
-- **Never restart, kill or signal it** without being asked. A restart wipes the in-memory
-  session→account pin map, and Anthropic's prompt cache is per-account, so every live session pays a
-  full cold prefix. It is the most expensive event in this system.
+- **Never restart, kill or signal it** without being asked. Anthropic's prompt cache is per-account,
+  so a session that comes back on a different account pays a full cold prefix. It is still the most
+  expensive event in this system.
+  A restart is no longer *automatic* total loss, though, and this line used to say it was. Session
+  affinity persists its pins to `~/.cache/teamclaude/session-affinity.json` and restores them at
+  boot: measured 2026-08-09, three restarts restored 7, 5 and 7 pins. The real limit is the TTL
+  (`affinity::PIN_TTL_MS`, 15 minutes) — a restart inside it keeps most sessions warm, and one after
+  it restores nothing at all (`restored=0 expired=27`, same log). None of that applies with
+  `sessionAffinity` off, which is the default in a fresh config. Read the log line the server prints
+  at boot rather than assuming either outcome.
+- **You cannot replace `/Applications/TcrBar.app` while the proxy is running.** TcrBar resolves the
+  *bundled* `tcr` ahead of `PATH` (`TcrTool.swift:69-82`) and supervises it as a child, so
+  `Contents/MacOS/tcr` is an executing image inside the very bundle being swapped. Finder and Sparkle
+  both refuse with "the item TcrBar is in use". Quitting TcrBar clears it — `applicationWillTerminate`
+  stops the child — which is why every TcrBar update also restarts the proxy and spends the
+  cold-prefix cost above. Plan the update for a quiet moment; it is not a free background operation.
 - **`cargo build --release` is safe while it is running.** Cargo writes a new file and renames, so the
   live process keeps its own inode and its own bytes (measured 2026-08-07, N=5 — a fresh `exec` during
   the build exits 0). The real hazard is overwriting a binary *in place*: `cp` onto a path something is
@@ -43,8 +56,8 @@ A `tcr` server may be serving real traffic on `127.0.0.1:3456`, with client sess
 ## Branching
 
 - **The primary checkout stays on `main`.** This is a convention, not something the repo checks — the
-  pre-commit hook in `.githooks/` runs a `gitleaks` secret scan and a `cargo fmt --check` gate, and
-  looks at no branch. Keeping to it is on you. Do feature work in a worktree:
+  pre-commit hook in `.githooks/` runs a secret scan, a private-disclosure scan, format gates and a
+  release-version gate, and looks at no branch. Keeping to it is on you. Do feature work in a worktree:
   `git worktree add ~/worktrees/<name> -b <branch> main`.
 - Branch **before** you start editing. Making changes in the primary checkout and then wanting a branch
   is a trap — a fresh worktree branches from `HEAD` without your uncommitted work, and any shared file

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaude-rs"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 description = "Lean single-user rotating Anthropic proxy with a live TUI — a Rust replacement for the personal teamclaude proxy"

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -237,31 +237,8 @@ struct FleetView: View {
                 .font(Tok.secondaryFont)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
-            HStack {
-                if server.state.isOurChild {
-                    Button("Stop server") { server.stop() }
-                } else {
-                    Button("Start server") { server.start() }
-                }
-                Button("Refresh") { Task { await poller.pollOnce() } }
-                Button("Add account…") { addAccount() }
-                    .help(
-                        "Opens `tcr login` in a Terminal window. It needs one: it "
-                            + "prompts for a name, may ask for a pasted code, and "
-                            + "refuses while a proxy is holding the port."
-                    )
-                Spacer()
-                // Disabled rather than silently no-op while Sparkle already has
-                // a check in flight — the same rule "Take over port…" follows.
-                Button("Check for Updates…") { updater.checkForUpdates() }
-                    .disabled(!updater.canCheckForUpdates)
-                    .help(
-                        "Ask the release feed whether a newer TcrBar exists. "
-                            + "Also reachable as `tcrbar://check-for-updates`."
-                    )
-                Button("Quit") { NSApplication.shared.terminate(nil) }
-            }
-            .buttonStyle(.bordered)
+            fleetActions
+            appActions
 
             if let loginError {
                 Text(loginError)
@@ -276,6 +253,66 @@ struct FleetView: View {
 
             dangerZone
         }
+    }
+
+    /// Actions that act on the FLEET: the proxy, the poll, the account list.
+    ///
+    /// Split from ``appActions`` because five bordered buttons do not fit.
+    ///
+    /// This was one row. The panel is `Tok.panelWidth` (380) wide with a
+    /// `Tok.gutter` (12) on each side, so a row has **356pt**, and the five
+    /// labels plus their bordered padding want roughly 460 — AppKit resolved
+    /// that by truncating, and the row rendered as
+    /// `Start se… · Refresh · Add ac… · Check fo… · Quit`. Three of the five no
+    /// longer named their own action, and "Start se…" is not even unambiguous
+    /// about its noun. A button whose label is cut is a button you have to click
+    /// to identify.
+    ///
+    /// Note this was invisible to every test and to VoiceOver: SwiftUI truncates
+    /// the DRAWN label and hands the full string to the accessibility layer, so
+    /// the bug existed only for people looking at it. `--render-states` is what
+    /// showed it, which is the harness working as intended.
+    ///
+    /// The split is by SCOPE, not by "what happened to fit". These three are
+    /// about the fleet this panel monitors; the two below are about TcrBar
+    /// itself — a distinction the footer already makes further down, where
+    /// `launchAtLogin` is documented as living beside Quit precisely because it
+    /// "is about TcrBar, not about the fleet".
+    private var fleetActions: some View {
+        HStack {
+            if server.state.isOurChild {
+                Button("Stop server") { server.stop() }
+            } else {
+                Button("Start server") { server.start() }
+            }
+            Button("Refresh") { Task { await poller.pollOnce() } }
+            Button("Add account…") { addAccount() }
+                .help(
+                    "Opens `tcr login` in a Terminal window. It needs one: it "
+                        + "prompts for a name, may ask for a pasted code, and "
+                        + "refuses while a proxy is holding the port."
+                )
+            Spacer()
+        }
+        .buttonStyle(.bordered)
+    }
+
+    /// Actions that act on the APP, trailing-aligned so they read as a separate
+    /// group from the fleet row above without needing a rule between them.
+    private var appActions: some View {
+        HStack {
+            Spacer()
+            // Disabled rather than silently no-op while Sparkle already has
+            // a check in flight — the same rule "Take over port…" follows.
+            Button("Check for Updates…") { updater.checkForUpdates() }
+                .disabled(!updater.canCheckForUpdates)
+                .help(
+                    "Ask the release feed whether a newer TcrBar exists. "
+                        + "Also reachable as `tcrbar://check-for-updates`."
+                )
+            Button("Quit") { NSApplication.shared.terminate(nil) }
+        }
+        .buttonStyle(.bordered)
     }
 
     /// Bring the proxy up when TcrBar starts. Pairs with "Launch at login" to

--- a/scripts/test-version-gate.sh
+++ b/scripts/test-version-gate.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Fixture test for the pre-commit release-version gate.
+#
+# A gate that has never been watched failing is not a gate. This runs the hook
+# against a staged index in three states and asserts the exit code each time,
+# including the negative controls -- a gate that blocks everything passes a
+# block-test for the wrong reason.
+#
+# Safe to run: it stages and resets in THIS worktree's index only, never commits,
+# and restores Cargo.toml at the end.
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+hook=.githooks/pre-commit
+original_version="$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([0-9][^"]*\)".*/\1/p' Cargo.toml | head -1)"
+pass=0
+fail=0
+
+restore() {
+  git checkout -- Cargo.toml 2>/dev/null
+  git reset -q 2>/dev/null
+}
+trap restore EXIT
+
+# Run the hook and report only whether the VERSION gate fired. Other gates in
+# the same script (gitleaks, disclosure, format) can also exit 1, and counting
+# their failure as ours would be a false positive for this test.
+check() {
+  local label="$1" expect="$2" out rc
+  out="$("$hook" 2>&1)"; rc=$?
+  local fired=no
+  case "$out" in *"is already a released tag"*) fired=yes ;; esac
+  if [ "$fired" = "$expect" ]; then
+    printf '  PASS  %-46s (gate fired=%s, exit=%s)\n' "$label" "$fired" "$rc"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL  %-46s (gate fired=%s, wanted=%s, exit=%s)\n' "$label" "$fired" "$expect" "$rc"
+    printf '%s\n' "$out" | sed 's/^/        /'
+    fail=$((fail + 1))
+  fi
+}
+
+echo "release-version gate — fixture test"
+echo "  Cargo.toml version: $original_version"
+echo "  tag v$original_version exists: $(git rev-parse -q --verify "refs/tags/v$original_version" >/dev/null 2>&1 && echo yes || echo no)"
+echo
+
+# 1. POSITIVE CONTROL — shipped code staged at an already-released version.
+git reset -q
+git add apps/macos/Sources/TcrBar/FleetView.swift 2>/dev/null
+check "code staged at released version -> BLOCK" yes
+
+# 2. NEGATIVE CONTROL — same staged code, version bumped past the tag.
+#    If this does not pass, the gate is blocking unconditionally and control 1
+#    proved nothing.
+sed -i '' "s/^version = \"$original_version\"/version = \"$original_version-gatetest\"/" Cargo.toml
+git add Cargo.toml apps/macos/Sources/TcrBar/FleetView.swift 2>/dev/null
+check "version bumped past the tag -> ALLOW" no
+git checkout -- Cargo.toml
+
+# 3. NEGATIVE CONTROL — docs-only commit at a released version is exempt.
+git reset -q
+printf '\n' >>README.md
+git add README.md
+check "docs-only at released version -> ALLOW" no
+git checkout -- README.md
+
+# 4. NEGATIVE CONTROL — nothing staged at all.
+git reset -q
+check "empty index -> ALLOW" no
+
+echo
+echo "  $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/scripts/test-version-gate.sh
+++ b/scripts/test-version-gate.sh
@@ -17,9 +17,16 @@ original_version="$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([0-9][^"]*\)".
 pass=0
 fail=0
 
+# Unstage FIRST, then restore from HEAD.
+#
+# `git checkout -- <file>` copies the INDEX over the worktree, so on a file
+# this script has just staged it restores the staged modification rather than
+# reverting it -- the test then leaves the tree dirty and the residue rides
+# along in whatever someone commits next. Caught exactly that way: a stray
+# newline on README.md blocked a rebase.
 restore() {
-  git checkout -- Cargo.toml 2>/dev/null
   git reset -q 2>/dev/null
+  git checkout HEAD -- Cargo.toml README.md 2>/dev/null
 }
 trap restore EXIT
 
@@ -47,9 +54,24 @@ echo "  tag v$original_version exists: $(git rev-parse -q --verify "refs/tags/v$
 echo
 
 # 1. POSITIVE CONTROL — shipped code staged at an already-released version.
-git reset -q
-git add apps/macos/Sources/TcrBar/FleetView.swift 2>/dev/null
-check "code staged at released version -> BLOCK" yes
+#
+# CONSTRUCT the condition; do not depend on the checked-in version happening
+# to equal a tag. The first draft did, and it passed only because the tree was
+# still sitting on the released version -- the moment the version was bumped
+# (the normal state for a repo between releases) the control stopped being
+# able to fire, and a control that cannot fire proves nothing about the gate.
+released="$(git tag --list 'v*' --sort=-v:refname | head -1 | sed 's/^v//')"
+if [ -z "$released" ]; then
+  printf '  SKIP  %-46s (no v* tag exists to test against)\n' "code staged at released version -> BLOCK"
+else
+  git reset -q
+  # ^version anchors to column 0, so this hits the [package] version and never
+  # an indented dependency version.
+  sed -i '' "s/^version = \".*\"/version = \"$released\"/" Cargo.toml
+  git add Cargo.toml apps/macos/Sources/TcrBar/FleetView.swift 2>/dev/null
+  check "code staged at released version -> BLOCK" yes
+  git reset -q && git checkout HEAD -- Cargo.toml
+fi
 
 # 2. NEGATIVE CONTROL — same staged code, version bumped past the tag.
 #    If this does not pass, the gate is blocking unconditionally and control 1
@@ -57,14 +79,14 @@ check "code staged at released version -> BLOCK" yes
 sed -i '' "s/^version = \"$original_version\"/version = \"$original_version-gatetest\"/" Cargo.toml
 git add Cargo.toml apps/macos/Sources/TcrBar/FleetView.swift 2>/dev/null
 check "version bumped past the tag -> ALLOW" no
-git checkout -- Cargo.toml
+git reset -q && git checkout HEAD -- Cargo.toml
 
 # 3. NEGATIVE CONTROL — docs-only commit at a released version is exempt.
 git reset -q
 printf '\n' >>README.md
 git add README.md
 check "docs-only at released version -> ALLOW" no
-git checkout -- README.md
+git reset -q && git checkout HEAD -- README.md
 
 # 4. NEGATIVE CONTROL — nothing staged at all.
 git reset -q


### PR DESCRIPTION
Bumps the version to **0.2.1**.

## The panel footer truncated three of its five buttons

The footer was one `HStack` with five bordered buttons. The panel is 380pt wide with a 12pt gutter each side, so the row has 356pt of content width, and the five labels plus their bordered padding want roughly 460. AppKit resolved that by truncating:

```
Start se… · Refresh · Add ac… · Check fo… · Quit
```

Three of the five stopped naming their own action, and "Start se…" is not even unambiguous about its noun.

Split by scope rather than by whatever happened to fit: `Start/Stop server`, `Refresh` and `Add account…` act on the fleet; `Check for Updates…` and `Quit` act on TcrBar. The footer already drew that line further down, where `launchAtLogin` is documented as sitting beside Quit because it "is about TcrBar, not about the fleet".

Verified with `--render-states`, which is also how it surfaced. SwiftUI truncates the *drawn* label and hands the full string to the accessibility layer, so this existed only for people looking at it — no test and no VoiceOver pass could have caught it.

## A gate against committing on top of a released version

v0.2.0 was tagged and published, then further commits landed on main with `Cargo.toml` still reading `0.2.0`. Two things broke off that one fact: a second GitHub release was created against the same tag, and every build in between called itself 0.2.0 while not being it (only `CFBundleVersion`, the commit count, kept moving — so the builds stayed orderable by macOS and became indistinguishable to a human).

The new `.githooks/pre-commit` gate refuses a commit that stages shipped files while the version equals an existing tag. It is self-clearing: it fires on the first commit after a release and goes quiet once the version moves, so it is not a bump-on-every-commit tax and keeps no state of its own — the tags already are the state. Documentation-only commits are exempt, and `--no-verify` remains the escape hatch.

It validates rather than mutates, which is why it can live in `pre-commit` at all: `build-tcrbar.sh:94-98` rules out the pre-push variant that *edits* a version file, because git resolves the refs to push before pre-push runs.

`scripts/test-version-gate.sh` is the fixture test — one positive control and three negative controls, so a gate that simply blocked everything could not pass it. The control constructs its own condition from the newest `v*` tag rather than depending on the checked-in version, and the run leaves the tree clean.

## CLAUDE.md

Replaces the claim that a restart wipes the session→account pin map. Measured across four restarts today: `restored=7/5/7/7` at a 15-minute TTL, with a 96% cache hit ratio over the 692 requests after the most recent one. A restart inside the TTL is cheap; only one after it loses everything. Also records that `Contents/MacOS/tcr` executes from inside the bundle any update must replace, which is what produces "the item TcrBar is in use" and why every app update also restarts the proxy.