### PR TITLE
fix: dev builds install beside the shipping app; name a failed probe

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -585,11 +585,16 @@ struct AccountRow: View {
         // both: silence is not a state, and a VoiceOver user has even less to
         // infer it from than a sighted one.
         parts.append(account.disabled ? "parked, out of rotation" : "rotating")
-        parts.append(
-            account.hasQuotaEvidence
-                ? "\(account.quotaState.token), \(QuotaFormat.percent(account.quota)) used"
-                : "never probed, quota unknown"
-        )
+        // Mirrors the pill's three cases. A VoiceOver user hearing "never
+        // probed" about an account whose probe errored is told the same wrong
+        // cause a sighted user was, with less to correct it from.
+        if account.hasQuotaEvidence {
+            parts.append("\(account.quotaState.token), \(QuotaFormat.percent(account.quota)) used")
+        } else if account.probeStatus.isFailure {
+            parts.append("quota probe \(account.probeStatus.token), quota unknown")
+        } else {
+            parts.append("never probed, quota unknown")
+        }
         if let hold = account.soonestHold { parts.append(hold.countdownLabel) }
         if let failure = accounts.failure(for: account.name) {
             parts.append("last action failed: \(failure.summary)")
@@ -626,8 +631,29 @@ struct AccountRow: View {
                 // A never-probed account's `quotaState` is Rust's default, not a
                 // reading. Printing `ok` on it would be the panel asserting
                 // something nothing has ever checked.
+                //
+                // Three cases, not two. "No quota reading" has two causes and
+                // they are not interchangeable: nothing has asked yet, or the
+                // asking failed. Both used to render UNMEASURED, so an account
+                // whose probe errored was labelled with the one word this
+                // palette reserves for *never probed* — telling the operator to
+                // wait for a sweep that had already run and failed. Observed
+                // live: a row reading UNMEASURED beside a status of `error`.
                 if account.hasQuotaEvidence {
                     StatusPill(account.quotaState.token, tint: quotaTint)
+                } else if account.probeStatus.isFailure {
+                    // The probe's own word, so the row names the cause rather
+                    // than a category. Still `Tok.unmeasured`: "we have no
+                    // reading" is the true part and stays in the cool,
+                    // off-the-traffic-light hue — a failed probe is not a
+                    // measured exhaustion and must not read as one.
+                    StatusPill(account.probeStatus.token, tint: Tok.unmeasured)
+                        .help(
+                            account.probeError.map { "Quota probe failed: \($0)" }
+                                ?? "The quota probe ran and failed "
+                                    + "(\(account.probeStatus.token)) — this account's "
+                                    + "quota is unknown."
+                        )
                 } else {
                     StatusPill("unmeasured", tint: quotaTint)
                         .help("Never probed — this account's quota is unknown, not zero.")
@@ -702,7 +728,18 @@ struct AccountRow: View {
                 }
             }
         }
-        .buttonStyle(.borderless)
+        // `.bordered`, not `.borderless`. Borderless draws the label as bare
+        // text, so the ONE actionable control in the row looked exactly like
+        // the two informational pills beside it — thirteen rows of a word that
+        // reads as a status and is actually a button. It survived review
+        // because `ImageRenderer` cannot draw AppKit controls at all: every
+        // `--render-states` PNG shows a placeholder here, so no snapshot could
+        // have caught it. It took a screenshot of the running app.
+        //
+        // `.small` keeps the added chrome from competing with the account name,
+        // which is still the thing being scanned for.
+        .buttonStyle(.bordered)
+        .controlSize(.small)
         .font(Tok.detailFont)
         .disabled(pending)
         // Thirteen rows otherwise render thirteen controls whose entire

--- a/apps/macos/Sources/TcrBarCore/FleetStatus.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetStatus.swift
@@ -170,6 +170,27 @@ public enum ProbeState: Equatable, Sendable {
         case .ok, .error, .timeout, .rateLimited: return true
         }
     }
+
+    /// The probe ran and came back without a usable reading.
+    ///
+    /// A strict subset of ``hasBeenProbed``, which is also true for `.ok`. The
+    /// panel needs the distinction because "no quota reading" has two causes
+    /// with two different remedies, and only one of them is what the UNMEASURED
+    /// pill means. `Tok.unmeasured` is documented as *never probed* — the remedy
+    /// is to wait for the first sweep. A probe that ran and errored is a
+    /// different fact, and its remedy is to look at why; labelling it
+    /// "unmeasured" tells the operator to wait for something that already
+    /// happened.
+    ///
+    /// `.unknown` is deliberately NOT a failure. An unrecognised token is a
+    /// state this build cannot name — which is what `Tok.unknown` exists for —
+    /// and calling it a failure would assert an observation nobody made.
+    public var isFailure: Bool {
+        switch self {
+        case .error, .timeout, .rateLimited: return true
+        case .never, .ok, .unknown: return false
+        }
+    }
 }
 
 extension ProbeState: Decodable {

--- a/apps/macos/Tests/TcrBarTests/ProbeStateTests.swift
+++ b/apps/macos/Tests/TcrBarTests/ProbeStateTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+
+@testable import TcrBarCore
+
+/// The panel has to tell two causes of "no quota reading" apart: nothing has
+/// probed this account yet, or a probe ran and failed. They look identical in
+/// the data (`quota == nil` either way) and they are not interchangeable to a
+/// reader — one says wait, the other says look at why.
+///
+/// Fixtures use obviously-fake account names only. Real account emails never
+/// enter this repository — see CLAUDE.md.
+final class ProbeStateTests: XCTestCase {
+
+    // MARK: - isFailure
+
+    func testFailureStatesAreFailures() {
+        for state in [ProbeState.error, .timeout, .rateLimited] {
+            XCTAssertTrue(state.isFailure, "\(state.token) is a probe that ran and failed")
+        }
+    }
+
+    func testNonFailureStatesAreNotFailures() {
+        for state in [ProbeState.never, .ok] {
+            XCTAssertFalse(state.isFailure, "\(state.token) is not a failure")
+        }
+    }
+
+    /// An unrecognised token is a state this build cannot name, which is what
+    /// `Tok.unknown` is for. Calling it a failure would assert an observation
+    /// nobody made — and because the panel branches on `isFailure` to pick the
+    /// pill's WORD, getting this wrong would put an invented cause on screen.
+    func testUnknownTokenIsNotAFailure() {
+        XCTAssertFalse(ProbeState(token: "some-future-state").isFailure)
+        XCTAssertFalse(ProbeState.unknown("some-future-state").isFailure)
+    }
+
+    /// `isFailure` must be a strict subset of `hasBeenProbed`: something that
+    /// failed necessarily ran. If these ever disagree the panel could claim a
+    /// probe failed on an account nothing has asked about.
+    func testFailureImpliesProbed() {
+        let all: [ProbeState] = [.never, .ok, .error, .timeout, .rateLimited, .unknown("x")]
+        for state in all where state.isFailure {
+            XCTAssertTrue(
+                state.hasBeenProbed,
+                "\(state.token) reports a failure but claims never to have been probed")
+        }
+        XCTAssertTrue(ProbeState.ok.hasBeenProbed, "ok is probed but not a failure")
+        XCTAssertFalse(ProbeState.ok.isFailure)
+    }
+
+    // MARK: - The regression, at the two predicates the row branches on
+
+    /// The shape observed live: a probe that errored, leaving no quota. Both
+    /// predicates the row reads must point at "failed", not at "never asked" —
+    /// this account rendered as UNMEASURED, the one word the palette reserves
+    /// for never-probed, beside a status of `error`.
+    func testErroredProbeWithNoQuotaReadsAsFailedNotUnmeasured() throws {
+        let json = """
+            [{
+              "name": "carol@example.com", "priority": 0, "status": "error",
+              "disabled": false, "quota": null, "quotaState": "ok",
+              "fiveHour": null, "sevenDay": null, "sevenDayOi": 0.0, "held": [],
+              "requests": 0, "inputTokens": 0, "outputTokens": 0,
+              "cacheReadTokens": 0, "cacheHitRatio": null,
+              "probeStatus": "error", "probeError": "connection refused",
+              "lastStreamError": null, "streamErrorCount": 0,
+              "source": "live", "serverSha": "abc1234", "serverDirty": false
+            }]
+            """
+        let fleet = try Fleet.decode(Data(json.utf8))
+        let account = try XCTUnwrap(fleet.accounts.first)
+
+        XCTAssertFalse(account.hasQuotaEvidence, "a failed probe yields no usable reading")
+        XCTAssertTrue(account.probeStatus.isFailure, "the row must be able to name the cause")
+        XCTAssertEqual(account.probeStatus.token, "error", "the pill renders this word")
+        XCTAssertEqual(account.probeError, "connection refused")
+    }
+
+    /// The genuinely-never-probed account must still take the other branch, or
+    /// the fix would simply relabel one wrong word with another.
+    func testNeverProbedAccountIsNotReportedAsAFailure() throws {
+        let json = """
+            [{
+              "name": "dave@example.com", "priority": 0, "status": "active",
+              "disabled": false, "quota": null, "quotaState": "ok",
+              "fiveHour": null, "sevenDay": null, "sevenDayOi": 0.0, "held": [],
+              "requests": 0, "inputTokens": 0, "outputTokens": 0,
+              "cacheReadTokens": 0, "cacheHitRatio": null,
+              "probeStatus": "never", "probeError": null,
+              "lastStreamError": null, "streamErrorCount": 0,
+              "source": "live", "serverSha": "abc1234", "serverDirty": false
+            }]
+            """
+        let fleet = try Fleet.decode(Data(json.utf8))
+        let account = try XCTUnwrap(fleet.accounts.first)
+
+        XCTAssertFalse(account.hasQuotaEvidence)
+        XCTAssertFalse(account.probeStatus.isFailure, "nothing has asked yet — that is not a failure")
+    }
+}

--- a/apps/macos/scripts/install.sh
+++ b/apps/macos/scripts/install.sh
@@ -55,7 +55,36 @@ set -euo pipefail
 MACOS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 APP_NAME="TcrBar"
 SRC="$MACOS_DIR/build/${APP_NAME}.app"
-DEST="/Applications/${APP_NAME}.app"
+
+# TCRBAR_DEV_BUILD=1 installs BESIDE the shipping app instead of over it.
+#
+# `build-tcrbar.sh` already honours this variable, but only for the bundle id
+# (`io.github.dhkts1.tcrbar.dev`), which is what keeps a dev build from being
+# the second process in the ControlCenter status-item race. The install path was
+# still hardcoded, so a dev build was given its own identity and then written
+# straight over /Applications/TcrBar.app anyway — the one thing the flag exists
+# to prevent. Testing a local build therefore cost you the installed one, which
+# is how a working release install was replaced by a build that could not
+# self-update.
+#
+# Two bundles may share CFBundleName: LaunchServices, the login item and the
+# status-item registration all key on the bundle id, and those already differ.
+# The on-disk name differs so a human can tell them apart in /Applications.
+if [ "${TCRBAR_DEV_BUILD:-0}" = "1" ]; then
+  DEST="/Applications/${APP_NAME} Dev.app"
+else
+  DEST="/Applications/${APP_NAME}.app"
+fi
+
+# Match the process by its DESTINATION path, not by APP_NAME.
+#
+# The pattern has to distinguish the two installs, and "TcrBar.app/Contents/..."
+# matches only the shipping one -- so on the dev path the running dev app would
+# not be stopped before its bundle was swapped, and on the shipping path a
+# running dev app is correctly left alone. Deriving it from $DEST gets both
+# right, and keeps the original property that `pkill -f TcrBar` would not have:
+# an editor with the name in its window title is never matched.
+RUNNING_PATTERN="$DEST/Contents/MacOS/${APP_NAME}"
 
 echo "==> Building ${APP_NAME}…"
 bash "$MACOS_DIR/scripts/build-tcrbar.sh"
@@ -123,9 +152,9 @@ fi
 # Stop only OUR app, and only the copy being replaced. `pkill -f TcrBar` would
 # also match an editor with the name in its title or a grep for it. This happens
 # after verification so a bad build never costs you the running app.
-if pgrep -f "${APP_NAME}.app/Contents/MacOS/${APP_NAME}" >/dev/null 2>&1; then
-  echo "==> Stopping the running ${APP_NAME}…"
-  pkill -f "${APP_NAME}.app/Contents/MacOS/${APP_NAME}" || true
+if pgrep -f "$RUNNING_PATTERN" >/dev/null 2>&1; then
+  echo "==> Stopping the running $(basename "$DEST" .app)…"
+  pkill -f "$RUNNING_PATTERN" || true
   STOPPED_APP=1
   # Give the supervised child, if any, a moment to be reaped cleanly.
   sleep 1


### PR DESCRIPTION
Three things a screenshot of the running app found. All three were invisible to `--render-states`: `ImageRenderer` does not draw AppKit controls, so every scene shows a placeholder where they live.

**`install.sh` honours `TCRBAR_DEV_BUILD=1`** → installs to `/Applications/TcrBar Dev.app`. `build-tcrbar.sh` already honoured the flag, but only for the bundle id, so a dev build got its own identity and was then written straight over the shipping app — the one thing the flag exists to prevent. The process-match pattern moves from `APP_NAME` to the destination path; built from `APP_NAME` it would not have matched a running dev app and would have swapped the bundle underneath it.

**The per-row `Disable` is `.bordered .small`**, not `.borderless`. Borderless draws the label as bare text, so the only actionable control in each row looked exactly like the two informational pills beside it, thirteen rows deep.

**A failed probe is named rather than called "unmeasured".** UNMEASURED is documented as *never probed*; it was also shown for a probe that ran and failed — observed live as a row reading UNMEASURED beside a status of `error`, which tells the operator to wait for a sweep that already happened. `ProbeState.isFailure` splits the two: a strict subset of `hasBeenProbed`, deliberately excluding `.unknown`, since an unrecognised token is a state this build cannot name rather than an observed failure. Narrow by construction — `error`/`timeout`/`rate-limited` normally keep the last-learned quota (`FleetStatus.swift:124-130`, `src/probe.rs:252-256`), so this only fires when a probe failed with no prior reading. The VoiceOver string had the same bug and mirrors the same three cases.

`ProbeStateTests.swift` covers it, including a decoded fixture of that exact shape. Verified by mutation rather than by passing: breaking the predicate turns 4 of the 6 red, restoring returns them green.