### PR TITLE
fix: stop offering "Add account…" when it cannot succeed

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -286,11 +286,33 @@ struct FleetView: View {
                 Button("Start server") { server.start() }
             }
             Button("Refresh") { Task { await poller.pollOnce() } }
+            // Disabled while a proxy is serving, for the same reason
+            // "Take over port…" is disabled while we supervise one: the click
+            // cannot succeed, so offering it is a promise the panel cannot keep.
+            //
+            // `tcr login` refuses outright when something holds the port — the
+            // server's next token refresh would overwrite the credentials the
+            // login just wrote. That refusal is correct. What was wrong is that
+            // the panel offered the button anyway, with the reason in a `.help`
+            // tooltip nobody hovers before clicking, so the flow was: click,
+            // watch a Terminal open, read an error, work out the remedy
+            // yourself. Reported from live use, which is the only way it
+            // surfaces — the button renders identically either way, so no
+            // screenshot and no `--render-states` scene could show it.
+            //
+            // The remedy is two clicks away and both are in this footer, so the
+            // help names them rather than describing the failure.
             Button("Add account…") { addAccount() }
+                .disabled(proxyHoldsThePort)
                 .help(
-                    "Opens `tcr login` in a Terminal window. It needs one: it "
-                        + "prompts for a name, may ask for a pasted code, and "
-                        + "refuses while a proxy is holding the port."
+                    proxyHoldsThePort
+                        ? "A proxy is serving on the port. `tcr login` refuses "
+                            + "while that is true, because the server's next token "
+                            + "refresh would overwrite the new credentials. Stop "
+                            + "the server, add the account, then start it again."
+                        : "Opens `tcr login` in a Terminal window. It needs one: it "
+                            + "prompts for a name, may ask for a pasted code, and "
+                            + "refuses while a proxy is holding the port."
                 )
             Spacer()
         }
@@ -387,6 +409,22 @@ struct FleetView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
+    }
+
+    /// True when a proxy is actually serving the port — the condition under
+    /// which `tcr login` refuses.
+    ///
+    /// The case alone is NOT the test. An offline read also decodes to
+    /// ``PollState/loaded(_:)``: `tcr status` answers from config with no
+    /// server up, which is precisely the state where adding an account
+    /// *works*. Keying on `.loaded` would disable the button exactly when it is
+    /// usable, and the panel already distinguishes the two — `source` is why
+    /// `offlineNotice` exists.
+    private var proxyHoldsThePort: Bool {
+        if case .loaded(let fleet) = poller.state {
+            return !fleet.source.countersAreStructural
+        }
+        return false
     }
 
     /// Hand `tcr login` to a Terminal window.


### PR DESCRIPTION
Reported from live use: clicking **Add account…** opened a Terminal and failed with

```
Error: OAuth login failed
Caused by: a tcr server is already running on port 3456 (pid …); logging in now
would be overwritten by the server's next token refresh
```

`tcr login`'s refusal is correct — the server's next token refresh would overwrite the credentials the login just wrote. The panel offering the button anyway was not. The reason was already written down, in a `.help` tooltip on the button, which nobody hovers before clicking. So the panel was simultaneously displaying "Supervised by TcrBar (pid N)" *and* offering an action that state guarantees will fail.

Now disabled with an explanation, matching what `Take over port…` already does three lines below. The help names the two buttons that fix it — **Stop server**, then **Start server** — rather than describing the failure, since both are in the same footer.

**The predicate is deliberately not `.loaded`.** An offline read also decodes to `.loaded` — `tcr status` answers from config with no server up, which is exactly the state where adding an account *works* — so keying on the case alone would disable the button precisely when it is usable. It keys on `source`, the same distinction `offlineNotice` exists for. Verified both ways in `--render-states`: greyed in `01-healthy`, enabled in `06-offline-source`.

Worth noting this one could not have surfaced from a screenshot or a render: the button draws identically in both states until something keys off them. It took using the app.