### PR TITLE
fix: release waits for the tag-triggered release instead of assuming it exists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaude-rs"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT"
 description = "Lean single-user rotating Anthropic proxy with a live TUI — a Rust replacement for the personal teamclaude proxy"

--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.1</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.1</link>
+      <sparkle:version>258</sparkle:version>
+      <sparkle:shortVersionString>0.2.1</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Sun, 09 Aug 2026 20:58:11 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.1/TcrBar-0.2.1.dmg" type="application/octet-stream" sparkle:edSignature="ZxtyfH+6uQV4HXojUZzOXGZYTkECioen9lGWl4CEsIxL7h6DAIwBTZA/ljq8SXhUnugr8T+1uwK4Uh1joYBqAw==" length="5874037" />
+    </item>
+    <item>
       <title>TcrBar 0.2.0</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.0</link>
       <sparkle:version>248</sparkle:version>

--- a/apps/macos/scripts/release-tcrbar.sh
+++ b/apps/macos/scripts/release-tcrbar.sh
@@ -471,8 +471,45 @@ main() {
     note "would upload $(basename "$dmg") and appcast.xml to $repo release $tag"
   else
     stage "stage 9/9  publish to the GitHub Release"
-    # --clobber: the release already exists (the CLI workflow creates it from
-    # the same tag), and a re-run must replace its assets rather than fail.
+
+    # WAIT for the release to exist. It is a race, not a given.
+    #
+    # This used to upload immediately, on the reasoning that "the release
+    # already exists (the CLI workflow creates it from the same tag)". The
+    # workflow does create it — asynchronously, off the tag push, after
+    # building every CLI target. So the release exists *eventually*, and
+    # RELEASING.md tells you to push the tag and then run this script, which is
+    # exactly the order that loses the race.
+    #
+    # Measured on v0.2.1: notarization finished, the ticket stapled, the appcast
+    # entry was written, and stage 9 died on `release not found` while the
+    # Release workflow was still in_progress. Everything expensive had already
+    # succeeded; only the upload was lost, and re-running meant notarizing a
+    # second time.
+    #
+    # Waiting rather than creating is deliberate. `gh release create` here would
+    # race the workflow the other way and can leave TWO releases on one tag —
+    # which happened on v0.2.0, and made `releases/latest/download/appcast.xml`
+    # resolve to the wrong one and 404 the update feed.
+    release_wait_seconds="${TCRBAR_RELEASE_WAIT:-600}"
+    waited=0
+    until gh release view "$tag" --repo "$repo" >/dev/null 2>&1; do
+      if [ "$waited" -ge "$release_wait_seconds" ]; then
+        die "release $tag still does not exist after ${release_wait_seconds}s." \
+            "  The tag-triggered Release workflow creates it; check:" \
+            "    gh run list --repo $repo --branch $tag" \
+            "  The DMG is built, notarized and stapled at:" \
+            "    $dmg" \
+            "  Re-run with --verify-only, or upload by hand once it appears:" \
+            "    gh release upload $tag '$dmg' '$appcast_path' --clobber --repo $repo"
+      fi
+      [ "$waited" = 0 ] && note "waiting for the tag-triggered Release workflow to create $tag…"
+      sleep 10
+      waited=$((waited + 10))
+    done
+    [ "$waited" -gt 0 ] && note "release appeared after ${waited}s"
+
+    # --clobber so a re-run replaces its assets rather than failing.
     gh release upload "$tag" "$dmg" "$appcast_path" --clobber --repo "$repo" \
       || die "gh release upload failed for $tag."
     note "uploaded to https://github.com/$repo/releases/tag/$tag"


### PR DESCRIPTION
Found by cutting v0.2.1 for real.

Stage 9 uploaded immediately, reasoning that *"the release already exists (the CLI workflow creates it from the same tag)"*. The workflow does create it — **asynchronously**, off the tag push, after building every CLI target. So it exists *eventually*, and `RELEASING.md` tells you to push the tag and then run the script, which is exactly the order that loses the race.

What that cost on v0.2.1: notarization returned `Accepted`, the ticket stapled and validated, the Sparkle signature was made and the appcast entry written — then stage 9 died on `release not found` with the Release workflow still `in_progress`. Every expensive step had already succeeded; only the upload was lost. Recovering meant notarizing again or finishing by hand.

Now it polls for the release (`TCRBAR_RELEASE_WAIT`, default 600s) and on timeout prints the path to the notarized DMG plus the exact upload command, rather than leaving you to reconstruct them.

**Waiting rather than creating is deliberate.** `gh release create` here would race the workflow the other way and can leave two releases on one tag — which is what happened on v0.2.0, made `releases/latest/download/appcast.xml` resolve to the wrong one, and 404'd the update feed.

Also carries the v0.2.1 appcast entry (build 258). The file is tracked so releases append rather than restart; leaving it uncommitted means the next release appends to a stale accumulator.

The bump to **0.2.2** is the release-version gate from #64 doing its job — v0.2.1 is now a published tag, so the tree has to move off it before shipping more code. It fired on this very commit, which is the first real test of it.