### PR TITLE
feat: hold what `caffeinate -i -m -s` holds, not just `-i`

### DIFF
--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -63,23 +63,30 @@ and therefore meant nothing.
 
 ## Keeping the Mac awake
 
-"Keep this Mac awake" in the panel holds an idle-system-sleep power assertion —
-the same thing `caffeinate -i` does — for as long as the box is ticked. While it
-is on, a second tinted mark appears beside the capacity gauge in the menu bar.
+"Keep this Mac awake" in the panel holds the three power assertions
+`caffeinate -i -m -s` holds — `PreventUserIdleSystemSleep`,
+`PreventSystemSleep` and `PreventDiskIdle`, taken through
+`IOPMAssertionCreateWithName` — for as long as the box is ticked. While it is
+on, a second tinted mark appears beside the capacity gauge in the menu bar.
 
 Three things it deliberately does not do:
 
 - **It does not keep the display awake.** The job is "a long run keeps running",
   and a dark screen does not stop a run. Holding the backlight on all night is a
   cost nobody asked for.
-- **It does not survive closing the lid.** No assertion of this class does. The
-  panel says so while the mode is on, because an operator who believes otherwise
-  comes back to a dead run and blames the proxy.
+- **It does not hold sleep off on battery.** `PreventSystemSleep` "is valid only
+  when system is running on AC power" (`man caffeinate`), and the power log
+  agrees: on AC the effective state carries `PrevSleep`, on battery it does not.
+  The panel says so while the mode is on. Whether the hold survives closing the
+  lid on AC has not been measured here, so nothing claims an answer either way.
 - **It does not persist across launches.** A Mac that silently never sleeps
   because of a box ticked last week is a worse bug than having to tick it again;
   the symptom (a laptop cooking in a bag) is nowhere near the cause.
 
-Untick it, or quit TcrBar, and the assertion is released.
+Untick it, or quit TcrBar, and all three are released. The take is
+all-or-nothing — if any one of the three fails the others are released again and
+the control reports OFF, so the checkbox can never disagree with what the
+machine is holding.
 
 ### Proving it, without a screenshot
 
@@ -89,26 +96,44 @@ agent may not have, so "look at the menu bar" is not available as a gate. This
 is:
 
 ```sh
+# The build is its own line on purpose. `--show-bin-path` PRINTS the path and
+# builds nothing, so folding the two together silently probes whatever binary
+# happened to be there — which is how an earlier draft of this gate passed a
+# controller with two of its three assertions deleted (2026-08-10, found by
+# mutating the source and watching the gate stay green).
+swift build --package-path apps/macos || exit 1
 BIN="$(swift build --package-path apps/macos --show-bin-path)/TcrBar"
 
-# Positive control, started HERE so the gate generates its own: a bare
-# `caffeinate` holds exactly one assertion, PreventUserIdleSystemSleep.
-caffeinate -t 15 &
-CAFF=$!
+# Two positive controls, started HERE so the gate generates its own. A bare
+# `caffeinate` holds exactly one assertion; `caffeinate -i -m -s` holds three.
+# The pair is what makes the count below discriminating: with only the 1-control
+# in place, a probe that had silently dropped two of its three assertions would
+# still look like "the grep can see assertions".
+caffeinate -t 20 &
+CAFF1=$!
+caffeinate -i -m -s -t 20 &
+CAFF3=$!
 
 "$BIN" --keep-awake-probe 6 &
 PROBE=$!
 
 sleep 3
-pmset -g assertions | grep -c "pid $CAFF"   # control: 1 — the grep can see assertions
-pmset -g assertions | grep TcrBar           # held:    PreventUserIdleSystemSleep, named
+pmset -g assertions | grep -c "pid $CAFF1("  # control: 1
+pmset -g assertions | grep -c "pid $CAFF3("  # control: 3
+pmset -g assertions | grep -c "pid $PROBE("  # held:    3 — one line per assertion
+pmset -g assertions | grep -A0 "pid $PROBE(" # named:   the three types, all "TcrBar is …"
 
 sleep 4                                      # past the release, inside the linger
 ps -p "$PROBE" >/dev/null && echo "probe still alive"
-pmset -g assertions | grep -c TcrBar        # released: 0, while the process still runs
+pmset -g assertions | grep -c TcrBar         # released: 0, while the process still runs
 
-wait "$PROBE"; kill "$CAFF" 2>/dev/null
+wait "$PROBE"; kill "$CAFF1" "$CAFF3" 2>/dev/null
 ```
+
+`grep -c "pid $PROBE("` rather than `grep TcrBar`: the count is the assertion
+that matters, and the trailing `(` stops pid 1847 matching pid 18470. A run of
+this gate on 2026-08-10 printed `1`, `3`, `3`, then `0` — the three named lines
+are `PreventUserIdleSystemSleep`, `PreventSystemSleep` and `PreventDiskIdle`.
 
 The flag holds the assertion for the given number of seconds and exits; like
 `--render-states` it is handled before the app starts, so no menu-bar item

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -368,8 +368,11 @@ struct FleetView: View {
     /// toggles anyway — all three are modes, not actions.
     ///
     /// The detail line is not decoration. "Keep this Mac awake" over-promises by
-    /// exactly the two cases an operator will hit, and hitting either means
-    /// coming back to a dead run and blaming the proxy.
+    /// exactly the two cases an operator will hit — a dark screen, and a laptop
+    /// on battery, where the `PreventSystemSleep` half of the hold is inert per
+    /// `man caffeinate` — and hitting either means coming back to a dead run and
+    /// blaming the proxy. It says nothing about a closed lid in either
+    /// direction, because nothing here has measured that.
     ///
     /// It carries `Tok.awake`, NOT `Tok.near`. Amber is this palette's "close to
     /// a gating limit", and it is what the login-item error directly above uses;
@@ -398,12 +401,12 @@ struct FleetView: View {
             .font(Tok.secondaryFont)
             .tint(Tok.awake)
             .help(
-                "Holds an idle-system-sleep power assertion for as long as this "
-                    + "is on — the same thing `caffeinate -i` does. Released when "
-                    + "you untick it or quit TcrBar."
+                "Holds the three power assertions `caffeinate -i -m -s` holds, for "
+                    + "as long as this is on. Released when you untick it or quit "
+                    + "TcrBar."
             )
             if awake.isOn {
-                Text("The display still sleeps, and closing the lid still sleeps the Mac.")
+                Text("The display still sleeps. Sleep itself is only held off on AC power.")
                     .font(Tok.detailFont)
                     .foregroundStyle(Tok.awake)
                     .fixedSize(horizontal: false, vertical: true)

--- a/apps/macos/Sources/TcrBarCore/AwakeController.swift
+++ b/apps/macos/Sources/TcrBarCore/AwakeController.swift
@@ -1,29 +1,50 @@
 import Combine
 import Foundation
+import IOKit.pwr_mgt
 
-/// "Keep this Mac awake" — what `caffeinate -i` does, held for exactly as long
-/// as the control is on.
+/// "Keep this Mac awake" — what `caffeinate -i -m -s` does, held for exactly as
+/// long as the control is on.
 ///
 /// ## Mechanism, measured rather than assumed
 ///
-/// `ProcessInfo.beginActivity(options:reason:)` with `.idleSystemSleepDisabled`
-/// (`NSActivityIdleSystemSleepDisabled`, "the computer must not idle sleep").
-/// With the activity held, `pmset -g assertions` lists the process by pid under
-/// `PreventUserIdleSystemSleep`, named with ``reason`` — the same assertion type
-/// `caffeinate` registers. ``KeepAwakeProbe`` is the flag that produces that
-/// line from a shell, and it is the gate: this claim is checkable in about
-/// fifteen seconds and should be re-checked rather than believed.
+/// Three power assertions taken together through
+/// `IOPMAssertionCreateWithName`, each named with ``reason``:
+/// `PreventUserIdleSystemSleep` (`-i`), `PreventSystemSleep` (`-s`) and
+/// `PreventDiskIdle` (`-m`). That is the set `caffeinate -i -m -s` registers
+/// under its own pid, which is checkable in one line:
+///
+///     caffeinate -i -m -s -t 8 & sleep 2; pmset -g assertions | grep -A1 caffeinate
+///
+/// `ProcessInfo.beginActivity(options: .idleSystemSleepDisabled,)` was the
+/// previous mechanism and is why this note exists. It can express `-i` and
+/// nothing else — the API has no option corresponding to `-s` or to `-m` — so
+/// the checkbox could not match the command line an operator actually trusts.
+///
+/// `PreventSystemSleep` is spelled as a raw string on purpose.
+/// `kIOPMAssertionTypePreventSystemSleep` is marked deprecated in `IOPMLib.h`
+/// and there is no modern replacement constant, yet `caffeinate` registers the
+/// same string today and `powerd` honours it. Deleting it because the header
+/// disapproves would silently drop `-s`.
+///
+/// ``KeepAwakeProbe`` is the flag that produces those lines from a shell, and
+/// it is the gate: the claim is checkable in about fifteen seconds and should
+/// be re-checked rather than believed.
 ///
 /// ## Deliberate scope
 ///
 /// **Idle *system* sleep only, never display sleep.** The job is "a long run
 /// keeps running", and the screen going dark does not stop a run. Holding the
 /// display awake all night is a real cost — backlight, burn-in, a bright room —
-/// that nobody asked for. `.idleDisplaySleepDisabled` exists and is not used.
+/// that nobody asked for. `PreventUserIdleDisplaySleep` exists and is not used.
 ///
-/// **This does not survive closing the lid.** No assertion of this class does;
-/// a clamshell sleep still sleeps. The panel says so, because an operator who
-/// believes otherwise comes back to a dead run and blames the proxy.
+/// **`PreventSystemSleep` is AC-only.** Per `man caffeinate`, `-s` "is valid
+/// only when system is running on AC power", and the power log agrees: the same
+/// assertion held on AC shows `[System: PrevIdle PrevSleep kCPU]` while on
+/// battery it shows no `PrevSleep` at all. On battery this control is `-i -m`.
+///
+/// Whether the assertion survives closing the lid on AC is **not known here**.
+/// No measurement of that exists on this machine, so neither the doc-comment
+/// nor the panel claims an answer in either direction.
 ///
 /// **Not persisted across launches.** There is deliberately no `@AppStorage`
 /// here. A Mac that silently never sleeps because of a box ticked a week ago is
@@ -34,21 +55,54 @@ import Foundation
 @MainActor
 public final class AwakeController: ObservableObject {
 
+    /// The three assertion types, in the order they are taken.
+    ///
+    /// Exposed because the gate needs to name them: `pmset -g assertions` is
+    /// the only thing that can see a power assertion, and a gate that greps for
+    /// one of three passes on a controller that dropped the other two.
+    public static let assertionTypes: [String] = [
+        kIOPMAssertPreventUserIdleSystemSleep as String,
+        // No modern constant exists; see the note above before "fixing" this.
+        "PreventSystemSleep",
+        kIOPMAssertPreventDiskIdle as String,
+    ]
+
+    /// Every assertion id of one hold, released together.
+    ///
+    /// One object for the whole set is what keeps partial state
+    /// unrepresentable: the controller stores one token, so it cannot end up
+    /// holding two of three assertions while reporting ON, and cannot release
+    /// some of them and forget the rest.
+    public final class Held: NSObject {
+        fileprivate let ids: [IOPMAssertionID]
+
+        fileprivate init(ids: [IOPMAssertionID]) {
+            self.ids = ids
+        }
+    }
+
     /// The begin/end pair, injected.
     ///
     /// Nothing in-process can observe another process's power assertions, so a
-    /// test against the real `ProcessInfo` could only prove that the calls did
-    /// not throw — while leaving the machine awake for as long as the suite ran.
+    /// test against the real IOKit could only prove that the calls did not
+    /// throw — while leaving the machine awake for as long as the suite ran.
     /// Taking the pair as a dependency is what makes the property that actually
     /// matters testable: that begin and end are called exactly once each, on the
     /// same token. `LoginItem.classify` is the precedent — keep the part with a
     /// decision in it separable from the part that talks to the system.
     public struct Activity {
-        public let begin: (String) -> NSObjectProtocol
+        /// `nil` means nothing is held.
+        ///
+        /// Unlike `beginActivity`, `IOPMAssertionCreateWithName` returns an
+        /// `IOReturn` and can fail. All-or-nothing is the only honest answer:
+        /// reporting ON while holding two of three assertions would be the
+        /// panel lying about the state of the machine, which is the defect this
+        /// whole class is shaped around.
+        public let begin: (String) -> NSObjectProtocol?
         public let end: (NSObjectProtocol) -> Void
 
         public init(
-            begin: @escaping (String) -> NSObjectProtocol,
+            begin: @escaping (String) -> NSObjectProtocol?,
             end: @escaping (NSObjectProtocol) -> Void
         ) {
             self.begin = begin
@@ -56,12 +110,30 @@ public final class AwakeController: ObservableObject {
         }
 
         /// The real one.
-        public static let processInfo = Activity(
+        public static let powerAssertions = Activity(
             begin: { reason in
-                ProcessInfo.processInfo.beginActivity(
-                    options: .idleSystemSleepDisabled, reason: reason)
+                var ids: [IOPMAssertionID] = []
+                for type in AwakeController.assertionTypes {
+                    var id: IOPMAssertionID = IOPMAssertionID(kIOPMNullAssertionID)
+                    let result = IOPMAssertionCreateWithName(
+                        type as CFString,
+                        IOPMAssertionLevel(kIOPMAssertionLevelOn),
+                        reason as CFString,
+                        &id)
+                    guard result == kIOReturnSuccess else {
+                        // Unwind, so a failure half way through the set leaves
+                        // the machine exactly as it was found.
+                        for taken in ids { IOPMAssertionRelease(taken) }
+                        return nil
+                    }
+                    ids.append(id)
+                }
+                return Held(ids: ids)
             },
-            end: { ProcessInfo.processInfo.endActivity($0) }
+            end: { token in
+                guard let held = token as? Held else { return }
+                for id in held.ids { IOPMAssertionRelease(id) }
+            }
         )
 
         /// A pair that holds nothing.
@@ -72,7 +144,7 @@ public final class AwakeController: ObservableObject {
         public static let inert = Activity(begin: { _ in NSObject() }, end: { _ in })
     }
 
-    /// The assertion's name in `pmset -g assertions`, and therefore the string a
+    /// The assertions' name in `pmset -g assertions`, and therefore the string a
     /// human greps for when their Mac will not sleep and they want to know who
     /// is holding it open.
     ///
@@ -81,7 +153,7 @@ public final class AwakeController: ObservableObject {
     /// both the gate and the human's search.
     public static let reason = "TcrBar is keeping this Mac awake"
 
-    /// Whether the activity is held. Read by the panel and the menu bar.
+    /// Whether the assertions are held. Read by the panel and the menu bar.
     @Published public private(set) var isOn = false
 
     /// The live token — the single source of truth, and the only thing that can
@@ -91,14 +163,15 @@ public final class AwakeController: ObservableObject {
     /// that set the flag without moving the token (or the reverse) would leave
     /// the panel reporting a state of the *machine* that is not true. Because
     /// the mirror is maintained here and nowhere else, "the checkbox is ticked"
-    /// and "a token is held" cannot disagree.
+    /// and "the assertions are held" cannot disagree — including when the take
+    /// fails, which stores `nil` and therefore reads OFF.
     private var token: NSObjectProtocol? {
         didSet { isOn = token != nil }
     }
 
     private let activity: Activity
 
-    public init(activity: Activity = .processInfo) {
+    public init(activity: Activity = .powerAssertions) {
         self.activity = activity
     }
 
@@ -112,11 +185,11 @@ public final class AwakeController: ObservableObject {
 
     /// Idempotent, and that is the whole point.
     ///
-    /// A second `beginActivity` would return a second token, and this class can
-    /// only store one — so the first would leak, unreleasable for the lifetime
-    /// of the process. The panel would then show OFF while the Mac still refused
-    /// to sleep: a control that lies about the state of the machine, with no way
-    /// back short of quitting the app.
+    /// A second take would return a second set of assertion ids, and this class
+    /// can only store one — so the first set would leak, unreleasable for the
+    /// lifetime of the process. The panel would then show OFF while the Mac
+    /// still refused to sleep: a control that lies about the state of the
+    /// machine, with no way back short of quitting the app.
     private func begin() {
         guard token == nil else { return }
         token = activity.begin(Self.reason)
@@ -125,8 +198,8 @@ public final class AwakeController: ObservableObject {
     /// Ends only a token this class began, and clears it as part of ending it.
     ///
     /// The clear happens *first* so there is no instant in which `token` names
-    /// an activity that has already been ended — which is the state from which
-    /// a double `endActivity` on the same token becomes possible.
+    /// assertions that have already been released — which is the state from
+    /// which a double release of the same id becomes possible.
     private func end() {
         guard let held = token else { return }
         token = nil
@@ -137,11 +210,8 @@ public final class AwakeController: ObservableObject {
     ///
     /// The kernel releases every power assertion a process holds when it dies,
     /// so this is not what lets the Mac sleep again — that would happen anyway.
-    /// It is here because "quitting TcrBar releases the assertion" should be
-    /// something this app *does*, not something it gets away with. Foundation
-    /// makes the same promise from the other side: per `NSProcessInfo.h`, an
-    /// activity token deallocated before `endActivity:` ends its activity
-    /// automatically.
+    /// It is here because "quitting TcrBar releases the assertions" should be
+    /// something this app *does*, not something it gets away with.
     public func releaseOnQuit() {
         end()
     }

--- a/apps/macos/Sources/TcrBarCore/KeepAwakeProbe.swift
+++ b/apps/macos/Sources/TcrBarCore/KeepAwakeProbe.swift
@@ -16,7 +16,12 @@ import Foundation
 ///
 ///     TcrBar --keep-awake-probe 10 &
 ///     sleep 3
-///     pmset -g assertions | grep TcrBar     # PreventUserIdleSystemSleep
+///     pmset -g assertions | grep -c 'pid <pid>'   # 3, one line per assertion
+///
+/// The count is the point. ``AwakeController`` holds three assertions —
+/// `PreventUserIdleSystemSleep`, `PreventSystemSleep`, `PreventDiskIdle` — and a
+/// gate that greps for one of them passes just as happily on a controller that
+/// dropped the other two.
 ///
 /// Like `--render-states` and `--render-icon` it is handled in
 /// `TcrBarEntry.main()` and exits before the shell is built, so no menu-bar item
@@ -29,8 +34,9 @@ public enum KeepAwakeProbe {
     ///
     /// Without this window the gate cannot attribute the release. A power
     /// assertion also disappears when its process dies, so a `pmset` reading
-    /// taken after the probe exits is equally consistent with "`endActivity`
-    /// released it" and with "it was never released and the kernel cleaned up" —
+    /// taken after the probe exits is equally consistent with
+    /// "`IOPMAssertionRelease` released it" and with "it was never released and
+    /// the kernel cleaned up" —
     /// the check would pass either way, which makes it not a check.
     ///
     /// Sampling inside this window separates them, and that separation was
@@ -78,7 +84,7 @@ public enum KeepAwakeProbe {
 
                 usage: TcrBar \(flag) <seconds>
 
-                Holds an idle-system-sleep assertion for <seconds>, releases it,
+                Holds \(AwakeController.assertionTypes.count) power assertions for <seconds>, releases them,
                 then lingers \(Int(lingerAfterRelease))s so the release is observable while this
                 process is still alive. Prove it with:
 
@@ -91,25 +97,35 @@ public enum KeepAwakeProbe {
             let controller = AwakeController()
             controller.setOn(true)
 
-            // There is deliberately no `guard controller.isOn` here, and its
-            // absence is the honest shape.
+            // This guard can fail, and that is why it is here.
             //
-            // `beginActivity` returns a non-optional, so `begin()` always
-            // stores a token and `isOn` is always true on the next line. A
-            // guard there cannot fail: it would read as a check on whether the
-            // assertion was really taken while checking nothing at all, which
-            // is worse than no check, because the next reader trusts it. What
-            // it purported to catch — a probe reporting success while holding
-            // nothing — is not observable in this process at all; only `pmset`
-            // can see a power assertion, and that reading is the gate in
+            // Under `beginActivity` it could not: the API returned a
+            // non-optional, so a check on it would have read as a check while
+            // checking nothing. `IOPMAssertionCreateWithName` returns an
+            // `IOReturn`, and ``AwakeController`` reports OFF unless all three
+            // assertions were taken — so `isOn` is now a real answer to "did
+            // the take succeed", and a probe that printed `holding` while
+            // holding nothing would make the gate below pass for the wrong
+            // reason. What the guard still cannot see is whether the kernel
+            // agrees; only `pmset` can, and that reading is the gate in
             // `apps/macos/README.md`.
             let pid = ProcessInfo.processInfo.processIdentifier
+            guard controller.isOn else {
+                write(
+                    to: FileHandle.standardError,
+                    """
+                    TcrBar: could not take the keep-awake assertions (pid \(pid))
+
+                    """)
+                exit(1)
+            }
             write(
                 to: FileHandle.standardOutput,
                 """
                 holding  pid \(pid)  for \(seconds)s
+                assertions: \(AwakeController.assertionTypes.joined(separator: ", "))
                 assertion name: \(AwakeController.reason)
-                check it:  pmset -g assertions | grep 'pid \(pid)'
+                check it:  pmset -g assertions | grep -c 'pid \(pid)'   # \(AwakeController.assertionTypes.count)
 
                 """)
             Thread.sleep(forTimeInterval: seconds)
@@ -119,7 +135,7 @@ public enum KeepAwakeProbe {
                 to: FileHandle.standardOutput,
                 """
                 released pid \(pid)  (staying alive \(Int(lingerAfterRelease))s so the release is \
-                attributable to endActivity, not to this process exiting)
+                attributable to IOPMAssertionRelease, not to this process exiting)
 
                 """)
             Thread.sleep(forTimeInterval: lingerAfterRelease)

--- a/apps/macos/Tests/TcrBarTests/AwakeControllerTests.swift
+++ b/apps/macos/Tests/TcrBarTests/AwakeControllerTests.swift
@@ -156,6 +156,46 @@ final class AwakeControllerTests: XCTestCase {
         XCTAssertTrue(AwakeController.reason.contains("TcrBar"), AwakeController.reason)
     }
 
+    /// The set is the point of the class: `caffeinate -i -m -s`, not `-i` alone.
+    ///
+    /// Spelled as literals rather than re-derived from the same constants the
+    /// production code uses, because a test that reads its expectation out of
+    /// the thing under test agrees with any change to it. These three strings
+    /// are what `pmset -g assertions` prints and what the README's gate counts.
+    func testTheThreeAssertionTypesAreTheOnesCaffeinateHolds() {
+        XCTAssertEqual(
+            AwakeController.assertionTypes,
+            ["PreventUserIdleSystemSleep", "PreventSystemSleep", "PreventDiskIdle"])
+    }
+
+    /// A take that fails reports OFF, not partially ON.
+    ///
+    /// `IOPMAssertionCreateWithName` returns an `IOReturn` and can fail, which
+    /// `beginActivity` could not. A controller that showed ON having taken some
+    /// smaller set than it promised would be the panel lying about the state of
+    /// the machine — the defect the single-token shape exists to prevent.
+    func testAFailedTakeLeavesTheControlOffAndRetryable() {
+        var attempts = 0
+        var ended = 0
+        let activity = AwakeController.Activity(
+            begin: { _ in
+                attempts += 1
+                return nil
+            },
+            end: { _ in ended += 1 })
+        let controller = AwakeController(activity: activity)
+
+        controller.setOn(true)
+        XCTAssertFalse(controller.isOn, "nothing was taken, so the control must read OFF")
+        XCTAssertEqual(ended, 0, "there is nothing to end")
+
+        // Not latched into a broken state: the next tick tries again, and the
+        // idempotence guard does not mistake a failed take for a live one.
+        controller.setOn(true)
+        XCTAssertEqual(attempts, 2)
+        XCTAssertFalse(controller.isOn)
+    }
+
     /// The harness pair must hold nothing. If `.inert` ever became the real one,
     /// rendering PNGs would stop the machine sleeping.
     func testInertActivityIsSafeForTheRenderHarness() {


### PR DESCRIPTION
## What

"Keep this Mac awake" held one power assertion, through
`ProcessInfo.beginActivity(options: .idleSystemSleepDisabled)`. That API can
express `caffeinate -i` and nothing else — it has no option corresponding to
`-s` or `-m` — so the checkbox could never match the command line an operator
actually trusts, and the panel honestly said `caffeinate -i`.

It now takes three assertions through `IOPMAssertionCreateWithName`, the set
`caffeinate -i -m -s` registers under one pid:

```
   pid 78916(TcrBar): [0x0000753e0001989a] 00:00:03 PreventUserIdleSystemSleep named: "TcrBar is keeping this Mac awake"
   pid 78916(TcrBar): [0x0000753e0007989b] 00:00:03 PreventSystemSleep named: "TcrBar is keeping this Mac awake"
   pid 78916(TcrBar): [0x0000753e000f989c] 00:00:03 PreventDiskIdle named: "TcrBar is keeping this Mac awake"
```

`PreventSystemSleep` is a raw string on purpose:
`kIOPMAssertionTypePreventSystemSleep` is marked deprecated in `IOPMLib.h` with
no replacement constant, while `caffeinate` registers the same string today and
`powerd` honours it.

## Invariants kept

One token remains the single source of truth for `isOn`, `begin()` is
idempotent, `end()` clears before releasing, and `releaseOnQuit()` still ends
what it began. Three ids live inside one token object, so partial state is
unrepresentable: a take that fails part way through releases what it already
took and stores `nil`, and the control reads OFF rather than claiming a hold it
does not have. That makes `Activity.begin` optional, which in turn makes the
probe's `guard controller.isOn` a check that can actually fail — the comment
explaining that it could not is corrected rather than left to mislead.

The injected-dependency shape is unchanged, so `AwakeControllerTests` and the
`.inert` pair the PNG harness needs both still work.

## What the docs no longer claim

The old text said the hold "does not survive closing the lid. No assertion of
this class does." Nothing here has measured that for these assertion types, so
neither the doc-comment nor the panel says anything about it in either
direction. What *is* measured is that `-s` is AC-only — `man caffeinate`, and
the power log shows no `PrevSleep` in the effective state on battery — so that
is what the panel line and the README say instead.

## Gate

`apps/macos/README.md` now counts assertion lines for the probe pid against two
controls (a bare `caffeinate` = 1, `caffeinate -i -m -s` = 3) instead of
grepping for one name. Run against this branch: `1`, `3`, `3`, then `0` after
the release with the probe still alive.

The snippet also builds before it reads `--show-bin-path`, and that line is not
cosmetic. `--show-bin-path` prints a path and builds nothing, so the first draft
of this gate reported PASS against a deliberately mutated controller that held
one assertion instead of three — it was probing the previous binary. With the
build in place the same mutation exits 1 with `FAIL: probe held 1 assertions,
expected 3`.

`swift build` 0, `swift test` 0 (144 tests), probe gate 0.
