### PR TITLE
feat: let a running proxy be told to park an account

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -554,17 +554,23 @@ private struct RowsHeightKey: PreferenceKey {
 /// matched the wrong account (the query is a substring match) shows up as the
 /// wrong row changing rather than as a lie. A non-zero exit is rendered in place.
 ///
-/// One thing this row deliberately does not claim: that the *running proxy* has
-/// picked the change up. `tcr` rewrites the config; whether a live server re-reads
-/// it without a restart is unverified from here, in either direction.
+/// This row no longer lets a toggle succeed silently. `tcr` rewrites the config
+/// and exits 0; a proxy that read `disabled` once at boot keeps reporting the old
+/// value, and `tcr status` prefers the live server — so the refresh used to come
+/// back unchanged and the row showed nothing at all. Every toggle now ends in a
+/// stated outcome from ``ToggleVerdict``, drawn by `verdictLine` and spoken by
+/// `rowAccessibilityLabel`.
 ///
 /// No confirmation dialog: disabling is reversible and costs nothing.
 struct AccountRow: View {
     let account: Account
     let countersAreStructural: Bool
     @ObservedObject var accounts: AccountController
-    /// Called after a successful toggle so the row re-reads reality.
-    let onChanged: () async -> Void
+    /// Called after a successful toggle so the row re-reads reality. It returns
+    /// the state of the read it just performed, which is what the verdict is
+    /// computed against — reading the poller's published `state` afterwards could
+    /// pick up a different, later poll.
+    let onChanged: () async -> PollState
 
     /// The single tint for this row's quota evidence. The pill and the bar both
     /// read it, so the two can never disagree about whether a quota is known.
@@ -636,6 +642,12 @@ struct AccountRow: View {
         if let hold = account.soonestHold { parts.append(hold.countdownLabel) }
         if let failure = accounts.failure(for: account.name) {
             parts.append("last action failed: \(failure.summary)")
+        }
+        // Spoken for the same reason the pill is: a confirmation only a sighted
+        // user gets is half built, and the `✓` in `rowLabel` is punctuation to a
+        // screen reader.
+        if let verdict = accounts.verdict(for: account.name, reportedDisabled: account.disabled) {
+            parts.append(verdict.spokenLabel)
         }
         return parts.joined(separator: ", ")
     }
@@ -746,6 +758,41 @@ struct AccountRow: View {
                     .foregroundStyle(Tok.spent)
                     .fixedSize(horizontal: false, vertical: true)
             }
+            verdictLine
+        }
+    }
+
+    /// The outcome of the last successful toggle, as the fleet then reported it.
+    ///
+    /// Three tints for three different facts. A not-honoured toggle is drawn in
+    /// `Tok.near` rather than `Tok.spent`: nothing failed — the call landed and
+    /// the config changed — so it must not wear the colour this palette reserves
+    /// for errors, which is already taken by the verbatim `tcr` failure directly
+    /// above it. The two lines can appear for different reasons and have to stay
+    /// tellable apart.
+    @ViewBuilder
+    private var verdictLine: some View {
+        if let verdict = accounts.verdict(for: account.name, reportedDisabled: account.disabled) {
+            Label(verdict.rowLabel, systemImage: Self.verdictGlyph(verdict))
+                .font(Tok.detailFont)
+                .foregroundStyle(Self.verdictTint(verdict))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private static func verdictGlyph(_ verdict: ToggleVerdict) -> String {
+        switch verdict {
+        case .confirmed: return "checkmark.circle"
+        case .notHonoured: return Tok.unreadableGlyph
+        case .unverified: return "questionmark.circle"
+        }
+    }
+
+    private static func verdictTint(_ verdict: ToggleVerdict) -> Color {
+        switch verdict {
+        case .confirmed: return Tok.ok
+        case .notHonoured: return Tok.near
+        case .unverified: return Tok.unmeasured
         }
     }
 
@@ -762,7 +809,13 @@ struct AccountRow: View {
         return Button(title) {
             Task {
                 if await accounts.setEnabled(enabling, account: account.name) {
-                    await onChanged()
+                    // Exit 0 is not the outcome — it is permission to go and find
+                    // out what the outcome was. The refresh's own result is
+                    // compared against what was asked, and the row says which of
+                    // the three things happened.
+                    let readback = await onChanged()
+                    accounts.record(
+                        readback: readback, requestedEnabled: enabling, account: account.name)
                 }
             }
         }

--- a/apps/macos/Sources/TcrBarCore/AccountControl.swift
+++ b/apps/macos/Sources/TcrBarCore/AccountControl.swift
@@ -20,10 +20,13 @@ import Foundation
 ///     whatever `tcr status` then reports.
 ///
 /// What this does **not** claim: that a running proxy observes the change
-/// immediately. `tcr` rewrites the config file; whether the live server re-reads it
-/// without a restart is **unverified** in either direction from this app's side.
-/// The panel therefore only ever asserts what `tcr status` reports, which is the
-/// config-level fact.
+/// immediately. `tcr` rewrites the config file; a live server that read `disabled`
+/// once at boot keeps serving the old value, and `tcr status` prefers the live
+/// server — so the re-poll can come back reporting the state that was just
+/// changed away from. That is a real, measured outcome on this fleet, not a
+/// theoretical one, and it is now RENDERED rather than assumed away: see
+/// ``ToggleVerdict``. The panel still only ever asserts what `tcr status`
+/// reports; it just no longer treats exit 0 as evidence that anything happened.
 public enum AccountCommand {
     /// The complete argument vector. `name` is passed positionally and verbatim —
     /// no `--org`, no flags, nothing that could name a process.
@@ -95,11 +98,55 @@ public enum AccountCommand {
 public final class AccountController: ObservableObject {
     @Published public private(set) var pending: Set<String> = []
     @Published public private(set) var failures: [String: AccountCommand.Failure] = [:]
+    /// The read-back verdict for the last successful toggle of each account —
+    /// what the fleet reported afterwards, compared against what was asked.
+    @Published public private(set) var verdicts: [String: RecordedVerdict] = [:]
 
     public init() {}
 
     public func isPending(_ name: String) -> Bool { pending.contains(name) }
     public func failure(for name: String) -> AccountCommand.Failure? { failures[name] }
+
+    /// Record what the poll that followed a successful toggle reported. Called by
+    /// the row immediately after its refresh, so the verdict describes the same
+    /// read the row is about to draw.
+    public func record(
+        readback: PollState,
+        requestedEnabled: Bool,
+        account name: String,
+        now: Date = Date()
+    ) {
+        let verdict = ToggleReadback.verdict(
+            requestedEnabled: requestedEnabled,
+            account: name,
+            readback: readback
+        )
+        verdicts[name] = RecordedVerdict(verdict: verdict, at: now)
+        guard verdict.isConfirmation else { return }
+        // A confirmation ages out (see ``ToggleReadback/visible(_:reportedDisabled:now:lifetime:)``),
+        // and `visible` is the authority on that. This timer exists only so the
+        // expiry is actually DRAWN: nothing else republishes when the deadline
+        // passes, and a row whose account is unchanged will not re-render on its
+        // own, so an expired ack would linger on screen until something else
+        // moved. The identity check keeps a later attempt's verdict safe.
+        let recorded = verdicts[name]
+        Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(ToggleReadback.confirmationLifetime * 1_000_000_000))
+            guard let self, self.verdicts[name] == recorded else { return }
+            self.verdicts[name] = nil
+        }
+    }
+
+    /// The verdict this row may show right now, or `nil`. `reportedDisabled` is
+    /// what the *current* fleet read says about the account, which is what stops a
+    /// confirmation from outliving its truth.
+    public func verdict(
+        for name: String,
+        reportedDisabled: Bool?,
+        now: Date = Date()
+    ) -> ToggleVerdict? {
+        ToggleReadback.visible(verdicts[name], reportedDisabled: reportedDisabled, now: now)
+    }
 
     /// Run the toggle. Returns `true` only when `tcr` exited 0 — the caller uses
     /// that to decide whether a status refresh is worth doing, never to update a
@@ -109,8 +156,11 @@ public final class AccountController: ObservableObject {
         guard !pending.contains(name) else { return false }
         pending.insert(name)
         // A new attempt clears the previous verdict; a stale error beside a
-        // now-succeeding row would be its own lie.
+        // now-succeeding row would be its own lie. The read-back verdict goes for
+        // the same reason: a `parked ✓` left over from the last click must not sit
+        // beside a call that is still in flight and might not be honoured.
         failures[name] = nil
+        verdicts[name] = nil
         defer { pending.remove(name) }
 
         let failure = await Task.detached(priority: .userInitiated) {

--- a/apps/macos/Sources/TcrBarCore/StatusPoller.swift
+++ b/apps/macos/Sources/TcrBarCore/StatusPoller.swift
@@ -103,10 +103,18 @@ public final class StatusPoller: ObservableObject {
         task = nil
     }
 
-    public func pollOnce() async {
+    /// Returns the state it just published, so a caller that polls *in order to
+    /// check something* can compare against the exact read it triggered rather
+    /// than against whatever `state` holds by the time it looks — a later timer
+    /// tick can land in between. The toggle read-back
+    /// (``AccountController/record(readback:requestedEnabled:account:now:)``)
+    /// depends on that.
+    @discardableResult
+    public func pollOnce() async -> PollState {
         let next = await Task.detached(priority: .utility) { Self.fetch() }.value
         state = next
         lastPollAt = Date()
+        return next
     }
 
     /// Blocking fetch — always called off the main actor.

--- a/apps/macos/Sources/TcrBarCore/ToggleVerdict.swift
+++ b/apps/macos/Sources/TcrBarCore/ToggleVerdict.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+/// What happened to a toggle, established by RE-READING the fleet rather than by
+/// assuming.
+///
+/// The defect this exists to close, measured on the live fleet: `tcr disable
+/// <name>` rewrites `~/.config/teamclaude.json` and exits 0, but a running proxy
+/// read `disabled` into memory once at boot and `tcr status` prefers the live
+/// server — so the row re-polled, got the OLD value back, and changed nothing.
+/// Exit 0 meant ``AccountController/failures`` stayed empty, so the row said
+/// nothing at all while the account kept taking traffic. A success that is
+/// indistinguishable from doing nothing is the worst of the three outcomes to
+/// render, because it is the one nobody investigates.
+///
+/// So a toggle has three renderable outcomes and this type carries the two that
+/// only a re-read can tell apart. The third — a non-zero exit — is
+/// ``AccountCommand/Failure`` and is unchanged: `tcr`'s own words, verbatim.
+///
+/// `requestedEnabled` is what the click ASKED for (`true` = put back in
+/// rotation), never what the row happened to show.
+public enum ToggleVerdict: Equatable, Sendable {
+    /// The fleet now reports the state that was asked for.
+    case confirmed(requestedEnabled: Bool)
+    /// `tcr` exited 0 and the fleet still reports the old state. This is the arm
+    /// that fires on a machine whose proxy predates the fix, and on a machine
+    /// whose proxy simply has not restarted yet — both deploy orders land here,
+    /// which is why it names the mechanism instead of just failing.
+    case notHonoured(requestedEnabled: Bool)
+    /// `tcr` exited 0 but the re-read could not answer: the status call itself
+    /// failed, the payload did not decode, or the account is no longer listed.
+    /// Distinct from both of the above on purpose — "I could not check" is not a
+    /// confirmation, and it is not evidence the proxy disagreed either.
+    case unverified(requestedEnabled: Bool, reason: String)
+
+    public var requestedEnabled: Bool {
+        switch self {
+        case .confirmed(let enabled), .notHonoured(let enabled): return enabled
+        case .unverified(let enabled, _): return enabled
+        }
+    }
+
+    /// True only for the arm that asserts the change took effect. Anything that
+    /// branches on "did this work" must read this and not `case let`, so a future
+    /// fourth arm cannot default into looking like a success.
+    public var isConfirmation: Bool {
+        if case .confirmed = self { return true }
+        return false
+    }
+
+    /// The row's own vocabulary: `rotating` / `parked`, matching the pill, so the
+    /// verdict line and the pill can never use two different words for one state.
+    private static func word(rotating: Bool) -> String { rotating ? "rotating" : "parked" }
+
+    /// One line for the row. Always non-empty.
+    public var rowLabel: String {
+        switch self {
+        case .confirmed(let enabled):
+            return "\(Self.word(rotating: enabled)) ✓"
+        case .notHonoured(let enabled):
+            // The old state is the opposite of what was asked for — that is what
+            // makes this arm this arm.
+            return "tcr accepted it — the running proxy still reports \(Self.word(rotating: !enabled))"
+        case .unverified(_, let reason):
+            return "tcr accepted it — could not confirm: \(reason)"
+        }
+    }
+
+    /// The same fact spoken. A confirmation only a sighted user gets is half
+    /// built, and ``rowLabel``'s `✓` is punctuation to VoiceOver.
+    public var spokenLabel: String {
+        switch self {
+        case .confirmed(let enabled):
+            return enabled ? "confirmed rotating" : "confirmed parked, out of rotation"
+        case .notHonoured(let enabled):
+            return "tcr accepted the change but the running proxy still reports "
+                + Self.word(rotating: !enabled)
+        case .unverified(_, let reason):
+            return "tcr accepted the change but it could not be confirmed: \(reason)"
+        }
+    }
+}
+
+/// A verdict plus when it was reached. The timestamp is what keeps a
+/// confirmation from outliving its truth.
+public struct RecordedVerdict: Equatable, Sendable {
+    public let verdict: ToggleVerdict
+    public let at: Date
+
+    public init(verdict: ToggleVerdict, at: Date) {
+        self.verdict = verdict
+        self.at = at
+    }
+}
+
+/// The pure half of the toggle read-back: turn a requested state plus whatever
+/// the next poll reported into a verdict, and decide whether a stored verdict is
+/// still true enough to show.
+///
+/// Pure on purpose. `ImageRenderer` cannot draw AppKit controls at all — every
+/// `--render-states` PNG shows a placeholder where this row's button is — so no
+/// snapshot can ever cover this logic. If it is not testable without a view it
+/// is not tested.
+public enum ToggleReadback {
+    /// How long a confirmation may sit on screen: two poll intervals
+    /// (``StatusPoller`` polls every 3s), so a confirmation always survives at
+    /// least one full refresh and then goes away on its own.
+    public static let confirmationLifetime: TimeInterval = 6
+
+    /// The comparison. `requestedEnabled` is what was asked; `readback` is the
+    /// poll that followed the successful call.
+    public static func verdict(
+        requestedEnabled: Bool,
+        account name: String,
+        readback: PollState
+    ) -> ToggleVerdict {
+        switch readback {
+        case .loaded(let fleet):
+            guard let account = fleet.accounts.first(where: { $0.name == name }) else {
+                return .unverified(
+                    requestedEnabled: requestedEnabled,
+                    reason: "the fleet no longer lists this account"
+                )
+            }
+            // `disabled` is the field the config and the live server disagree
+            // about, so it is the only thing worth comparing. `status` keeps
+            // saying "active" on a disabled account (verified against live
+            // output) and would confirm every toggle.
+            return account.disabled == !requestedEnabled
+                ? .confirmed(requestedEnabled: requestedEnabled)
+                : .notHonoured(requestedEnabled: requestedEnabled)
+        case .pending:
+            return .unverified(requestedEnabled: requestedEnabled, reason: "no fleet read has completed")
+        case .toolMissing, .commandFailed, .undecodable:
+            return .unverified(requestedEnabled: requestedEnabled, reason: readback.summary)
+        }
+    }
+
+    /// Whether a stored verdict may still be rendered, given what the fleet
+    /// reports for that account *now*. `reportedDisabled` is `nil` when the
+    /// current poll has no row for it.
+    ///
+    /// Two different lifetimes, because the two arms make different claims:
+    ///
+    ///  - A **confirmation** asserts "the fleet reports what you asked for". It
+    ///    drops the moment that stops being true — a rotation change, or an
+    ///    account that vanished — and otherwise ages out after
+    ///    ``confirmationLifetime``. A `parked ✓` still sitting beside a row that
+    ///    has since gone back into rotation is exactly the class of lie this
+    ///    whole type exists to prevent, and an ack that never expires becomes
+    ///    one eventually by sitting there.
+    ///  - A **not-honoured** verdict names an UNRESOLVED disagreement between
+    ///    the config and the running proxy. It deliberately does not age out;
+    ///    hiding it after six seconds would restore the original defect, where
+    ///    the row said nothing. It clears only when the fleet finally reports the
+    ///    requested state — i.e. when the proxy actually caught up.
+    ///  - **unverified** clears on the same condition, and never promotes itself
+    ///    to a confirmation: nothing observed the change take effect, so this
+    ///    only ever stops being said, it is never upgraded.
+    public static func visible(
+        _ recorded: RecordedVerdict?,
+        reportedDisabled: Bool?,
+        now: Date,
+        lifetime: TimeInterval = confirmationLifetime
+    ) -> ToggleVerdict? {
+        guard let recorded else { return nil }
+        let requested = recorded.verdict.requestedEnabled
+        let fleetAgrees = reportedDisabled == !requested
+        switch recorded.verdict {
+        case .confirmed:
+            guard fleetAgrees else { return nil }
+            guard now.timeIntervalSince(recorded.at) < lifetime else { return nil }
+            return recorded.verdict
+        case .notHonoured, .unverified:
+            return fleetAgrees ? nil : recorded.verdict
+        }
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/ToggleVerdictTests.swift
+++ b/apps/macos/Tests/TcrBarTests/ToggleVerdictTests.swift
@@ -1,0 +1,270 @@
+import Foundation
+import XCTest
+
+@testable import TcrBarCore
+
+/// The toggle used to be able to do nothing at all, visibly. `tcr disable <name>`
+/// rewrites the config and exits 0, a running proxy keeps serving the value it
+/// read at boot, and `tcr status` prefers the live server — so the row re-polled,
+/// got the OLD state back, and rendered no change and no error. These tests pin
+/// the arm that closes it: exit 0 plus a fleet still reporting the old value is
+/// NOT a confirmation.
+///
+/// The comparison is a pure function precisely so it can be tested here.
+/// `ImageRenderer` cannot draw AppKit controls, so no snapshot could ever cover
+/// the row that renders it.
+///
+/// Account names are obviously fake — this repository is public.
+final class ToggleVerdictTests: XCTestCase {
+
+    private let alice = "alice@example.com"
+
+    // MARK: - the arm that matters
+
+    /// The measured live defect, in one test: the operator asked for `disable`,
+    /// `tcr` exited 0 (so we are on this code path at all), and the fleet still
+    /// reports the account as rotating.
+    func testExitZeroWithAFleetStillReportingTheOldStateIsNotHonoured() {
+        let verdict = ToggleReadback.verdict(
+            requestedEnabled: false,
+            account: alice,
+            readback: .loaded(Fleet(accounts: [account(alice, disabled: false)]))
+        )
+        XCTAssertEqual(verdict, .notHonoured(requestedEnabled: false))
+        XCTAssertFalse(verdict.isConfirmation, "a proxy still reporting the old state is not a success")
+        XCTAssertEqual(
+            verdict.rowLabel,
+            "tcr accepted it — the running proxy still reports rotating"
+        )
+    }
+
+    /// The same defect in the other direction — an enable the proxy has not
+    /// picked up. Both deploy orders (old proxy + new app, new app before the
+    /// proxy restarts) land on this arm, so both directions have to.
+    func testEnableThatTheFleetStillReportsAsParkedIsNotHonoured() {
+        let verdict = ToggleReadback.verdict(
+            requestedEnabled: true,
+            account: alice,
+            readback: .loaded(Fleet(accounts: [account(alice, disabled: true)]))
+        )
+        XCTAssertEqual(verdict, .notHonoured(requestedEnabled: true))
+        XCTAssertEqual(verdict.rowLabel, "tcr accepted it — the running proxy still reports parked")
+    }
+
+    // MARK: - confirmed
+
+    func testFleetReportingTheRequestedStateConfirms() {
+        let parked = ToggleReadback.verdict(
+            requestedEnabled: false,
+            account: alice,
+            readback: .loaded(Fleet(accounts: [account(alice, disabled: true)]))
+        )
+        XCTAssertEqual(parked, .confirmed(requestedEnabled: false))
+        XCTAssertTrue(parked.isConfirmation)
+        XCTAssertEqual(parked.rowLabel, "parked ✓")
+
+        let rotating = ToggleReadback.verdict(
+            requestedEnabled: true,
+            account: alice,
+            readback: .loaded(Fleet(accounts: [account(alice, disabled: false)]))
+        )
+        XCTAssertEqual(rotating, .confirmed(requestedEnabled: true))
+        XCTAssertEqual(rotating.rowLabel, "rotating ✓")
+    }
+
+    /// A fleet of thirteen must be compared row-wise. Confirming from some other
+    /// account's `disabled` would confirm essentially every toggle.
+    func testTheComparisonUsesTheRequestedAccountNotItsNeighbours() {
+        let fleet = Fleet(
+            accounts: [
+                account("bob@example.com", disabled: true),
+                account(alice, disabled: false),
+                account("carol@example.com", disabled: true),
+            ]
+        )
+        XCTAssertEqual(
+            ToggleReadback.verdict(requestedEnabled: false, account: alice, readback: .loaded(fleet)),
+            .notHonoured(requestedEnabled: false)
+        )
+    }
+
+    // MARK: - unverified
+
+    /// "I could not check" must be its own arm. Folding a failed re-read into
+    /// `confirmed` is the original defect with extra steps; folding it into
+    /// `notHonoured` would assert a disagreement nobody observed.
+    func testAFailedReadbackIsNeitherConfirmedNorNotHonoured() {
+        let states: [PollState] = [
+            .pending,
+            .toolMissing(searched: ["/usr/local/bin"]),
+            .commandFailed(exitCode: 1, message: "connection refused"),
+            .undecodable(message: "dataCorrupted"),
+        ]
+        for state in states {
+            let verdict = ToggleReadback.verdict(
+                requestedEnabled: false, account: alice, readback: state)
+            XCTAssertFalse(verdict.isConfirmation, "\(state) must not read as a confirmation")
+            guard case .unverified = verdict else {
+                return XCTFail("\(state) should be unverified, got \(verdict)")
+            }
+            XCTAssertTrue(verdict.rowLabel.hasPrefix("tcr accepted it — could not confirm: "))
+        }
+    }
+
+    func testAnAccountMissingFromTheReadbackIsUnverified() {
+        let verdict = ToggleReadback.verdict(
+            requestedEnabled: false,
+            account: alice,
+            readback: .loaded(Fleet(accounts: [account("bob@example.com", disabled: false)]))
+        )
+        XCTAssertEqual(
+            verdict,
+            .unverified(requestedEnabled: false, reason: "the fleet no longer lists this account")
+        )
+    }
+
+    // MARK: - a confirmation must not outlive its truth
+
+    func testAFreshConfirmationIsVisibleWhileTheFleetStillAgrees() {
+        let now = Date()
+        let recorded = RecordedVerdict(verdict: .confirmed(requestedEnabled: false), at: now)
+        XCTAssertEqual(
+            ToggleReadback.visible(recorded, reportedDisabled: true, now: now.addingTimeInterval(1)),
+            .confirmed(requestedEnabled: false)
+        )
+    }
+
+    func testAConfirmationDisappearsWhenTheReportedStateMovesOn() {
+        let now = Date()
+        let recorded = RecordedVerdict(verdict: .confirmed(requestedEnabled: false), at: now)
+        // The account went back into rotation. A `parked ✓` here would be a lie of
+        // exactly the class this type exists to prevent.
+        XCTAssertNil(
+            ToggleReadback.visible(recorded, reportedDisabled: false, now: now.addingTimeInterval(1)))
+        // And when the fleet has no row for it at all, there is nothing to affirm.
+        XCTAssertNil(
+            ToggleReadback.visible(recorded, reportedDisabled: nil, now: now.addingTimeInterval(1)))
+    }
+
+    func testAConfirmationAgesOut() {
+        let now = Date()
+        let recorded = RecordedVerdict(verdict: .confirmed(requestedEnabled: true), at: now)
+        let late = now.addingTimeInterval(ToggleReadback.confirmationLifetime + 0.5)
+        XCTAssertNil(ToggleReadback.visible(recorded, reportedDisabled: false, now: late))
+        // Long enough to survive at least one 3s poll, or it would flicker away
+        // before the operator saw it.
+        XCTAssertGreaterThan(ToggleReadback.confirmationLifetime, 3)
+    }
+
+    /// The unresolved-disagreement arm deliberately does NOT age out: hiding it
+    /// after a few seconds restores the original defect, where the row said
+    /// nothing while the proxy kept serving a parked account.
+    func testANotHonouredVerdictPersistsPastTheConfirmationLifetime() {
+        let now = Date()
+        let recorded = RecordedVerdict(verdict: .notHonoured(requestedEnabled: false), at: now)
+        let muchLater = now.addingTimeInterval(ToggleReadback.confirmationLifetime * 100)
+        XCTAssertEqual(
+            ToggleReadback.visible(recorded, reportedDisabled: false, now: muchLater),
+            .notHonoured(requestedEnabled: false)
+        )
+    }
+
+    /// …and clears exactly when reality catches up — a proxy restart, say.
+    func testANotHonouredVerdictClearsWhenTheFleetFinallyAgrees() {
+        let now = Date()
+        let recorded = RecordedVerdict(verdict: .notHonoured(requestedEnabled: false), at: now)
+        XCTAssertNil(
+            ToggleReadback.visible(recorded, reportedDisabled: true, now: now.addingTimeInterval(30)))
+    }
+
+    func testAnUnverifiedVerdictNeverPromotesToAConfirmation() {
+        let now = Date()
+        let recorded = RecordedVerdict(
+            verdict: .unverified(requestedEnabled: false, reason: "no fleet read has completed"),
+            at: now
+        )
+        // Once the fleet reports the requested state the line simply stops being
+        // said; it does not turn into a `✓` nothing observed.
+        XCTAssertNil(
+            ToggleReadback.visible(recorded, reportedDisabled: true, now: now.addingTimeInterval(1)))
+        XCTAssertEqual(
+            ToggleReadback.visible(recorded, reportedDisabled: false, now: now.addingTimeInterval(1)),
+            recorded.verdict
+        )
+    }
+
+    func testNoRecordedVerdictRendersNothing() {
+        XCTAssertNil(ToggleReadback.visible(nil, reportedDisabled: false, now: Date()))
+    }
+
+    // MARK: - every arm is spoken
+
+    /// A verdict with no spoken form is invisible to VoiceOver, and the `✓` is
+    /// punctuation. Every arm has to say something, and the three have to differ.
+    func testEveryArmHasADistinctSpokenAndWrittenForm() {
+        let all: [ToggleVerdict] = [
+            .confirmed(requestedEnabled: false),
+            .confirmed(requestedEnabled: true),
+            .notHonoured(requestedEnabled: false),
+            .notHonoured(requestedEnabled: true),
+            .unverified(requestedEnabled: false, reason: "tcr status failed (exit 1): no output"),
+        ]
+        for verdict in all {
+            XCTAssertFalse(verdict.rowLabel.isEmpty)
+            XCTAssertFalse(verdict.spokenLabel.isEmpty)
+            XCTAssertFalse(verdict.spokenLabel.contains("✓"), "a screen reader reads ✓ as punctuation")
+        }
+        XCTAssertEqual(Set(all.map(\.rowLabel)).count, all.count)
+        XCTAssertEqual(Set(all.map(\.spokenLabel)).count, all.count)
+    }
+
+    // MARK: - the controller records what the row will draw
+
+    @MainActor
+    func testControllerStoresTheVerdictAndANewAttemptClearsIt() async {
+        let controller = AccountController()
+        let now = Date()
+        controller.record(
+            readback: .loaded(Fleet(accounts: [account(alice, disabled: false)])),
+            requestedEnabled: false,
+            account: alice,
+            now: now
+        )
+        XCTAssertEqual(
+            controller.verdict(for: alice, reportedDisabled: false, now: now),
+            .notHonoured(requestedEnabled: false)
+        )
+        // A verdict for one account must not surface on another row.
+        XCTAssertNil(controller.verdict(for: "bob@example.com", reportedDisabled: false, now: now))
+    }
+}
+
+/// Inert account with only the fields this comparison reads. `status` is
+/// deliberately "active" even when parked — that is what live output does, and it
+/// is why `disabled` is the only field compared.
+private func account(_ name: String, disabled: Bool) -> Account {
+    Account(
+        name: name,
+        priority: 1,
+        status: "active",
+        disabled: disabled,
+        quota: 0,
+        quotaState: .ok,
+        fiveHour: 0,
+        sevenDay: 0,
+        sevenDayOi: 0,
+        held: [],
+        requests: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheHitRatio: nil,
+        probeStatus: .ok,
+        probeError: nil,
+        lastStreamError: nil,
+        streamErrorCount: 0,
+        source: .live,
+        serverSha: "abc1234",
+        serverDirty: false
+    )
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,7 +25,7 @@ use anyhow::{bail, Context as _};
 use time::OffsetDateTime;
 
 use crate::build_info::{self, BuildInfo};
-use crate::config::{self, Account, Config};
+use crate::config::{self, Config};
 use crate::identity;
 use crate::manager::Manager;
 use crate::oauth::{NoRefresh, TokenRefresher};
@@ -92,30 +92,34 @@ fn save_after_edit(config_path: &Path, config: &Config) -> anyhow::Result<()> {
 /// silently resolving to the first entry. Zero or more-than-one surviving
 /// candidate is an error — the ambiguous error lists the candidate names so the
 /// caller can disambiguate. (`Account.name` IS the email.)
-pub fn resolve_account(
-    accounts: &[Account],
+pub fn resolve_account<T: identity::Queryable>(
+    accounts: &[T],
     query: &str,
     org: Option<&str>,
 ) -> anyhow::Result<usize> {
-    let candidates = identity::match_accounts(accounts, query, org);
-
-    match candidates.as_slice() {
-        [] => {
+    match identity::match_one(accounts, query, org) {
+        identity::Match::One(only) => Ok(only),
+        identity::Match::None => {
             let org_note = org
                 .map(|o| format!(" (with org matching '{o}')"))
                 .unwrap_or_default();
             bail!("no account matches '{query}'{org_note}");
         }
-        [only] => Ok(*only),
-        many => {
-            let names: Vec<&str> = many.iter().map(|&i| accounts[i].name.as_str()).collect();
-            bail!(
-                "'{query}' is ambiguous — matches {} accounts: {}. Narrow with --org or use an exact name.",
-                names.len(),
-                names.join(", ")
-            );
+        identity::Match::Ambiguous(names) => {
+            bail!("{}", ambiguous_query_message(query, &names));
         }
     }
+}
+
+/// The one-line explanation of an ambiguous query, shared by the CLI's own
+/// resolution and by the live control endpoint's 409 body, so a caller gets the
+/// same actionable sentence — and the same candidate list — whichever answered.
+pub fn ambiguous_query_message(query: &str, names: &[String]) -> String {
+    format!(
+        "'{query}' is ambiguous — matches {} accounts: {}. Narrow with --org or use an exact name.",
+        names.len(),
+        names.join(", ")
+    )
 }
 
 /// Load → resolve `(query, org)` to one account → hand it to `mutate` → save.
@@ -194,26 +198,245 @@ pub fn set_priority(
     Ok(())
 }
 
-/// Enable or disable the account matching `query`.
+/// Enable or disable the account matching `query`, **in the running proxy first**.
 ///
-/// `disabled = true` writes `"disabled": true`; `disabled = false` sets the
-/// field to `None` so `skip_serializing_if = Option::is_none` DROPS the key
-/// entirely — matching the JS `delete account.disabled`, not a `false` literal.
-pub fn set_enabled(
+/// A file-only write was the bug. The proxy reads `disabled` from the config once,
+/// at `Manager::new`, and never again — so `tcr disable alice` exited 0, printed
+/// "Disabled account 'alice'.", and the serving process kept handing that account
+/// live traffic. `tcr status` prefers the live server, so nothing anywhere said
+/// otherwise. Two accounts were measured in that state on the live fleet.
+///
+/// So: ask the server ([`crate::proxy::DISABLED_PATH`]), which applies the flag to
+/// its in-memory rotation AND persists it, and fall back to the file only when no
+/// server answered. The fallback is not silent when a server DID answer and could
+/// not do the job — that silence is the entire reason the defect was invisible.
+///
+/// `disabled = false` on the file path sets the field to `None` so
+/// `skip_serializing_if = Option::is_none` DROPS the key entirely — matching the
+/// JS `delete account.disabled`, not a `false` literal. `Manager::set_disabled`'s
+/// persist does the same, so both paths leave the same document.
+pub async fn set_enabled(
     config_path: &Path,
     query: &str,
     org: Option<&str>,
     disabled: bool,
 ) -> anyhow::Result<()> {
-    let name = edit_account(config_path, query, org, |config, idx| {
-        config.accounts[idx].disabled = if disabled { Some(true) } else { None };
-        config.accounts[idx].name.clone()
-    })?;
+    // A config we cannot read has no port and no api-key to reach a server with;
+    // fall through to the file path, which reports the load failure as it always
+    // has. Never a silent skip of the live attempt for any other reason.
+    if let Ok(config) = config::load(config_path) {
+        match post_set_disabled(&config, query, org, disabled).await {
+            Ok(applied) => {
+                println!(
+                    "{} account '{}'.",
+                    if disabled { "Disabled" } else { "Enabled" },
+                    applied.name
+                );
+                if let Some(warning) = &applied.warning {
+                    eprintln!("[tcr] warning: {warning}");
+                }
+                return Ok(());
+            }
+            // Nothing is listening: the historical case, and the only quiet one.
+            // There is no live rotation to disagree with the file.
+            Err(LiveControlError::NoServer) => {}
+            // A server is there and REFUSED us. Writing the file here would be the
+            // old lie in a new place: the config would say benched while the proxy
+            // we could not talk to keeps rotating. Change nothing, exit non-zero.
+            Err(LiveControlError::Unauthorized) => {
+                bail!(
+                    "the proxy on :{} rejected the api-key in {} — the config was NOT changed, because writing it would leave the running proxy still rotating this account. Fix `proxy.apiKey` and retry.",
+                    config.proxy.port,
+                    config_path.display()
+                );
+            }
+            // The route is missing: an older tcr is serving. The file write is all
+            // we can do, and it is HALF a disable — say so loudly. This arm is the
+            // one that used to be the whole function, silently.
+            Err(LiveControlError::NoRoute) => {
+                let name = write_disabled_flag(config_path, query, org, disabled)?;
+                eprintln!(
+                    "[tcr] WARNING: the proxy running on :{} is too old to accept live account control (no {} route), so only the config file was changed. It will KEEP {} '{name}' until it restarts. Run `tcr restart` when a cold prompt cache is acceptable.",
+                    config.proxy.port,
+                    crate::proxy::DISABLED_PATH,
+                    if disabled { "routing to" } else { "benching" },
+                );
+                return Ok(());
+            }
+            // The route ran and refused the QUERY: it matched no live account, or
+            // matched several. Do not fall back — the file's own resolution could
+            // land on a different account than the one the server was talking
+            // about, and a disable applied to the wrong row is worse than none.
+            Err(LiveControlError::Rejected(message)) => {
+                bail!(
+                    "the proxy running on :{} refused this: {message} Nothing was changed.",
+                    config.proxy.port
+                );
+            }
+            // It answered something we cannot use, or did not answer at all. Same
+            // shape of consequence as the arm above, different cause, and equally
+            // never silent.
+            Err(other) => {
+                let name = write_disabled_flag(config_path, query, org, disabled)?;
+                eprintln!(
+                    "[tcr] WARNING: could not apply this to the proxy running on :{} ({}), so only the config file was changed. It may KEEP {} '{name}' until it restarts.",
+                    config.proxy.port,
+                    other.why(),
+                    if disabled { "routing to" } else { "benching" },
+                );
+                return Ok(());
+            }
+        }
+    }
+
+    let name = write_disabled_flag(config_path, query, org, disabled)?;
     println!(
         "{} account '{name}'.",
         if disabled { "Disabled" } else { "Enabled" }
     );
     Ok(())
+}
+
+/// The file half of enable/disable: resolve, set the flag, save, return the
+/// resolved name. Exactly what `set_enabled` did before it learned to ask the
+/// server.
+fn write_disabled_flag(
+    config_path: &Path,
+    query: &str,
+    org: Option<&str>,
+    disabled: bool,
+) -> anyhow::Result<String> {
+    edit_account(config_path, query, org, |config, idx| {
+        config.accounts[idx].disabled = if disabled { Some(true) } else { None };
+        config.accounts[idx].name.clone()
+    })
+}
+
+/// Why a live account-control request did not apply.
+///
+/// The arms are the CLI's decision table, not decoration: one of them must NOT
+/// write the config (`Unauthorized`), one writes it quietly (`NoServer`), and the
+/// rest write it and shout. Collapsing them is how a half-applied disable becomes
+/// invisible again.
+#[derive(Debug)]
+enum LiveControlError {
+    /// Nothing is listening on the configured port. No live rotation exists, so
+    /// the file IS the whole truth — the ordinary offline case.
+    NoServer,
+    /// A server answered, but the account-control route is not there: an older
+    /// tcr, identified structurally by the absent
+    /// [`crate::proxy::ENDPOINT_HEADER`] on a 404/405, never by error text.
+    NoRoute,
+    /// The proxy rejected our api-key. The one arm that must not touch the file.
+    Unauthorized,
+    /// Something is listening but produced no usable response before the deadline.
+    NoAnswer(String),
+    /// It answered and the answer was not one we can act on: a 4xx/5xx from the
+    /// route itself, or a body that is not ours.
+    Unusable(String),
+    /// The route resolved our query to nothing, or to more than one account. The
+    /// server's own message is carried through verbatim — it names the candidates.
+    Rejected(String),
+}
+
+impl LiveControlError {
+    fn why(&self) -> String {
+        match self {
+            LiveControlError::NoServer => "nothing is listening".to_string(),
+            LiveControlError::NoRoute => {
+                "the running proxy has no account-control route".to_string()
+            }
+            LiveControlError::Unauthorized => "the proxy api-key was rejected".to_string(),
+            LiveControlError::NoAnswer(why)
+            | LiveControlError::Unusable(why)
+            | LiveControlError::Rejected(why) => why.clone(),
+        }
+    }
+}
+
+/// Ask the running proxy to park/unpark an account. Mirrors [`fetch_live_status`]:
+/// same `no_proxy()` client (`HTTP_PROXY` commonly points AT tcr, so honouring it
+/// would send this command through the proxy it is about), same timeouts, same
+/// api-key header — the control route has no loopback exemption either.
+async fn post_set_disabled(
+    config: &Config,
+    query: &str,
+    org: Option<&str>,
+    disabled: bool,
+) -> Result<crate::proxy::SetDisabledResponse, LiveControlError> {
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .connect_timeout(Duration::from_secs(2))
+        .timeout(Duration::from_secs(5))
+        .build()
+        .map_err(|e| LiveControlError::Unusable(format!("http client: {e}")))?;
+
+    let url = format!(
+        "http://127.0.0.1:{}{}",
+        config.proxy.port,
+        crate::proxy::DISABLED_PATH
+    );
+    let mut request = client.post(&url).json(&serde_json::json!({
+        "query": query,
+        "org": org,
+        "disabled": disabled,
+    }));
+    if let Some(key) = config.proxy.api_key.as_deref() {
+        request = request.header("x-api-key", key);
+    }
+
+    let response = match request.send().await {
+        Ok(r) => r,
+        Err(e) if e.is_connect() => return Err(LiveControlError::NoServer),
+        Err(e) if e.is_timeout() => {
+            return Err(LiveControlError::NoAnswer(
+                "the server did not answer within 5s".to_string(),
+            ))
+        }
+        Err(e) => return Err(LiveControlError::NoAnswer(e.to_string())),
+    };
+
+    let status = response.status();
+    // Whether THIS route produced the answer, decided structurally. A 404 from a
+    // tcr without the route and a 404 meaning "no such account" are the same status
+    // code with opposite consequences, and the header is the only difference that
+    // is not a matched error string.
+    let from_route = response
+        .headers()
+        .get(crate::proxy::ENDPOINT_HEADER)
+        .and_then(|v| v.to_str().ok())
+        == Some(crate::proxy::DISABLED_ENDPOINT);
+    let body = response.text().await.unwrap_or_default();
+
+    if status.is_success() {
+        return serde_json::from_str(&body).map_err(|e| {
+            LiveControlError::Unusable(format!(
+                "the response was not a tcr account-control payload ({e})"
+            ))
+        });
+    }
+    if status.as_u16() == 401 {
+        return Err(LiveControlError::Unauthorized);
+    }
+    if !from_route && matches!(status.as_u16(), 404 | 405) {
+        return Err(LiveControlError::NoRoute);
+    }
+    if from_route && matches!(status.as_u16(), 404 | 409) {
+        return Err(LiveControlError::Rejected(
+            error_message_of(&body).unwrap_or_else(|| format!("HTTP {status}")),
+        ));
+    }
+    Err(LiveControlError::Unusable(format!("HTTP {status}")))
+}
+
+/// Pull `error.message` out of the proxy's standard error envelope.
+fn error_message_of(body: &str) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(body)
+        .ok()?
+        .get("error")?
+        .get("message")?
+        .as_str()
+        .map(str::to_string)
 }
 
 /// Build an OFFLINE snapshot from `config`: a [`Manager`] with `config_path =
@@ -1060,27 +1283,167 @@ mod tests {
 
     // --- enable / disable --------------------------------------------------
 
-    #[test]
-    fn set_enabled_true_writes_disabled_true() {
-        let path = write_config("disable", TWO_ACCOUNTS);
-        set_enabled(&path, "alice@example.com", None, true).unwrap();
+    /// A free port nothing is listening on: bound, then dropped.
+    async fn dead_port() -> u16 {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        listener.local_addr().unwrap().port()
+    }
+
+    /// `TWO_ACCOUNTS` pointed at a port nothing serves, written to a temp file.
+    ///
+    /// Load-bearing safety, not tidiness: `set_enabled` is live-first now, and
+    /// `TWO_ACCOUNTS` names port **3456** — the port a REAL tcr serves Gil's fleet
+    /// on. A test left on that port would POST an account-control command at the
+    /// live proxy. The substitution is asserted below because a silent no-op here
+    /// would aim every one of these tests at the running server.
+    async fn config_on_a_dead_port(tag: &str) -> std::path::PathBuf {
+        let port = dead_port().await;
+        let json = TWO_ACCOUNTS.replace("\"port\": 3456", &format!("\"port\": {port}"));
+        assert!(
+            !json.contains("\"port\": 3456") && json.contains(&format!("\"port\": {port}")),
+            "the port substitution must apply, or this test talks to the live proxy"
+        );
+        write_config(tag, &json)
+    }
+
+    #[tokio::test]
+    async fn set_enabled_true_writes_disabled_true() {
+        let path = config_on_a_dead_port("disable").await;
+        set_enabled(&path, "alice@example.com", None, true)
+            .await
+            .unwrap();
         let raw = fs::read_to_string(&path).unwrap();
         let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
         assert_eq!(value["accounts"][0]["disabled"], serde_json::json!(true));
         fs::remove_file(&path).ok();
     }
 
-    #[test]
-    fn set_enabled_false_drops_the_disabled_key() {
-        let path = write_config("enable", TWO_ACCOUNTS);
+    #[tokio::test]
+    async fn set_enabled_false_drops_the_disabled_key() {
+        let path = config_on_a_dead_port("enable").await;
         // First disable, then re-enable — the key must vanish entirely.
-        set_enabled(&path, "alice@example.com", None, true).unwrap();
-        set_enabled(&path, "alice@example.com", None, false).unwrap();
+        set_enabled(&path, "alice@example.com", None, true)
+            .await
+            .unwrap();
+        set_enabled(&path, "alice@example.com", None, false)
+            .await
+            .unwrap();
         let raw = fs::read_to_string(&path).unwrap();
         let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
         assert!(
             value["accounts"][0].get("disabled").is_none(),
             "re-enable must DROP the disabled key, not write false"
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    /// THE BITING TEST for the CLI half, end to end through the PRODUCTION path:
+    /// a real hybrid listener (the thing that injects `ClientAddr`), a real socket,
+    /// the real router, and `set_enabled` as `tcr disable` calls it.
+    ///
+    /// The two assertions after the call are the whole bug. Pre-change `set_enabled`
+    /// wrote the file and stopped, so the RUNNING manager's `disabled` stayed
+    /// `false` and the account it named kept being handed traffic — measured on the
+    /// live fleet, two accounts deep. A file-only assertion passes against that
+    /// defect; the in-memory one does not.
+    #[tokio::test]
+    async fn set_enabled_parks_the_account_in_the_running_proxy() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let path = config_on_a_dead_port("live-disable").await;
+        let mut config = load(&path);
+        config.proxy.port = port;
+
+        // The server owns the SAME config file the CLI is pointed at, exactly as
+        // the real proxy does — so the durable half lands where `tcr` looks.
+        let manager = Manager::with_live_refresher(config.clone(), Some(path.clone()));
+        let served = Arc::clone(&manager);
+        tokio::spawn(async move { crate::mitm::serve(listener, served, None).await });
+
+        // Point the CLI at the live port by rewriting the file it will load.
+        let raw = fs::read_to_string(&path).unwrap();
+        let mut doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        doc["proxy"]["port"] = serde_json::json!(port);
+        fs::write(&path, serde_json::to_string_pretty(&doc).unwrap()).unwrap();
+
+        set_enabled(&path, "alice@example.com", None, true)
+            .await
+            .unwrap();
+
+        // 1. THE RUNNING ROTATION. Not a fresh Manager, not the file — the process
+        //    that would serve the next request.
+        let live = manager.snapshot(OffsetDateTime::now_utc());
+        assert_eq!(live.accounts[0].name, "alice@example.com");
+        assert!(
+            live.accounts[0].disabled,
+            "the account is parked IN THE SERVING PROCESS, not just on disk"
+        );
+        assert!(
+            !live.accounts[1].disabled,
+            "and only the resolved account was touched"
+        );
+
+        // 2. …and the file carries it, so the bench survives a restart.
+        let after: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(
+            after["accounts"][0]["disabled"],
+            serde_json::json!(true),
+            "the durable half landed too: {after}"
+        );
+
+        // 3. Re-enable, live, and the key is DROPPED from the document — the same
+        //    contract the file-only path has always had.
+        set_enabled(&path, "alice@example.com", None, false)
+            .await
+            .unwrap();
+        assert!(
+            !manager.snapshot(OffsetDateTime::now_utc()).accounts[0].disabled,
+            "re-enable reaches the live rotation too"
+        );
+        let after: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(
+            after["accounts"][0].get("disabled").is_none(),
+            "re-enable DROPS the key rather than writing false: {after}"
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    /// An ambiguous query is refused by the SERVER and the CLI does not fall back:
+    /// the file's own resolution could land on a different row than the one the
+    /// server was talking about, and a disable applied to the wrong account is
+    /// worse than none. Both accounts share an email here, so `--org` is the fix
+    /// the message must name.
+    #[tokio::test]
+    async fn set_enabled_refuses_an_ambiguous_query_without_writing() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let path = config_on_a_dead_port("live-ambiguous").await;
+        // Same email in two orgs — the shape `--org` exists for.
+        let raw = fs::read_to_string(&path).unwrap();
+        let mut doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        doc["proxy"]["port"] = serde_json::json!(port);
+        doc["accounts"][1]["name"] = serde_json::json!("alice@example.com");
+        fs::write(&path, serde_json::to_string_pretty(&doc).unwrap()).unwrap();
+        let before = fs::read_to_string(&path).unwrap();
+
+        let config = load(&path);
+        let manager = Manager::with_live_refresher(config, Some(path.clone()));
+        tokio::spawn(async move { crate::mitm::serve(listener, manager, None).await });
+
+        let err = set_enabled(&path, "alice@example.com", None, true)
+            .await
+            .expect_err("an ambiguous query must not be applied");
+        let text = err.to_string();
+        assert!(
+            text.contains("ambiguous") && text.contains("--org"),
+            "the refusal names the candidates and the fix: {text}"
+        );
+        assert_eq!(
+            before,
+            fs::read_to_string(&path).unwrap(),
+            "a refused command leaves the config byte-identical"
         );
         fs::remove_file(&path).ok();
     }

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -136,34 +136,94 @@ pub fn email_of(name: &str) -> &str {
     name
 }
 
+/// The three fields a user-supplied account query is matched against.
+///
+/// It exists so ONE resolution rule runs over both representations of the fleet:
+/// the config file's [`Account`] records (what the CLI edits) and the running
+/// proxy's in-memory rotation slots (`manager::AccountRuntime`, what the live
+/// control endpoint mutates). Duplicating the rule instead is how a CLI and an
+/// endpoint come to disagree about which account `disable alice` names — and the
+/// endpoint's index is a rotation slot, so disagreeing there benches the wrong
+/// account.
+pub trait Queryable {
+    fn query_name(&self) -> &str;
+    fn query_org_name(&self) -> Option<&str>;
+    fn query_org_uuid(&self) -> Option<&str>;
+}
+
+impl Queryable for Account {
+    fn query_name(&self) -> &str {
+        &self.name
+    }
+    fn query_org_name(&self) -> Option<&str> {
+        self.org_name.as_deref()
+    }
+    fn query_org_uuid(&self) -> Option<&str> {
+        self.org_uuid.as_deref()
+    }
+}
+
 /// Indices of accounts matching `query` (exact name, else email), narrowed by
 /// `org_filter` (org name exact, or org uuid exact/prefix). Caller decides on
 /// 0/1/many.
-pub fn match_accounts(accounts: &[Account], query: &str, org_filter: Option<&str>) -> Vec<usize> {
+pub fn match_accounts<T: Queryable>(
+    accounts: &[T],
+    query: &str,
+    org_filter: Option<&str>,
+) -> Vec<usize> {
     let mut matches: Vec<usize> = accounts
         .iter()
         .enumerate()
-        .filter(|(_, a)| a.name == query)
+        .filter(|(_, a)| a.query_name() == query)
         .map(|(i, _)| i)
         .collect();
     if matches.is_empty() {
         matches = accounts
             .iter()
             .enumerate()
-            .filter(|(_, a)| email_of(&a.name) == query)
+            .filter(|(_, a)| email_of(a.query_name()) == query)
             .map(|(i, _)| i)
             .collect();
     }
     if let Some(f) = org_filter {
         matches.retain(|&i| {
             let a = &accounts[i];
-            a.org_name.as_deref().is_some_and(|n| n == f)
-                || a.org_uuid
-                    .as_deref()
+            a.query_org_name().is_some_and(|n| n == f)
+                || a.query_org_uuid()
                     .is_some_and(|u| u == f || u.starts_with(f))
         });
     }
     matches
+}
+
+/// What a user-supplied `(query, org)` resolved to.
+///
+/// Separate from [`Resolved`], which resolves a stored IDENTITY against records.
+/// This one resolves a human's argument, so its ambiguous arm carries the
+/// candidate NAMES: every caller has to put them in front of the person who
+/// typed the query, or `--org` is unusable advice.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Match {
+    /// Exactly one account matched, at this index.
+    One(usize),
+    /// Nothing matched.
+    None,
+    /// Two or more matched; these are their names, in fleet order.
+    Ambiguous(Vec<String>),
+}
+
+/// [`match_accounts`] collapsed to the 0 / 1 / many decision every caller makes.
+pub fn match_one<T: Queryable>(accounts: &[T], query: &str, org_filter: Option<&str>) -> Match {
+    let candidates = match_accounts(accounts, query, org_filter);
+    match candidates.as_slice() {
+        [] => Match::None,
+        [only] => Match::One(*only),
+        many => Match::Ambiguous(
+            many.iter()
+                .map(|&i| accounts[i].query_name().to_string())
+                .collect(),
+        ),
+    }
 }
 
 /// Build a lightweight probe [`Account`] carrying only the identity fields, for

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,8 +212,8 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Accounts(args)) => run_accounts(args).await,
         Some(Command::Remove(args)) => run_remove(args),
         Some(Command::Priority(args)) => run_priority(args),
-        Some(Command::Enable(args)) => run_enable(args),
-        Some(Command::Disable(args)) => run_disable(args),
+        Some(Command::Enable(args)) => run_enable(args).await,
+        Some(Command::Disable(args)) => run_disable(args).await,
         Some(Command::Status(args)) => run_status(args).await,
         Some(Command::Update(args)) => update::run_update(args.force),
         Some(Command::Demo) => demo::run_demo().await.map_err(anyhow::Error::from),
@@ -249,16 +249,18 @@ fn run_priority(args: PriorityArgs) -> anyhow::Result<()> {
     cli::set_priority(&config_path, &args.query, priority, args.org.as_deref())
 }
 
-/// `tcr enable <query> [--org]` — clear an account's `disabled` flag.
-fn run_enable(args: EnableArgs) -> anyhow::Result<()> {
+/// `tcr enable <query> [--org]` — clear an account's `disabled` flag, in the
+/// RUNNING proxy where there is one (async for that reason alone).
+async fn run_enable(args: EnableArgs) -> anyhow::Result<()> {
     let config_path = args.config.unwrap_or_else(config::default_path);
-    cli::set_enabled(&config_path, &args.query, args.org.as_deref(), false)
+    cli::set_enabled(&config_path, &args.query, args.org.as_deref(), false).await
 }
 
-/// `tcr disable <query> [--org]` — hold an account out of rotation.
-fn run_disable(args: DisableArgs) -> anyhow::Result<()> {
+/// `tcr disable <query> [--org]` — hold an account out of rotation, in the RUNNING
+/// proxy where there is one.
+async fn run_disable(args: DisableArgs) -> anyhow::Result<()> {
     let config_path = args.config.unwrap_or_else(config::default_path);
-    cli::set_enabled(&config_path, &args.query, args.org.as_deref(), true)
+    cli::set_enabled(&config_path, &args.query, args.org.as_deref(), true).await
 }
 
 /// `tcr status [--json]` — probe every account's live quota and print it.

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -261,6 +261,40 @@ pub struct AccountRuntime {
     pub last_stream_error: Option<String>,
 }
 
+/// A rotation slot answers a user's account query by the same three fields a
+/// config record does, so [`Manager::set_disabled_by_query`] can run the CLI's
+/// own resolution rule over the LIVE fleet.
+impl crate::identity::Queryable for AccountRuntime {
+    fn query_name(&self) -> &str {
+        &self.name
+    }
+    fn query_org_name(&self) -> Option<&str> {
+        self.org_name.as_deref()
+    }
+    fn query_org_uuid(&self) -> Option<&str> {
+        self.org_uuid.as_deref()
+    }
+}
+
+/// What [`Manager::set_disabled_by_query`] did.
+///
+/// `Applied` carries the RESOLVED name (the caller's query may have been a
+/// substring, and the answer has to name what was actually parked) plus the
+/// durable half's fate, which the caller must surface — see
+/// [`DisablePersist::warning`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SetDisabledOutcome {
+    Applied {
+        name: String,
+        persist: DisablePersist,
+    },
+    /// The query named no account in the live rotation.
+    NoMatch,
+    /// The query named more than one, listed here so the caller can tell the user
+    /// what to pass `--org` for.
+    Ambiguous(Vec<String>),
+}
+
 impl AccountRuntime {
     fn from_config(account: &config::Account) -> Self {
         Self {
@@ -1061,6 +1095,42 @@ impl Manager {
             )
         };
         self.persist_disabled(idx, &target, disabled)
+    }
+
+    /// Resolve a user-supplied `(query, org)` against the LIVE rotation and apply
+    /// `disabled` to whatever it names — the whole operation the control endpoint
+    /// performs, kept here so no caller outside this module has to know that a
+    /// rotation index is what [`Self::set_disabled`] takes.
+    ///
+    /// Resolution runs over `self.accounts` — the rotation slots themselves — and
+    /// NOT over the boot-time config snapshot, so the index handed to
+    /// `set_disabled` is a slot by construction. Matching the config's vector and
+    /// then indexing the runtime one would be correct only while the two stay the
+    /// same length in the same order forever, which is not a property anything
+    /// here enforces.
+    ///
+    /// The read guard is released before `set_disabled` takes its write guard —
+    /// `RwLock` is not reentrant, so holding it across the call would deadlock.
+    pub fn set_disabled_by_query(
+        &self,
+        query: &str,
+        org: Option<&str>,
+        disabled: bool,
+    ) -> SetDisabledOutcome {
+        let (idx, name) = {
+            let accounts = self.accounts.read().expect("accounts lock poisoned");
+            match crate::identity::match_one(&accounts[..], query, org) {
+                crate::identity::Match::One(idx) => (idx, accounts[idx].name.clone()),
+                crate::identity::Match::None => return SetDisabledOutcome::NoMatch,
+                crate::identity::Match::Ambiguous(names) => {
+                    return SetDisabledOutcome::Ambiguous(names)
+                }
+            }
+        };
+        SetDisabledOutcome::Applied {
+            name,
+            persist: self.set_disabled(idx, disabled),
+        }
     }
 
     /// Record which account actually served the most recent request.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -37,7 +37,7 @@ use futures::StreamExt;
 use serde_json::Value;
 use time::OffsetDateTime;
 
-use crate::manager::{AccountStatus, Manager};
+use crate::manager::{AccountStatus, DisablePersist, Manager, SetDisabledOutcome};
 use crate::stats::{RequestLogEntry, SessionKind};
 
 /// Cap on a buffered request body (256 MiB) — a single-user localhost proxy has
@@ -375,6 +375,42 @@ fn stable_session_key(headers: &HeaderMap, body: &[u8], proxy_key: Option<&str>)
 /// ever answers locally belongs under this prefix.
 pub const STATUS_PATH: &str = "/_tcr/status";
 
+/// Path of the live account-control endpoint [`set_disabled_handler`] serves —
+/// `POST` only, the one route on this process that MUTATES rotation.
+///
+/// It exists because `disabled` was, until now, a boot-time read: `tcr disable`
+/// wrote the config file and the running proxy never re-read it, so an account the
+/// operator had parked kept being handed live traffic while every surface reported
+/// it benched. The TUI's `d` key was the only correct path, and a `--headless`
+/// proxy has no TUI.
+///
+/// Under [`LOCAL_PREFIX`] for the reason given there, which matters more for a
+/// mutating verb than for the read next door: registered as a real route it is
+/// matched BEFORE the catch-all, so a `POST` here can never be rewritten onto
+/// api.anthropic.com carrying a pooled OAuth Bearer.
+pub const DISABLED_PATH: &str = "/_tcr/accounts/disabled";
+
+/// Marks every response produced by the account-control route itself, so a caller
+/// can tell "this proxy has no such route" from "the route answered and said no".
+///
+/// Both are a 404: a tcr too old to have the route hits the [`LOCAL_PREFIX`]
+/// catch-all guard (or, older still, gets Anthropic's own 404 back), and a query
+/// naming no account is a 404 from the handler. The CLI's two reactions are
+/// opposite — write the file and warn loudly that the live proxy is stale, versus
+/// report a bad query — so the distinction cannot rest on matching an error
+/// string. This header is the structural discriminator. It is a response header,
+/// never a request one, so it authorizes nothing.
+pub const ENDPOINT_HEADER: &str = "x-tcr-endpoint";
+
+/// The [`ENDPOINT_HEADER`] value the account-control route stamps.
+pub const DISABLED_ENDPOINT: &str = "accounts-disabled";
+
+/// Body cap for the local control route: a JSON object with three short fields.
+/// Deliberately not [`MAX_BODY_BYTES`] (256 MiB, sized for model requests) — this
+/// route buffers into memory in a credential-holding process, and nothing
+/// legitimate here is larger than a line.
+const CONTROL_BODY_LIMIT: usize = 8 * 1024;
+
 /// The path segment [`STATUS_PATH`] lives under. Every path beneath it belongs to
 /// the PROXY, never to Anthropic, so anything under it that is not a registered
 /// route is answered with a LOCAL 404 (see the guard in [`handle`]) instead of
@@ -549,8 +585,73 @@ pub fn app(manager: Arc<Manager>) -> Router {
             STATUS_PATH,
             axum::routing::get(status_handler).fallback(status_method_not_allowed),
         )
+        // The one MUTATING local route. Same reasoning as above, and the method
+        // fallback matters more here: an unregistered method must answer a local
+        // 405, never fall through to `handle` and be forwarded upstream.
+        .route(
+            DISABLED_PATH,
+            axum::routing::post(set_disabled_handler).fallback(disabled_method_not_allowed),
+        )
         .fallback(handle)
         .with_state(manager)
+}
+
+/// The two gates every locally-answered `/_tcr/…` route passes, or the refusal to
+/// return. `Some(response)` means REFUSED; `None` means proceed.
+///
+/// ONE implementation, deliberately: these routes live on a process holding every
+/// account's OAuth access and refresh token, and the gate is the whole of their
+/// authorization. Two copies of it drift, and the copy that drifts is the one on
+/// whichever route was added later — which is also the more dangerous route,
+/// since the second one added mutates rotation.
+///
+/// 1. **Origin.** The peer must be loopback, proven by the [`ClientAddr`]
+///    extension the hybrid listener injects from the real socket address (the
+///    same extension the auth gate in [`handle`] uses). It is not a header, so a
+///    client cannot forge it. Absent — a request that did not arrive through the
+///    listener — we fail CLOSED. Bind scope is not authorization: `127.0.0.1` is
+///    reachable by every process and every container on this host, so "we only
+///    bind loopback" is not a claim about who is calling.
+/// 2. **Key.** When a proxy api-key is configured it is REQUIRED here, with no
+///    loopback exemption — deliberately stricter than [`handle`], which exempts
+///    loopback because `claude` authenticates with its own OAuth and never sends
+///    the proxy key. Nothing on this host needs to read or steer the fleet without
+///    the operator's secret, so doing either costs the same secret that using the
+///    proxy does. The compare is [`key_matches`] (constant-time, length-safe).
+///
+/// `endpoint` names the route in the 403 body only. It is not a capability: no
+/// value of it weakens either check.
+fn local_endpoint_gate(
+    parts: &axum::http::request::Parts,
+    manager: &Manager,
+    endpoint: &str,
+) -> Option<Response> {
+    let client_is_loopback = parts
+        .extensions
+        .get::<ClientAddr>()
+        .is_some_and(|a| a.0.ip().is_loopback());
+    if !client_is_loopback {
+        return Some(error_response(
+            StatusCode::FORBIDDEN,
+            "permission_error",
+            &format!("The tcr {endpoint} endpoint is loopback-only."),
+            None,
+        ));
+    }
+
+    if let Some(expected) = manager.proxy_api_key() {
+        let provided = parts.headers.get("x-api-key").and_then(|v| v.to_str().ok());
+        if !key_matches(provided, expected) {
+            return Some(error_response(
+                StatusCode::UNAUTHORIZED,
+                "authentication_error",
+                "Missing or invalid x-api-key.",
+                None,
+            ));
+        }
+    }
+
+    None
 }
 
 /// A non-`GET` on [`STATUS_PATH`]. Answered locally with 405 so the request is
@@ -567,23 +668,10 @@ async fn status_method_not_allowed() -> Response {
 
 /// `GET /_tcr/status` — the live fleet snapshot, for `tcr status`.
 ///
-/// This is a **new attack surface on a process holding every account's OAuth
-/// access and refresh token**, so it is gated twice and reads nothing but state
-/// that is already on screen in the TUI:
-///
-/// 1. **Origin.** The peer must be loopback, proven by the [`ClientAddr`]
-///    extension the hybrid listener injects from the real socket address (the
-///    same extension the auth gate in [`handle`] uses). It is not a header, so a
-///    client cannot forge it. Absent — a request that did not arrive through the
-///    listener — we fail CLOSED. Bind scope is not authorization: `127.0.0.1` is
-///    reachable by every process and every container on this host, so "we only
-///    bind loopback" is not a claim about who is calling.
-/// 2. **Key.** When a proxy api-key is configured it is REQUIRED here, with no
-///    loopback exemption — deliberately stricter than [`handle`], which exempts
-///    loopback because `claude` authenticates with its own OAuth and never sends
-///    the proxy key. Nothing on this host needs to read the fleet's state without
-///    the operator's secret, so reading it costs the same secret that using the
-///    proxy does. The compare is [`key_matches`] (constant-time, length-safe).
+/// This is an **attack surface on a process holding every account's OAuth access
+/// and refresh token**, so it is gated twice — origin and key, see
+/// [`local_endpoint_gate`] for both and for why bind scope is not authorization —
+/// and reads nothing but state that is already on screen in the TUI.
 ///
 /// It takes only [`Parts`](axum::http::request::Parts), so the request body is
 /// never read; it touches no `&mut` state, triggers no probe, no token refresh
@@ -594,29 +682,8 @@ async fn status_handler(
     State(manager): State<Arc<Manager>>,
     parts: axum::http::request::Parts,
 ) -> Response {
-    let client_is_loopback = parts
-        .extensions
-        .get::<ClientAddr>()
-        .is_some_and(|a| a.0.ip().is_loopback());
-    if !client_is_loopback {
-        return error_response(
-            StatusCode::FORBIDDEN,
-            "permission_error",
-            "The tcr status endpoint is loopback-only.",
-            None,
-        );
-    }
-
-    if let Some(expected) = manager.proxy_api_key() {
-        let provided = parts.headers.get("x-api-key").and_then(|v| v.to_str().ok());
-        if !key_matches(provided, expected) {
-            return error_response(
-                StatusCode::UNAUTHORIZED,
-                "authentication_error",
-                "Missing or invalid x-api-key.",
-                None,
-            );
-        }
+    if let Some(refusal) = local_endpoint_gate(&parts, &manager, "status") {
+        return refusal;
     }
 
     let now = OffsetDateTime::now_utc();
@@ -639,6 +706,151 @@ async fn status_handler(
     // credential-holding process — never store it anywhere.
     headers.insert("cache-control", HeaderValue::from_static("no-store"));
     response
+}
+
+/// A non-`POST` on [`DISABLED_PATH`]. Answered locally with 405 — the route is a
+/// command, and a command has exactly one verb. Stamped with [`ENDPOINT_HEADER`]
+/// so a caller can tell this 405 (the route exists, wrong verb) from the local 404
+/// a tcr without the route returns.
+async fn disabled_method_not_allowed() -> Response {
+    stamp_endpoint(error_response(
+        StatusCode::METHOD_NOT_ALLOWED,
+        "invalid_request_error",
+        "The tcr account-control endpoint takes POST.",
+        None,
+    ))
+}
+
+/// Add [`ENDPOINT_HEADER`] to a response the account-control route produced.
+fn stamp_endpoint(mut response: Response) -> Response {
+    response
+        .headers_mut()
+        .insert(ENDPOINT_HEADER, HeaderValue::from_static(DISABLED_ENDPOINT));
+    response
+}
+
+/// The request body of [`DISABLED_PATH`].
+///
+/// `query` and `disabled` are `Option` rather than required fields so a body that
+/// omits either is a 400 naming the field, instead of axum's own rejection text:
+/// this route is what a person reaches for when the fleet is already misbehaving,
+/// and an unhelpful 400 there is its own outage.
+#[derive(serde::Deserialize)]
+struct SetDisabledRequest {
+    query: Option<String>,
+    #[serde(default)]
+    org: Option<String>,
+    disabled: Option<bool>,
+}
+
+/// The 200 body of [`DISABLED_PATH`]. Deserializable too — `tcr enable`/`disable`
+/// read it, and both halves of the wire contract belong to one type.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct SetDisabledResponse {
+    /// The RESOLVED account name. The query may have been an email or a partial,
+    /// so the answer names what was actually parked.
+    pub name: String,
+    /// The state now in force in the live rotation.
+    pub disabled: bool,
+    /// Whether the config file also carries it. `false` with a `warning` is a
+    /// change that is live but will not survive a restart.
+    pub persisted: bool,
+    /// [`crate::manager::DisablePersist::warning`], verbatim, or `null`.
+    pub warning: Option<String>,
+}
+
+/// `POST /_tcr/accounts/disabled` — park or unpark an account IN THE LIVE
+/// ROTATION, for `tcr disable` / `tcr enable`.
+///
+/// The endpoint exists because the flag was previously only ever read at boot:
+/// see [`DISABLED_PATH`] for the defect. This is the only route on the proxy that
+/// changes what the next request is routed to, so it is gated exactly as
+/// [`status_handler`] is — [`local_endpoint_gate`], no weaker for being a write —
+/// and it does the work through [`Manager::set_disabled_by_query`], which is the
+/// same call the TUI's `d` key makes. It does not invent a resolution rule: the
+/// CLI's own [`crate::identity::match_one`] runs against the server's live
+/// rotation slots, so the two cannot disagree about which account a query names.
+///
+/// The durable half is NOT swallowed. `persisted: false` plus a `warning` is a
+/// change that is in force right now and will vanish on restart, which is
+/// precisely the state the old code left the operator in silently.
+async fn set_disabled_handler(State(manager): State<Arc<Manager>>, req: Request) -> Response {
+    let (parts, body) = req.into_parts();
+    if let Some(refusal) = local_endpoint_gate(&parts, &manager, "account-control") {
+        // NOT stamped: a refusal must not confirm the route exists to a caller
+        // that failed the gate, and the CLI never needs the discriminator on a
+        // 401/403 — both are terminal for it.
+        return refusal;
+    }
+
+    let Ok(bytes) = to_bytes(body, CONTROL_BODY_LIMIT).await else {
+        return stamp_endpoint(error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            "Could not read the request body.",
+            None,
+        ));
+    };
+    let Ok(parsed) = serde_json::from_slice::<SetDisabledRequest>(&bytes) else {
+        return stamp_endpoint(error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            "Expected a JSON object: {\"query\": \"<account>\", \"org\": null, \"disabled\": true}.",
+            None,
+        ));
+    };
+    let (Some(query), Some(disabled)) = (parsed.query, parsed.disabled) else {
+        return stamp_endpoint(error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            "Both \"query\" (string) and \"disabled\" (bool) are required.",
+            None,
+        ));
+    };
+    if query.trim().is_empty() {
+        return stamp_endpoint(error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            "\"query\" must not be empty.",
+            None,
+        ));
+    }
+
+    match manager.set_disabled_by_query(&query, parsed.org.as_deref(), disabled) {
+        SetDisabledOutcome::NoMatch => stamp_endpoint(error_response(
+            StatusCode::NOT_FOUND,
+            "not_found_error",
+            &format!("No account in the live rotation matches '{query}'."),
+            None,
+        )),
+        SetDisabledOutcome::Ambiguous(names) => stamp_endpoint(error_response(
+            StatusCode::CONFLICT,
+            "invalid_request_error",
+            &crate::cli::ambiguous_query_message(&query, &names),
+            None,
+        )),
+        SetDisabledOutcome::Applied { name, persist } => {
+            let payload = SetDisabledResponse {
+                name,
+                disabled,
+                persisted: matches!(persist, DisablePersist::Persisted),
+                warning: persist.warning(disabled).map(str::to_string),
+            };
+            let Ok(body) = serde_json::to_string(&payload) else {
+                return stamp_endpoint(error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "api_error",
+                    "Could not serialize the account-control result.",
+                    None,
+                ));
+            };
+            let mut response = Response::new(Body::from(body));
+            let headers = response.headers_mut();
+            headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+            headers.insert("cache-control", HeaderValue::from_static("no-store"));
+            stamp_endpoint(response)
+        }
+    }
 }
 
 /// The catch-all proxy handler.
@@ -2904,6 +3116,544 @@ mod tests {
         }
     }
 
+    // --- POST /_tcr/accounts/disabled ---------------------------------------
+
+    /// A two-account config with distinct orgs, written to `path` so the manager
+    /// that boots from it has a real durable half to write back to.
+    ///
+    /// Obviously-fake identities only: this repository is public.
+    fn two_account_config(api_key: Option<&str>) -> Config {
+        let account = |name: &str, org: &str, uuid: &str, priority: i64| Account {
+            name: name.to_string(),
+            account_type: "oauth".to_string(),
+            account_uuid: Some(uuid.to_string()),
+            org_uuid: Some(format!("11111111-1111-1111-1111-{org}")),
+            org_name: Some(format!("Org {org}")),
+            access_token: format!("at-{org}"),
+            refresh_token: Some(format!("rt-{org}")),
+            // Not expired, so booting triggers no token refresh.
+            expires_at: Some(crate::now_ms() + 3_600_000),
+            priority: Some(priority),
+            switch_threshold: None,
+            disabled: None,
+            extra: serde_json::Map::new(),
+        };
+        Config {
+            accounts: vec![
+                account("alice@example.com", "aaaaaaaaaaaa", "22222222-a", 0),
+                account("bob@example.com", "bbbbbbbbbbbb", "33333333-b", 1),
+            ],
+            ..dummy_config(api_key, "http://127.0.0.1:1")
+        }
+    }
+
+    fn control_config_path(tag: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "tcr-control-test-{tag}-{}-{}.json",
+            std::process::id(),
+            crate::now_ms()
+        ))
+    }
+
+    /// A manager booted from a config that is ALSO on disk, so both halves of a
+    /// `disabled` change are observable: `manager.snapshot()` for the live rotation
+    /// and the file for the durable flag.
+    fn control_manager(tag: &str, api_key: Option<&str>) -> (Arc<Manager>, std::path::PathBuf) {
+        let path = control_config_path(tag);
+        let config = two_account_config(api_key);
+        crate::config::save(&path, &config).expect("write the test config");
+        let manager = Manager::with_live_refresher(config, Some(path.clone()));
+        (manager, path)
+    }
+
+    /// Drive the router with a `ClientAddr` we control, like [`status_request`].
+    /// `body` is sent verbatim so a malformed one is testable.
+    async fn control_request(
+        manager: Arc<Manager>,
+        method: Method,
+        peer: Option<SocketAddr>,
+        api_key: Option<&str>,
+        body: &str,
+    ) -> (StatusCode, HeaderMap, Bytes) {
+        use tower::ServiceExt as _;
+        let mut builder = Request::builder().method(method).uri(DISABLED_PATH);
+        if let Some(key) = api_key {
+            builder = builder.header("x-api-key", key);
+        }
+        let mut req = builder
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string()))
+            .expect("build request");
+        if let Some(addr) = peer {
+            req.extensions_mut().insert(ClientAddr(addr));
+        }
+        let response = app(manager).oneshot(req).await.expect("router response");
+        let status = response.status();
+        let headers = response.headers().clone();
+        let bytes = to_bytes(response.into_body(), MAX_BODY_BYTES)
+            .await
+            .expect("read body");
+        (status, headers, bytes)
+    }
+
+    fn disabled_in_file(path: &std::path::Path, index: usize) -> Option<serde_json::Value> {
+        let raw = std::fs::read_to_string(path).expect("read the test config");
+        let doc: serde_json::Value = serde_json::from_str(&raw).expect("valid json");
+        doc["accounts"][index].get("disabled").cloned()
+    }
+
+    /// THE BITING TEST for the whole change: after the endpoint answers, the
+    /// account is parked **in the process that will serve the next request**, and
+    /// the config file carries it too.
+    ///
+    /// Pre-change there was no route at all, and `tcr disable` wrote only the file
+    /// — so the running rotation kept the account. Asserting HTTP 200 alone would
+    /// re-create exactly that defect at a new altitude: the in-memory assertion is
+    /// the one that fails against a handler that answers politely and changes
+    /// nothing.
+    #[tokio::test]
+    async fn control_endpoint_parks_the_account_in_memory_and_on_disk() {
+        let (manager, path) = control_manager("apply", None);
+        let before = manager.snapshot(OffsetDateTime::now_utc());
+        assert!(!before.accounts[0].disabled, "alice starts in rotation");
+
+        let (status, headers, body) = control_request(
+            Arc::clone(&manager),
+            Method::POST,
+            Some(loopback_peer()),
+            None,
+            r#"{"query":"alice@example.com","org":null,"disabled":true}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        assert_eq!(
+            headers.get(ENDPOINT_HEADER).and_then(|v| v.to_str().ok()),
+            Some(DISABLED_ENDPOINT),
+            "the route stamps itself so a caller can tell it from a missing route"
+        );
+
+        let payload: SetDisabledResponse =
+            serde_json::from_slice(&body).expect("an account-control payload");
+        assert_eq!(payload.name, "alice@example.com", "the RESOLVED name");
+        assert!(payload.disabled);
+        assert!(payload.persisted, "the durable half succeeded");
+        assert_eq!(payload.warning, None, "so there is nothing to warn about");
+
+        // 1. THE LIVE ROTATION — the assertion that catches the original bug.
+        let after = manager.snapshot(OffsetDateTime::now_utc());
+        assert!(
+            after.accounts[0].disabled,
+            "alice is out of the LIVE rotation, not merely acknowledged"
+        );
+        assert!(
+            !after.accounts[1].disabled,
+            "and only the resolved account moved"
+        );
+
+        // 2. …AND the file, so the bench survives a restart.
+        assert_eq!(disabled_in_file(&path, 0), Some(serde_json::json!(true)));
+        assert_eq!(disabled_in_file(&path, 1), None, "bob's row is untouched");
+
+        // Re-enabling drops the key rather than writing `false`, matching the CLI's
+        // long-standing file contract.
+        let (status, _headers, body) = control_request(
+            Arc::clone(&manager),
+            Method::POST,
+            Some(loopback_peer()),
+            None,
+            r#"{"query":"alice@example.com","disabled":false}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        assert!(
+            !manager.snapshot(OffsetDateTime::now_utc()).accounts[0].disabled,
+            "re-enable reaches the live rotation"
+        );
+        assert_eq!(
+            disabled_in_file(&path, 0),
+            None,
+            "re-enable DROPS the key, never writes false"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// SECURITY GUARD 1 — origin, on the MUTATING route. A non-loopback peer and an
+    /// absent `ClientAddr` (a request that never came through the listener, so its
+    /// origin is unprovable) are both refused, and neither may change rotation.
+    #[tokio::test]
+    async fn control_endpoint_rejects_a_non_loopback_client() {
+        for (label, peer) in [
+            ("a routable peer", Some(remote_peer())),
+            ("no ClientAddr at all", None),
+        ] {
+            let (manager, path) = control_manager("origin", None);
+            let (status, _headers, _body) = control_request(
+                Arc::clone(&manager),
+                Method::POST,
+                peer,
+                None,
+                r#"{"query":"alice@example.com","disabled":true}"#,
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::FORBIDDEN,
+                "{label} must be refused, got {status}"
+            );
+            assert!(
+                !manager.snapshot(OffsetDateTime::now_utc()).accounts[0].disabled,
+                "{label}: a refused caller changed the live rotation"
+            );
+            assert_eq!(
+                disabled_in_file(&path, 0),
+                None,
+                "{label}: a refused caller wrote the config"
+            );
+            std::fs::remove_file(&path).ok();
+        }
+    }
+
+    /// SECURITY GUARD 2 — the key, on the MUTATING route. Every case is a LOOPBACK
+    /// peer, so what is asserted is precisely that loopback alone does not license
+    /// steering the rotation of a process holding every account's tokens.
+    #[tokio::test]
+    async fn control_endpoint_rejects_a_bad_api_key() {
+        for (label, provided) in [
+            ("no key at all", None),
+            ("a wrong key", Some("wrong-key")),
+            ("a prefix of the key", Some("secret")),
+            ("an empty key", Some("")),
+        ] {
+            let (manager, path) = control_manager("key", Some("secret-key"));
+            let (status, _headers, _body) = control_request(
+                Arc::clone(&manager),
+                Method::POST,
+                Some(loopback_peer()),
+                provided,
+                r#"{"query":"alice@example.com","disabled":true}"#,
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::UNAUTHORIZED,
+                "{label} must be refused, got {status}"
+            );
+            assert!(
+                !manager.snapshot(OffsetDateTime::now_utc()).accounts[0].disabled,
+                "{label}: an unauthenticated caller changed the live rotation"
+            );
+            std::fs::remove_file(&path).ok();
+        }
+
+        // …and the right key, from loopback, is served.
+        let (manager, path) = control_manager("key-ok", Some("secret-key"));
+        let (status, _headers, body) = control_request(
+            Arc::clone(&manager),
+            Method::POST,
+            Some(loopback_peer()),
+            Some("secret-key"),
+            r#"{"query":"alice@example.com","disabled":true}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        assert!(manager.snapshot(OffsetDateTime::now_utc()).accounts[0].disabled);
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// The bad-request table. Each row is a body a caller can realistically send,
+    /// and none of them may half-apply anything.
+    #[tokio::test]
+    async fn control_endpoint_rejects_malformed_bodies() {
+        for (label, body) in [
+            ("an empty body", ""),
+            ("not json", "disable alice"),
+            ("a json array", r#"["alice@example.com", true]"#),
+            ("no disabled field", r#"{"query":"alice@example.com"}"#),
+            ("no query field", r#"{"disabled":true}"#),
+            ("an empty query", r#"{"query":"   ","disabled":true}"#),
+            (
+                "disabled as a string",
+                r#"{"query":"alice@example.com","disabled":"true"}"#,
+            ),
+        ] {
+            let (manager, path) = control_manager("badbody", None);
+            let (status, headers, response) = control_request(
+                Arc::clone(&manager),
+                Method::POST,
+                Some(loopback_peer()),
+                None,
+                body,
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::BAD_REQUEST,
+                "{label} must be a 400, got {status}: {}",
+                String::from_utf8_lossy(&response)
+            );
+            assert_eq!(
+                headers.get(ENDPOINT_HEADER).and_then(|v| v.to_str().ok()),
+                Some(DISABLED_ENDPOINT),
+                "{label}: a 400 still identifies the route that produced it"
+            );
+            assert!(
+                !manager.snapshot(OffsetDateTime::now_utc()).accounts[0].disabled,
+                "{label}: a rejected body still changed the rotation"
+            );
+            assert_eq!(
+                disabled_in_file(&path, 0),
+                None,
+                "{label}: and wrote the file"
+            );
+            std::fs::remove_file(&path).ok();
+        }
+    }
+
+    /// A query naming no live account is a 404 **from the route** (stamped), which
+    /// is what lets the CLI tell it from the local 404 an older tcr returns for a
+    /// path it does not serve. Same status, opposite reactions.
+    #[tokio::test]
+    async fn control_endpoint_404s_an_unknown_account_and_names_itself() {
+        let (manager, path) = control_manager("nomatch", None);
+        let (status, headers, body) = control_request(
+            Arc::clone(&manager),
+            Method::POST,
+            Some(loopback_peer()),
+            None,
+            r#"{"query":"nobody@example.com","disabled":true}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(
+            headers.get(ENDPOINT_HEADER).and_then(|v| v.to_str().ok()),
+            Some(DISABLED_ENDPOINT),
+            "without this stamp the CLI cannot tell this from a missing route"
+        );
+        let text = String::from_utf8_lossy(&body);
+        assert!(text.contains("nobody@example.com"), "{text}");
+        assert!(
+            !manager.snapshot(OffsetDateTime::now_utc()).accounts[0].disabled
+                && !manager.snapshot(OffsetDateTime::now_utc()).accounts[1].disabled,
+            "a miss parks nobody"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// An ambiguous query is a 409 that NAMES the candidates — otherwise `--org` is
+    /// advice the caller cannot act on. Refusing is not pedantry: guessing would
+    /// bench an account the operator did not ask about.
+    #[tokio::test]
+    async fn control_endpoint_409s_an_ambiguous_query_naming_the_candidates() {
+        let path = control_config_path("ambiguous");
+        let mut config = two_account_config(None);
+        // The same person in two orgs: one email, two rows, `--org` the only fix.
+        config.accounts[1].name = "alice@example.com".to_string();
+        crate::config::save(&path, &config).expect("write the test config");
+        let manager = Manager::with_live_refresher(config, Some(path.clone()));
+
+        let (status, headers, body) = control_request(
+            Arc::clone(&manager),
+            Method::POST,
+            Some(loopback_peer()),
+            None,
+            r#"{"query":"alice@example.com","disabled":true}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(
+            headers.get(ENDPOINT_HEADER).and_then(|v| v.to_str().ok()),
+            Some(DISABLED_ENDPOINT)
+        );
+        let text = String::from_utf8_lossy(&body);
+        assert!(
+            text.contains("ambiguous") && text.contains("--org"),
+            "the 409 says what to do about it: {text}"
+        );
+        let live = manager.snapshot(OffsetDateTime::now_utc());
+        assert!(
+            !live.accounts[0].disabled && !live.accounts[1].disabled,
+            "an unbreakable tie parks NEITHER row"
+        );
+        assert_eq!(disabled_in_file(&path, 0), None);
+        assert_eq!(disabled_in_file(&path, 1), None);
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// `--org` narrows the same ambiguous fleet to exactly one row, and it is the
+    /// row named — the resolution rule is the CLI's own
+    /// [`crate::identity::match_one`], run against the LIVE rotation slots.
+    #[tokio::test]
+    async fn control_endpoint_org_narrows_to_one_account() {
+        let path = control_config_path("org");
+        let mut config = two_account_config(None);
+        config.accounts[1].name = "alice@example.com".to_string();
+        crate::config::save(&path, &config).expect("write the test config");
+        let manager = Manager::with_live_refresher(config, Some(path.clone()));
+
+        let (status, _headers, body) = control_request(
+            Arc::clone(&manager),
+            Method::POST,
+            Some(loopback_peer()),
+            None,
+            r#"{"query":"alice@example.com","org":"Org bbbbbbbbbbbb","disabled":true}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let live = manager.snapshot(OffsetDateTime::now_utc());
+        assert!(
+            !live.accounts[0].disabled && live.accounts[1].disabled,
+            "the SECOND row — the one whose org was named — is the one parked"
+        );
+        assert_eq!(disabled_in_file(&path, 0), None);
+        assert_eq!(disabled_in_file(&path, 1), Some(serde_json::json!(true)));
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// A manager with no `config_path` (`tcr demo`, `tcr status --probe`, tests)
+    /// applies the change LIVE and has nothing to persist to. That is reported
+    /// honestly — `persisted: false` — and, per
+    /// [`crate::manager::DisablePersist::warning`], it needs no warning: there is
+    /// no file that was supposed to carry it.
+    #[tokio::test]
+    async fn control_endpoint_reports_an_unpersisted_change_honestly() {
+        let manager = Manager::with_live_refresher(two_account_config(None), None);
+        let (status, _headers, body) = control_request(
+            Arc::clone(&manager),
+            Method::POST,
+            Some(loopback_peer()),
+            None,
+            r#"{"query":"alice@example.com","disabled":true}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let payload: SetDisabledResponse = serde_json::from_slice(&body).expect("payload");
+        assert!(
+            manager.snapshot(OffsetDateTime::now_utc()).accounts[0].disabled,
+            "the live change still happened"
+        );
+        assert!(
+            !payload.persisted,
+            "…and the answer does not claim it is durable"
+        );
+        assert_eq!(
+            payload.warning, None,
+            "memory-only by design, not a failure"
+        );
+    }
+
+    /// A `DisablePersist` arm that changed memory but NOT the file is surfaced, not
+    /// swallowed: the change is in force now and dies on restart, which is the exact
+    /// state the old file-only code left operators in silently. Here the config file
+    /// does not exist at all, so the write fails.
+    #[tokio::test]
+    async fn control_endpoint_surfaces_a_failed_persist() {
+        let path = control_config_path("nofile");
+        std::fs::remove_file(&path).ok();
+        let manager = Manager::with_live_refresher(two_account_config(None), Some(path.clone()));
+
+        let (status, _headers, body) = control_request(
+            Arc::clone(&manager),
+            Method::POST,
+            Some(loopback_peer()),
+            None,
+            r#"{"query":"alice@example.com","disabled":true}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "the LIVE half succeeded");
+        let payload: SetDisabledResponse = serde_json::from_slice(&body).expect("payload");
+        assert!(
+            manager.snapshot(OffsetDateTime::now_utc()).accounts[0].disabled,
+            "the account is parked in the live rotation"
+        );
+        assert!(!payload.persisted, "but the file does not carry it");
+        let warning = payload.warning.expect("a not-saved warning, never silence");
+        assert!(
+            warning.contains("NOT SAVED") && warning.contains("returns to rotation on restart"),
+            "the warning is DisablePersist::warning verbatim, direction included: {warning}"
+        );
+    }
+
+    /// The OTHER half of the discriminator, and the half that is easy to get wrong:
+    /// a path this proxy does not serve answers 404 **without** the stamp.
+    ///
+    /// This is what `tcr` reads as "the running proxy is too old to accept live
+    /// account control", which makes it write the file and warn loudly. If the
+    /// catch-all ever started stamping, that arm would silently become the
+    /// route-refused arm and the CLI would report a bad query instead of a stale
+    /// proxy — the original invisible-failure shape, restored.
+    #[tokio::test]
+    async fn an_unrouted_local_path_is_not_stamped_as_the_control_route() {
+        use tower::ServiceExt as _;
+        for uri in [
+            "/_tcr/accounts",
+            "/_tcr/accounts/disable",
+            "/_tcr/accounts/disabled/extra",
+        ] {
+            let (manager, path) = control_manager("unstamped", None);
+            let mut req = Request::builder()
+                .method(Method::POST)
+                .uri(uri)
+                .body(Body::from(
+                    r#"{"query":"alice@example.com","disabled":true}"#,
+                ))
+                .expect("build request");
+            req.extensions_mut().insert(ClientAddr(loopback_peer()));
+            let response = app(Arc::clone(&manager))
+                .oneshot(req)
+                .await
+                .expect("router response");
+            assert_eq!(response.status(), StatusCode::NOT_FOUND, "{uri}");
+            assert!(
+                response.headers().get(ENDPOINT_HEADER).is_none(),
+                "{uri} must not claim to be the account-control route"
+            );
+            assert!(
+                !manager.snapshot(OffsetDateTime::now_utc()).accounts[0].disabled,
+                "{uri} changed nothing"
+            );
+            std::fs::remove_file(&path).ok();
+        }
+    }
+
+    /// The route is `POST`-only, and a wrong method is answered LOCALLY — never
+    /// forwarded, and never able to mutate. The stamp distinguishes this 405 (route
+    /// exists) from an older tcr's 404 (route absent).
+    #[tokio::test]
+    async fn control_endpoint_refuses_other_methods_locally() {
+        for method in [Method::GET, Method::PUT, Method::DELETE, Method::PATCH] {
+            let (manager, path) = control_manager("method", None);
+            let (status, headers, _body) = control_request(
+                Arc::clone(&manager),
+                method.clone(),
+                Some(loopback_peer()),
+                None,
+                r#"{"query":"alice@example.com","disabled":true}"#,
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::METHOD_NOT_ALLOWED,
+                "{method} on the control path is refused locally"
+            );
+            assert_ne!(
+                status,
+                StatusCode::BAD_GATEWAY,
+                "{method} must never fall through to the upstream forwarder"
+            );
+            assert_eq!(
+                headers.get(ENDPOINT_HEADER).and_then(|v| v.to_str().ok()),
+                Some(DISABLED_ENDPOINT),
+                "{method}: the 405 identifies the route, so a caller does not read \
+                 it as a proxy too old to have one"
+            );
+            assert!(
+                !manager.snapshot(OffsetDateTime::now_utc()).accounts[0].disabled,
+                "{method} changed the rotation"
+            );
+            std::fs::remove_file(&path).ok();
+        }
+    }
+
     // --- rotation-bypassing relays -----------------------------------------
 
     /// What a fake upstream saw — one of these per request it received.
@@ -3396,6 +4146,15 @@ mod tests {
             (Method::GET, "/_tcr/"),
             (Method::GET, "/_tcr"),
             (Method::GET, "/_tcr/status?x=1&y=2/../nope"),
+            // Near-misses of the account-control route. The mutating verb makes
+            // these the rows that matter most: a `POST` that fell through the
+            // catch-all would be rewritten onto api.anthropic.com carrying a pooled
+            // OAuth Bearer, which is the shape that burned an account.
+            (Method::POST, "/_tcr/accounts"),
+            (Method::POST, "/_tcr/accounts/"),
+            (Method::POST, "/_tcr/accounts/disable"),
+            (Method::POST, "/_tcr/accounts/disabled/extra"),
+            (Method::POST, "/_tcr/accounts/priority"),
         ] {
             let manager = Manager::with_live_refresher(dummy_config(None, &upstream), None);
             let (status, body) = drive(


### PR DESCRIPTION
## The defect

`tcr disable <name>` rewrote `~/.config/teamclaude.json` and nothing else. The proxy reads `disabled` into memory once, at `Manager::new` (`src/manager/mod.rs`), and never re-reads the file. So the CLI exited 0, printed `Disabled account 'x'.`, and the serving process kept handing that account live traffic. `tcr status` prefers the live server, so no surface anywhere disagreed with the file.

Measured on the live fleet before this change: two accounts parked in the config were rotating in the running process. The one correct code path was the TUI's `d`/`e` key → `Manager::set_disabled`, and the proxy runs `--headless` under TcrBar, where there is no TUI to press it in.

## What this changes (Rust half)

**`POST /_tcr/accounts/disabled`** on the proxy, wired to the same `Manager::set_disabled` the TUI key calls, so the live rotation and the config file move together.

Request:

```json
{"query": "<name or email>", "org": null, "disabled": true}
```

| code | when | body |
|---|---|---|
| 200 | applied | `{"name","disabled","persisted","warning"}` |
| 400 | body absent / unparseable / missing `query` or `disabled` / empty `query` | error envelope |
| 401 | api-key configured and header missing or wrong | error envelope |
| 403 | peer not loopback, **or `ClientAddr` absent** (fail closed) | error envelope |
| 404 | no account in the live rotation matched | error envelope |
| 405 | any other method | local 405, never forwarded |
| 409 | the query matched several accounts — the candidates are named | error envelope |

Every response the route itself produces carries `x-tcr-endpoint: accounts-disabled`. That is not decoration: "this proxy has no such route" and "that query names no account" are both `404` with opposite consequences for the caller, and the alternative discriminator is matching error text.

The gate is the status endpoint's, not a new one — both routes now go through a single `local_endpoint_gate`: loopback proven by the `ClientAddr` extension the hybrid listener injects (a header cannot forge it; absent ⇒ 403), and the proxy api-key REQUIRED with no loopback exemption. A mutating verb gets no weaker a gate than the read next door, and one implementation cannot drift from itself. It is a registered route, so it is matched before the catch-all and can never be rewritten onto `api.anthropic.com` carrying a pooled OAuth Bearer.

**`tcr enable` / `tcr disable` go live-first**, mirroring `fetch_live_status` (same `no_proxy()` client — `HTTP_PROXY` commonly points at tcr):

- 200 → the existing success line, any `warning` on stderr, exit 0.
- connect refused → today's file write, quiet. Nothing is listening, so the file is the whole truth.
- 404/405 without the endpoint stamp (a proxy too old to have the route) → file write **plus a loud stderr warning** that the running proxy will keep routing to the account until it restarts. That arm's former silence is the entire reason this bug was invisible.
- 401 → writes nothing and exits non-zero, rather than leaving the config claiming a bench the proxy is not honouring.
- 404/409 from the route itself → refused, nothing written: the file's own resolution could land on a different row than the one the server was talking about, and a disable applied to the wrong account is worse than none.

Resolution is the CLI's own rule (`identity::match_one`, lifted behind a `Queryable` trait) run against the server's **live rotation slots**, so the CLI and the endpoint cannot disagree about which account a query names, and the index handed to `set_disabled` is a rotation slot by construction rather than by an assumed correspondence between two vectors.

`DisablePersist::warning` is carried through verbatim. `persisted: false` with a warning is a change that is in force right now and dies on restart — precisely the state the old code left operators in silently.

`priority`, `remove` and `login` have the same defect and are deliberately untouched here.

## Verification

- `cargo fmt --check` — 0
- `cargo clippy --all-targets -- -D warnings` — 0
- `cargo test` — 0 (556 + 13 + 5 + 11 pass)

The biting tests assert the **in-memory `Manager` flipped AND the file carries it**; an HTTP-200-only assertion would re-create the defect at a new altitude. Both were watched failing:

- reverting the CLI to file-only ⇒ `set_enabled_parks_the_account_in_the_running_proxy` fails on *"the account is parked IN THE SERVING PROCESS, not just on disk"* — while still printing `Disabled account 'alice@example.com'.` and exiting 0, which is the live defect exactly;
- dropping `account.disabled = disabled` from `set_disabled` ⇒ five endpoint tests red on their live-rotation assertions with every `200` and every file write intact.

The method/path table is extended with `/_tcr/accounts`, `/_tcr/accounts/`, `/_tcr/accounts/disable`, `/_tcr/accounts/disabled/extra` and `/_tcr/accounts/priority`, all `POST`, so a future refactor cannot silently make this path forwardable — and a companion test asserts those near-misses are **not** stamped, since the CLI reads an unstamped 404 as a stale proxy.

The CLI's own enable/disable tests are pinned to a bound-then-dropped port, and the substitution is asserted: the shared fixture named port 3456, which is where a real proxy serves.

## Note

The `apps/macos/**` commits on this branch are a concurrent sibling change (TcrBar's client for this endpoint). The gate results above are for the Rust half.
