### PR TITLE
fix: close the control route to a browser, stop the row ticking a change that will not survive a restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaude-rs"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "MIT"
 description = "Lean single-user rotating Anthropic proxy with a live TUI — a Rust replacement for the personal teamclaude proxy"

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -36,16 +36,25 @@ Each row has an Enable/Disable button. It shells out to `tcr enable <name>` /
 `tcr disable <name>` and nothing else — TcrBar never writes
 `~/.config/teamclaude.json`, because that file holds credentials and `tcr` owns it.
 
-`tcr`'s account query is a *case-insensitive substring* match, so even passing the
-exact configured name is not a guarantee of a unique hit. The exit code and stderr
-are therefore captured and the CLI's own words are rendered in the row on failure;
-a toggle that did not happen never looks like one that did. On success the panel
-re-polls rather than flipping its own copy of `disabled`, so what you see is
-always what `tcr status` reports.
+`tcr`'s account query is an *exact* match — the configured name, else the email
+parsed out of it — and it is case-sensitive and untrimmed. It is not a substring
+match, which this file claimed until 0.2.3: for an account named
+`alice@example.com`, the queries `alice`, `alice@`, `example`, the same address
+spelled in capitals, and the address with a trailing space all resolve to nothing. Two accounts sharing one name string are refused as ambiguous
+rather than resolved, so a toggle cannot land on a row you did not name.
 
-That is a statement about the *config*. Whether a proxy that is already running
-picks the change up without a restart is not something this app verifies, in
-either direction, and it does not claim to.
+The exit code and both streams are captured. A non-zero exit renders the CLI's own
+words in the row; a *zero* exit that still wrote to stderr is not treated as a
+clean success either, because that is how `tcr` says a change was applied but not
+saved. On success the panel re-polls and compares what the fleet then reports
+against what was asked, rather than flipping its own copy of `disabled` — so a
+change the running proxy did not honour reads as exactly that, not as a tick.
+
+Since 0.2.3 the change also reaches a **running** proxy: `tcr enable`/`disable`
+ask the live server first (`POST /_tcr/accounts/disabled`, loopback-only, api-key
+required when one is configured, JSON content-type required) and fall back to
+writing the config only when no server answers. A proxy too old for that route
+still gets a config write, and the row says so instead of showing a tick.
 
 Disabling is reversible, so there is no confirmation dialog.
 

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -554,8 +554,12 @@ private struct RowsHeightKey: PreferenceKey {
 /// never touches `~/.config/teamclaude.json`, which holds credentials. The row
 /// does not optimistically flip its own `disabled` — on success it asks for a
 /// fresh poll and renders whatever `tcr status` then reports, so a call that
-/// matched the wrong account (the query is a substring match) shows up as the
-/// wrong row changing rather than as a lie. A non-zero exit is rendered in place.
+/// resolved to some other account shows up as the wrong row changing rather than
+/// as a lie. That is a backstop, not the expectation: resolution is an exact
+/// name match falling back to an exact email match, case-sensitive both times
+/// (`src/identity.rs`, `match_accounts`), and two accounts sharing an email
+/// across orgs come back ambiguous rather than resolved. A non-zero exit is
+/// rendered in place.
 ///
 /// This row no longer lets a toggle succeed silently. `tcr` rewrites the config
 /// and exits 0; a proxy that read `disabled` once at boot keeps reporting the old
@@ -788,6 +792,11 @@ struct AccountRow: View {
         case .confirmed: return "checkmark.circle"
         case .notHonoured: return Tok.unreadableGlyph
         case .unverified: return "questionmark.circle"
+        // A `tcr` notice never wears the tick, whatever it qualifies — including a
+        // confirmation. `checkmark.circle` beside "the fleet now reports parked"
+        // would put the glyph an operator scans for on a park that may not survive
+        // a restart, which is the whole defect.
+        case .spokeUp: return Tok.unreadableGlyph
         }
     }
 
@@ -796,6 +805,11 @@ struct AccountRow: View {
         case .confirmed: return Tok.ok
         case .notHonoured: return Tok.near
         case .unverified: return Tok.unmeasured
+        // `Tok.near`, sharing the not-honoured hue for the same reason: nothing
+        // failed — `tcr` exited 0 — so it must not take the error colour already
+        // spoken for by the verbatim failure line above, and it must not take
+        // `Tok.ok`, which is the clean case's alone.
+        case .spokeUp: return Tok.near
         }
     }
 
@@ -811,15 +825,25 @@ struct AccountRow: View {
         let title = pending ? (enabling ? "Enabling…" : "Disabling…") : verb
         return Button(title) {
             Task {
-                if await accounts.setEnabled(enabling, account: account.name) {
-                    // Exit 0 is not the outcome — it is permission to go and find
-                    // out what the outcome was. The refresh's own result is
-                    // compared against what was asked, and the row says which of
-                    // the three things happened.
-                    let readback = await onChanged()
-                    accounts.record(
-                        readback: readback, requestedEnabled: enabling, account: account.name)
-                }
+                // Exit 0 is not the outcome — it is permission to go and find out
+                // what the outcome was. The refresh's own result is compared
+                // against what was asked, and the row says which thing happened.
+                //
+                // `notice` is threaded through rather than dropped: `tcr` reports
+                // half-done work (a park the config cannot persist, a proxy too old
+                // for the route) on stderr while exiting 0, and the read-back
+                // cannot see it — `disabled` flipped, so the comparison confirms.
+                // Losing it here is what let the row stamp `parked ✓` on a change
+                // that would not survive a restart.
+                let attempt = await accounts.setEnabled(enabling, account: account.name)
+                guard case .accepted(let notice) = attempt else { return }
+                let readback = await onChanged()
+                accounts.record(
+                    readback: readback,
+                    requestedEnabled: enabling,
+                    account: account.name,
+                    notice: notice
+                )
             }
         }
         // `.bordered`, not `.borderless`. Borderless draws the label as bare

--- a/apps/macos/Sources/TcrBarCore/AccountControl.swift
+++ b/apps/macos/Sources/TcrBarCore/AccountControl.swift
@@ -11,13 +11,24 @@ import Foundation
 ///     `tcr disable <name>` — exactly like the server control, and this process
 ///     stays credential-free.
 ///  2. **A failed call must never look like a success.** `query` on the Rust side
-///     (`src/main.rs`, `EnableArgs` / `DisableArgs`) is a *case-insensitive
-///     substring* match, so passing an exact account name is still not a guarantee
-///     of a unique hit: if one configured name is a substring of another, `tcr` can
-///     refuse as ambiguous, or resolve to the wrong account. The exit code and
-///     stderr are therefore captured and surfaced in the row, and the UI never
-///     optimistically flips its own copy of `disabled` — it re-polls and shows
-///     whatever `tcr status` then reports.
+///     (`src/identity.rs`, `match_accounts`) is an EXACT match on the account name,
+///     falling back to an exact match on the email part — case-sensitive `==` both
+///     times, no substring anywhere. Passing the row's own `name` therefore resolves
+///     to that row or to nothing, except where two accounts share an email across
+///     orgs, which `match_one` returns as ambiguous rather than picking one. The
+///     exit code and stderr are still captured and surfaced in the row, and the UI
+///     never optimistically flips its own copy of `disabled` — it re-polls and
+///     shows whatever `tcr status` then reports.
+///  3. **Exit 0 with anything on stderr is not a clean success.** `tcr` reports
+///     durability on the success path: it exits 0 having parked the live rotation
+///     and warns on stderr that no config entry matched, so the account returns to
+///     rotation on restart (`src/cli.rs`, the `warning` on
+///     `SetDisabledOutcome::Applied`), or that the running proxy was too old for
+///     the control route and only the file changed. Reading only the exit code
+///     dropped both at the process boundary, and the row stamped `parked ✓` on a
+///     change that would not survive a restart. So stderr is captured on the
+///     success path too and carried, verbatim and un-parsed, into
+///     ``ToggleVerdict/spokeUp(notice:about:)``.
 ///
 /// What this does **not** claim: that a running proxy observes the change
 /// immediately. `tcr` rewrites the config file; a live server that read `disabled`
@@ -57,25 +68,39 @@ public enum AccountCommand {
         }
     }
 
-    /// Pure classification of a finished invocation. `nil` is success.
-    public static func classify(enabling: Bool, exitCode: Int32, stderr: String) -> Failure? {
-        guard exitCode != 0 else { return nil }
-        return Failure(
-            enabling: enabling,
-            exitCode: exitCode,
-            message: stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-        )
+    /// What a finished invocation was. Three arms, because exit 0 has two
+    /// meanings: `tcr` either said nothing or said something, and the second is
+    /// not a clean success (rule 3 above).
+    public enum Outcome: Equatable, Sendable {
+        /// Exit 0, nothing on stderr. The only outcome that may end in a bare `✓`.
+        case clean
+        /// Exit 0 and `tcr` wrote to stderr. `notice` is those bytes, trimmed at
+        /// the ends and otherwise verbatim — never matched against a phrase, so a
+        /// warning added to `tcr` next year reaches the row without a change here.
+        case spoke(notice: String)
+        /// A non-zero exit, or this app failing to run `tcr` at all.
+        case failed(Failure)
+    }
+
+    /// Pure classification of a finished invocation.
+    public static func classify(enabling: Bool, exitCode: Int32, stderr: String) -> Outcome {
+        let text = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard exitCode == 0 else {
+            return .failed(Failure(enabling: enabling, exitCode: exitCode, message: text))
+        }
+        return text.isEmpty ? .clean : .spoke(notice: text)
     }
 
     /// Blocking invocation — always called off the main actor.
-    nonisolated static func perform(enabled: Bool, name: String) -> Failure? {
+    nonisolated static func perform(enabled: Bool, name: String) -> Outcome {
         switch TcrTool.resolve() {
         case .failure(let notFound):
-            return Failure(
-                enabling: enabled,
-                exitCode: -1,
-                message: "tcr not found (searched \(notFound.searched.count) locations)"
-            )
+            return .failed(
+                Failure(
+                    enabling: enabled,
+                    exitCode: -1,
+                    message: "tcr not found (searched \(notFound.searched.count) locations)"
+                ))
         case .success(let executable):
             do {
                 let output = try TcrTool.run(
@@ -84,7 +109,8 @@ public enum AccountCommand {
                 )
                 return classify(enabling: enabled, exitCode: output.exitCode, stderr: output.stderr)
             } catch {
-                return Failure(enabling: enabled, exitCode: -1, message: error.localizedDescription)
+                return .failed(
+                    Failure(enabling: enabled, exitCode: -1, message: error.localizedDescription))
             }
         }
     }
@@ -110,28 +136,38 @@ public final class AccountController: ObservableObject {
     /// Record what the poll that followed a successful toggle reported. Called by
     /// the row immediately after its refresh, so the verdict describes the same
     /// read the row is about to draw.
+    /// `notice` is whatever `tcr` wrote to stderr while exiting 0 (see
+    /// ``AccountCommand/Outcome/spoke(notice:)``) — normally `nil`. It qualifies
+    /// the verdict rather than replacing it.
     public func record(
         readback: PollState,
         requestedEnabled: Bool,
         account name: String,
+        notice: String? = nil,
         now: Date = Date()
     ) {
         let verdict = ToggleReadback.verdict(
             requestedEnabled: requestedEnabled,
             account: name,
-            readback: readback
+            readback: readback,
+            notice: notice
         )
         verdicts[name] = RecordedVerdict(verdict: verdict, at: now)
-        guard verdict.isConfirmation else { return }
-        // A confirmation ages out (see ``ToggleReadback/visible(_:reportedDisabled:now:lifetime:)``),
-        // and `visible` is the authority on that. This timer exists only so the
+        // Every verdict ages out (see ``ToggleReadback/visible(_:reportedDisabled:now:)``),
+        // and `visible` is the authority on how long. This timer exists only so the
         // expiry is actually DRAWN: nothing else republishes when the deadline
         // passes, and a row whose account is unchanged will not re-render on its
-        // own, so an expired ack would linger on screen until something else
+        // own, so an expired line would linger on screen until something else
         // moved. The identity check keeps a later attempt's verdict safe.
+        //
+        // It is armed for the unresolved arms too, not just confirmations. Those
+        // normally clear on agreement long before their deadline, but the case the
+        // deadline exists for — an account that left the fleet, where agreement can
+        // never come — is exactly the case where nothing else would ever clear it.
         let recorded = verdicts[name]
+        let lifetime = ToggleReadback.lifetime(of: verdict)
         Task { [weak self] in
-            try? await Task.sleep(nanoseconds: UInt64(ToggleReadback.confirmationLifetime * 1_000_000_000))
+            try? await Task.sleep(nanoseconds: UInt64(lifetime * 1_000_000_000))
             guard let self, self.verdicts[name] == recorded else { return }
             self.verdicts[name] = nil
         }
@@ -148,12 +184,25 @@ public final class AccountController: ObservableObject {
         ToggleReadback.visible(verdicts[name], reportedDisabled: reportedDisabled, now: now)
     }
 
-    /// Run the toggle. Returns `true` only when `tcr` exited 0 — the caller uses
-    /// that to decide whether a status refresh is worth doing, never to update a
-    /// local copy of `disabled`.
+    /// What a click did, as far as the subprocess can say.
+    public enum Attempt: Equatable, Sendable {
+        /// A call for this account was already in flight; nothing was run.
+        case skipped
+        /// A non-zero exit. The words are in ``AccountController/failures``.
+        case refused
+        /// `tcr` exited 0, so a status refresh is worth doing. `notice` carries
+        /// anything it printed to stderr — exit 0 with output is accepted, not
+        /// clean, and the caller must pass this to ``record(readback:requestedEnabled:account:notice:now:)``
+        /// or the durability half of the outcome dies here.
+        case accepted(notice: String?)
+    }
+
+    /// Run the toggle. `.accepted` only when `tcr` exited 0 — the caller uses that
+    /// to decide whether a status refresh is worth doing, never to update a local
+    /// copy of `disabled`.
     @discardableResult
-    public func setEnabled(_ enabled: Bool, account name: String) async -> Bool {
-        guard !pending.contains(name) else { return false }
+    public func setEnabled(_ enabled: Bool, account name: String) async -> Attempt {
+        guard !pending.contains(name) else { return .skipped }
         pending.insert(name)
         // A new attempt clears the previous verdict; a stale error beside a
         // now-succeeding row would be its own lie. The read-back verdict goes for
@@ -163,12 +212,18 @@ public final class AccountController: ObservableObject {
         verdicts[name] = nil
         defer { pending.remove(name) }
 
-        let failure = await Task.detached(priority: .userInitiated) {
+        let outcome = await Task.detached(priority: .userInitiated) {
             AccountCommand.perform(enabled: enabled, name: name)
         }.value
 
-        guard let failure else { return true }
-        failures[name] = failure
-        return false
+        switch outcome {
+        case .clean:
+            return .accepted(notice: nil)
+        case .spoke(let notice):
+            return .accepted(notice: notice)
+        case .failed(let failure):
+            failures[name] = failure
+            return .refused
+        }
     }
 }

--- a/apps/macos/Sources/TcrBarCore/ToggleVerdict.swift
+++ b/apps/macos/Sources/TcrBarCore/ToggleVerdict.swift
@@ -16,6 +16,18 @@ import Foundation
 /// only a re-read can tell apart. The third — a non-zero exit — is
 /// ``AccountCommand/Failure`` and is unchanged: `tcr`'s own words, verbatim.
 ///
+/// A fourth arm, ``spokeUp(notice:about:)``, closes the sibling of that defect at
+/// the *process* boundary rather than the poll boundary. `tcr` can exit 0 and
+/// still tell you the change is only half done — the park applied to the live
+/// rotation but no config entry matched it, so it comes back on restart
+/// (`src/cli.rs`, `SetDisabledOutcome`'s `warning`), or the running proxy was too
+/// old for the control route and only the file changed. Both are printed to
+/// stderr with exit 0. The read-back cannot see either: `disabled` DID flip, so
+/// the comparison below confirms, and the row used to stamp `parked ✓` on a
+/// change that will not survive a restart. The rule is structural, not lexical —
+/// **a zero exit with anything on stderr is not a clean success** — so a warning
+/// nobody has written yet lands on this arm too.
+///
 /// `requestedEnabled` is what the click ASKED for (`true` = put back in
 /// rotation), never what the row happened to show.
 public enum ToggleVerdict: Equatable, Sendable {
@@ -31,17 +43,38 @@ public enum ToggleVerdict: Equatable, Sendable {
     /// Distinct from both of the above on purpose — "I could not check" is not a
     /// confirmation, and it is not evidence the proxy disagreed either.
     case unverified(requestedEnabled: Bool, reason: String)
+    /// `tcr` exited 0 **and wrote to stderr**, so whatever the re-read then said
+    /// is qualified by words this app is not allowed to interpret. It wraps the
+    /// read-back verdict rather than replacing it, because the two facts are
+    /// independent: the live rotation may well have changed (`about:
+    /// .confirmed`) while the change is not durable, and an old proxy's
+    /// "only the config file was changed" arrives beside a `.notHonoured` whose
+    /// remedy is in the notice and nowhere else.
+    ///
+    /// `notice` is `tcr`'s bytes, trimmed of surrounding whitespace and
+    /// otherwise verbatim. Nothing here greps it: a keyword test would pass every
+    /// warning added after the test was written, which is the exact failure this
+    /// arm exists to prevent. It never nests — the only construction site is
+    /// ``ToggleReadback/verdict(requestedEnabled:account:readback:notice:)``,
+    /// which builds it from a plain read-back verdict.
+    indirect case spokeUp(notice: String, about: ToggleVerdict)
 
     public var requestedEnabled: Bool {
         switch self {
         case .confirmed(let enabled), .notHonoured(let enabled): return enabled
         case .unverified(let enabled, _): return enabled
+        case .spokeUp(_, let about): return about.requestedEnabled
         }
     }
 
-    /// True only for the arm that asserts the change took effect. Anything that
-    /// branches on "did this work" must read this and not `case let`, so a future
-    /// fourth arm cannot default into looking like a success.
+    /// True only for the arm that asserts the change took effect, cleanly.
+    /// Anything that branches on "did this work" must read this and not `case
+    /// let`, so a future arm cannot default into looking like a success.
+    ///
+    /// ``spokeUp(notice:about:)`` is deliberately NOT a confirmation even when it
+    /// wraps one: `tcr` said something on the success path, and the whole point of
+    /// the arm is that "the flag flipped" and "the change will survive a restart"
+    /// are different claims.
     public var isConfirmation: Bool {
         if case .confirmed = self { return true }
         return false
@@ -52,16 +85,39 @@ public enum ToggleVerdict: Equatable, Sendable {
     private static func word(rotating: Bool) -> String { rotating ? "rotating" : "parked" }
 
     /// One line for the row. Always non-empty.
+    ///
+    /// The `✓` belongs to ``confirmed(requestedEnabled:)`` alone. A qualified
+    /// confirmation spells the same fact out in words instead, so a glance can
+    /// never read it as the clean case — the tick is the thing an operator scans
+    /// for, and putting one on a change that may not survive a restart is the
+    /// defect this arm was added for.
     public var rowLabel: String {
         switch self {
         case .confirmed(let enabled):
             return "\(Self.word(rotating: enabled)) ✓"
+        case .notHonoured, .unverified:
+            return statement
+        case .spokeUp(let notice, let about):
+            return "\(about.statement) — tcr said: \(notice)"
+        }
+    }
+
+    /// The same outcome with no `✓` in it, for composing under
+    /// ``spokeUp(notice:about:)``.
+    private var statement: String {
+        switch self {
+        case .confirmed(let enabled):
+            return "the fleet now reports \(Self.word(rotating: enabled))"
         case .notHonoured(let enabled):
             // The old state is the opposite of what was asked for — that is what
             // makes this arm this arm.
             return "tcr accepted it — the running proxy still reports \(Self.word(rotating: !enabled))"
         case .unverified(_, let reason):
             return "tcr accepted it — could not confirm: \(reason)"
+        case .spokeUp(let notice, let about):
+            // Never constructed; see the arm's own documentation. Rendering the
+            // notice rather than dropping it keeps a construction bug legible.
+            return "\(about.statement) — tcr said: \(notice)"
         }
     }
 
@@ -76,6 +132,22 @@ public enum ToggleVerdict: Equatable, Sendable {
                 + Self.word(rotating: !enabled)
         case .unverified(_, let reason):
             return "tcr accepted the change but it could not be confirmed: \(reason)"
+        case .spokeUp(let notice, let about):
+            // "confirmed" is withheld here for the same reason the `✓` is: the
+            // spoken form has to be as qualified as the written one.
+            return "\(about.spokenStatement), and tcr said: \(notice)"
+        }
+    }
+
+    /// ``spokenLabel`` with the unqualified "confirmed" removed, for composing
+    /// under ``spokeUp(notice:about:)``.
+    private var spokenStatement: String {
+        switch self {
+        case .confirmed(let enabled):
+            return enabled
+                ? "the fleet now reports rotating" : "the fleet now reports parked, out of rotation"
+        case .notHonoured, .unverified, .spokeUp:
+            return spokenLabel
         }
     }
 }
@@ -106,9 +178,65 @@ public enum ToggleReadback {
     /// least one full refresh and then goes away on its own.
     public static let confirmationLifetime: TimeInterval = 6
 
+    /// How long a confirmation that carries a `tcr` notice may sit on screen.
+    /// Longer than ``confirmationLifetime`` because it is not an acknowledgement
+    /// the operator can ignore: it is the only place the warning appears — `tcr`
+    /// wrote it to a stderr no one is reading — and it names something still to
+    /// be done. It does age out, because nothing can re-verify it and the panel is
+    /// a live view rather than a log.
+    public static let noticeLifetime: TimeInterval = 60
+
+    /// How long a ``ToggleVerdict/notHonoured(requestedEnabled:)`` or
+    /// ``ToggleVerdict/unverified(requestedEnabled:reason:)`` may sit on screen
+    /// when the fleet has not resolved it.
+    ///
+    /// These arms clear on agreement, so an expiry looks redundant — and it is,
+    /// as long as the account stays in the fleet. It does not always: with the
+    /// account gone, `reportedDisabled` is `nil`, `nil == !requested` is never
+    /// true, and the verdict was retained *forever*. An account that left the
+    /// fleet and returned an hour later dragged a stale line back with it. So the
+    /// rule is an **expiry, not a clear**: fifteen minutes from the moment the
+    /// verdict was reached, whether or not the account is still listed. Long
+    /// enough that a real disagreement is never hidden from the operator who
+    /// caused it (the original defect was a row that said *nothing*), short
+    /// enough that it cannot reappear beside a later state it knows nothing about.
+    public static let unresolvedLifetime: TimeInterval = 15 * 60
+
+    /// How long this verdict may be rendered after it was reached. Total over the
+    /// arms on purpose: an arm with no lifetime is an arm that can outlive its
+    /// truth, and that is how the absence bug above got in.
+    public static func lifetime(of verdict: ToggleVerdict) -> TimeInterval {
+        switch verdict {
+        case .confirmed: return confirmationLifetime
+        case .notHonoured, .unverified: return unresolvedLifetime
+        case .spokeUp(_, let about):
+            if case .confirmed = about { return noticeLifetime }
+            return unresolvedLifetime
+        }
+    }
+
     /// The comparison. `requestedEnabled` is what was asked; `readback` is the
     /// poll that followed the successful call.
+    ///
+    /// `notice` is whatever `tcr` wrote to stderr while exiting 0 — normally
+    /// nothing. When it is non-empty the verdict is wrapped in
+    /// ``ToggleVerdict/spokeUp(notice:about:)`` whatever the re-read said, because
+    /// exit 0 plus output is not a clean success and this app does not read `tcr`'s
+    /// prose to decide how bad it is.
     public static func verdict(
+        requestedEnabled: Bool,
+        account name: String,
+        readback: PollState,
+        notice: String? = nil
+    ) -> ToggleVerdict {
+        let plain = plainVerdict(
+            requestedEnabled: requestedEnabled, account: name, readback: readback)
+        guard let notice, !notice.isEmpty else { return plain }
+        return .spokeUp(notice: notice, about: plain)
+    }
+
+    /// The read-back comparison alone, with no knowledge of what `tcr` printed.
+    private static func plainVerdict(
         requestedEnabled: Bool,
         account name: String,
         readback: PollState
@@ -156,21 +284,26 @@ public enum ToggleReadback {
     ///  - **unverified** clears on the same condition, and never promotes itself
     ///    to a confirmation: nothing observed the change take effect, so this
     ///    only ever stops being said, it is never upgraded.
+    ///  - A **notice** (``ToggleVerdict/spokeUp(notice:about:)``) follows the
+    ///    clearing rule of the verdict it wraps — it is a qualification of that
+    ///    verdict, not a separate claim — and gets its own, longer lifetime.
+    ///
+    /// Every arm now has a lifetime (``lifetime(of:)``), including the unresolved
+    /// ones. That is the fix for a verdict about a departed account: agreement can
+    /// never clear it, because `nil` is not `!requested`, so an expiry has to.
     public static func visible(
         _ recorded: RecordedVerdict?,
         reportedDisabled: Bool?,
-        now: Date,
-        lifetime: TimeInterval = confirmationLifetime
+        now: Date
     ) -> ToggleVerdict? {
         guard let recorded else { return nil }
+        guard now.timeIntervalSince(recorded.at) < lifetime(of: recorded.verdict) else { return nil }
         let requested = recorded.verdict.requestedEnabled
         let fleetAgrees = reportedDisabled == !requested
         switch recorded.verdict {
-        case .confirmed:
-            guard fleetAgrees else { return nil }
-            guard now.timeIntervalSince(recorded.at) < lifetime else { return nil }
-            return recorded.verdict
-        case .notHonoured, .unverified:
+        case .confirmed, .spokeUp(_, .confirmed):
+            return fleetAgrees ? recorded.verdict : nil
+        case .notHonoured, .unverified, .spokeUp:
             return fleetAgrees ? nil : recorded.verdict
         }
     }

--- a/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
@@ -499,8 +499,9 @@ final class AccountCommandTests: XCTestCase {
     }
 
     func testTheNameIsNeverTruncatedOrFlagged() {
-        // `query` is a case-insensitive substring match on the Rust side, so an
-        // abbreviated name could silently hit a different account. Pass it whole.
+        // `query` resolves by exact name, then exact email (`src/identity.rs`,
+        // `match_accounts`) — an abbreviated name matches nothing at all. Pass it
+        // whole; the row already knows the exact value.
         let name = "alice+tag@example.com"
         let arguments = AccountCommand.arguments(enabled: false, name: name)
         XCTAssertEqual(arguments.count, 2, "no flags, no --org, nothing else")
@@ -516,33 +517,58 @@ final class AccountCommandTests: XCTestCase {
         XCTAssertEqual(Set([enable[0], disable[0]]), ["enable", "disable"])
     }
 
-    func testExitZeroIsSuccess() {
-        XCTAssertNil(AccountCommand.classify(enabling: true, exitCode: 0, stderr: ""))
-        XCTAssertNil(
+    func testExitZeroWithASilentStderrIsTheOnlyCleanSuccess() {
+        XCTAssertEqual(AccountCommand.classify(enabling: true, exitCode: 0, stderr: ""), .clean)
+        // Whitespace is not output.
+        XCTAssertEqual(AccountCommand.classify(enabling: true, exitCode: 0, stderr: " \n"), .clean)
+    }
+
+    /// This test used to assert the opposite — "exit code decides, not stderr
+    /// chatter" — and that sentence was the bug. `tcr` reports a park it could not
+    /// persist by exiting 0 and warning on stderr (`src/cli.rs`), so exit 0 with
+    /// output means *accepted, with something still to do*, and dropping the text
+    /// here stamped `parked ✓` on a change that would not survive a restart.
+    ///
+    /// The rule is structural: ANY output, no phrase matched. A keyword list would
+    /// pass every warning added to `tcr` after the day it was written.
+    func testExitZeroWithAnythingOnStderrIsNotClean() {
+        XCTAssertEqual(
             AccountCommand.classify(enabling: false, exitCode: 0, stderr: "some chatter"),
-            "exit code decides, not stderr chatter"
+            .spoke(notice: "some chatter")
+        )
+        let notSaved =
+            "[tcr] warning: NOT SAVED: no config entry matches this account "
+            + "— it returns to rotation on restart"
+        XCTAssertEqual(
+            AccountCommand.classify(enabling: false, exitCode: 0, stderr: "\(notSaved)\n"),
+            .spoke(notice: notSaved),
+            "trimmed at the ends, otherwise verbatim — this app does not paraphrase tcr"
         )
     }
 
     func testAnAmbiguousQueryIsSurfacedVerbatim() {
-        // The realistic failure: one configured name is a substring of another.
-        let failure = AccountCommand.classify(
-            enabling: false,
-            exitCode: 1,
-            stderr: "  no unique account matches \"alice\" (2 candidates)\n"
-        )
-        XCTAssertEqual(failure?.exitCode, 1)
-        XCTAssertEqual(failure?.message, "no unique account matches \"alice\" (2 candidates)")
+        // The realistic failure: two accounts share an email across two orgs, so
+        // the email fallback resolves to both and `tcr` refuses rather than picking.
+        guard
+            case .failed(let failure) = AccountCommand.classify(
+                enabling: false,
+                exitCode: 1,
+                stderr: "  no unique account matches \"alice@example.com\" (2 candidates)\n"
+            )
+        else { return XCTFail("a non-zero exit must classify as failed") }
+        XCTAssertEqual(failure.exitCode, 1)
+        XCTAssertEqual(failure.message, "no unique account matches \"alice@example.com\" (2 candidates)")
         XCTAssertEqual(
-            failure?.summary,
-            "disable failed (exit 1): no unique account matches \"alice\" (2 candidates)"
+            failure.summary,
+            "disable failed (exit 1): no unique account matches \"alice@example.com\" (2 candidates)"
         )
     }
 
     func testASilentFailureStillSaysSomething() {
-        let failure = AccountCommand.classify(enabling: true, exitCode: 2, stderr: "")
-        XCTAssertEqual(failure?.summary, "enable failed (exit 2): no output")
-        XCTAssertFalse(failure?.summary.isEmpty ?? true)
+        guard case .failed(let failure) = AccountCommand.classify(enabling: true, exitCode: 2, stderr: "")
+        else { return XCTFail("a non-zero exit must classify as failed") }
+        XCTAssertEqual(failure.summary, "enable failed (exit 2): no output")
+        XCTAssertFalse(failure.summary.isEmpty)
     }
 }
 

--- a/apps/macos/Tests/TcrBarTests/ToggleVerdictTests.swift
+++ b/apps/macos/Tests/TcrBarTests/ToggleVerdictTests.swift
@@ -19,6 +19,150 @@ final class ToggleVerdictTests: XCTestCase {
 
     private let alice = "alice@example.com"
 
+    /// `tcr`'s own words on the success path, from the live reproduction: the park
+    /// applied to the running rotation, no config entry matched it, so it comes
+    /// back on restart. Exit code 0.
+    private let notSaved =
+        "[tcr] warning: NOT SAVED: no config entry matches this account "
+        + "— it returns to rotation on restart"
+
+    private func fleet(_ disabled: Bool) -> PollState {
+        .loaded(Fleet(accounts: [account(alice, disabled: disabled)]))
+    }
+
+    // MARK: - the durability arm: exit 0 with output is not a clean success
+
+    /// The measured live defect this arm closes. `tcr disable alice` exited 0, the
+    /// live rotation DID park the account — so the read-back confirms, and every
+    /// signal the row had said success — while stderr said the change is not
+    /// persisted and will be gone on restart. The row stamped `parked ✓`.
+    func testAWarningOnStderrDowngradesAConfirmation() {
+        // The control: the same read-back with nothing on stderr confirms cleanly.
+        // Without this line the test could pass on a verdict that never confirms.
+        XCTAssertEqual(
+            ToggleReadback.verdict(requestedEnabled: false, account: alice, readback: fleet(true)),
+            .confirmed(requestedEnabled: false)
+        )
+
+        let verdict = ToggleReadback.verdict(
+            requestedEnabled: false, account: alice, readback: fleet(true), notice: notSaved)
+
+        XCTAssertEqual(verdict, .spokeUp(notice: notSaved, about: .confirmed(requestedEnabled: false)))
+        XCTAssertNotEqual(verdict, .confirmed(requestedEnabled: false))
+        XCTAssertFalse(verdict.isConfirmation, "exit 0 with output is accepted, not confirmed")
+        XCTAssertFalse(
+            verdict.rowLabel.contains("✓"),
+            "the tick is what an operator scans for; it may not appear on a park that will not survive a restart"
+        )
+        XCTAssertTrue(verdict.rowLabel.contains(notSaved), "tcr's own text, verbatim")
+        XCTAssertEqual(
+            verdict.rowLabel,
+            "the fleet now reports parked — tcr said: \(notSaved)"
+        )
+        XCTAssertTrue(verdict.spokenLabel.contains(notSaved))
+        XCTAssertFalse(
+            verdict.spokenLabel.contains("confirmed"),
+            "the spoken form has to be as qualified as the written one"
+        )
+    }
+
+    /// The downgrade is structural — any output at all — and NOT a phrase match. A
+    /// keyword list would silently pass every warning added to `tcr` after the day
+    /// it was written, which is the same class of defect one level up.
+    func testTheDowngradeIsStructuralNotLexical() {
+        let unheardOf = "an entirely different warning nobody has written yet"
+        XCTAssertEqual(
+            ToggleReadback.verdict(
+                requestedEnabled: true, account: alice, readback: fleet(false), notice: unheardOf),
+            .spokeUp(notice: unheardOf, about: .confirmed(requestedEnabled: true))
+        )
+        // And an empty notice is not output: it must not manufacture the arm.
+        XCTAssertEqual(
+            ToggleReadback.verdict(
+                requestedEnabled: true, account: alice, readback: fleet(false), notice: ""),
+            .confirmed(requestedEnabled: true)
+        )
+    }
+
+    /// The other warning that died at the process boundary: an older proxy with no
+    /// control route, where only the config file changed. Its readback is
+    /// `notHonoured` — the live proxy still reports the old value — and the notice
+    /// is the only place the remedy (`tcr restart`) is named, so it has to survive
+    /// beside the verdict rather than being replaced by it.
+    func testANoticeAndANotHonouredReadbackBothSurvive() {
+        let tooOld =
+            "[tcr] WARNING: the proxy running on :3456 is too old to accept live account "
+            + "control, so only the config file was changed. Run `tcr restart` ..."
+        let verdict = ToggleReadback.verdict(
+            requestedEnabled: false, account: alice, readback: fleet(false), notice: tooOld)
+        XCTAssertEqual(verdict, .spokeUp(notice: tooOld, about: .notHonoured(requestedEnabled: false)))
+        XCTAssertFalse(verdict.isConfirmation)
+        XCTAssertTrue(verdict.rowLabel.contains(tooOld), "the remedy is in tcr's words or nowhere")
+        XCTAssertTrue(
+            verdict.rowLabel.contains("the running proxy still reports rotating"),
+            "and the read-back's own finding is not lost to the notice"
+        )
+    }
+
+    /// A qualified confirmation is not an acknowledgement to be blinked past: it
+    /// lives long enough to read, but it still ages out, because nothing can
+    /// re-verify it and this panel is a live view, not a log.
+    func testANoticeOutlivesACleanConfirmationAndStillExpires() {
+        let now = Date()
+        let recorded = RecordedVerdict(
+            verdict: .spokeUp(notice: notSaved, about: .confirmed(requestedEnabled: false)), at: now)
+        XCTAssertGreaterThan(ToggleReadback.noticeLifetime, ToggleReadback.confirmationLifetime)
+        XCTAssertEqual(
+            ToggleReadback.visible(
+                recorded, reportedDisabled: true,
+                now: now.addingTimeInterval(ToggleReadback.confirmationLifetime + 1)),
+            recorded.verdict,
+            "still on screen when a clean ✓ would already be gone"
+        )
+        XCTAssertNil(
+            ToggleReadback.visible(
+                recorded, reportedDisabled: true,
+                now: now.addingTimeInterval(ToggleReadback.noticeLifetime + 1)))
+        // …and it clears the moment the fleet stops reporting what was asked, for
+        // the same reason a clean confirmation does.
+        XCTAssertNil(
+            ToggleReadback.visible(
+                recorded, reportedDisabled: false, now: now.addingTimeInterval(1)))
+    }
+
+    /// A verdict about an account that LEFT the fleet used to be immortal:
+    /// `reportedDisabled` is `nil`, `nil == !requested` is never true, so the
+    /// clear-on-agreement rule could not fire, and an account that came back an
+    /// hour later dragged the old line onto its row. The rule is now an expiry.
+    func testAnUnresolvedVerdictAboutADepartedAccountExpires() {
+        let now = Date()
+        for verdict: ToggleVerdict in [
+            .notHonoured(requestedEnabled: false),
+            .unverified(requestedEnabled: false, reason: "the fleet no longer lists this account"),
+            .spokeUp(notice: notSaved, about: .notHonoured(requestedEnabled: false)),
+        ] {
+            let recorded = RecordedVerdict(verdict: verdict, at: now)
+            // Fresh, and unresolvable: still said, because the operator who caused
+            // it has to see it at all.
+            XCTAssertEqual(
+                ToggleReadback.visible(
+                    recorded, reportedDisabled: nil, now: now.addingTimeInterval(1)),
+                verdict
+            )
+            let expired = now.addingTimeInterval(ToggleReadback.unresolvedLifetime + 1)
+            XCTAssertNil(
+                ToggleReadback.visible(recorded, reportedDisabled: nil, now: expired),
+                "\(verdict) about a departed account must expire, not wait for agreement"
+            )
+            // The drag: the account returns, rotating, long after a disable was
+            // asked for. Nothing from the old attempt may reappear beside it.
+            XCTAssertNil(
+                ToggleReadback.visible(recorded, reportedDisabled: false, now: expired),
+                "\(verdict) must not come back with the account"
+            )
+        }
+    }
+
     // MARK: - the arm that matters
 
     /// The measured live defect, in one test: the operator asked for `disable`,
@@ -208,6 +352,8 @@ final class ToggleVerdictTests: XCTestCase {
             .notHonoured(requestedEnabled: false),
             .notHonoured(requestedEnabled: true),
             .unverified(requestedEnabled: false, reason: "tcr status failed (exit 1): no output"),
+            .spokeUp(notice: notSaved, about: .confirmed(requestedEnabled: false)),
+            .spokeUp(notice: notSaved, about: .notHonoured(requestedEnabled: false)),
         ]
         for verdict in all {
             XCTAssertFalse(verdict.rowLabel.isEmpty)
@@ -236,6 +382,35 @@ final class ToggleVerdictTests: XCTestCase {
         )
         // A verdict for one account must not surface on another row.
         XCTAssertNil(controller.verdict(for: "bob@example.com", reportedDisabled: false, now: now))
+    }
+
+    /// The whole path the row takes, with the durability warning in it: what the
+    /// controller stores is what the row will draw, and it is not a clean `✓`.
+    @MainActor
+    func testControllerCarriesTheNoticeIntoWhatTheRowDraws() async {
+        let controller = AccountController()
+        let now = Date()
+        controller.record(
+            readback: .loaded(Fleet(accounts: [account(alice, disabled: true)])),
+            requestedEnabled: false,
+            account: alice,
+            notice: notSaved,
+            now: now
+        )
+        let drawn = controller.verdict(for: alice, reportedDisabled: true, now: now)
+        XCTAssertEqual(drawn, .spokeUp(notice: notSaved, about: .confirmed(requestedEnabled: false)))
+        XCTAssertEqual(drawn?.isConfirmation, false)
+        XCTAssertEqual(drawn?.rowLabel.contains("✓"), false)
+        XCTAssertEqual(drawn?.rowLabel.contains(notSaved), true)
+        // The same call with nothing on stderr is the clean case, unchanged.
+        controller.record(
+            readback: .loaded(Fleet(accounts: [account(alice, disabled: true)])),
+            requestedEnabled: false,
+            account: alice,
+            now: now
+        )
+        XCTAssertEqual(
+            controller.verdict(for: alice, reportedDisabled: true, now: now)?.rowLabel, "parked ✓")
     }
 }
 

--- a/apps/macos/scripts/release-tcrbar.sh
+++ b/apps/macos/scripts/release-tcrbar.sh
@@ -503,15 +503,46 @@ main() {
             "  Re-run with --verify-only, or upload by hand once it appears:" \
             "    gh release upload $tag '$dmg' '$appcast_path' --clobber --repo $repo"
       fi
-      [ "$waited" = 0 ] && note "waiting for the tag-triggered Release workflow to create $tag…"
+      # `${tag}`, braced. A bare `$tag` here was followed directly by the UTF-8
+      # ellipsis, and the shell read that character's leading byte as part of the
+      # variable NAME — so under `set -u` this line aborted the whole script with
+      # `tag?: unbound variable`. It fired on the FIRST iteration, i.e. on every
+      # release where the workflow had not finished yet, which is all of them:
+      # v0.2.2 notarized, stapled, signed and wrote its appcast entry, then died
+      # here without uploading anything. Braces around any variable that touches
+      # a non-ASCII character.
+      [ "$waited" = 0 ] && note "waiting for the tag-triggered Release workflow to create ${tag}…"
       sleep 10
       waited=$((waited + 10))
     done
     [ "$waited" -gt 0 ] && note "release appeared after ${waited}s"
 
+    # HIDE the release while it has no appcast, then reveal it once it does.
+    #
+    # Sparkle's feed is `releases/latest/download/appcast.xml`, so "latest" and
+    # "has an appcast" must become true in that order. The tag-triggered workflow
+    # publishes a normal (latest) release carrying only CLI tarballs, which leaves
+    # a window where the feed URL resolves to a release with no appcast.xml — and
+    # GitHub's CDN caches that 404 against the exact URL Sparkle requests. Measured
+    # on v0.2.2: the bare URL returned 404 while the same URL with `?cb=1` returned
+    # 200, for about two minutes, i.e. every installed copy's update check failed
+    # while the release looked fine in the UI.
+    #
+    # Marking it prerelease first keeps "latest" on the previous good release for
+    # the whole upload, so the window never exists.
+    gh release edit "$tag" --prerelease --repo "$repo" >/dev/null \
+      || die "could not mark $tag prerelease before uploading." \
+             "  Uploading anyway would leave the update feed 404ing on a cached miss."
+
     # --clobber so a re-run replaces its assets rather than failing.
     gh release upload "$tag" "$dmg" "$appcast_path" --clobber --repo "$repo" \
       || die "gh release upload failed for $tag."
+
+    # Only now is it safe to be the newest thing Sparkle looks at.
+    gh release edit "$tag" --prerelease=false --latest --repo "$repo" >/dev/null \
+      || die "assets uploaded, but $tag is still marked prerelease — Sparkle will never offer it." \
+             "  Flip it by hand:" \
+             "    gh release edit $tag --prerelease=false --latest --repo $repo"
     note "uploaded to https://github.com/$repo/releases/tag/$tag"
   fi
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,8 @@ struct RemoveArgs {
     /// Path to the config file (default: ~/.config/teamclaude.json).
     #[arg(long)]
     config: Option<PathBuf>,
-    /// Account name (email) or a case-insensitive substring of it.
+    /// Account name, or its bare email if the name carries an org suffix. Exact
+    /// and case-sensitive — not a substring.
     query: String,
     /// Narrow an ambiguous match to a single org (name or uuid).
     #[arg(long)]
@@ -91,7 +92,8 @@ struct PriorityArgs {
     /// Path to the config file (default: ~/.config/teamclaude.json).
     #[arg(long)]
     config: Option<PathBuf>,
-    /// Account name (email) or a case-insensitive substring of it.
+    /// Account name, or its bare email if the name carries an org suffix. Exact
+    /// and case-sensitive — not a substring.
     query: String,
     /// The explicit priority value (lower = preferred). Omit with --first/--last.
     #[arg(conflicts_with_all = ["first", "last"])]
@@ -112,7 +114,8 @@ struct EnableArgs {
     /// Path to the config file (default: ~/.config/teamclaude.json).
     #[arg(long)]
     config: Option<PathBuf>,
-    /// Account name (email) or a case-insensitive substring of it.
+    /// Account name, or its bare email if the name carries an org suffix. Exact
+    /// and case-sensitive — not a substring.
     query: String,
     /// Narrow an ambiguous match to a single org (name or uuid).
     #[arg(long)]
@@ -124,7 +127,8 @@ struct DisableArgs {
     /// Path to the config file (default: ~/.config/teamclaude.json).
     #[arg(long)]
     config: Option<PathBuf>,
-    /// Account name (email) or a case-insensitive substring of it.
+    /// Account name, or its bare email if the name carries an org suffix. Exact
+    /// and case-sensitive — not a substring.
     query: String,
     /// Narrow an ambiguous match to a single org (name or uuid).
     #[arg(long)]

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -278,10 +278,17 @@ impl crate::identity::Queryable for AccountRuntime {
 
 /// What [`Manager::set_disabled_by_query`] did.
 ///
-/// `Applied` carries the RESOLVED name (the caller's query may have been a
-/// substring, and the answer has to name what was actually parked) plus the
-/// durable half's fate, which the caller must surface — see
-/// [`DisablePersist::warning`].
+/// `Applied` carries the RESOLVED name plus the durable half's fate, which the
+/// caller must surface — see [`DisablePersist::warning`].
+///
+/// The name is resolved, not echoed, because the query may have been the account's
+/// bare EMAIL where its stored name carries an org suffix (`me@example.com
+/// (Acme)`) — so the answer has to say what was actually parked. It is NOT a
+/// substring or case-insensitive match: [`crate::identity::match_accounts`] tries
+/// exact name, then exact email, byte-for-byte and untrimmed. Do not "fix"
+/// resolution to match a looser description; a widened rule is how a query
+/// silently parks an account nobody named, which is exactly what the `Ambiguous`
+/// arm below exists to refuse.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SetDisabledOutcome {
     Applied {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -455,10 +455,14 @@ pub const STATUS_PATH: &str = "/_tcr/status";
 /// it benched. The TUI's `d` key was the only correct path, and a `--headless`
 /// proxy has no TUI.
 ///
-/// Under [`LOCAL_PREFIX`] for the reason given there, which matters more for a
-/// mutating verb than for the read next door: registered as a real route it is
-/// matched BEFORE the catch-all, so a `POST` here can never be rewritten onto
-/// api.anthropic.com carrying a pooled OAuth Bearer.
+/// Under [`LOCAL_PREFIX`] for the reason given there — but what protects a
+/// MUTATING verb is not the prefix guard, whose reach is only the exact spelling.
+/// It is that this path is REGISTERED as a real route, so axum matches it exactly
+/// and matches it BEFORE the catch-all: a `POST` here can never be rewritten onto
+/// api.anthropic.com carrying a pooled OAuth Bearer, and a near-miss spelling can
+/// never land ON the handler. What authorizes the mutation itself is
+/// [`local_endpoint_gate`] plus the `application/json` requirement in
+/// [`set_disabled_handler`], neither of which the path shape has any part in.
 pub const DISABLED_PATH: &str = "/_tcr/accounts/disabled";
 
 /// Marks every response produced by the account-control route itself, so a caller
@@ -491,7 +495,21 @@ const CONTROL_BODY_LIMIT: usize = 8 * 1024;
 /// upstream route could ever answer.
 ///
 /// Stored WITHOUT a trailing slash and matched by [`path_is_under`], so the bare
-/// `/_tcr` has no unguarded edge.
+/// `/_tcr` is covered along with everything beneath it — but the guard is a
+/// BYTE-EXACT, case-sensitive compare on the raw request target, and that is the
+/// whole of what it covers. Three spellings a URL parser would fold onto this
+/// prefix are NOT under it and are forwarded upstream (measured): `//_tcr/…`
+/// (empty first segment), `/_TCR/…` (case) and `/%5ftcr/…` (percent-encoded `_`,
+/// which `uri.path()` hands over undecoded).
+///
+/// That is a wart, not a hole, and it is deliberately left alone here: those
+/// spellings reach Anthropic with a pooled Bearer and come back 404 — the
+/// account-burn shape this guard exists to stop, at the cost of one 404 rather
+/// than a mutation. They cannot mutate anything, because the local routes are
+/// matched by their EXACT paths ([`STATUS_PATH`], [`DISABLED_PATH`]) before this
+/// catch-all, so a spelling that misses the prefix misses the routes too. Do not
+/// read this comment as "nothing unguarded gets past" — read it as "what gets past
+/// is a forwarded 404".
 const LOCAL_PREFIX: &str = "/_tcr";
 
 /// Paths whose upstream call must carry the **client's own** credential and which
@@ -617,6 +635,115 @@ fn path_is_ambiguous(path: &str) -> bool {
     path.contains('\\') || path.split('/').any(is_dot_segment)
 }
 
+/// The host this request was ADDRESSED to, or `None` when nothing says.
+///
+/// Absolute-form / forward-proxy request lines carry an authority in the target
+/// itself, which wins; otherwise it is the `Host` header minus any `:port`. `None`
+/// is a real answer, not a failure: an origin-form base-URL request with no `Host`
+/// (every direct-axum caller, and HTTP/1.0) names no host at all.
+///
+/// ONE derivation, shared by the forwarding path's misroute guard and by
+/// [`local_endpoint_gate`], so "which host did the client mean" cannot come out
+/// two different ways on the two paths. Pure — unit-tested.
+fn target_host<'a>(uri: &'a axum::http::Uri, headers: &'a HeaderMap) -> Option<&'a str> {
+    uri.host().or_else(|| {
+        headers
+            .get(HOST)
+            .and_then(|v| v.to_str().ok())
+            .map(strip_port)
+    })
+}
+
+/// `authority` without its `:port`, if it has one.
+///
+/// A bracketed IPv6 literal is why this is not one `rsplit_once(':')`: the last
+/// colon in `[::1]` is INSIDE the address, so splitting on it yields `[:` — a host
+/// that matches nothing, which turned an IPv6 loopback client into a misroute. The
+/// port, when present, always follows the `]`.
+fn strip_port(authority: &str) -> &str {
+    if authority.starts_with('[') {
+        return authority.split_inclusive(']').next().unwrap_or(authority);
+    }
+    authority
+        .rsplit_once(':')
+        .map_or(authority, |(host, _)| host)
+}
+
+/// Is `host` a name for THIS machine's loopback interface?
+///
+/// The `IpAddr::is_loopback` primitive the client-peer checks use, plus the one
+/// name that is loopback without being an IP literal. `[::1]` arrives bracketed in
+/// a `Host` header, and the brackets are not part of the address, so they are
+/// stripped before parsing — without that, the v6 loopback fails a check the v4
+/// one passes. Pure — unit-tested.
+fn host_is_loopback(host: &str) -> bool {
+    let bare = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+    bare.parse::<std::net::IpAddr>()
+        .is_ok_and(|ip| ip.is_loopback())
+        || host.eq_ignore_ascii_case("localhost")
+}
+
+/// Is this `content-type` `application/json`?
+///
+/// The mutating local route's whole browser defence, and the reason it is a
+/// content-type check rather than something cleverer: `text/plain`,
+/// `application/x-www-form-urlencoded` and `multipart/form-data` are the three
+/// CORS **simple** media types, so a cross-origin POST carrying one is sent with
+/// NO preflight. `application/json` is not simple, and this process answers no
+/// `OPTIONS` and emits no `Access-Control-*` header — so requiring it means a
+/// browser's preflight fails and the POST is never sent at all.
+///
+/// Measured on the route as merged (#71), from a loopback peer with no proxy
+/// api-key configured, which is a fresh install: `text/plain` and
+/// `application/x-www-form-urlencoded` both returned **200 and parked a live
+/// account**. That the page cannot read the reply is irrelevant — the entire
+/// payoff of a mutating route IS the side effect.
+///
+/// ABSENT is a refusal too: a request with no `content-type` is simple as well.
+/// Only the media type is compared, case-insensitively — RFC 9110 makes the type
+/// case-insensitive and a `; charset=utf-8` parameter legitimate, and a check that
+/// rejected either would break real callers while closing nothing.
+fn is_json_content_type(headers: &HeaderMap) -> bool {
+    headers
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|value| {
+            value.split(';').next().is_some_and(|media_type| {
+                media_type.trim().eq_ignore_ascii_case("application/json")
+            })
+        })
+}
+
+/// Does this request carry positive evidence that a BROWSER initiated it on
+/// behalf of some other site?
+///
+/// Two independent signals, either of which is disqualifying:
+/// - an `Origin` header. A cross-origin POST always carries one, and this process
+///   serves no HTML, so there is no page whose same-origin `Origin` we would need
+///   to allow — any value at all means a browser context we do not own.
+/// - `Sec-Fetch-Site` anything other than `same-origin` or `none` — the browser
+///   stating the relationship itself. `none` is a user-initiated request (typed
+///   URL, bookmark), not a site's.
+///
+/// A non-browser caller sends neither, so this costs `tcr disable` nothing. It is
+/// deliberately additive to [`is_json_content_type`] rather than a replacement:
+/// the content-type check is what closes the no-preflight class, and this is what
+/// keeps a future local route that is NOT JSON from reopening it. Neither closes
+/// DNS rebinding, where the page is genuinely same-origin — that is
+/// [`host_is_loopback`]'s job.
+fn is_cross_site_request(headers: &HeaderMap) -> bool {
+    if headers.contains_key(axum::http::header::ORIGIN) {
+        return true;
+    }
+    headers
+        .get("sec-fetch-site")
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|site| !matches!(site.trim(), "same-origin" | "none"))
+}
+
 /// Classify a request as one of the rotation-bypassing relays, or `None` for the
 /// normal pooled-credential forwarding path. Takes the path WITHOUT its query, so
 /// a `?…` can never smuggle a path past the match. Pure — unit-tested.
@@ -689,9 +816,27 @@ pub fn app(manager: Arc<Manager>) -> Router {
 ///    the proxy key. Nothing on this host needs to read or steer the fleet without
 ///    the operator's secret, so doing either costs the same secret that using the
 ///    proxy does. The compare is [`key_matches`] (constant-time, length-safe).
+/// 3. **Addressed to us.** The host the request names ([`target_host`]) must be
+///    loopback, or absent. This is the DNS-rebinding check, and it is the only one
+///    of the four that closes it: a page served from a name resolving to 127.0.0.1
+///    is genuinely SAME-ORIGIN with this process, so it sends no `Origin`, needs no
+///    preflight, and may use any content type — the one thing that still gives it
+///    away is the name it addressed us by. It also refuses an absolute-form
+///    (forward-proxy) request line, which is never how a caller reaches a route
+///    that only exists here.
+/// 4. **Not cross-site.** [`is_cross_site_request`] — belt-and-braces for a
+///    browser that did preflight, or a future local route that is not JSON.
+///
+/// Checks 3 and 4 were added after the FIRST mutating route shipped under this
+/// gate: a read that a page cannot read is harmless, but the account-control route
+/// is the first one whose entire payoff is the side effect, and a browser on this
+/// host is a loopback caller. They live here, on the shared gate, rather than on
+/// the mutating handler — see the paragraph above about which copy drifts. What
+/// stays route-local is the `application/json` requirement
+/// ([`is_json_content_type`]), because a GET has no body to type.
 ///
 /// `endpoint` names the route in the 403 body only. It is not a capability: no
-/// value of it weakens either check.
+/// value of it weakens any check.
 fn local_endpoint_gate(
     parts: &axum::http::request::Parts,
     manager: &Manager,
@@ -720,6 +865,34 @@ fn local_endpoint_gate(
                 None,
             ));
         }
+    }
+
+    if let Some(host) = target_host(&parts.uri, &parts.headers) {
+        if !host_is_loopback(host) {
+            tracing::debug!(
+                target_host = %host,
+                endpoint,
+                "refused a tcr endpoint request addressed to a non-loopback host"
+            );
+            return Some(error_response(
+                StatusCode::MISDIRECTED_REQUEST,
+                "invalid_request_error",
+                &format!(
+                    "The tcr {endpoint} endpoint answers only to a loopback host, \
+                     not to '{host}'."
+                ),
+                None,
+            ));
+        }
+    }
+
+    if is_cross_site_request(&parts.headers) {
+        return Some(error_response(
+            StatusCode::FORBIDDEN,
+            "permission_error",
+            &format!("The tcr {endpoint} endpoint does not serve cross-site requests."),
+            None,
+        ));
     }
 
     None
@@ -818,8 +991,14 @@ struct SetDisabledRequest {
 /// read it, and both halves of the wire contract belong to one type.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct SetDisabledResponse {
-    /// The RESOLVED account name. The query may have been an email or a partial,
+    /// The RESOLVED account name. The query may have been the account's bare
+    /// EMAIL where its stored name carries an org suffix (`me@example.com (Acme)`),
     /// so the answer names what was actually parked.
+    ///
+    /// It is NOT a partial or fuzzy match: [`crate::identity::match_accounts`] is
+    /// exact name, then exact email, byte-for-byte, case-sensitive and untrimmed.
+    /// Measured against a fleet holding `alice@example.com`: `alice`, `alice@`,
+    /// `example`, `ALICE@EXAMPLE.COM` and a trailing space are each a 404.
     pub name: String,
     /// The state now in force in the live rotation.
     pub disabled: bool,
@@ -852,6 +1031,22 @@ async fn set_disabled_handler(State(manager): State<Arc<Manager>>, req: Request)
         // that failed the gate, and the CLI never needs the discriminator on a
         // 401/403 — both are terminal for it.
         return refusal;
+    }
+
+    // The browser gate. `application/json` is not a CORS simple media type, so
+    // requiring it forces a preflight this process never answers — see
+    // [`is_json_content_type`] for the four shapes that reached this handler and
+    // parked a live account before the check existed. Stamped, unlike the gate's
+    // refusals above: this is a request-shape error like the 400s below it, and the
+    // CLI reads the stamp to tell a route that answered from a tcr too old to have
+    // one.
+    if !is_json_content_type(&parts.headers) {
+        return stamp_endpoint(error_response(
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "invalid_request_error",
+            "The tcr account-control endpoint requires Content-Type: application/json.",
+            None,
+        ));
     }
 
     let Ok(bytes) = to_bytes(body, CONTROL_BODY_LIMIT).await else {
@@ -995,7 +1190,10 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
     //     a proxy-private path onto api.anthropic.com WITH A POOLED OAUTH BEARER
     //     attached: that is how a typo'd status probe once put Gil's bearer on
     //     `api.anthropic.com/_tcr/status` and burned an account. [`path_is_under`]
-    //     covers the bare `/_tcr` too, so the prefix has no unguarded edge.
+    //     covers the bare `/_tcr` too — but only as SPELLED: the compare is
+    //     byte-exact and case-sensitive, so `//_tcr/…`, `/_TCR/…` and `/%5ftcr/…`
+    //     miss it and are forwarded (measured). See [`LOCAL_PREFIX`] for why that is
+    //     a forwarded 404 rather than a hole, and why it is left as it is.
     if path_is_under(&path, LOCAL_PREFIX) {
         return error_response(
             StatusCode::NOT_FOUND,
@@ -1025,21 +1223,13 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
     //     direct-axum test harness) the guard is skipped — fail OPEN for the
     //     ambiguous local case, closed only for a host we can positively identify
     //     as neither loopback nor Anthropic.
-    let target_host: Option<&str> = parts.uri.host().or_else(|| {
-        req_headers
-            .get(HOST)
-            .and_then(|v| v.to_str().ok())
-            .map(|h| h.rsplit_once(':').map_or(h, |(host, _)| host))
-    });
-    if let Some(host) = target_host {
-        // Loopback (base-URL mode) reuses the `IpAddr::is_loopback` primitive the
-        // client-peer check uses above; `localhost` is not an IP literal so it is
-        // matched by name. `rsplit_once` mirrors the crate's CONNECT-target split.
-        let is_loopback = host
-            .parse::<std::net::IpAddr>()
-            .is_ok_and(|ip| ip.is_loopback())
-            || host == "localhost";
-        if !is_loopback && !crate::mitm::host_allowed(host) {
+    let target = target_host(&parts.uri, &req_headers);
+    if let Some(host) = target {
+        // [`host_is_loopback`] (base-URL mode) reuses the `IpAddr::is_loopback`
+        // primitive the client-peer check uses above, and the same derivation the
+        // local-endpoint gate runs — one answer to "which host did the client
+        // mean", on both paths.
+        if !host_is_loopback(host) && !crate::mitm::host_allowed(host) {
             tracing::debug!(target_host = %host, "rejected misrouted forward-proxy request");
             return error_response(
                 StatusCode::MISDIRECTED_REQUEST,
@@ -3808,6 +3998,451 @@ mod tests {
             );
             std::fs::remove_file(&path).ok();
         }
+    }
+
+    /// Drive the control route with FULL control over the request line and every
+    /// header, so a BROWSER-shaped or forward-proxy-shaped request is testable as
+    /// it would actually arrive. [`control_request`] always sends
+    /// `content-type: application/json` on an origin-form target — which is
+    /// precisely the one shape that was never the attack.
+    ///
+    /// The peer is always loopback and no proxy api-key is configured, because that
+    /// is the population this class applies to: [`crate::config`] defaults
+    /// `api_key: None` and nothing generates one, so on a fresh install loopback is
+    /// the whole gate. With a key configured the route is closed by the key check
+    /// (see [`control_endpoint_rejects_a_bad_api_key`]) — requiring a header also
+    /// makes the request non-simple, so a browser never sends it at all.
+    async fn control_request_shaped(
+        manager: Arc<Manager>,
+        uri: &str,
+        headers: &[(&str, &str)],
+        body: &str,
+    ) -> (StatusCode, HeaderMap, Bytes) {
+        use tower::ServiceExt as _;
+        let mut builder = Request::builder().method(Method::POST).uri(uri);
+        for (name, value) in headers {
+            builder = builder.header(*name, *value);
+        }
+        let mut req = builder
+            .body(Body::from(body.to_string()))
+            .expect("build request");
+        req.extensions_mut().insert(ClientAddr(loopback_peer()));
+        let response = app(manager).oneshot(req).await.expect("router response");
+        let status = response.status();
+        let response_headers = response.headers().clone();
+        let bytes = to_bytes(response.into_body(), MAX_BODY_BYTES)
+            .await
+            .expect("read body");
+        (status, response_headers, bytes)
+    }
+
+    /// One row of a request-SHAPE table: what it is, the request target, the
+    /// headers, and the status it must come back with.
+    type ShapeCase<'a> = (&'a str, &'a str, Vec<(&'a str, &'a str)>, StatusCode);
+    /// A row of a table every case of which must be SERVED, so there is no status
+    /// column to get wrong.
+    type ServedCase<'a> = (&'a str, &'a str, Vec<(&'a str, &'a str)>);
+    /// A row that varies only in its headers — the target is fixed.
+    type HeaderCase<'a> = (&'a str, Vec<(&'a str, &'a str)>, StatusCode);
+
+    /// THE CSRF TABLE — the biting test for this change. Every row is a request a
+    /// WEB PAGE open in a browser on this host can actually cause, and each of the
+    /// first four **returned 200 and parked a live account** before these checks
+    /// existed (measured on the route as merged in #71).
+    ///
+    /// Why a browser can send them at all: `text/plain`,
+    /// `application/x-www-form-urlencoded` and `multipart/form-data` are the three
+    /// CORS **simple** content types, so a cross-origin `fetch`/form POST carrying
+    /// one is sent with NO preflight. The page cannot read the reply — this proxy
+    /// emits no `Access-Control-*` header — which is irrelevant: the entire payoff
+    /// of this route IS the side effect, so write-only is the whole attack. The
+    /// read route next door was immune by being a read; this class arrives with the
+    /// FIRST mutating route, and the loopback gate's own doc-comment already argues
+    /// that bind scope is not authorization. The browser is the caller it failed to
+    /// enumerate.
+    ///
+    /// The rebound `Host` row is the DNS-rebinding shape and the reason a
+    /// content-type check alone is not enough: a page served from a name that
+    /// resolves to 127.0.0.1 is SAME-ORIGIN with the proxy, so it sends no `Origin`,
+    /// triggers no preflight, and may use any content type it likes. The only thing
+    /// that distinguishes it from a real local caller is the name it addressed us
+    /// by.
+    ///
+    /// The assertion that bites is the in-memory one: a handler that answers 415
+    /// politely and parks the account anyway passes a status-only check.
+    #[tokio::test]
+    async fn control_endpoint_refuses_every_browser_reachable_shape() {
+        let json = r#"{"query":"alice@example.com","disabled":true}"#;
+        let absolute_form = format!("http://api.anthropic.com{DISABLED_PATH}");
+        let cases: Vec<ShapeCase> = vec![
+            (
+                "a text/plain body — a CORS simple request, so no preflight",
+                DISABLED_PATH,
+                vec![("content-type", "text/plain;charset=UTF-8")],
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            ),
+            (
+                "an x-www-form-urlencoded body — simple too, and what a bare \
+                 <form> posts",
+                DISABLED_PATH,
+                vec![("content-type", "application/x-www-form-urlencoded")],
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            ),
+            (
+                "a multipart/form-data body — the third simple type",
+                DISABLED_PATH,
+                vec![("content-type", "multipart/form-data; boundary=x")],
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            ),
+            (
+                "no content-type at all — absent is simple as well",
+                DISABLED_PATH,
+                vec![],
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            ),
+            (
+                "a rebound Host — a name that resolves to 127.0.0.1, so the page \
+                 is same-origin and sends nothing that marks it cross-site",
+                DISABLED_PATH,
+                vec![
+                    ("content-type", "application/json"),
+                    ("host", "rebound.example.com"),
+                ],
+                StatusCode::MISDIRECTED_REQUEST,
+            ),
+            (
+                "an absolute-form request line naming anthropic — a forward-proxy \
+                 request, never something addressed to this route",
+                &absolute_form,
+                vec![("content-type", "application/json")],
+                StatusCode::MISDIRECTED_REQUEST,
+            ),
+            (
+                "a cross-origin fetch that DID preflight (a future route may not \
+                 be JSON, so the Origin is refused on its own merits)",
+                DISABLED_PATH,
+                vec![
+                    ("content-type", "application/json"),
+                    ("origin", "https://evil.example.com"),
+                ],
+                StatusCode::FORBIDDEN,
+            ),
+            (
+                "Sec-Fetch-Site: cross-site — the browser saying so itself",
+                DISABLED_PATH,
+                vec![
+                    ("content-type", "application/json"),
+                    ("sec-fetch-site", "cross-site"),
+                ],
+                StatusCode::FORBIDDEN,
+            ),
+            (
+                "Sec-Fetch-Site: same-site — a sibling subdomain is not us",
+                DISABLED_PATH,
+                vec![
+                    ("content-type", "application/json"),
+                    ("sec-fetch-site", "same-site"),
+                ],
+                StatusCode::FORBIDDEN,
+            ),
+        ];
+
+        for (label, uri, headers, expected) in cases {
+            let (manager, path) = control_manager("csrf", None);
+            let (status, _headers, body) =
+                control_request_shaped(Arc::clone(&manager), uri, &headers, json).await;
+            assert_eq!(
+                status,
+                expected,
+                "{label}: expected {expected}, got {status}: {}",
+                String::from_utf8_lossy(&body)
+            );
+            // THE assertion. A refusal that still mutates is the same defect one
+            // altitude up, and a status-only table would not see it.
+            assert!(
+                !manager.snapshot(OffsetDateTime::now_utc()).accounts[0].disabled,
+                "{label}: a refused request changed the LIVE rotation"
+            );
+            assert_eq!(
+                disabled_in_file(&path, 0),
+                None,
+                "{label}: a refused request wrote the config"
+            );
+            std::fs::remove_file(&path).ok();
+        }
+    }
+
+    /// The other direction, so the checks above cannot be satisfied by refusing
+    /// everything: every shape a LEGITIMATE local caller emits is still served and
+    /// still mutates. `tcr disable` builds its request with reqwest's `.json()`
+    /// against `http://127.0.0.1:<port>` (`cli.rs`), which is row 1.
+    #[tokio::test]
+    async fn control_endpoint_still_serves_every_legitimate_local_shape() {
+        let json = r#"{"query":"alice@example.com","disabled":true}"#;
+        let loopback_form = format!("http://127.0.0.1:3456{DISABLED_PATH}");
+        let cases: Vec<ServedCase> = vec![
+            (
+                "what `tcr disable` sends: reqwest .json() to a loopback literal",
+                DISABLED_PATH,
+                vec![
+                    ("content-type", "application/json"),
+                    ("host", "127.0.0.1:3456"),
+                ],
+            ),
+            (
+                "a charset parameter on the media type — RFC 9110 legitimate",
+                DISABLED_PATH,
+                vec![("content-type", "application/json; charset=utf-8")],
+            ),
+            (
+                "an upper-case media type — the type is case-insensitive",
+                DISABLED_PATH,
+                vec![("content-type", "Application/JSON")],
+            ),
+            (
+                "Host: localhost — loopback by name, not by literal",
+                DISABLED_PATH,
+                vec![
+                    ("content-type", "application/json"),
+                    ("host", "localhost:3456"),
+                ],
+            ),
+            (
+                "Host: [::1] — the v6 loopback literal, port stripped like the \
+                 forwarding path's own host guard does",
+                DISABLED_PATH,
+                vec![("content-type", "application/json"), ("host", "[::1]:3456")],
+            ),
+            (
+                "no Host header at all — an origin-form base-URL request, which is \
+                 also every direct-axum caller",
+                DISABLED_PATH,
+                vec![("content-type", "application/json")],
+            ),
+            (
+                "an absolute-form loopback target — the authority is still ours",
+                &loopback_form,
+                vec![("content-type", "application/json")],
+            ),
+            (
+                "Sec-Fetch-Site: same-origin",
+                DISABLED_PATH,
+                vec![
+                    ("content-type", "application/json"),
+                    ("sec-fetch-site", "same-origin"),
+                ],
+            ),
+            (
+                "Sec-Fetch-Site: none — a user-initiated request, not a site's",
+                DISABLED_PATH,
+                vec![
+                    ("content-type", "application/json"),
+                    ("sec-fetch-site", "none"),
+                ],
+            ),
+        ];
+
+        for (label, uri, headers) in cases {
+            let (manager, path) = control_manager("legit", None);
+            let (status, headers, body) =
+                control_request_shaped(Arc::clone(&manager), uri, &headers, json).await;
+            assert_eq!(
+                status,
+                StatusCode::OK,
+                "{label}: {}",
+                String::from_utf8_lossy(&body)
+            );
+            assert_eq!(
+                headers.get(ENDPOINT_HEADER).and_then(|v| v.to_str().ok()),
+                Some(DISABLED_ENDPOINT),
+                "{label}: the route still stamps itself"
+            );
+            assert!(
+                manager.snapshot(OffsetDateTime::now_utc()).accounts[0].disabled,
+                "{label}: a served request must still reach the LIVE rotation"
+            );
+            assert_eq!(
+                disabled_in_file(&path, 0),
+                Some(serde_json::json!(true)),
+                "{label}: and the durable half"
+            );
+            std::fs::remove_file(&path).ok();
+        }
+    }
+
+    /// The READ route is deliberately NOT content-type gated (a GET has no body to
+    /// type), and this pins that: the shapes the mutating route now refuses with a
+    /// 415 are served here, unchanged. Changing it would buy nothing — the route is
+    /// side-effect-free and a page cannot read its reply — and would break `tcr
+    /// status`, which sends no content-type on a GET.
+    ///
+    /// The cross-site and host checks DO apply, because they live in the shared
+    /// [`local_endpoint_gate`]: one implementation for both routes, per that
+    /// function's own reasoning about which copy of a duplicated gate drifts.
+    #[tokio::test]
+    async fn status_endpoint_is_not_content_type_gated_but_is_cross_site_gated() {
+        use tower::ServiceExt as _;
+        let served = [
+            ("no content-type — what `tcr status` actually sends", vec![]),
+            (
+                "a text/plain content-type on a GET",
+                vec![("content-type", "text/plain")],
+            ),
+        ];
+        let refused: [HeaderCase; 3] = [
+            (
+                "a cross-origin Origin",
+                vec![("origin", "https://evil.example.com")],
+                StatusCode::FORBIDDEN,
+            ),
+            (
+                "Sec-Fetch-Site: cross-site",
+                vec![("sec-fetch-site", "cross-site")],
+                StatusCode::FORBIDDEN,
+            ),
+            (
+                "a rebound Host",
+                vec![("host", "rebound.example.com")],
+                StatusCode::MISDIRECTED_REQUEST,
+            ),
+        ];
+
+        let probe_status = |headers: Vec<(&'static str, &'static str)>| async move {
+            let manager = Manager::with_live_refresher(two_account_config(None), None);
+            let mut builder = Request::builder().method(Method::GET).uri(STATUS_PATH);
+            for (name, value) in &headers {
+                builder = builder.header(*name, *value);
+            }
+            let mut req = builder.body(Body::empty()).expect("build request");
+            req.extensions_mut().insert(ClientAddr(loopback_peer()));
+            app(manager)
+                .oneshot(req)
+                .await
+                .expect("router response")
+                .status()
+        };
+
+        for (label, headers) in served {
+            assert_eq!(probe_status(headers).await, StatusCode::OK, "{label}");
+        }
+        for (label, headers, expected) in refused {
+            assert_eq!(probe_status(headers).await, expected, "{label}");
+        }
+    }
+
+    /// The three new pure helpers, in isolation — the negatives are the point.
+    #[test]
+    fn local_gate_helpers_classify_their_edges() {
+        // A loopback name is any 127/8 address, the v6 loopback bracketed or bare,
+        // and `localhost` in any case. Nothing else, including the addresses a
+        // rebound page would be served from.
+        for host in [
+            "127.0.0.1",
+            "127.0.0.53",
+            "::1",
+            "[::1]",
+            "localhost",
+            "LocalHost",
+        ] {
+            assert!(host_is_loopback(host), "{host} is loopback");
+        }
+        for host in [
+            "rebound.example.com",
+            "api.anthropic.com",
+            "169.254.169.254",
+            "0.0.0.0",
+            "192.168.1.10",
+            "localhost.evil.example.com",
+            "",
+        ] {
+            assert!(!host_is_loopback(host), "{host} is NOT loopback");
+        }
+
+        let with = |name: &str, value: &str| {
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                axum::http::HeaderName::from_bytes(name.as_bytes()).expect("header name"),
+                HeaderValue::from_str(value).expect("header value"),
+            );
+            headers
+        };
+
+        // Only `application/json`, parameters and case allowed; ABSENT is a no.
+        for value in [
+            "application/json",
+            "Application/JSON",
+            "application/json; charset=utf-8",
+            "application/json;charset=UTF-8",
+        ] {
+            assert!(
+                is_json_content_type(&with("content-type", value)),
+                "{value} is json"
+            );
+        }
+        for value in [
+            "text/plain",
+            "text/plain;charset=UTF-8",
+            "application/x-www-form-urlencoded",
+            "multipart/form-data; boundary=x",
+            "application/json-patch+json",
+            "application/jsonx",
+            "",
+        ] {
+            assert!(
+                !is_json_content_type(&with("content-type", value)),
+                "{value} is NOT json"
+            );
+        }
+        assert!(
+            !is_json_content_type(&HeaderMap::new()),
+            "no content-type at all is a CORS simple request too"
+        );
+
+        // Cross-site: any Origin, or a Sec-Fetch-Site that is not ours.
+        assert!(is_cross_site_request(&with(
+            "origin",
+            "https://evil.example.com"
+        )));
+        assert!(is_cross_site_request(&with("origin", "null")));
+        assert!(is_cross_site_request(&with("sec-fetch-site", "cross-site")));
+        assert!(is_cross_site_request(&with("sec-fetch-site", "same-site")));
+        assert!(!is_cross_site_request(&with(
+            "sec-fetch-site",
+            "same-origin"
+        )));
+        assert!(!is_cross_site_request(&with("sec-fetch-site", "none")));
+        assert!(
+            !is_cross_site_request(&HeaderMap::new()),
+            "a non-browser caller sends neither header, and must not be refused"
+        );
+
+        // The authority in an absolute-form target WINS over the Host header, and
+        // an origin-form request with no Host names no host at all.
+        let absolute: axum::http::Uri =
+            "http://api.anthropic.com/_tcr/status".parse().expect("uri");
+        assert_eq!(
+            target_host(&absolute, &with("host", "127.0.0.1:3456")),
+            Some("api.anthropic.com"),
+            "the request line is what the client asked for"
+        );
+        let origin_form: axum::http::Uri = "/_tcr/status".parse().expect("uri");
+        assert_eq!(
+            target_host(&origin_form, &with("host", "localhost:3456")),
+            Some("localhost"),
+            "the port is stripped"
+        );
+        assert_eq!(
+            target_host(&origin_form, &with("host", "[::1]:3456")),
+            Some("[::1]"),
+            "…and a bracketed v6 literal survives it, brackets included"
+        );
+        assert_eq!(
+            target_host(&origin_form, &with("host", "[::1]")),
+            Some("[::1]"),
+            "a v6 literal with NO port keeps every colon: splitting on the last \
+             one yields '[:' and misroutes an IPv6 loopback client"
+        );
+        assert_eq!(target_host(&origin_form, &HeaderMap::new()), None);
     }
 
     // --- rotation-bypassing relays -----------------------------------------


### PR DESCRIPTION
Follow-up to #71, which added `POST /_tcr/accounts/disabled` so a running proxy can be told to park an account. Three defects in that change, plus the two on the release path that stopped v0.2.2 from ever publishing.

## The mutating route was reachable from a browser on this host

`serde_json::from_slice` with no content-type check meant `text/plain`, `multipart/form-data` and `application/x-www-form-urlencoded` all worked — and those are CORS **simple requests**, so a page open in a browser here could POST cross-origin and park an account with no preflight. It could not read the reply, which is irrelevant: the mutation had already landed. The pre-existing status route was immune by being a read — side-effect-free and unreadable cross-origin. This was the first route whose entire payoff is the side effect, and it inherited a gate written for a reader.

Three checks now, and the split is deliberate. `Content-Type: application/json` is required on the mutating route only (415 otherwise), which forces a preflight for anything a browser originates. A present `Origin`, or a `Sec-Fetch-Site` that is not `same-origin`/`none`, is refused (403). And the `Host` must be loopback (421), because the first two do **not** close DNS rebinding: a page served from a name that resolves to 127.0.0.1 is genuinely same-origin with the proxy, sends no `Origin`, needs no preflight, and may use any content type — the name it addressed us by is the only thing that gives it away. The host and cross-site arms live in the shared gate, per that gate's own argument about which copy of a duplicated check drifts; the read route's content-type behaviour is untouched.

Nine attack shapes are pinned by tests, each asserting that the live rotation **and** the config file are unchanged — a handler that answers 415 politely and parks the account anyway passes a status-only assertion. A second table of nine legitimate local shapes asserts they are still served *and still mutate*, so the checks cannot be satisfied by refusing everything.

Extracting the host parse also fixed a latent bug in `handle`: `Host: [::1]` split on its last colon yields the host `[:`, so an IPv6 loopback client was misrouted.

## The panel could stamp a tick on a change that would not survive a restart

The server already reports `persisted: false` with `NOT SAVED: … it returns to rotation on restart`, and the CLI prints it to stderr while still exiting 0. `AccountCommand.classify` opened with `guard exitCode != 0`, and the success path read neither stream — so the durability half died at the process boundary and the row rendered `parked ✓` for a change the next restart would undo. The same boundary swallowed the warning that names the remedy when the running proxy is too old for the route.

The rule is now structural: **a zero exit with output on stderr is not a clean success.** The text is rendered verbatim beside the outcome, with no tick, and the downgrade wraps the read-back verdict rather than replacing it, so the remedy survives next to a not-honoured row too. Nothing compares stderr to a phrase — a test feeds a warning string that does not exist anywhere in the tree, so the check cannot decay into keyword matching.

## Comments that lied

Three surfaces claimed the account query is a case-insensitive substring match. It is exact name, then the email parsed out of it, case-sensitive and untrimmed. This mattered because two of those surfaces *reasoned from* the false premise to explain why a wrong-account toggle would be visible — so a reader who "fixed" resolution to match the comment would have reintroduced exactly the wrong-account mutation the ambiguity arm exists to refuse. Also corrected: the claim that the `/_tcr` prefix has no unguarded edge. `//_tcr/…`, `/_TCR/…` and `/%5ftcr/…` miss the byte-exact compare and are forwarded; they cannot mutate, because the local routes match on exact path, and saying so is not the same as claiming the prefix is airtight.

## Why v0.2.2 exists but was never published

Its DMG was built, notarized, stapled and signed, and then the release script aborted before uploading: a bare `$tag` directly followed by a UTF-8 ellipsis, so the shell read that character's leading byte as part of the variable name and `set -u` killed the script on the wait loop's first iteration — which is every release whose workflow has not finished yet.

Separately, the upload ran against a release the workflow had already published as *latest*, so between the tag push and the upload `releases/latest/download/appcast.xml` resolved to a release with no appcast, and the CDN cached that 404 against the exact URL Sparkle requests. Measured: the bare URL returned 404 while the same URL with a query string returned 200, for about two minutes. The upload is now bracketed by prerelease → upload → latest, so that window cannot exist.

The v0.2.2 release is marked prerelease and carries no DMG, so the update feed stayed on v0.2.1 throughout. 0.2.3 is the version that ships any of this.
