### PR TITLE
fix: make claude.ai connectors work through the proxy

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -326,8 +326,11 @@ fn run_claude(args: RunArgs) -> anyhow::Result<()> {
     cmd.args(&args.args);
 
     if cli::proxy_is_up(port) {
-        if let Some(key) = config.proxy.api_key.as_deref() {
-            cmd.env("ANTHROPIC_API_KEY", key);
+        if let Some(notice) = withheld_api_key_notice(
+            config.proxy.api_key.is_some(),
+            std::env::var_os("ANTHROPIC_API_KEY").is_some(),
+        ) {
+            eprintln!("{notice}");
         }
         // Two ways to route claude at ourselves, and they are NOT equivalent to
         // Claude Code — see `apply_see_through_env` for why we prefer the first.
@@ -379,6 +382,29 @@ fn see_through_ca() -> Option<PathBuf> {
             None
         }
     }
+}
+
+/// Why `tcr run` does NOT hand the configured proxy key to `claude` as
+/// `ANTHROPIC_API_KEY`, and says so.
+///
+/// It used to. Setting that variable makes Claude Code treat an API key as its auth
+/// source AHEAD of the claude.ai login, and that **disables every claude.ai
+/// connector** — announced once, in one startup line that scrolls away, after which
+/// the tools are simply absent. It bought nothing in exchange: the `x-api-key` gate
+/// exempts loopback clients (see `proxy::handle`), and the server binds 127.0.0.1
+/// only, so a `tcr run` child is always exempt. Measured with the variable absent:
+/// `/v1/messages` served and rotated across accounts, and every connector loaded.
+///
+/// A value the CALLER exported is inherited untouched — an explicit choice wins, and
+/// it is the escape hatch for a `claude` with no claude.ai login of its own, which
+/// does need some credential to start.
+fn withheld_api_key_notice(configured: bool, caller_set: bool) -> Option<&'static str> {
+    (configured && !caller_set).then_some(
+        "[tcr] not exporting ANTHROPIC_API_KEY from proxy.apiKey: it would outrank claude's \
+         claude.ai login and disable every claude.ai connector. The proxy does not need it — \
+         its api-key gate exempts loopback clients. Export it yourself if this `claude` has no \
+         claude.ai login of its own.",
+    )
 }
 
 /// SEE-THROUGH mode — the preferred route. `claude` keeps the REAL first-party
@@ -938,6 +964,57 @@ mod tests {
     fn silent() -> cli::Liveness {
         cli::Liveness::Silent {
             why: "the server did not answer within 5s".to_string(),
+        }
+    }
+
+    /// Pins that a configured proxy key is withheld from `claude`, and says why.
+    #[test]
+    fn the_proxy_key_is_withheld_from_claude_with_the_reason() {
+        let notice = withheld_api_key_notice(true, false).expect("a configured key is withheld");
+        assert!(
+            notice.contains("connector"),
+            "the notice must name what exporting it costs: {notice}"
+        );
+        assert!(
+            notice.contains("Export it yourself"),
+            "the notice must name the escape hatch: {notice}"
+        );
+
+        assert_eq!(
+            withheld_api_key_notice(false, false),
+            None,
+            "nothing is withheld when no proxy key is configured"
+        );
+        assert_eq!(
+            withheld_api_key_notice(true, true),
+            None,
+            "a key the caller exported is their choice — we neither replace it nor comment"
+        );
+    }
+
+    /// Neither routing mode may hand `claude` an `ANTHROPIC_API_KEY`.
+    #[test]
+    fn no_routing_mode_gives_claude_an_api_key() {
+        for (label, apply) in [
+            (
+                "see-through",
+                &(|cmd: &mut std::process::Command| {
+                    apply_see_through_env(cmd, 3456, Path::new("/tmp/ca.pem"))
+                }) as &dyn Fn(&mut std::process::Command),
+            ),
+            (
+                "base-URL",
+                &(|cmd: &mut std::process::Command| apply_base_url_env(cmd, 3456)),
+            ),
+        ] {
+            let mut cmd = std::process::Command::new("claude");
+            apply(&mut cmd);
+            assert!(
+                !cmd.get_envs()
+                    .any(|(k, v)| k == "ANTHROPIC_API_KEY" && v.is_some()),
+                "{label} mode must not set ANTHROPIC_API_KEY — it outranks the claude.ai \
+                 login and disables every claude.ai connector"
+            );
         }
     }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -525,17 +525,30 @@ const LOCAL_PREFIX: &str = "/_tcr";
 ///   file uploaded from claude.ai belongs to the paired identity, so fetching it
 ///   with a pooled token 403s and **Claude Code silently drops the image from the
 ///   message** — nothing surfaces the failure, the turn just loses its attachment.
+/// - `/v1/mcp_servers` is the claude.ai connector list. The ids it returns are scoped
+///   to the identity that asked, and the MCP traffic that follows them goes to
+///   `mcp-proxy.anthropic.com` — a host the CONNECT path blind-tunnels, so it carries
+///   the CLIENT's own token. A pooled list therefore hands the client ids its own
+///   identity cannot resolve.
 ///
 /// Measured on the live log while every one of these still went through rotation:
 /// 13 of 57 sessionless requests came back 404 (22.8%), against 0 of 1556 pinned ones.
+/// The connector list was measured the same way, one `claude mcp list` per pooled
+/// account: served by the wrong one, all 9 connectors reported
+/// `not_found_error: "Server not found"`; served by the client's own identity, every
+/// one connected. That is why this reads as intermittent — it tracks rotation.
 ///
 /// Written WITHOUT trailing slashes and matched by [`path_is_under`] — an entry
 /// matches the exact path or that path followed by `/`, never a longer identifier.
 /// Both edges of a raw `starts_with` were live defects: `"/api/oauth/file_upload"`
 /// (no terminator) also relayed `/api/oauth/file_upload_v2`, and `"/v1/code/"`
 /// (with one) missed the bare `/v1/code`.
-const CLIENT_CREDENTIAL_PREFIXES: [&str; 3] =
-    ["/v1/code", "/api/oauth/files", "/api/oauth/file_upload"];
+const CLIENT_CREDENTIAL_PREFIXES: [&str; 4] = [
+    "/v1/code",
+    "/api/oauth/files",
+    "/api/oauth/file_upload",
+    "/v1/mcp_servers",
+];
 
 /// The CLIENT's own OAuth token refresh. Relayed raw — no auth header at all,
 /// because a refresh carries its credentials in the BODY. The proxy manages its own
@@ -4574,6 +4587,7 @@ mod tests {
             "/v1/code/session/abc",
             "/api/oauth/files/file_0123",
             "/api/oauth/file_upload",
+            "/v1/mcp_servers",
         ] {
             assert_eq!(
                 relay_mode(&Method::POST, path),
@@ -4611,7 +4625,12 @@ mod tests {
     #[test]
     fn relay_mode_matches_whole_segments_at_both_edges() {
         // Bare, with no trailing slash: a real route, previously missed by `/v1/code/`.
-        for path in ["/v1/code", "/api/oauth/files", "/api/oauth/file_upload"] {
+        for path in [
+            "/v1/code",
+            "/api/oauth/files",
+            "/api/oauth/file_upload",
+            "/v1/mcp_servers",
+        ] {
             assert_eq!(
                 relay_mode(&Method::POST, path),
                 Some(RelayMode::ClientCredential),
@@ -4647,6 +4666,30 @@ mod tests {
             None,
             "a longer identifier is not the token endpoint"
         );
+    }
+
+    /// Pins the claude.ai connector list onto the client's own credential.
+    #[test]
+    fn the_connector_list_never_takes_a_pooled_token() {
+        for method in [Method::GET, Method::POST] {
+            assert_eq!(
+                relay_mode(&method, "/v1/mcp_servers"),
+                Some(RelayMode::ClientCredential),
+                "{method} /v1/mcp_servers must not be re-credentialled"
+            );
+        }
+        assert_eq!(
+            relay_mode(&Method::GET, "/v1/mcp_servers/srv_0123"),
+            Some(RelayMode::ClientCredential),
+            "one connector is the same route as the collection"
+        );
+        for path in ["/v1/mcp_servers_v2", "/v1/mcp_serversX"] {
+            assert_eq!(
+                relay_mode(&Method::GET, path),
+                None,
+                "{path} only shares a prefix — it is not the route"
+            );
+        }
     }
 
     /// `path_is_under` in isolation — the single rule every prefix decision uses.
@@ -4733,11 +4776,13 @@ mod tests {
     #[tokio::test]
     async fn client_credential_paths_forward_the_clients_own_credential() {
         let (upstream, hits) = spawn_echo_upstream().await;
-        for path in [
+        let paths = [
             "/v1/code/session/abc",
             "/api/oauth/files/file_0123",
             "/api/oauth/file_upload",
-        ] {
+            "/v1/mcp_servers",
+        ];
+        for path in paths {
             let manager = Manager::with_live_refresher(dummy_config(None, &upstream), None);
             let (status, body) = drive(
                 manager,
@@ -4765,7 +4810,11 @@ mod tests {
                 "{path} must never carry the pooled account token"
             );
         }
-        assert_eq!(hits.load(std::sync::atomic::Ordering::SeqCst), 3);
+        assert_eq!(
+            hits.load(std::sync::atomic::Ordering::SeqCst),
+            paths.len(),
+            "one upstream hit per relayed path"
+        );
     }
 
     /// The proxy's own gate credential never leaves this process. An `x-api-key`


### PR DESCRIPTION
Two independent defects, both of which had to go for a single claude.ai connector
to work through `tcr`. Either one alone leaves them broken, so they ship together.

## 1. The connector list took a pooled credential

```
Reconnected to claude.ai Linear, but fetching tools failed: Streamable HTTP error:
Error POSTing to endpoint: {"type":"error","error":{"type":"not_found_error",
"message":"Server not found"}, ...}
```

Two legs of one feature were taking different identities:

| Leg | Host | How tcr treats it | Credential |
|---|---|---|---|
| connector list | `api.anthropic.com/v1/mcp_servers` | MITM-terminated, rotated | **pooled account** |
| MCP traffic | `mcp-proxy.anthropic.com` | blind-tunnelled (not in `ALLOWED_HOSTS`) | **client's own** |

The list returns connector ids scoped to the identity that asked. The traffic that
follows those ids authenticates as the client. When the pooled account is not the
client's own identity the ids resolve for nobody, and every connector reports
`not_found_error: "Server not found"`. It reads as intermittent because it tracks
rotation — it works whenever the list happens to be served by the account that is
also the client's login.

Measured, one `claude mcp list` per pooled account through the same proxy:

| `/v1/mcp_servers` served by | Result |
|---|---|
| account A | all 9 connectors `not_found_error: "Server not found"` |
| account B | all connected |
| no proxy (control) | all connected |

Same command, same build; only the account on the list request differs.

**Change:** `/v1/mcp_servers` joins `CLIENT_CREDENTIAL_PREFIXES`, so it relays on the
client's own credential and spends nothing the rotation owns. Same class as `/v1/code`
and `/api/oauth/files` already in that list, and the same 404 signature the constant's
doc-comment already records. The `mcp-proxy.anthropic.com` leg needs no change — it
was already right.

## 2. `tcr run` disabled the connectors outright

With `proxy.apiKey` configured, `tcr run` exported it as `ANTHROPIC_API_KEY`. Claude
Code then takes an API key as its auth source ahead of the claude.ai login and turns
every claude.ai connector off:

```
⚠ claude.ai connectors are disabled because ANTHROPIC_API_KEY or another auth source
  is set and takes precedence over your claude.ai login
```

It is announced once, in a startup line that scrolls away, after which the tools are
simply absent — so fix 1 was unreachable from `tcr run` at all; reproducing it needed
the see-through env minus that key.

The export bought nothing: the `x-api-key` gate exempts loopback clients and the
server binds `127.0.0.1` only, so a `tcr run` child was always exempt. It carried no
doc-comment and no test, and dates to the initial commit.

**Change:** stop exporting it, and print why. A value the caller exported is still
inherited untouched — an explicit choice wins, and that is the escape hatch for a
`claude` with no claude.ai login of its own, which does need some credential to start.
That is the one behaviour trade-off here: such a setup now sees a login prompt plus a
line naming the fix, instead of silently losing every connector.

## Verification

- Both new tests were watched **failing first**, each for its intended reason, with all
  pre-existing tests still green — then restored and re-run.
- 595 tests, `cargo fmt --check`, `clippy --all-targets -D warnings` all clean.
- Live, fix 1: `relayed response path=/v1/mcp_servers?limit=1000 mode=ClientCredential
  status=200`, no account serving it, every connector connected on three consecutive runs.
- Live, fix 2: `/v1/messages` served and rotated normally with no `ANTHROPIC_API_KEY`, in
  **both** routing modes (see-through and base-URL).
- Live, together: `tcr run -- mcp list` — no disabled-connector warning, every connector
  connected.

Known gap: no test asserts that `run_claude` itself never sets `ANTHROPIC_API_KEY`, since
it builds a `Command` and spawns it. `no_routing_mode_gives_claude_an_api_key` covers the
two env-appliers, and the notice test covers the decision.