### PR TITLE
Add an account to a running proxy, without restarting it

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -116,17 +116,18 @@ Runs the browser OAuth flow and adds the resulting account to the pool.
 | flag | type | default | effect |
 |---|---|---|---|
 | `--config <path>` | path | `~/.config/teamclaude.json` | config to write into |
-| `--force` | bool | `false` | skip the live proxy entirely and write the config file |
+| `--force` | bool | `false` | override a refusal and write the config file anyway — never overrides a confirmed live route or a rejected api-key |
 
 **A running proxy no longer has to be stopped.** Before opening the browser, `tcr login`
 asks the proxy on the configured port whether it can take an account live, by POSTing a
-deliberately-invalid body to `/_tcr/accounts` and reading the reply. What happens next
-depends only on that answer:
+deliberately-invalid body to `/_tcr/accounts` and reading the reply — always, even with
+`--force`. What happens next depends on that answer:
 
 | the proxy on the port | what login does |
 |---|---|
-| answers, and has the route | hands the account to the **running** proxy; it joins rotation immediately and the proxy writes the config itself |
-| answers, but has no such route (an older `tcr`) | refuses, exactly as it always did |
+| answers, and has the route | hands the account to the **running** proxy; it joins rotation immediately and the proxy writes the config itself — wins even under `--force` |
+| answers, but rejects the configured api-key | refuses outright — `--force` does not override this |
+| answers, but has no such route (an older `tcr`), or answers unusably (wedged or timed out) | refuses, unless `--force`, which writes the config file instead |
 | nothing listening | writes the config file, exactly as it always did |
 
 The live path is the one worth having. Restarting the proxy to pick up a new account
@@ -147,11 +148,16 @@ server, run `tcr login`, then start it again. If the pid belongs to a host appli
 the proxy in-process (TcrBar), it says so and tells you to quit the application rather than
 kill the pid: killing it skips shutdown and loses the pin map.
 
-`--force` **skips the probe and writes the config file**, even when the running proxy would
-have accepted the account safely. That makes it the unsafe path rather than the way around a
-blocked one, and you almost certainly do not want it: the login succeeds and the running
-server's next refresh can overwrite it. It remains only as an escape hatch for a proxy that
-answers but misbehaves. Detection is read-only throughout; the server is never signalled.
+`--force` **overrides a refusal**, not the probe: the probe still runs, and still wins when it
+confirms a safe path. It never overrides a confirmed live route — that path is already safe,
+so there is nothing to force. It never overrides a rejected api-key either: a rejection is
+proof the proxy is alive and answering, which makes it the worst-informed moment to write the
+config file beside it — fix `proxy.apiKey` to match the running server, or stop it and log in
+offline, instead. Where `--force` *does* apply — no route on the port (an older `tcr`), or an
+unusable answer (wedged or timed out) — it makes the unsafe path available anyway: the login
+succeeds and the running server's next refresh can overwrite it. It remains only as an escape
+hatch for a proxy that answers but misbehaves. Detection is read-only throughout; the server is
+never signalled.
 
 The callback server binds a random loopback port, and tokens are never printed or logged.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -111,26 +111,47 @@ credential to start. The process exits with `claude`'s own exit code.
 
 ## `tcr login`
 
-Runs the browser OAuth flow and writes the resulting account into the config.
+Runs the browser OAuth flow and adds the resulting account to the pool.
 
 | flag | type | default | effect |
 |---|---|---|---|
 | `--config <path>` | path | `~/.config/teamclaude.json` | config to write into |
-| `--force` | bool | `false` | log in even while a proxy holds the port |
+| `--force` | bool | `false` | skip the live proxy entirely and write the config file |
 
-**It refuses while a proxy is running on the configured port.** The refusal is not caution:
-the server reads the config at boot and its next token refresh writes its *boot-time* tokens
-back over the file, silently clobbering the ones a fresh login just wrote, observed live.
-The message names the port, the pid, and the ordered remedy: stop the server, run
-`tcr login`, then start it again.
+**A running proxy no longer has to be stopped.** Before opening the browser, `tcr login`
+asks the proxy on the configured port whether it can take an account live, by POSTing a
+deliberately-invalid body to `/_tcr/accounts` and reading the reply. What happens next
+depends only on that answer:
 
-If the pid it names belongs to a host application serving the proxy in-process (TcrBar), the
-message says so and tells you to quit the application rather than kill the pid. Killing it
-skips shutdown and loses the session pin map.
+| the proxy on the port | what login does |
+|---|---|
+| answers, and has the route | hands the account to the **running** proxy; it joins rotation immediately and the proxy writes the config itself |
+| answers, but has no such route (an older `tcr`) | refuses, exactly as it always did |
+| nothing listening | writes the config file, exactly as it always did |
 
-`--force` is the deliberate escape hatch, and it is genuinely unsafe: the login succeeds and
-then the running server's next refresh overwrites it. Detection is read-only either way; the
-server is never signalled.
+The live path is the one worth having. Restarting the proxy to pick up a new account
+discards the session→account pin map, so every live session cold-starts its prompt cache on
+its next turn — the most expensive event in this system. Adding an account live costs none of
+that. It also removes a second hazard: when the CLI writes the file itself while a proxy is
+running, the two can interleave, and because Anthropic's refresh tokens are single-use, a
+reverted write is not recoverable by retrying. On the live path only one process writes.
+
+Logging in again as an account already in the pool is the same operation — its credentials
+are replaced in place, and it keeps its position, its priority and its learned quota.
+
+**The refusal still exists, and still means what it said.** Against a proxy too old to have
+the route, the original hazard is real: that server reads the config at boot and its next
+token refresh writes its *boot-time* tokens back over the file, silently clobbering a fresh
+login (observed live). The message names the port, the pid, and the ordered remedy — stop the
+server, run `tcr login`, then start it again. If the pid belongs to a host application serving
+the proxy in-process (TcrBar), it says so and tells you to quit the application rather than
+kill the pid: killing it skips shutdown and loses the pin map.
+
+`--force` **skips the probe and writes the config file**, even when the running proxy would
+have accepted the account safely. That makes it the unsafe path rather than the way around a
+blocked one, and you almost certainly do not want it: the login succeeds and the running
+server's next refresh can overwrite it. It remains only as an escape hatch for a proxy that
+answers but misbehaves. Detection is read-only throughout; the server is never signalled.
 
 The callback server binds a random loopback port, and tokens are never printed or logged.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -53,8 +53,18 @@ upstream for a local fault.
 
 ## `tcr login` refuses to run
 
-A proxy is holding the port and its next token refresh would overwrite what the login
-writes. Stop it, log in, start it again, or use `--force`.
+A running proxy on its own no longer causes this — `tcr login` adds the account to a live
+proxy without stopping it. The refusal means the proxy holding the port is an **older build
+without the `/_tcr/accounts` route**, and against that build the original hazard is real: it
+reads the config at boot and its next token refresh writes its boot-time tokens back over the
+file, silently clobbering the fresh login.
+
+Update the running proxy and log in again, or stop it, log in, and start it again. `--force`
+also gets past it, but it skips the live path and writes the file, which is the unsafe
+behaviour this refusal exists to prevent — reach for it last, not first.
+
+If the pid named belongs to TcrBar, quit the application rather than killing the pid: killing
+it skips shutdown and loses the session pin map.
 
 ## `tcr ui` or a TcrBar update will not replace the app
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,7 +25,7 @@ use anyhow::{bail, Context as _};
 use time::OffsetDateTime;
 
 use crate::build_info::{self, BuildInfo};
-use crate::config::{self, Config};
+use crate::config::{self, Account, Config};
 use crate::identity;
 use crate::manager::Manager;
 use crate::oauth::{NoRefresh, TokenRefresher};
@@ -318,8 +318,12 @@ fn write_disabled_flag(
 /// write the config (`Unauthorized`), one writes it quietly (`NoServer`), and the
 /// rest write it and shout. Collapsing them is how a half-applied disable becomes
 /// invisible again.
+///
+/// `pub(crate)`: [`crate::oauth`]'s live-login half reuses this exact enum for
+/// [`post_add_account`] rather than defining a parallel one — see that
+/// function's doc-comment.
 #[derive(Debug)]
-enum LiveControlError {
+pub(crate) enum LiveControlError {
     /// Nothing is listening on the configured port. No live rotation exists, so
     /// the file IS the whole truth — the ordinary offline case.
     NoServer,
@@ -340,7 +344,7 @@ enum LiveControlError {
 }
 
 impl LiveControlError {
-    fn why(&self) -> String {
+    pub(crate) fn why(&self) -> String {
         match self {
             LiveControlError::NoServer => "nothing is listening".to_string(),
             LiveControlError::NoRoute => {
@@ -422,6 +426,94 @@ async fn post_set_disabled(
         return Err(LiveControlError::NoRoute);
     }
     if from_route && matches!(status.as_u16(), 404 | 409) {
+        return Err(LiveControlError::Rejected(
+            error_message_of(&body).unwrap_or_else(|| format!("HTTP {status}")),
+        ));
+    }
+    Err(LiveControlError::Unusable(format!("HTTP {status}")))
+}
+
+/// Ask the running proxy to add an account to the live rotation, or — when the
+/// submitted identity already matches one — replace its credentials in place.
+/// No restart, so no session pin is invalidated. Mirrors [`post_set_disabled`]:
+/// same `no_proxy()` client (`HTTP_PROXY` commonly points AT tcr), same
+/// timeouts, same api-key header — the control route has no loopback
+/// exemption either.
+///
+/// `account` is POSTed directly as the request body: [`config::Account`]
+/// already serializes to the exact wire shape
+/// [`crate::proxy::ADD_ACCOUNT_PATH`] expects (see that route's
+/// `AddAccountRequest` doc-comment), so a caller builds the credential once —
+/// for a real login, or [`crate::oauth::probe_add_capability`]'s deliberately
+/// blank probe — and this function never re-lists its fields.
+///
+/// Reuses [`LiveControlError`] rather than a parallel enum, extended with one
+/// more structural case [`post_set_disabled`] never needs: a `400` FROM the
+/// route (stamped) is this route's own request-validation failure — e.g. a
+/// blank name or token — and is exactly as much a "the route said no" signal
+/// as the `404`/`409` [`post_set_disabled`] already treats that way. The
+/// [`crate::proxy::ENDPOINT_HEADER`] stamp remains the only thing that
+/// decides "no such route" vs "the route said no" — never error text.
+pub(crate) async fn post_add_account(
+    config: &Config,
+    account: &Account,
+) -> Result<crate::proxy::AddAccountResponse, LiveControlError> {
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .connect_timeout(Duration::from_secs(2))
+        .timeout(Duration::from_secs(5))
+        .build()
+        .map_err(|e| LiveControlError::Unusable(format!("http client: {e}")))?;
+
+    let url = format!(
+        "http://127.0.0.1:{}{}",
+        config.proxy.port,
+        crate::proxy::ADD_ACCOUNT_PATH
+    );
+    let mut request = client.post(&url).json(account);
+    if let Some(key) = config.proxy.api_key.as_deref() {
+        request = request.header("x-api-key", key);
+    }
+
+    let response = match request.send().await {
+        Ok(r) => r,
+        Err(e) if e.is_connect() => return Err(LiveControlError::NoServer),
+        Err(e) if e.is_timeout() => {
+            return Err(LiveControlError::NoAnswer(
+                "the server did not answer within 5s".to_string(),
+            ))
+        }
+        Err(e) => return Err(LiveControlError::NoAnswer(e.to_string())),
+    };
+
+    let status = response.status();
+    // Same structural discriminator `post_set_disabled` uses: whether THIS
+    // route produced the answer, decided by the header, never by status code
+    // or error text alone.
+    let from_route = response
+        .headers()
+        .get(crate::proxy::ENDPOINT_HEADER)
+        .and_then(|v| v.to_str().ok())
+        == Some(crate::proxy::ADD_ACCOUNT_ENDPOINT);
+    let body = response.text().await.unwrap_or_default();
+
+    if status.is_success() {
+        return serde_json::from_str(&body).map_err(|e| {
+            LiveControlError::Unusable(format!(
+                "the response was not a tcr account-add payload ({e})"
+            ))
+        });
+    }
+    if status.as_u16() == 401 {
+        return Err(LiveControlError::Unauthorized);
+    }
+    if !from_route && matches!(status.as_u16(), 404 | 405) {
+        return Err(LiveControlError::NoRoute);
+    }
+    // 400: the route's own request validation (blank name/token) — the
+    // positive capability signal `probe_add_capability` looks for. 409: the
+    // submitted identity matched more than one live account.
+    if from_route && matches!(status.as_u16(), 400 | 409) {
         return Err(LiveControlError::Rejected(
             error_message_of(&body).unwrap_or_else(|| format!("HTTP {status}")),
         ));
@@ -1447,6 +1539,179 @@ mod tests {
             "a refused command leaves the config byte-identical"
         );
         fs::remove_file(&path).ok();
+    }
+
+    // --- post_add_account ---------------------------------------------------
+
+    /// A minimal valid live server config: the port, no accounts, no api-key.
+    fn add_route_config(port: u16) -> Config {
+        serde_json::from_str(&format!(r#"{{ "proxy": {{ "port": {port} }} }}"#)).unwrap()
+    }
+
+    /// A blank credential — the deliberately-invalid probe body — always
+    /// rejected by [`crate::proxy::add_account_handler`]'s own validation, so
+    /// this can never add a real account.
+    fn blank_account() -> Account {
+        Account {
+            name: String::new(),
+            account_type: "oauth".to_string(),
+            account_uuid: None,
+            org_uuid: None,
+            org_name: None,
+            access_token: String::new(),
+            refresh_token: None,
+            expires_at: None,
+            priority: None,
+            switch_threshold: None,
+            disabled: None,
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn post_add_account_reads_a_stamped_400_as_rejected() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let config = add_route_config(port);
+        let manager = Manager::with_live_refresher(config.clone(), None);
+        tokio::spawn(async move { crate::mitm::serve(listener, manager, None).await });
+
+        let err = post_add_account(&config, &blank_account())
+            .await
+            .expect_err("a blank name/token must be refused by the route's own validation");
+        assert!(
+            matches!(err, LiveControlError::Rejected(ref msg) if msg.contains("required")),
+            "a stamped 400 is a structural Rejected, not a guess from status alone: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn post_add_account_unstamped_404_is_no_route() {
+        // An "older tcr": something answers, but not on this route — no
+        // `ENDPOINT_HEADER`, unlike every response this crate's own router
+        // produces (even its 404s and 405s).
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, axum::Router::new()).await;
+        });
+        let config = add_route_config(port);
+
+        let err = post_add_account(&config, &blank_account())
+            .await
+            .expect_err("nothing is registered at this path");
+        assert!(
+            matches!(err, LiveControlError::NoRoute),
+            "an unstamped 404 must read as NoRoute, never Rejected: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn post_add_account_wrong_api_key_is_unauthorized() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server_config: Config = serde_json::from_str(&format!(
+            r#"{{ "proxy": {{ "port": {port}, "apiKey": "correct-key" }} }}"#
+        ))
+        .unwrap();
+        let manager = Manager::with_live_refresher(server_config, None);
+        tokio::spawn(async move { crate::mitm::serve(listener, manager, None).await });
+
+        let client_config: Config = serde_json::from_str(&format!(
+            r#"{{ "proxy": {{ "port": {port}, "apiKey": "wrong-key" }} }}"#
+        ))
+        .unwrap();
+        let err = post_add_account(&client_config, &blank_account())
+            .await
+            .expect_err("a wrong api-key must be refused");
+        assert!(
+            matches!(err, LiveControlError::Unauthorized),
+            "must surface as Unauthorized, never NoRoute: {err:?}"
+        );
+    }
+
+    /// THE ROUND TRIP: a real account, POSTed to a real live server, lands in
+    /// the SERVING rotation — not just in the response body.
+    #[tokio::test]
+    async fn post_add_account_adds_a_new_account_to_the_live_rotation() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let config = add_route_config(port);
+        let manager = Manager::with_live_refresher(config.clone(), None);
+        let served = Arc::clone(&manager);
+        tokio::spawn(async move { crate::mitm::serve(listener, served, None).await });
+
+        let account = Account {
+            name: "new@example.com".to_string(),
+            account_type: "oauth".to_string(),
+            account_uuid: None,
+            org_uuid: None,
+            org_name: None,
+            access_token: "at-new".to_string(),
+            refresh_token: Some("rt-new".to_string()),
+            expires_at: Some(1_893_456_000_000),
+            priority: None,
+            switch_threshold: None,
+            disabled: None,
+            extra: serde_json::Map::new(),
+        };
+        let applied = post_add_account(&config, &account)
+            .await
+            .expect("a fresh identity must be added, not rejected");
+        assert!(
+            applied.added,
+            "a nonexistent identity is ADDED: {applied:?}"
+        );
+        assert_eq!(applied.name, "new@example.com");
+
+        let live = manager.snapshot(OffsetDateTime::now_utc());
+        assert!(
+            live.accounts.iter().any(|a| a.name == "new@example.com"),
+            "the account must be in the SERVING rotation, not just the response"
+        );
+    }
+
+    /// An ambiguous identity is refused by the route, structurally — never
+    /// guessed onto one of the candidates.
+    #[tokio::test]
+    async fn post_add_account_ambiguous_identity_is_rejected_not_guessed() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        // Two live accounts share a name and neither carries an org — the
+        // legacy shape `same_identity`/`match_one` cannot break a tie on.
+        let seed = format!(
+            r#"{{ "proxy": {{ "port": {port} }}, "accounts": [
+                {{ "name": "dup@example.com", "type": "oauth", "accessToken": "at-1",
+                  "refreshToken": "rt-1", "priority": 0 }},
+                {{ "name": "dup@example.com", "type": "oauth", "accessToken": "at-2",
+                  "refreshToken": "rt-2", "priority": 1 }}
+            ] }}"#
+        );
+        let config: Config = serde_json::from_str(&seed).unwrap();
+        let manager = Manager::with_live_refresher(config.clone(), None);
+        tokio::spawn(async move { crate::mitm::serve(listener, manager, None).await });
+
+        let account = Account {
+            name: "dup@example.com".to_string(),
+            account_type: "oauth".to_string(),
+            account_uuid: None,
+            org_uuid: None,
+            org_name: None,
+            access_token: "at-new".to_string(),
+            refresh_token: Some("rt-new".to_string()),
+            expires_at: None,
+            priority: None,
+            switch_threshold: None,
+            disabled: None,
+            extra: serde_json::Map::new(),
+        };
+        let err = post_add_account(&config, &account)
+            .await
+            .expect_err("an ambiguous identity must be refused, not guessed");
+        assert!(
+            matches!(err, LiveControlError::Rejected(ref msg) if msg.contains("ambiguous")),
+            "{err:?}"
+        );
     }
 
     // --- resolve_account ---------------------------------------------------

--- a/src/config.rs
+++ b/src/config.rs
@@ -1127,6 +1127,157 @@ fn find_account_entry<'a>(
         .ok_or(DisabledWrite::NoEntry)
 }
 
+/// What a targeted [`save_account`] upsert did to the on-disk document.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccountWrite {
+    /// No entry on disk carried this identity — a new one was appended, holding
+    /// every field `account` carries (identity, credentials, and routing knobs).
+    Added,
+    /// Exactly one entry carried this identity — its CREDENTIAL fields
+    /// (`accessToken` / `refreshToken` / `expiresAt`) were updated in place,
+    /// `type` was stamped to `account.account_type` unconditionally, and any
+    /// of `accountUuid` / `orgUuid` / `orgName` the entry was MISSING got
+    /// backfilled from `account` (never overwriting a value already present —
+    /// this is what permanently stops a legacy no-org entry from loosely
+    /// matching every org variant of that person forever). `priority`,
+    /// `disabled`, `switchThreshold`, and any unmodelled `extra` key are
+    /// untouched, exactly as [`merge_tokens`] leaves them.
+    Updated,
+    /// More than one on-disk entry carries this identity; nothing was written.
+    /// Same refusal as [`DisabledWrite::Ambiguous`], for the same reason: a
+    /// write here would have to guess which entry to overwrite.
+    Ambiguous,
+    /// The document has an `accounts` key that exists but is not a JSON array —
+    /// too corrupt a shape to append into blindly. Nothing was written.
+    Unwritable,
+}
+
+impl std::fmt::Display for AccountWrite {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Added => "added",
+            Self::Updated => "updated",
+            Self::Ambiguous => "more than one entry on disk carries this identity",
+            Self::Unwritable => "the accounts key is not an array",
+        })
+    }
+}
+
+/// Insert-or-replace, by identity, the ONE `accounts` entry matching `account` —
+/// the durable half of live account-add (`POST /_tcr/accounts`,
+/// [`crate::manager::Manager::add_or_update_account`]).
+///
+/// Sibling of [`save_disabled`], and it shares its whole shape: read the raw
+/// document, mutate ONLY what needs to change, write back atomically only if
+/// something did. It differs from `save_disabled` in exactly one place — a MISS
+/// is not a refusal here. `save_disabled` refuses on [`DisabledWrite::NoEntry`]
+/// because its `target` is an identity-only probe with no real credential to
+/// write ([`crate::identity::probe`] leaves `access_token` empty); appending it
+/// would create a useless entry. `account` here is always a COMPLETE record —
+/// either a brand-new login or an existing account's own identity with fresh
+/// credentials merged in (`Manager::persist_replaced`) — so a miss is filled in
+/// rather than refused. That is also why `find_account_entry` (which returns
+/// only the refuse-on-miss `DisabledWrite`) is not reused directly here; this
+/// calls the lower-level [`locate_account_entry`] it is itself built on, so both
+/// functions still run the identical resolution scan.
+///
+/// An identity matching MORE than one on-disk entry still refuses: guessing
+/// which one to overwrite risks stamping fresh credentials over a DIFFERENT
+/// account's single-use refresh token — exactly the failure `find_account_entry`
+/// exists to rule out.
+pub fn save_account(path: &Path, account: &Account) -> Result<AccountWrite, ConfigError> {
+    let mut doc = read_document(path)?;
+    let outcome = merge_account(&mut doc, account)?;
+    if matches!(outcome, AccountWrite::Added | AccountWrite::Updated) {
+        write_atomic(path, &serde_json::to_string_pretty(&doc)?)?;
+    }
+    Ok(outcome)
+}
+
+/// Insert-or-replace `account` by identity in `doc`. See [`save_account`].
+fn merge_account(
+    doc: &mut Map<String, Value>,
+    account: &Account,
+) -> Result<AccountWrite, ConfigError> {
+    match locate_account_entry(doc, account) {
+        EntryMatch::Many => Ok(AccountWrite::Ambiguous),
+        EntryMatch::One(index) => {
+            // Proven present by the immutable scan `locate_account_entry` just
+            // ran; this chain cannot miss in practice, but a save must never
+            // silently drop a credential if it somehow does.
+            if let Some(entry) = doc
+                .get_mut("accounts")
+                .and_then(Value::as_array_mut)
+                .and_then(|entries| entries.get_mut(index))
+                .and_then(Value::as_object_mut)
+            {
+                let credentials = Credentials {
+                    access_token: &account.access_token,
+                    refresh_token: account.refresh_token.as_deref(),
+                    expires_at: account.expires_at,
+                };
+                if let Value::Object(fields) = serde_json::to_value(&credentials)? {
+                    entry.extend(fields);
+                }
+                // `type` always wins — `save_account` is only ever called with a
+                // real credential, so a stale stored type (e.g. an API-key row
+                // re-added as OAuth) is corrected here; leaving it wrong is a
+                // silent death (`refresh_plan` skips any account whose type is
+                // not `"oauth"`).
+                //
+                // Identity fields are BACKFILLED — written only where the entry
+                // does not already carry a value, never overwriting one that is
+                // present. `locate_account_entry` may have matched loosely (the
+                // org-unknown tolerance), so this is what turns a legacy no-org
+                // entry into a fully-known one: the NEXT submission for a
+                // genuinely different org of the same person then requires an
+                // exact match instead of tolerating the still-unknown org key,
+                // closing the split-brain trigger for good rather than only
+                // for this one write.
+                entry.insert(
+                    "type".to_string(),
+                    Value::String(account.account_type.clone()),
+                );
+                let present = |entry: &Map<String, Value>, key: &str| matches!(entry.get(key), Some(Value::String(s)) if !s.is_empty());
+                if !present(entry, "accountUuid") {
+                    if let Some(uuid) = &account.account_uuid {
+                        entry.insert("accountUuid".to_string(), Value::String(uuid.clone()));
+                    }
+                }
+                if !present(entry, "orgUuid") {
+                    if let Some(uuid) = &account.org_uuid {
+                        entry.insert("orgUuid".to_string(), Value::String(uuid.clone()));
+                    }
+                }
+                if !present(entry, "orgName") {
+                    if let Some(name) = &account.org_name {
+                        entry.insert("orgName".to_string(), Value::String(name.clone()));
+                    }
+                }
+            }
+            Ok(AccountWrite::Updated)
+        }
+        EntryMatch::None => {
+            // Distinguished from "no `accounts` key at all" (fine — create it)
+            // so a document where `accounts` is present but the wrong JSON type
+            // is never silently overwritten with a fresh single-element array.
+            if matches!(doc.get("accounts"), Some(v) if !v.is_array()) {
+                return Ok(AccountWrite::Unwritable);
+            }
+            let entries = doc
+                .entry("accounts".to_string())
+                .or_insert_with(|| Value::Array(Vec::new()));
+            let Value::Array(entries) = entries else {
+                // Unreachable given the check above, but never index into a
+                // shape that was not actually verified to be an array.
+                return Ok(AccountWrite::Unwritable);
+            };
+            entries.push(serde_json::to_value(account)?);
+            Ok(AccountWrite::Added)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2393,6 +2544,155 @@ mod tests {
         assert_eq!(
             fs::metadata(&path).unwrap().permissions().mode() & 0o777,
             0o600
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    // --- save_account (the durable half of live account-add) ----------------
+
+    /// A full, valid account record — the shape `Manager::add_or_update_account`
+    /// always hands `save_account`, whether it is a brand-new login or an
+    /// existing account's own identity with fresh credentials merged in.
+    fn full_account(name: &str, access_token: &str) -> Account {
+        Account {
+            name: name.to_string(),
+            account_type: "oauth".to_string(),
+            account_uuid: None,
+            org_uuid: None,
+            org_name: None,
+            access_token: access_token.to_string(),
+            refresh_token: Some(format!("rt-{access_token}")),
+            expires_at: Some(1_800_000_000_000),
+            priority: Some(2),
+            switch_threshold: None,
+            disabled: None,
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    /// A miss appends a brand-new entry carrying every field, and leaves the
+    /// rest of the document untouched.
+    #[test]
+    fn save_account_appends_a_new_identity() {
+        let path = tmp_path("add-append");
+        fs::write(&path, DISABLE_SAMPLE).unwrap();
+
+        assert_eq!(
+            save_account(&path, &full_account("carol@example.com", "at-carol")).unwrap(),
+            AccountWrite::Added
+        );
+
+        let after = read_json(&path);
+        let accounts = after["accounts"].as_array().expect("accounts array");
+        assert_eq!(accounts.len(), 3, "appended, not replacing anything");
+        assert_eq!(accounts[2]["name"], json!("carol@example.com"));
+        assert_eq!(accounts[2]["accessToken"], json!("at-carol"));
+        assert_eq!(accounts[2]["refreshToken"], json!("rt-at-carol"));
+        assert_eq!(accounts[2]["priority"], json!(2));
+        // The pre-existing rows and unmodelled top-level keys are untouched.
+        assert_eq!(accounts[0]["name"], json!("acct-a"));
+        assert_eq!(accounts[1]["name"], json!("acct-b"));
+        assert_eq!(after["warmupSeconds"], json!(900));
+        fs::remove_file(&path).ok();
+    }
+
+    /// A hit replaces ONLY the credential triple on the matching entry — name,
+    /// type, and every unmodelled key (here `models`) survive untouched, exactly
+    /// as `merge_tokens` leaves them.
+    #[test]
+    fn save_account_updates_an_existing_identity_in_place() {
+        let path = tmp_path("add-update");
+        fs::write(&path, DISABLE_SAMPLE).unwrap();
+
+        let fresh = Account {
+            expires_at: Some(999),
+            priority: Some(99), // deliberately different — must NOT land on disk
+            ..full_account("acct-a", "at-a-fresh")
+        };
+        assert_eq!(save_account(&path, &fresh).unwrap(), AccountWrite::Updated);
+
+        let after = read_json(&path);
+        let accounts = after["accounts"].as_array().expect("accounts array");
+        assert_eq!(accounts.len(), 2, "no duplicate row");
+        assert_eq!(accounts[0]["name"], json!("acct-a"), "identity untouched");
+        assert_eq!(accounts[0]["accessToken"], json!("at-a-fresh"));
+        assert_eq!(accounts[0]["refreshToken"], json!("rt-at-a-fresh"));
+        assert_eq!(accounts[0]["expiresAt"], json!(999));
+        assert!(
+            accounts[0].get("priority").is_none(),
+            "priority was never on this entry and the update must not add it: {after}"
+        );
+        assert_eq!(
+            accounts[0]["models"],
+            json!(["claude-fable-5"]),
+            "an unmodelled per-account key survives the credential-only merge"
+        );
+        // The account we did NOT name keeps its own credentials.
+        assert_eq!(accounts[1]["accessToken"], json!("at-b"));
+        fs::remove_file(&path).ok();
+    }
+
+    /// An identity matching more than one on-disk entry refuses rather than
+    /// guesses which one to overwrite — same posture as `save_disabled`.
+    #[test]
+    fn save_account_refuses_an_ambiguous_identity() {
+        const TWINS: &str = r#"{
+          "accounts": [
+            { "name": "dup@example.com", "type": "oauth", "accessToken": "at-1" },
+            { "name": "dup@example.com", "type": "oauth", "accessToken": "at-2" }
+          ]
+        }"#;
+        let path = tmp_path("add-ambiguous");
+        fs::write(&path, TWINS).unwrap();
+
+        assert_eq!(
+            save_account(&path, &full_account("dup@example.com", "at-new")).unwrap(),
+            AccountWrite::Ambiguous
+        );
+
+        let after = read_json(&path);
+        assert_eq!(after["accounts"][0]["accessToken"], json!("at-1"));
+        assert_eq!(after["accounts"][1]["accessToken"], json!("at-2"));
+        fs::remove_file(&path).ok();
+    }
+
+    /// A miss on a document with NO `accounts` key at all still succeeds — the
+    /// key is created — because (unlike `save_disabled`'s target) `account` here
+    /// is always a complete, real record worth creating a home for.
+    #[test]
+    fn save_account_creates_the_accounts_array_when_absent() {
+        let path = tmp_path("add-no-accounts-key");
+        fs::write(&path, r#"{"warmupSeconds": 900}"#).unwrap();
+
+        assert_eq!(
+            save_account(&path, &full_account("carol@example.com", "at-carol")).unwrap(),
+            AccountWrite::Added
+        );
+
+        let after = read_json(&path);
+        assert_eq!(after["accounts"][0]["name"], json!("carol@example.com"));
+        assert_eq!(after["warmupSeconds"], json!(900));
+        fs::remove_file(&path).ok();
+    }
+
+    /// An `accounts` key that is present but NOT an array is too corrupt a shape
+    /// to append into blindly — refused, and the document is left byte-identical.
+    #[test]
+    fn save_account_refuses_when_accounts_key_is_not_an_array() {
+        const MALFORMED: &str = r#"{"accounts": "not-an-array"}"#;
+        let path = tmp_path("add-not-array");
+        fs::write(&path, MALFORMED).unwrap();
+
+        assert_eq!(
+            save_account(&path, &full_account("carol@example.com", "at-carol")).unwrap(),
+            AccountWrite::Unwritable
+        );
+
+        let after: Value = serde_json::from_str(MALFORMED).unwrap();
+        assert_eq!(
+            read_json(&path),
+            after,
+            "an unwritable shape is left untouched"
         );
         fs::remove_file(&path).ok();
     }

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -9,8 +9,10 @@
 //! run loop unchanged; nothing here is ever exercised by the serving path.
 
 use std::io;
+use std::sync::Arc;
 
 use time::{Duration, OffsetDateTime};
+use tokio::sync::Mutex as AsyncMutex;
 
 use crate::manager::{AccountRuntime, AccountStatus, Manager};
 use crate::probe::ProbeStatus;
@@ -75,6 +77,7 @@ fn base(name: &str, priority: i64) -> AccountRuntime {
         probe_error: None,
         stream_error_times_ms: std::collections::VecDeque::new(),
         last_stream_error: None,
+        refresh_lock: Arc::new(AsyncMutex::new(())),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,9 +157,13 @@ struct LoginArgs {
     /// Path to the config file (default: ~/.config/teamclaude.json).
     #[arg(long)]
     config: Option<PathBuf>,
-    /// Log in even when a proxy server is already running on the configured port.
-    /// Unsafe: the server's next token refresh will overwrite this login — stop the
-    /// server first instead. This is the deliberate escape hatch.
+    /// Skip the refusal a running proxy would otherwise trigger, and write the
+    /// login to the config file directly. Still probes the proxy first and still
+    /// prefers its live account-add route when one is confirmed and safe — this
+    /// only overrides the cases login would otherwise refuse or error on (an
+    /// older proxy with no route, one that answered unusably, or a rejected
+    /// api-key). Unsafe when it takes the file path: the running server's next
+    /// token refresh can overwrite what was just written.
     #[arg(long)]
     force: bool,
 }

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -323,6 +323,43 @@ pub enum SetDisabledOutcome {
     Ambiguous(Vec<String>),
 }
 
+/// What [`Manager::add_or_update_account`] did.
+///
+/// Same shape as [`SetDisabledOutcome`] — resolve by identity against the LIVE
+/// rotation, then report what happened plus the durable half's fate — but with
+/// one difference `SetDisabledOutcome` never needs: a disable/enable query only
+/// ever names an account that must already exist, so a miss is failure
+/// (`NoMatch`). An account-add legitimately names one nobody has seen before, so
+/// `Match::None` here is the SUCCESS arm (`Added`), not a rejection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AddAccountOutcome {
+    /// No account in the live rotation carried this identity — appended at the
+    /// END via [`Manager::add_account`]. Pins are in-memory `(session_key,
+    /// account_index)`, so appending is the only insertion that cannot re-key a
+    /// live session onto the wrong account.
+    Added {
+        idx: usize,
+        name: String,
+        persist: AddPersist,
+    },
+    /// Exactly one account already carried this identity — its credentials were
+    /// replaced IN PLACE at `idx` (see [`Manager::add_or_update_account`]). Its
+    /// `account_type` is always stamped to the submitted value and any identity
+    /// field (`account_uuid`/`org_uuid`/`org_name`) it was missing is backfilled
+    /// — never a value it already carried. Routing state — priority, disabled
+    /// flag, switch threshold, learned quota, counters — is untouched, and
+    /// `idx` never moves.
+    Updated {
+        idx: usize,
+        name: String,
+        persist: AddPersist,
+    },
+    /// The submitted identity matches more than one account in the live
+    /// rotation; these are their names, so the caller can tell the operator
+    /// what to disambiguate with. Never guessed.
+    Ambiguous(Vec<String>),
+}
+
 impl AccountRuntime {
     fn from_config(account: &config::Account) -> Self {
         Self {
@@ -427,6 +464,44 @@ impl DisablePersist {
             } else {
                 "NOT SAVED: writing the config failed — it stays benched after a restart"
             }),
+        }
+    }
+}
+
+/// What [`Manager::add_or_update_account`] achieved about DURABILITY. Same role
+/// as [`DisablePersist`], deliberately simpler: an upsert either lands or it does
+/// not, and there is no "no such account" / "no config entry" arm here — a MISS
+/// on the durable side is FILLED IN by [`config::save_account`], never refused
+/// (see that function's doc-comment for why it differs from
+/// [`config::save_disabled`] on exactly this point).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AddPersist {
+    /// The config file carries the new or replaced credentials — written just
+    /// now.
+    Persisted,
+    /// No config file behind this manager (`tcr demo`, `tcr status --probe`,
+    /// tests). Memory-only BY DESIGN.
+    NoConfigFile,
+    /// More than one entry on disk carries this identity; the write was refused
+    /// rather than landed on a guess. See [`config::AccountWrite::Ambiguous`].
+    Ambiguous,
+    /// The write itself failed: unreadable, malformed or unwritable file, or a
+    /// document whose `accounts` key exists but is not a JSON array.
+    WriteFailed,
+}
+
+impl AddPersist {
+    /// The one line to put in front of the operator, or `None` when the outcome
+    /// needs no explanation.
+    pub fn warning(self) -> Option<&'static str> {
+        match self {
+            Self::Persisted | Self::NoConfigFile => None,
+            Self::Ambiguous => Some(
+                "NOT SAVED: another config entry shares this account's identity — give it its own orgUuid",
+            ),
+            Self::WriteFailed => {
+                Some("NOT SAVED: writing the config failed — this will not survive a restart")
+            }
         }
     }
 }
@@ -1193,6 +1268,387 @@ impl Manager {
             config.accounts.push(account);
         }
         idx
+    }
+
+    /// Resolve `account` against the LIVE rotation by identity and either append
+    /// it (nothing matched) or replace an existing account's credentials in
+    /// place (exactly one matched) — the whole operation `POST /_tcr/accounts`
+    /// performs, kept here for the same reason [`Self::set_disabled_by_query`]
+    /// is: no caller outside this module needs to know that a rotation index is
+    /// what the mutating primitives take.
+    ///
+    /// Resolution uses [`crate::identity::resolve`]/[`crate::identity::same_identity`]
+    /// — the SAME rule the durable half ([`config::save_account`]) and `tcr
+    /// login` (`oauth::upsert_account`) already run — never
+    /// [`crate::identity::match_one`]. `match_one` goes through
+    /// [`crate::identity::Queryable`], which exposes only name and org: it
+    /// cannot compare `account_uuid`, so it was structurally unable to tell two
+    /// different people sharing a display name apart. Unifying on `resolve`
+    /// fixes that (a differing `account_uuid` never matches, so a same-named
+    /// different person is APPENDED, never overwritten) and it fixes the
+    /// live/durable split brain the old rule caused: `resolve` tolerates an
+    /// unknown org on either side exactly as the durable write does, so a
+    /// legacy no-org row and a submission carrying its own org now agree on
+    /// which one account that is, on both halves, every time — not only when
+    /// there happen to be two orgs in play.
+    ///
+    /// One `match_one`-style fallback survives, deliberately narrow: when
+    /// `account` carries NO identity fields at all (a bare name — the ordinary
+    /// single-account case), `resolve`'s exact name-equality miss is retried
+    /// through `match_one` so a bare email still finds a stored display name
+    /// carrying an org suffix (`email (Org)`), the way the CLI's own query
+    /// resolution always has. It is gated on "no identity fields submitted"
+    /// and nothing looser: widening it to a submission that DOES carry an
+    /// `account_uuid` would resurrect the exact bug this rewrite fixes, by
+    /// matching on name/email again after the uuid comparison already said
+    /// "different person".
+    ///
+    /// Resolve AND mutate under ONE write-lock acquisition of `self.accounts` —
+    /// closing a TOCTOU the old two-lock version had: it resolved under a READ
+    /// lock, released it, then took a separate WRITE lock to append. Two
+    /// concurrent submissions of the same brand-new identity could both resolve
+    /// "no match" before either had appended, and both would append —
+    /// duplicating the live row. Holding one write lock across resolve-then-
+    /// mutate means the second caller's resolve runs after the first caller's
+    /// append is already visible, so it finds the row and updates it instead.
+    pub fn add_or_update_account(&self, account: config::Account) -> AddAccountOutcome {
+        let target = crate::identity::probe(
+            &account.name,
+            account.account_uuid.clone(),
+            account.org_uuid.clone(),
+            account.org_name.clone(),
+        );
+        let bare_identity = account.account_uuid.is_none()
+            && account.org_uuid.is_none()
+            && account.org_name.is_none();
+
+        /// What the locked resolve-and-mutate section below produced, so the
+        /// (unlocked) durable write can run after the lock is released —
+        /// `persist_added`/`persist_replaced` do their own file I/O and must
+        /// never run under `self.accounts`'s lock.
+        enum Resolution {
+            Added {
+                idx: usize,
+            },
+            Updated {
+                idx: usize,
+                name: String,
+                /// The row's OWN identity (post-backfill) plus its REAL routing
+                /// state (priority/switch_threshold/disabled) — never
+                /// `identity::probe`'s placeholders, see [`Self::persist_replaced`]
+                /// and the F5 note there. Boxed: `Added` is a bare `usize`, and
+                /// clippy flags the size gap between variants otherwise.
+                target: Box<config::Account>,
+            },
+        }
+
+        let resolution = {
+            let mut accounts = self.accounts.write().expect("accounts lock poisoned");
+
+            let probes: Vec<(usize, config::Account)> = accounts
+                .iter()
+                .enumerate()
+                .map(|(i, a)| {
+                    (
+                        i,
+                        crate::identity::probe(
+                            &a.name,
+                            a.account_uuid.clone(),
+                            a.org_uuid.clone(),
+                            a.org_name.clone(),
+                        ),
+                    )
+                })
+                .collect();
+
+            let matched =
+                match crate::identity::resolve(probes.iter().map(|(i, p)| (*i, p)), &target) {
+                    crate::identity::Resolved::One(idx) => Some(idx),
+                    crate::identity::Resolved::Many => {
+                        // Recompute the loose set for its names: `Resolved::Many`
+                        // itself carries none, and this is exactly the set
+                        // `resolve` drew from (same predicate, same candidates).
+                        let names = accounts
+                            .iter()
+                            .filter(|a| {
+                                crate::identity::same_identity(
+                                    &target,
+                                    &crate::identity::probe(
+                                        &a.name,
+                                        a.account_uuid.clone(),
+                                        a.org_uuid.clone(),
+                                        a.org_name.clone(),
+                                    ),
+                                )
+                            })
+                            .map(|a| a.name.clone())
+                            .collect();
+                        return AddAccountOutcome::Ambiguous(names);
+                    }
+                    crate::identity::Resolved::None if bare_identity => {
+                        match crate::identity::match_one(&accounts[..], &account.name, None) {
+                            crate::identity::Match::One(idx) => Some(idx),
+                            crate::identity::Match::None => None,
+                            crate::identity::Match::Ambiguous(names) => {
+                                return AddAccountOutcome::Ambiguous(names);
+                            }
+                        }
+                    }
+                    crate::identity::Resolved::None => None,
+                };
+
+            match matched {
+                Some(idx) => {
+                    let row = accounts
+                        .get_mut(idx)
+                        .expect("idx was just resolved against this same vec");
+                    row.access_token = account.access_token.clone();
+                    row.refresh_token = account.refresh_token.clone();
+                    row.expires_at_ms = account.expires_at.map(oauth::normalize_expires_at);
+                    // F4: fresh credentials clear a stuck error — `eligible`
+                    // hard-gates on `status == Error` — but do NOT clear a
+                    // rate-limit hold. That hold expires on its own
+                    // (`MAX_RATE_LIMIT_HOLD_SECONDS`) and the next 429 re-arms
+                    // it; clearing it here bought nothing but the ability to
+                    // race a genuinely-still-limited account back into
+                    // rotation early.
+                    if row.status == AccountStatus::Error {
+                        row.status = AccountStatus::Active;
+                    }
+                    // F6: the submitted type always wins — this route only
+                    // ever carries a real credential, so a row whose stored
+                    // type was stale (e.g. `"api"`) is corrected, or
+                    // `refresh_plan` silently never refreshes it again.
+                    // Identity fields are BACKFILLED — filled in only where
+                    // the row does not already carry a value — mirroring
+                    // `oauth::upsert_account`. Backfilling (rather than
+                    // ignoring) is what permanently closes the split-brain
+                    // trigger: once a legacy no-org row's org is filled in,
+                    // it stops being loosely matched by every org variant of
+                    // that person and starts requiring an exact org match,
+                    // like any other fully-known account.
+                    row.account_type = account.account_type.clone();
+                    if row.account_uuid.is_none() {
+                        row.account_uuid = account.account_uuid.clone();
+                    }
+                    if row.org_uuid.is_none() {
+                        row.org_uuid = account.org_uuid.clone();
+                    }
+                    if row.org_name.is_none() {
+                        row.org_name = account.org_name.clone();
+                    }
+                    // F5: carry the row's REAL routing state, not
+                    // `identity::probe`'s None placeholders — see
+                    // `persist_replaced`'s doc-comment for the restart-un-bench
+                    // this replaces.
+                    let target = config::Account {
+                        name: row.name.clone(),
+                        account_type: row.account_type.clone(),
+                        account_uuid: row.account_uuid.clone(),
+                        org_uuid: row.org_uuid.clone(),
+                        org_name: row.org_name.clone(),
+                        access_token: String::new(),
+                        refresh_token: None,
+                        expires_at: None,
+                        priority: Some(row.priority),
+                        switch_threshold: row.switch_threshold,
+                        disabled: row.disabled.then_some(true),
+                        extra: serde_json::Map::new(),
+                    };
+                    Resolution::Updated {
+                        idx,
+                        name: row.name.clone(),
+                        target: Box::new(target),
+                    }
+                }
+                None => {
+                    let runtime = AccountRuntime::from_config(&account);
+                    accounts.push(runtime);
+                    Resolution::Added {
+                        idx: accounts.len() - 1,
+                    }
+                }
+            }
+        };
+
+        match resolution {
+            Resolution::Added { idx } => {
+                // Sequential, never nested with the accounts lock above — same
+                // discipline `add_account` documents.
+                {
+                    let mut config = self.config.lock().expect("config lock poisoned");
+                    config.accounts.push(account.clone());
+                }
+                let name = account.name.clone();
+                let persist = self.persist_added(&account);
+                AddAccountOutcome::Added { idx, name, persist }
+            }
+            Resolution::Updated { idx, name, target } => {
+                let persist = self.persist_replaced(idx, &target, &account);
+                AddAccountOutcome::Updated { idx, name, persist }
+            }
+        }
+    }
+
+    /// Durably persist a newly-appended account (see [`Self::add_account`]) to
+    /// the config file. Same INV1 discipline as [`Self::persist_disabled`]: the
+    /// whole `config::save_account` read-modify-write runs under
+    /// `config_write`, never `self.config` — nothing here needs the in-memory
+    /// snapshot, because [`Self::add_account`] already pushed `account` onto it.
+    fn persist_added(&self, account: &config::Account) -> AddPersist {
+        let Some(path) = &self.config_path else {
+            return AddPersist::NoConfigFile;
+        };
+        let _writing = self
+            .config_write
+            .lock()
+            .expect("config write lock poisoned");
+        match config::save_account(path, account) {
+            Ok(config::AccountWrite::Added) => {
+                tracing::info!(account = %account.name, "persisted newly added account to config");
+                AddPersist::Persisted
+            }
+            Ok(config::AccountWrite::Updated) => {
+                // The on-disk document already carried this identity even
+                // though the live rotation did not — an entry added to the
+                // file by hand while the proxy ran, or a stale boot snapshot.
+                // The fresh credentials still landed, just as an update to
+                // that row rather than a new one.
+                tracing::info!(
+                    account = %account.name,
+                    "an on-disk entry already carried this identity; its credentials were updated instead of appending a duplicate"
+                );
+                AddPersist::Persisted
+            }
+            Ok(config::AccountWrite::Ambiguous) => {
+                tracing::warn!(
+                    account = %account.name,
+                    path = %path.display(),
+                    "more than one config entry carries this account's identity; refusing to guess, so the new account will NOT survive a restart"
+                );
+                AddPersist::Ambiguous
+            }
+            Ok(config::AccountWrite::Unwritable) => {
+                tracing::error!(
+                    account = %account.name,
+                    path = %path.display(),
+                    "the config document's accounts key is not a JSON array; refusing to touch it"
+                );
+                AddPersist::WriteFailed
+            }
+            Err(err) => {
+                tracing::error!(
+                    error = %err,
+                    account = %account.name,
+                    path = %path.display(),
+                    "failed to persist the newly added account to config"
+                );
+                AddPersist::WriteFailed
+            }
+        }
+    }
+
+    /// Durably persist replaced credentials for the account at live index `idx`,
+    /// identified by `target` — its OWN stored identity (post-backfill), never
+    /// the submitted request's (see [`Self::add_or_update_account`] for why).
+    ///
+    /// `target` also carries the row's REAL `priority`/`switch_threshold`/
+    /// `disabled`, not `identity::probe`'s `None` placeholders. That matters
+    /// only on the rare path below where no in-memory or on-disk entry carries
+    /// this identity and one gets APPENDED from `target`: a placeholder-routing
+    /// `target` would append a fresh, un-benched entry for an account that was
+    /// deliberately disabled, so it would come back into rotation on the very
+    /// next restart — the exact bug `persist_disabled` exists to prevent.
+    fn persist_replaced(
+        &self,
+        idx: usize,
+        target: &config::Account,
+        fresh: &config::Account,
+    ) -> AddPersist {
+        let Some(path) = &self.config_path else {
+            return AddPersist::NoConfigFile;
+        };
+        let _writing = self
+            .config_write
+            .lock()
+            .expect("config write lock poisoned");
+        let mut for_disk = target.clone();
+        for_disk.access_token = fresh.access_token.clone();
+        for_disk.refresh_token = fresh.refresh_token.clone();
+        for_disk.expires_at = fresh.expires_at;
+
+        let outcome = config::save_account(path, &for_disk);
+        // INV3, mirroring `persist_disabled`: touch the in-memory snapshot only
+        // once the FILE actually carries the new credentials. Without this, the
+        // snapshot `persist_tokens`/`persist_now` later clone and write back on
+        // shutdown would still hold the OLD (just-replaced) token and stamp it
+        // back over the file this call just fixed.
+        if matches!(
+            outcome,
+            Ok(config::AccountWrite::Updated) | Ok(config::AccountWrite::Added)
+        ) {
+            let mut config = self.config.lock().expect("config lock poisoned");
+            match crate::identity::resolve(config.accounts.iter().enumerate(), target) {
+                crate::identity::Resolved::One(position) => {
+                    if let Some(entry) = config.accounts.get_mut(position) {
+                        entry.access_token = for_disk.access_token.clone();
+                        entry.refresh_token = for_disk.refresh_token.clone();
+                        entry.expires_at = for_disk.expires_at;
+                    }
+                }
+                // No in-memory entry carries this identity either — the disk
+                // row `save_account` just appended has no counterpart here.
+                // Mirror the append so a later persist can still find it.
+                crate::identity::Resolved::None => config.accounts.push(for_disk.clone()),
+                // A tie the in-memory snapshot cannot break either; leave it
+                // alone rather than guess which entry to overwrite.
+                crate::identity::Resolved::Many => {}
+            }
+        }
+
+        match outcome {
+            Ok(config::AccountWrite::Updated) => {
+                tracing::info!(account = %target.name, index = idx, "persisted replaced credentials to config");
+                AddPersist::Persisted
+            }
+            Ok(config::AccountWrite::Added) => {
+                tracing::warn!(
+                    account = %target.name,
+                    index = idx,
+                    path = %path.display(),
+                    "no config entry carried this account's identity; a fresh entry was appended"
+                );
+                AddPersist::Persisted
+            }
+            Ok(config::AccountWrite::Ambiguous) => {
+                tracing::warn!(
+                    account = %target.name,
+                    index = idx,
+                    path = %path.display(),
+                    "more than one config entry carries this account's identity; refusing to guess, so the replaced credentials will NOT survive a restart"
+                );
+                AddPersist::Ambiguous
+            }
+            Ok(config::AccountWrite::Unwritable) => {
+                tracing::error!(
+                    account = %target.name,
+                    index = idx,
+                    path = %path.display(),
+                    "the config document's accounts key is not a JSON array; refusing to touch it"
+                );
+                AddPersist::WriteFailed
+            }
+            Err(err) => {
+                tracing::error!(
+                    error = %err,
+                    account = %target.name,
+                    index = idx,
+                    path = %path.display(),
+                    "failed to persist replaced credentials to config"
+                );
+                AddPersist::WriteFailed
+            }
+        }
     }
 }
 
@@ -5105,6 +5561,414 @@ mod tests {
         manager.set_disabled(9, true);
 
         assert_eq!(std::fs::read_to_string(&path).unwrap(), before);
+        std::fs::remove_file(&path).ok();
+    }
+
+    // ---- live account-add identity resolution (`POST /_tcr/accounts`) ----
+
+    /// A manager whose in-memory config AND on-disk file both start out equal
+    /// to `config` — so both halves of `add_or_update_account` are observable:
+    /// `manager.accounts`/`manager.config` for the live view, and reloading
+    /// `path` for the durable one. Mirrors `proxy.rs`'s `control_manager`.
+    fn build_manager_with_disk(config: Config, tag: &str) -> (Arc<Manager>, PathBuf) {
+        let path = tmp_config_path(tag);
+        config::save(&path, &config).expect("write test config");
+        (build_manager_with_path(config, path.clone()), path)
+    }
+
+    /// F1 — CRITICAL regression. `{alice@example.com, uuid 1111…, rt-CORP}` is
+    /// on record; a submission of `{alice@example.com, uuid 2222…, rt-PERSONAL}`
+    /// is a DIFFERENT PERSON who happens to share a display name. The old rule
+    /// (`identity::match_one`, which goes through `Queryable` and cannot compare
+    /// `account_uuid` at all) matched it onto Corp's row and overwrote its
+    /// single-use refresh token — unrecoverable without a hand re-auth. It must
+    /// APPEND instead, leaving Corp's row untouched, in memory and on disk.
+    #[test]
+    fn add_or_update_account_never_overwrites_a_different_persons_refresh_token() {
+        let corp = Account {
+            account_uuid: Some("uuid-1111".to_string()),
+            access_token: "at-CORP".to_string(),
+            refresh_token: Some("rt-CORP".to_string()),
+            ..account("alice@example.com", 0)
+        };
+        let (manager, path) = build_manager_with_disk(config_with(vec![corp]), "f1-uuid-mismatch");
+
+        let submission = Account {
+            account_uuid: Some("uuid-2222".to_string()),
+            access_token: "at-PERSONAL".to_string(),
+            refresh_token: Some("rt-PERSONAL".to_string()),
+            ..account("alice@example.com", 0)
+        };
+        let outcome = manager.add_or_update_account(submission);
+
+        let (idx, persist) = match outcome {
+            AddAccountOutcome::Added { idx, persist, .. } => (idx, persist),
+            other => panic!(
+                "a different account_uuid under the same name must APPEND, not \
+                 update or refuse: {other:?}"
+            ),
+        };
+        assert_eq!(idx, 1, "appended at the end, Corp's row never moves");
+        assert_eq!(persist, AddPersist::Persisted);
+
+        // In memory: Corp's row is byte-identical.
+        {
+            let accounts = manager.accounts.read().expect("accounts lock poisoned");
+            assert_eq!(accounts.len(), 2);
+            assert_eq!(
+                accounts[0].refresh_token.as_deref(),
+                Some("rt-CORP"),
+                "Corp's single-use refresh token was overwritten in memory"
+            );
+            assert_eq!(accounts[0].access_token, "at-CORP");
+            assert_eq!(accounts[1].refresh_token.as_deref(), Some("rt-PERSONAL"));
+        }
+
+        // On disk: same.
+        let reloaded = config::load(&path).expect("reload persisted config");
+        assert_eq!(reloaded.accounts.len(), 2);
+        assert_eq!(
+            reloaded.accounts[0].refresh_token.as_deref(),
+            Some("rt-CORP"),
+            "Corp's single-use refresh token was overwritten on disk"
+        );
+        assert_eq!(
+            reloaded.accounts[1].refresh_token.as_deref(),
+            Some("rt-PERSONAL")
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// F2 — CRITICAL regression. A legacy row with NO stored org, met by a
+    /// submission carrying the row's OWN org (even just profiled for the first
+    /// time), must resolve to the SAME row on both the live and durable halves
+    /// — never split into a second live row backed by the same one disk entry.
+    #[test]
+    fn add_or_update_account_backfills_a_legacy_no_org_row_instead_of_splitting_the_fleet() {
+        let legacy = Account {
+            account_uuid: Some("uuid-legacy".to_string()),
+            refresh_token: Some("rt-legacy".to_string()),
+            ..account("alice@example.com", 0)
+        };
+        let (manager, path) = build_manager_with_disk(config_with(vec![legacy]), "f2-legacy-org");
+
+        let submission = Account {
+            account_uuid: Some("uuid-legacy".to_string()),
+            org_uuid: Some("org-corp-uuid".to_string()),
+            org_name: Some("Corp".to_string()),
+            access_token: "at-fresh".to_string(),
+            refresh_token: Some("rt-fresh".to_string()),
+            ..account("alice@example.com", 0)
+        };
+        let outcome = manager.add_or_update_account(submission);
+
+        let (idx, persist) = match outcome {
+            AddAccountOutcome::Updated { idx, persist, .. } => (idx, persist),
+            other => panic!(
+                "a legacy no-org row meeting its own org must UPDATE in place, \
+                 not split the fleet: {other:?}"
+            ),
+        };
+        assert_eq!(idx, 0);
+        assert_eq!(persist, AddPersist::Persisted);
+
+        // LIVE: one row, now carrying the org and the fresh credentials.
+        {
+            let accounts = manager.accounts.read().expect("accounts lock poisoned");
+            assert_eq!(
+                accounts.len(),
+                1,
+                "a second live row appeared — the split brain this fixes"
+            );
+            assert_eq!(accounts[0].org_uuid.as_deref(), Some("org-corp-uuid"));
+            assert_eq!(accounts[0].org_name.as_deref(), Some("Corp"));
+            assert_eq!(accounts[0].refresh_token.as_deref(), Some("rt-fresh"));
+        }
+
+        // DISK: agrees — one entry, same identity, now carrying the org too, so
+        // the NEXT submission (a genuinely different org) requires an exact
+        // match instead of tolerating a still-unknown org key forever.
+        let reloaded = config::load(&path).expect("reload persisted config");
+        assert_eq!(reloaded.accounts.len(), 1, "disk split into a second entry");
+        assert_eq!(
+            reloaded.accounts[0].org_uuid.as_deref(),
+            Some("org-corp-uuid")
+        );
+        assert_eq!(
+            reloaded.accounts[0].refresh_token.as_deref(),
+            Some("rt-fresh")
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// F3 — HIGH regression. The old two-lock version resolved under a READ
+    /// lock, released it, then took a separate WRITE lock to append — so N
+    /// concurrent submissions of the same brand-new identity could all resolve
+    /// "no match" before any of them had appended (measured 73 duplicate rows
+    /// in 200 concurrent rounds). Fire N concurrent adds of ONE new identity and
+    /// assert exactly one caller appended, on both halves.
+    #[test]
+    fn concurrent_adds_of_one_new_identity_never_duplicate_the_live_row() {
+        use std::thread;
+        let (manager, path) = build_manager_with_disk(
+            config_with(vec![account("alice@example.com", 0)]),
+            "f3-toctou",
+        );
+
+        let n = 16usize;
+        let submission = Account {
+            account_uuid: Some("uuid-new".to_string()),
+            access_token: "at-new".to_string(),
+            refresh_token: Some("rt-new".to_string()),
+            ..account("carol@example.com", 0)
+        };
+
+        let handles: Vec<_> = (0..n)
+            .map(|_| {
+                let m = Arc::clone(&manager);
+                let acct = submission.clone();
+                thread::spawn(move || m.add_or_update_account(acct))
+            })
+            .collect();
+        let outcomes: Vec<AddAccountOutcome> = handles
+            .into_iter()
+            .map(|h| h.join().expect("add_or_update_account thread panicked"))
+            .collect();
+
+        let added = outcomes
+            .iter()
+            .filter(|o| matches!(o, AddAccountOutcome::Added { .. }))
+            .count();
+        let updated = outcomes
+            .iter()
+            .filter(|o| matches!(o, AddAccountOutcome::Updated { .. }))
+            .count();
+        assert_eq!(
+            added, 1,
+            "exactly one concurrent caller may append a brand-new identity; \
+             the rest must see it as already-added (Updated): added={added} updated={updated}"
+        );
+        assert_eq!(updated, n - 1);
+
+        let accounts = manager.accounts.read().expect("accounts lock poisoned");
+        assert_eq!(
+            accounts.len(),
+            2,
+            "alice's row plus exactly one new row for carol — not a duplicate"
+        );
+        drop(accounts);
+
+        let reloaded = config::load(&path).expect("reload persisted config");
+        assert_eq!(
+            reloaded.accounts.len(),
+            2,
+            "disk duplicated the new identity"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// F4 — an `Error` row given fresh credentials must clear back to `Active`
+    /// (`eligible` hard-gates on `status == Error`) but its rate-limit hold must
+    /// SURVIVE the credential replace — clearing it bought nothing but the
+    /// ability to race a genuinely-still-limited account back into rotation
+    /// early. An EXPIRED hold proves both facts at once without contradiction:
+    /// the field keeps its stamped value, and the account is selectable because
+    /// that value is already in the past.
+    #[test]
+    fn add_or_update_account_clears_error_status_but_keeps_the_rate_limit_hold() {
+        let (manager, path) = build_manager_with_disk(
+            config_with(vec![account("alice@example.com", 0)]),
+            "f4-hold-survives",
+        );
+        let hold_until = crate::now_ms() - 1_000;
+        {
+            let mut accounts = manager.accounts.write().expect("accounts lock poisoned");
+            accounts[0].status = AccountStatus::Error;
+            accounts[0].rate_limited_until_ms = Some(hold_until);
+        }
+
+        let submission = Account {
+            access_token: "at-fresh".to_string(),
+            refresh_token: Some("rt-fresh".to_string()),
+            ..account("alice@example.com", 0)
+        };
+        let outcome = manager.add_or_update_account(submission);
+        assert!(
+            matches!(outcome, AddAccountOutcome::Updated { idx: 0, .. }),
+            "{outcome:?}"
+        );
+
+        {
+            let accounts = manager.accounts.read().expect("accounts lock poisoned");
+            assert_eq!(
+                accounts[0].status,
+                AccountStatus::Active,
+                "fresh credentials must clear a stuck error"
+            );
+            assert_eq!(
+                accounts[0].rate_limited_until_ms,
+                Some(hold_until),
+                "the rate-limit hold must survive a credential replace"
+            );
+        }
+
+        assert_eq!(
+            manager.select(&HashSet::new(), OffsetDateTime::now_utc(), None, None),
+            Some(0),
+            "active status + an EXPIRED hold ⇒ immediately selectable"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// F5 hardening. When the durable write must APPEND on `persist_replaced`'s
+    /// path (no on-disk entry carries this identity — e.g. it was deleted while
+    /// the proxy ran), the appended record must carry the row's REAL
+    /// `priority`/`disabled`, never `identity::probe`'s `None` placeholders —
+    /// otherwise a deliberately-benched account comes back into rotation on the
+    /// very next restart, the exact bug `persist_disabled` exists to prevent.
+    #[test]
+    fn add_or_update_account_persists_real_routing_state_when_appending_via_replace() {
+        let alice = Account {
+            account_uuid: Some("uuid-alice".to_string()),
+            priority: Some(5),
+            disabled: Some(true),
+            ..account("alice@example.com", 5)
+        };
+        let (manager, path) = build_manager_with_disk(config_with(vec![alice]), "f5-routing-state");
+
+        // The disk entry vanishes out from under the live process — the durable
+        // write must now APPEND.
+        std::fs::write(&path, r#"{"accounts": []}"#).expect("rewrite disk config");
+
+        let submission = Account {
+            account_uuid: Some("uuid-alice".to_string()),
+            access_token: "at-fresh".to_string(),
+            refresh_token: Some("rt-fresh".to_string()),
+            ..account("alice@example.com", 0)
+        };
+        let outcome = manager.add_or_update_account(submission);
+        assert!(
+            matches!(outcome, AddAccountOutcome::Updated { idx: 0, .. }),
+            "{outcome:?}"
+        );
+
+        let reloaded = config::load(&path).expect("reload persisted config");
+        assert_eq!(reloaded.accounts.len(), 1);
+        assert_eq!(
+            reloaded.accounts[0].priority,
+            Some(5),
+            "a benched account's priority must survive an append-via-replace"
+        );
+        assert_eq!(
+            reloaded.accounts[0].disabled,
+            Some(true),
+            "…and its disabled flag — the exact restart-un-bench persist_disabled exists to prevent"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// F6 — an update backfills every identity field the row is missing
+    /// (`account_uuid`/`org_uuid`/`org_name`) and always corrects `account_type`
+    /// to the submitted value: a row left at a stale non-`"oauth"` type is a
+    /// silent death, because `refresh_plan` skips any account whose type is not
+    /// `"oauth"`. On both the live row and the disk entry.
+    #[test]
+    fn add_or_update_account_backfills_identity_and_corrects_a_stale_account_type() {
+        let legacy_api_row = Account {
+            account_type: "api".to_string(),
+            account_uuid: None,
+            org_uuid: None,
+            org_name: None,
+            access_token: "sk-old".to_string(),
+            refresh_token: None,
+            ..account("alice@example.com", 0)
+        };
+        let (manager, path) =
+            build_manager_with_disk(config_with(vec![legacy_api_row]), "f6-backfill");
+
+        let submission = Account {
+            account_type: "oauth".to_string(),
+            account_uuid: Some("uuid-alice".to_string()),
+            org_uuid: Some("org-corp-uuid".to_string()),
+            org_name: Some("Corp".to_string()),
+            access_token: "at-fresh".to_string(),
+            refresh_token: Some("rt-fresh".to_string()),
+            ..account("alice@example.com", 0)
+        };
+        let outcome = manager.add_or_update_account(submission);
+        assert!(
+            matches!(outcome, AddAccountOutcome::Updated { idx: 0, .. }),
+            "{outcome:?}"
+        );
+
+        {
+            let accounts = manager.accounts.read().expect("accounts lock poisoned");
+            assert_eq!(
+                accounts[0].account_type, "oauth",
+                "a stale non-oauth type must be corrected, or refresh_plan silently \
+                 never refreshes this account again"
+            );
+            assert_eq!(accounts[0].account_uuid.as_deref(), Some("uuid-alice"));
+            assert_eq!(accounts[0].org_uuid.as_deref(), Some("org-corp-uuid"));
+            assert_eq!(accounts[0].org_name.as_deref(), Some("Corp"));
+        }
+
+        let reloaded = config::load(&path).expect("reload persisted config");
+        assert_eq!(reloaded.accounts[0].account_type, "oauth");
+        assert_eq!(
+            reloaded.accounts[0].account_uuid.as_deref(),
+            Some("uuid-alice")
+        );
+        assert_eq!(
+            reloaded.accounts[0].org_uuid.as_deref(),
+            Some("org-corp-uuid")
+        );
+        assert_eq!(reloaded.accounts[0].org_name.as_deref(), Some("Corp"));
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// Preservation guard: a submission with NO identity fields at all (a bare
+    /// name) must still find a stored row whose display name carries an org
+    /// suffix, via the CLI's own email-of fallback — `identity::resolve`'s exact
+    /// name equality alone would miss it and append a duplicate. This is the
+    /// one case the bare-name `match_one` fallback exists for.
+    #[test]
+    fn add_or_update_account_bare_email_still_matches_a_display_name_with_org_suffix() {
+        let display_named = Account {
+            name: "alice@example.com (Corp)".to_string(),
+            refresh_token: Some("rt-old".to_string()),
+            ..account("alice@example.com (Corp)", 0)
+        };
+        let (manager, path) =
+            build_manager_with_disk(config_with(vec![display_named]), "f-bare-email-fallback");
+
+        let submission = Account {
+            access_token: "at-fresh".to_string(),
+            refresh_token: Some("rt-fresh".to_string()),
+            ..account("alice@example.com", 0)
+        };
+        let outcome = manager.add_or_update_account(submission);
+        let idx = match outcome {
+            AddAccountOutcome::Updated { idx, .. } => idx,
+            other => panic!("a bare email must still match its display-named row: {other:?}"),
+        };
+        assert_eq!(idx, 0);
+        assert_eq!(
+            manager
+                .accounts
+                .read()
+                .expect("accounts lock poisoned")
+                .len(),
+            1,
+            "no duplicate appended"
+        );
+
         std::fs::remove_file(&path).ok();
     }
 

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -275,6 +275,11 @@ pub struct AccountRuntime {
     /// The most recent stream error's `error.type` (e.g. `"overloaded_error"`),
     /// alongside the decayed count above.
     pub last_stream_error: Option<String>,
+    /// Coalescing gate for THIS account's OAuth refresh. Lives on the account rather
+    /// than in a parallel Vec indexed by position, so an account added after startup
+    /// cannot be missing one — the desync it replaces made `ensure_fresh` a silent
+    /// no-op (no log, no status change) until the initial token expired.
+    pub refresh_lock: Arc<AsyncMutex<()>>,
 }
 
 /// A rotation slot answers a user's account query by the same three fields a
@@ -357,6 +362,7 @@ impl AccountRuntime {
             probe_error: None,
             stream_error_times_ms: VecDeque::new(),
             last_stream_error: None,
+            refresh_lock: Arc::new(AsyncMutex::new(())),
         }
     }
 }
@@ -440,8 +446,6 @@ struct SessionStat {
 /// Owns all rotation state and the machinery to refresh tokens and reach upstream.
 pub struct Manager {
     accounts: RwLock<Vec<AccountRuntime>>,
-    /// One coalescing gate per account, indexed by account position.
-    refresh_locks: Vec<Arc<AsyncMutex<()>>>,
     refresher: Arc<dyn TokenRefresher>,
     /// Reads each account's quota from the zero-spend usage endpoint on a timer.
     prober: Arc<dyn UsageProber>,
@@ -640,10 +644,6 @@ impl Manager {
         config_path: Option<PathBuf>,
         accounts: Vec<AccountRuntime>,
     ) -> Arc<Self> {
-        let refresh_locks = accounts
-            .iter()
-            .map(|_| Arc::new(AsyncMutex::new(())))
-            .collect();
         let upstream = config.upstream.clone();
         let proxy_api_key = config.proxy.api_key.clone();
         let global_threshold = config.switch_threshold;
@@ -666,7 +666,6 @@ impl Manager {
 
         let manager = Arc::new(Self {
             accounts: RwLock::new(accounts),
-            refresh_locks,
             refresher,
             prober,
             warmer,
@@ -1159,6 +1158,41 @@ impl Manager {
     /// Record which account actually served the most recent request.
     pub fn set_current(&self, idx: usize) {
         *self.current.lock().expect("current lock poisoned") = Some(idx);
+    }
+
+    /// Append a new account to the live rotation and return its index.
+    ///
+    /// APPEND-ONLY — this is a hard requirement, not a style choice. Pins are
+    /// in-memory `(session_key, account_index)`; appending keeps every existing
+    /// index valid, whereas inserting or reordering would re-key live sessions
+    /// and cold-start their prompt cache, which is the exact cost this whole
+    /// feature exists to avoid. Never insert at a position other than the end,
+    /// and never reorder either vec.
+    ///
+    /// Updates both `self.accounts` (the live rotation `AccountRuntime`s) and
+    /// `self.config`'s accounts vec (so later identity-resolution in
+    /// `persist_tokens` / `persist_disabled` finds the row instead of logging
+    /// the "no loaded config account carries this identity" WARN). The two
+    /// locks are taken SEQUENTIALLY, never nested — the same discipline
+    /// `set_disabled` documents: holding both at once risks inverting the lock
+    /// order `warm_targets` reads them in.
+    ///
+    /// Derives the runtime row via [`AccountRuntime::from_config`], which is
+    /// exactly how every other account's runtime state is built at startup, so
+    /// an appended account gets its own `refresh_lock` for free — there is no
+    /// longer a parallel structure to keep in sync.
+    pub fn add_account(&self, account: config::Account) -> usize {
+        let runtime = AccountRuntime::from_config(&account);
+        let idx = {
+            let mut accounts = self.accounts.write().expect("accounts lock poisoned");
+            accounts.push(runtime);
+            accounts.len() - 1
+        };
+        {
+            let mut config = self.config.lock().expect("config lock poisoned");
+            config.accounts.push(account);
+        }
+        idx
     }
 }
 
@@ -2256,6 +2290,42 @@ mod tests {
 
         assert_eq!(calls.load(Ordering::SeqCst), 1);
         assert_eq!(manager.access_token(0).as_deref(), Some("fresh-access"));
+    }
+
+    /// The refresh coalescing lock now lives on `AccountRuntime` itself rather than
+    /// in a parallel `Vec` sized at construction — an account appended after
+    /// startup via [`Manager::add_account`] must still refresh. Before this fix,
+    /// the appended account's index was beyond `refresh_locks.len()` and
+    /// `ensure_fresh_inner` returned `false` SILENTLY (no log, no error) — this
+    /// test proves refresh actually fires for it, not just that the call returns.
+    #[tokio::test]
+    async fn appended_account_refreshes() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let refresher = Arc::new(CountingRefresher {
+            calls: calls.clone(),
+        });
+        // Seed with one pre-existing account so the appended one is NOT index 0 —
+        // the desync this guards against only bites an index beyond the
+        // construction-time Vec's length.
+        let manager = build_manager(config_with(vec![account("seed", 0)]), refresher);
+
+        let mut appended = account("appended", 0);
+        appended.expires_at = Some(crate::now_ms() - 60_000); // already expired
+        let idx = manager.add_account(appended);
+        assert_eq!(idx, 1, "appended account must land at the next index");
+
+        manager.ensure_fresh(idx).await;
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "refresh must actually fire for an account appended after construction"
+        );
+        assert_eq!(
+            manager.access_token(idx).as_deref(),
+            Some("fresh-access"),
+            "the appended account's access token must be the refreshed one"
+        );
     }
 
     /// Transient-leader coalescing (the bug this fixes): when the leader's

--- a/src/manager/refresh.rs
+++ b/src/manager/refresh.rs
@@ -29,8 +29,13 @@ impl Manager {
             return false;
         };
 
-        let lock = match self.refresh_locks.get(idx) {
-            Some(lock) => lock.clone(),
+        let lock = match self
+            .accounts
+            .read()
+            .expect("accounts lock poisoned")
+            .get(idx)
+        {
+            Some(account) => account.refresh_lock.clone(),
             None => return false,
         };
         let _guard = lock.lock().await;

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -744,29 +744,55 @@ fn login_target_port(config_path: &Path) -> u16 {
         .port
 }
 
+/// What `login()` should do with the finished credential, decided purely from
+/// the incumbent detected on the guarded port, whether a probe already
+/// confirmed THAT incumbent carries the live account-add route, and
+/// `--force`. Returned by [`login_guard_refusal`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum LoginRoute {
+    /// No live proxy on the port, or `--force`: the historical file-only
+    /// login. `--force` always means this, even when the live route WAS
+    /// confirmed — it is the deliberate escape hatch past the live
+    /// coordination below, not just past the old refusal.
+    File,
+    /// A live proxy is there and its add route is confirmed: route the
+    /// finished credential through it instead of the file.
+    Live,
+    /// A live proxy is there without the route, and `--force` was not given:
+    /// refuse outright with this message, unchanged from before this route
+    /// existed.
+    Refuse(String),
+}
+
 /// The pure login-guard DECISION: given any live proxy server detected on the
-/// port, the port, and the `--force` flag, return the one-line refusal message to
-/// abort with, or `None` to proceed. Split from the impure lsof-based detection
-/// ([`crate::singleton::live_proxy_server`]) so the refuse/allow logic is
-/// unit-testable, mirroring singleton's pure-decision / impure-executor split.
+/// port, whether that incumbent's live account-add route was already
+/// confirmed (never probed in here — see [`probe_add_capability`]), the port,
+/// and the `--force` flag, return which [`LoginRoute`] `login()` should take.
+/// Split from the impure lsof-based detection
+/// ([`crate::singleton::live_proxy_server`]) AND from the impure HTTP
+/// capability probe so the decision itself stays unit-testable, mirroring
+/// singleton's pure-decision / impure-executor split.
 ///
-/// The incumbent's KIND decides the instruction, and it is not cosmetic. Since
-/// the owner file, detection reaches a proxy served INSIDE a host application,
-/// and the pid reported is then the HOST's. "kill {pid}" would SIGTERM a GUI
-/// process that installs no handler for it: no `applicationWillTerminate`, no
-/// final session→account pin write, and every live session cold-starts its
-/// prompt cache at the next boot. `takeover_decision` and `incumbents_to_signal`
-/// are both hardened against exactly that signal; a message that ADVISES it would
-/// walk around both. So an embedded incumbent is told to be quit, not killed.
+/// The incumbent's KIND decides the REFUSAL instruction, and it is not
+/// cosmetic. Since the owner file, detection reaches a proxy served INSIDE a
+/// host application, and the pid reported is then the HOST's. "kill {pid}"
+/// would SIGTERM a GUI process that installs no handler for it: no
+/// `applicationWillTerminate`, no final session→account pin write, and every
+/// live session cold-starts its prompt cache at the next boot.
+/// `takeover_decision` and `incumbents_to_signal` are both hardened against
+/// exactly that signal; a message that ADVISES it would walk around both. So
+/// an embedded incumbent is told to be quit, not killed — whether or not it
+/// has the add route, since that's the refusal-message case regardless.
 fn login_guard_refusal(
     incumbent: Option<singleton::Incumbent>,
+    has_add_route: bool,
     port: u16,
     force: bool,
-) -> Option<String> {
+) -> LoginRoute {
     match incumbent {
-        Some(incumbent) if !force => {
+        Some(incumbent) if !force && !has_add_route => {
             let pid = incumbent.pid;
-            Some(match incumbent.kind {
+            LoginRoute::Refuse(match incumbent.kind {
                 singleton::ProxyKind::TcrEmbedded => format!(
                     "a tcr server is already running on port {port} (pid {pid}); logging in now would be overwritten by the server's next token refresh — that pid is the HOST APPLICATION serving the proxy in-process, so do not signal it: quit the host application (killing it skips its shutdown and loses the session pin map), run 'tcr login', then start it again. Re-run with --force to log in anyway."
                 ),
@@ -775,24 +801,114 @@ fn login_guard_refusal(
                 ),
             })
         }
-        _ => None,
+        Some(_) if !force => LoginRoute::Live,
+        _ => LoginRoute::File,
     }
 }
 
-/// Run the full browser OAuth login and persist the account to `config_path`.
-/// Returns the account name on success. Never logs or prints the tokens.
+/// What a live proxy said, structurally, about whether it can accept a live
+/// account add. Read from [`crate::cli::post_add_account`]'s own
+/// [`crate::cli::LiveControlError`] classification, which is itself driven by
+/// [`crate::proxy::ENDPOINT_HEADER`] — never by matching error text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AddCapability {
+    /// The route answered (stamped, whatever the status) — a live add is
+    /// possible.
+    Present,
+    /// Nothing usable answered: no server, a route-less 404/405 (an older
+    /// tcr), or the probe timed out / returned something unreadable. All
+    /// three collapse to the same conservative answer: `login_guard_refusal`
+    /// treats "confirmed absent" and "could not confirm" identically, always
+    /// falling back to the historical refusal rather than guessing a route is
+    /// there.
+    Absent,
+    /// The proxy answered and rejected our api-key. Its own condition — never
+    /// folded into `Absent`: that would either wrongly read as an older proxy
+    /// with no route, or let `login()` silently fall back to writing the file
+    /// out from under a server that is right there, listening.
+    Unauthorized,
+}
+
+/// Probe whether the proxy `config` points at can accept a live account add,
+/// via a deliberately-invalid POST to [`crate::proxy::ADD_ACCOUNT_PATH`] — a
+/// blank name and access token, always rejected by the route's own
+/// validation — so this can run BEFORE any OAuth tokens exist and before the
+/// browser opens. Never probes by adding a real account.
+async fn probe_add_capability(config: &Config) -> AddCapability {
+    let probe = Account {
+        name: String::new(),
+        account_type: "oauth".to_string(),
+        account_uuid: None,
+        org_uuid: None,
+        org_name: None,
+        access_token: String::new(),
+        refresh_token: None,
+        expires_at: None,
+        priority: None,
+        switch_threshold: None,
+        disabled: None,
+        extra: serde_json::Map::new(),
+    };
+    match crate::cli::post_add_account(config, &probe).await {
+        // A blank name/token can never be added, so `Ok` cannot happen in
+        // practice — but a stamped success is just as much "the route
+        // exists" as a stamped rejection, so it counts as `Present` too.
+        Ok(_) => AddCapability::Present,
+        // The route validated the (deliberately bad) body and said so,
+        // stamped — exactly the positive capability signal.
+        Err(crate::cli::LiveControlError::Rejected(_)) => AddCapability::Present,
+        Err(crate::cli::LiveControlError::Unauthorized) => AddCapability::Unauthorized,
+        Err(_) => AddCapability::Absent,
+    }
+}
+
+/// Resolve which [`LoginRoute`] `login()` should take, running the impure
+/// capability probe only when it can matter — a live incumbent is on the port
+/// and `--force` was not given. Fully resolves before `login()` starts the
+/// OAuth dance, so a user is never told to stop a server AFTER completing a
+/// full browser round-trip, and never silently falls back to the file when
+/// the incumbent answered but rejected our api-key.
+async fn login_route(
+    config_path: &Path,
+    incumbent: Option<singleton::Incumbent>,
+    port: u16,
+    force: bool,
+) -> anyhow::Result<LoginRoute> {
+    if force || incumbent.is_none() {
+        return Ok(login_guard_refusal(incumbent, false, port, force));
+    }
+    let config = load_or_default(config_path)?;
+    match probe_add_capability(&config).await {
+        AddCapability::Unauthorized => bail!(
+            "the proxy on :{port} rejected the api-key in {} while checking whether it could \
+             take a live login — no browser was opened and nothing was changed. Fix \
+             `proxy.apiKey` and retry, or re-run with --force to log in via the file instead \
+             (this still risks the running server overwriting it on its next token refresh).",
+            config_path.display()
+        ),
+        AddCapability::Present => Ok(login_guard_refusal(incumbent, true, port, force)),
+        AddCapability::Absent => Ok(login_guard_refusal(incumbent, false, port, force)),
+    }
+}
+
+/// Run the full browser OAuth login and persist the account. Returns the
+/// account name on success. Never logs or prints the tokens.
 ///
-/// Refuses (unless `force`) when a live proxy server already holds the configured
-/// port: the server reads config only at boot and its next `persist_tokens`
-/// writes its boot-time TOKENS back over the file, silently clobbering the fresh
-/// ones this login writes (observed live 2026-07-19 — a server refresh overwrote
-/// a re-login within seconds). Persisting is otherwise tokens-only
-/// ([`config::save_tokens`]), so a live server no longer reverts the user's
-/// SETTINGS — but credentials are exactly what a login writes, so the guard
-/// stands. Detection is read-only; the server is never signalled.
+/// Refuses (unless `force`) when a live proxy server already holds the
+/// configured port AND that proxy has no live account-add route: an older
+/// tcr reads config only at boot, and its next `persist_tokens` writes its
+/// boot-time TOKENS back over the file, silently clobbering the fresh ones
+/// this login writes (observed live 2026-07-19 — a server refresh overwrote a
+/// re-login within seconds). When the live route IS there, this routes the
+/// finished credential through the server instead ([`finish_login`]) — the
+/// server owns the write with its own current state, so the window above
+/// does not exist on that path at all. Detection is read-only; the server is
+/// never signalled.
 pub async fn login(config_path: &Path, force: bool) -> anyhow::Result<String> {
     let port = login_target_port(config_path);
-    if let Some(msg) = login_guard_refusal(singleton::live_proxy_server(port), port, force) {
+    let incumbent = singleton::live_proxy_server(port);
+    let route = login_route(config_path, incumbent, port, force).await?;
+    if let LoginRoute::Refuse(msg) = route {
         bail!("{}", msg);
     }
 
@@ -800,8 +916,8 @@ pub async fn login(config_path: &Path, force: bool) -> anyhow::Result<String> {
     let listener = TcpListener::bind(("127.0.0.1", 0))
         .await
         .context("bind local OAuth callback server")?;
-    let port = listener.local_addr()?.port();
-    let redirect_uri = format!("http://localhost:{port}/callback");
+    let callback_port = listener.local_addr()?.port();
+    let redirect_uri = format!("http://localhost:{callback_port}/callback");
 
     // PKCE + CSRF state + authorize URL, built by the oauth2 crate.
     let flow = build_login_flow(&redirect_uri)?;
@@ -826,18 +942,145 @@ pub async fn login(config_path: &Path, force: bool) -> anyhow::Result<String> {
         None => prompt_account_name(&fallback),
     };
 
+    finish_login(config_path, route, &mut config, &name, &tokens, profile).await
+}
+
+/// The file half of a login: `upsert_account` + whole-file [`config::save`].
+/// Exactly what `login()` always did, kept as its own function so both
+/// [`LoginRoute::File`] and every live-path fallback in [`finish_login`] run
+/// the identical sequence rather than duplicating it.
+fn persist_via_file(
+    config_path: &Path,
+    config: &mut Config,
+    name: &str,
+    tokens: &Tokens,
+    profile: Profile,
+) -> anyhow::Result<String> {
     upsert_account(
-        &mut config,
-        &name,
-        &tokens,
+        config,
+        name,
+        tokens,
         profile.account_uuid,
         profile.org_uuid,
         profile.org_name,
     );
-    config::save(config_path, &config).context("save config after login")?;
-
+    config::save(config_path, config).context("save config after login")?;
     println!("Saved account '{name}' to {}", config_path.display());
-    Ok(name)
+    Ok(name.to_string())
+}
+
+/// Persist the finished OAuth credential per `route`: through the live proxy
+/// when it is [`LoginRoute::Live`], via [`persist_via_file`] when it is
+/// [`LoginRoute::File`]. Split out of [`login`] so WHERE the credential lands
+/// is testable without driving a real browser.
+///
+/// On the live path the running server owns the durable write — this must
+/// NOT also whole-file [`config::save`] the (possibly already-stale) `config`
+/// this process is holding; that write is exactly the clobber this unit
+/// exists to remove. Falls back to the file only on the quiet
+/// [`crate::cli::LiveControlError::NoServer`] case, mirroring
+/// [`crate::cli::set_enabled`]'s discipline: a server that answered and
+/// REFUSED us (`Unauthorized`, `Rejected`) must surface, never silently write
+/// the file instead, because the two halves would then disagree about what
+/// the account's credentials are.
+async fn finish_login(
+    config_path: &Path,
+    route: LoginRoute,
+    config: &mut Config,
+    name: &str,
+    tokens: &Tokens,
+    profile: Profile,
+) -> anyhow::Result<String> {
+    match route {
+        LoginRoute::Refuse(_) => {
+            unreachable!("login() bails on a refusal before fetching tokens")
+        }
+        LoginRoute::File => persist_via_file(config_path, config, name, tokens, profile),
+        LoginRoute::Live => {
+            let account = Account {
+                name: name.to_string(),
+                account_type: "oauth".to_string(),
+                account_uuid: profile.account_uuid.clone(),
+                org_uuid: profile.org_uuid.clone(),
+                org_name: profile.org_name.clone(),
+                access_token: tokens.access_token.clone(),
+                refresh_token: Some(tokens.refresh_token.clone()),
+                expires_at: Some(tokens.expires_at_ms),
+                priority: None,
+                switch_threshold: None,
+                disabled: None,
+                extra: serde_json::Map::new(),
+            };
+            match crate::cli::post_add_account(config, &account).await {
+                Ok(applied) => {
+                    println!(
+                        "Saved account '{}' to the running proxy on :{}",
+                        applied.name, config.proxy.port
+                    );
+                    if let Some(warning) = &applied.warning {
+                        eprintln!("[tcr] warning: {warning}");
+                    }
+                    if !applied.persisted {
+                        eprintln!(
+                            "[tcr] warning: this account is live but NOT saved to {} — it will not survive a restart.",
+                            config_path.display()
+                        );
+                    }
+                    Ok(applied.name)
+                }
+                // Nothing is listening any more (it exited between the probe
+                // and here): the quiet fallback, same discipline as
+                // `set_enabled`.
+                Err(crate::cli::LiveControlError::NoServer) => {
+                    persist_via_file(config_path, config, name, tokens, profile)
+                }
+                // The proxy rejected our api-key. Writing the file here would
+                // be the clobber this unit exists to remove, in a new place:
+                // the running server keeps whatever it already had while the
+                // file quietly disagrees. Change nothing, exit non-zero.
+                Err(crate::cli::LiveControlError::Unauthorized) => bail!(
+                    "the proxy on :{} rejected the api-key in {} — the config was NOT changed, \
+                     because writing it would leave the running proxy unaware of this login. \
+                     Fix `proxy.apiKey` and retry.",
+                    config.proxy.port,
+                    config_path.display()
+                ),
+                // The route ran and refused the submission itself (e.g. the
+                // identity matched more than one live account). Do not fall
+                // back — the file's own resolution could land on a different
+                // account than the one the server was talking about.
+                Err(crate::cli::LiveControlError::Rejected(message)) => bail!(
+                    "the proxy running on :{} refused this: {message} Nothing was changed.",
+                    config.proxy.port
+                ),
+                // The route is missing: the capability probe said it was
+                // there and it no longer is (a race, or a downgrade mid-run).
+                // The file write is all we can do, and it is HALF a login —
+                // say so loudly, mirroring `set_enabled`'s NoRoute arm.
+                Err(crate::cli::LiveControlError::NoRoute) => {
+                    let saved = persist_via_file(config_path, config, name, tokens, profile)?;
+                    eprintln!(
+                        "[tcr] WARNING: the proxy running on :{} is too old to accept a live login (no {} route), so only the config file was changed. Run `tcr restart` when a cold prompt cache is acceptable.",
+                        config.proxy.port,
+                        crate::proxy::ADD_ACCOUNT_PATH,
+                    );
+                    Ok(saved)
+                }
+                // It answered something unusable, or did not answer in time.
+                // Same shape of consequence as NoRoute, different cause, and
+                // equally never silent.
+                Err(other) => {
+                    let why = other.why();
+                    let saved = persist_via_file(config_path, config, name, tokens, profile)?;
+                    eprintln!(
+                        "[tcr] WARNING: could not apply this login to the proxy running on :{} ({why}), so only the config file was changed.",
+                        config.proxy.port,
+                    );
+                    Ok(saved)
+                }
+            }
+        }
+    }
 }
 
 /// Load the config, treating a missing file as an empty default (so the very
@@ -1239,10 +1482,25 @@ mod tests {
         Some(singleton::Incumbent { pid: 4242, kind })
     }
 
+    /// Unwrap a [`LoginRoute::Refuse`]'s message, or panic naming what came back
+    /// instead — every existing refusal test still wants the bare message
+    /// string, and this is the one place that unwrap lives now that the guard
+    /// returns a three-way enum instead of `Option<String>`.
+    fn expect_refuse(route: LoginRoute) -> String {
+        match route {
+            LoginRoute::Refuse(msg) => msg,
+            other => panic!("expected a refusal, got {other:?}"),
+        }
+    }
+
     #[test]
     fn login_guard_refusal_message_carries_pid_and_stop_login_restart_sequence() {
-        let msg = login_guard_refusal(incumbent(singleton::ProxyKind::Tcr), 3456, false)
-            .expect("a live server without --force must refuse");
+        let msg = expect_refuse(login_guard_refusal(
+            incumbent(singleton::ProxyKind::Tcr),
+            false,
+            3456,
+            false,
+        ));
         // Actionable + greppable: names the port, the PID, and the escape hatch.
         assert!(msg.contains("3456"), "names the port: {msg}");
         assert!(msg.contains("4242"), "names the pid: {msg}");
@@ -1269,10 +1527,39 @@ mod tests {
 
     #[test]
     fn login_guard_allows_with_force_or_no_server() {
-        // --force is the deliberate escape hatch even when a server is live.
-        assert!(login_guard_refusal(incumbent(singleton::ProxyKind::Tcr), 3456, true).is_none());
+        // --force is the deliberate escape hatch even when a server is live —
+        // it takes the file path regardless of whether the route is there.
+        assert_eq!(
+            login_guard_refusal(incumbent(singleton::ProxyKind::Tcr), false, 3456, true),
+            LoginRoute::File
+        );
         // No server on the port → nothing to refuse.
-        assert!(login_guard_refusal(None, 3456, false).is_none());
+        assert_eq!(
+            login_guard_refusal(None, false, 3456, false),
+            LoginRoute::File
+        );
+    }
+
+    /// THE NEW OUTCOME. A live proxy that HAS the add route is no longer
+    /// refused at all — the whole point of this unit.
+    #[test]
+    fn login_guard_proceeds_live_when_the_incumbent_has_the_add_route() {
+        assert_eq!(
+            login_guard_refusal(incumbent(singleton::ProxyKind::Tcr), true, 3456, false),
+            LoginRoute::Live
+        );
+        // Even an embedded host, whose absent-route refusal has the special
+        // "quit, don't kill" wording — once the route is confirmed there is
+        // nothing left to refuse, embedded or not.
+        assert_eq!(
+            login_guard_refusal(
+                incumbent(singleton::ProxyKind::TcrEmbedded),
+                true,
+                3456,
+                false
+            ),
+            LoginRoute::Live
+        );
     }
 
     /// THE ADVICE MUST BE SURVIVABLE. `live_proxy_server` can now name the pid of
@@ -1284,8 +1571,12 @@ mod tests {
     /// than no guard, because the operator does what the tool says.
     #[test]
     fn the_login_guard_never_tells_an_operator_to_kill_a_host_application() {
-        let msg = login_guard_refusal(incumbent(singleton::ProxyKind::TcrEmbedded), 3456, false)
-            .expect("an embedded server must still block a login");
+        let msg = expect_refuse(login_guard_refusal(
+            incumbent(singleton::ProxyKind::TcrEmbedded),
+            false,
+            3456,
+            false,
+        ));
         assert!(
             !msg.contains("kill 4242"),
             "must not advise signalling the host application: {msg}"
@@ -1313,8 +1604,12 @@ mod tests {
         // And the control: a plain CLI peer, which the operator CAN signal, still
         // gets the kill instruction — so the assertions above are about the kind,
         // not about the message having been softened for everyone.
-        let cli = login_guard_refusal(incumbent(singleton::ProxyKind::Tcr), 3456, false)
-            .expect("a live CLI server must block a login");
+        let cli = expect_refuse(login_guard_refusal(
+            incumbent(singleton::ProxyKind::Tcr),
+            false,
+            3456,
+            false,
+        ));
         assert!(cli.contains("kill 4242"), "{cli}");
     }
 
@@ -1336,7 +1631,10 @@ mod tests {
                 is_proxy_server(&argv),
                 "the bool and the classifying form must agree: {cmd:?}"
             );
-            login_guard_refusal(server, 3456, false).is_some()
+            matches!(
+                login_guard_refusal(server, false, 3456, false),
+                LoginRoute::Refuse(_)
+            )
         };
         assert!(
             refuses(&["/opt/teamclaude-rs/target/release/tcr", "server"]),
@@ -1363,5 +1661,268 @@ mod tests {
         // A missing/unreadable config falls back to the serde default (3456).
         let missing = std::env::temp_dir().join("tcr-oauth-login-port-does-not-exist.json");
         assert_eq!(login_target_port(&missing), 3456);
+    }
+
+    // --- probe_add_capability -----------------------------------------------
+
+    #[tokio::test]
+    async fn probe_add_capability_reads_a_stamped_400_as_present() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let config: Config =
+            serde_json::from_str(&format!(r#"{{ "proxy": {{ "port": {port} }} }}"#)).unwrap();
+        let manager = crate::manager::Manager::with_live_refresher(config.clone(), None);
+        tokio::spawn(async move { crate::mitm::serve(listener, manager, None).await });
+
+        assert_eq!(probe_add_capability(&config).await, AddCapability::Present);
+    }
+
+    #[tokio::test]
+    async fn probe_add_capability_unstamped_404_is_absent() {
+        // An "older tcr": something answers, but not on this route at all — no
+        // `ENDPOINT_HEADER`, unlike every response this crate's own router
+        // produces (even its 404s and 405s).
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, axum::Router::new()).await;
+        });
+        let config: Config =
+            serde_json::from_str(&format!(r#"{{ "proxy": {{ "port": {port} }} }}"#)).unwrap();
+        assert_eq!(probe_add_capability(&config).await, AddCapability::Absent);
+    }
+
+    #[tokio::test]
+    async fn probe_add_capability_wrong_api_key_is_unauthorized_not_absent() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server_config: Config = serde_json::from_str(&format!(
+            r#"{{ "proxy": {{ "port": {port}, "apiKey": "correct-key" }} }}"#
+        ))
+        .unwrap();
+        let manager = crate::manager::Manager::with_live_refresher(server_config, None);
+        tokio::spawn(async move { crate::mitm::serve(listener, manager, None).await });
+
+        // The caller's config carries the WRONG key.
+        let client_config: Config = serde_json::from_str(&format!(
+            r#"{{ "proxy": {{ "port": {port}, "apiKey": "wrong-key" }} }}"#
+        ))
+        .unwrap();
+        assert_eq!(
+            probe_add_capability(&client_config).await,
+            AddCapability::Unauthorized,
+            "a rejected api-key must surface as itself, never read as 'no route'"
+        );
+    }
+
+    // --- finish_login ---------------------------------------------------------
+
+    /// A [`Profile`] carrying only an email — the common case, no org info.
+    fn profile_named(email: &str) -> Profile {
+        Profile {
+            email: Some(email.to_string()),
+            account_uuid: None,
+            org_uuid: None,
+            org_name: None,
+        }
+    }
+
+    /// THE BITING TEST for the whole-file-write hazard `finish_login` exists to
+    /// remove. The documented failure: `login()` loads a config snapshot, does
+    /// slow async work (a profile fetch, an unbounded stdin prompt), and THEN
+    /// whole-file `config::save`s that now-stale snapshot — silently reverting
+    /// any account the live server rotated in the meantime. Refresh tokens are
+    /// single-use, so that does not just lose a write, it bricks the reverted
+    /// account.
+    ///
+    /// Reproduced here without a real browser: seed a live server + config file
+    /// with two accounts, take a CLIENT-SIDE snapshot (what `login()` would be
+    /// holding across its own async window), then have the LIVE SERVER itself
+    /// rotate one of those accounts' credentials — via the same
+    /// `/_tcr/accounts` route, a real re-login — AFTER the snapshot was taken.
+    /// Only then does `finish_login` run, on the STALE snapshot, adding a THIRD
+    /// account live. If it whole-file-saved that snapshot, the rotation would
+    /// be reverted. It must not be.
+    #[tokio::test]
+    async fn finish_login_live_path_does_not_clobber_a_concurrent_rotation() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-live-clobber-{}-{port}.json",
+            std::process::id()
+        ));
+        let seed = format!(
+            r#"{{ "proxy": {{ "port": {port} }}, "accounts": [
+                {{ "name": "alice@example.com", "type": "oauth", "accessToken": "at-alice",
+                  "refreshToken": "rt-alice", "expiresAt": 1893456000000, "priority": 0 }},
+                {{ "name": "bob@example.com", "type": "oauth", "accessToken": "at-bob-STALE",
+                  "refreshToken": "rt-bob-STALE", "expiresAt": 1893456000000, "priority": 1 }}
+            ] }}"#
+        );
+        std::fs::write(&path, &seed).unwrap();
+
+        let server_config: Config = serde_json::from_str(&seed).unwrap();
+        let manager =
+            crate::manager::Manager::with_live_refresher(server_config, Some(path.clone()));
+        tokio::spawn(async move { crate::mitm::serve(listener, manager, None).await });
+
+        // The stale snapshot: what `login()` would have loaded before its own
+        // async window (profile fetch / stdin prompt) opened.
+        let mut client_config = load_or_default(&path).unwrap();
+
+        // The live server rotates bob's credentials WHILE that snapshot is
+        // held — a real re-login through the same route this unit adds,
+        // exactly the race `login()`'s doc-comment describes.
+        let rotated_bob = Account {
+            name: "bob@example.com".to_string(),
+            account_type: "oauth".to_string(),
+            account_uuid: None,
+            org_uuid: None,
+            org_name: None,
+            access_token: "at-bob-ROTATED".to_string(),
+            refresh_token: Some("rt-bob-ROTATED".to_string()),
+            expires_at: Some(1_893_456_000_000),
+            priority: None,
+            switch_threshold: None,
+            disabled: None,
+            extra: serde_json::Map::new(),
+        };
+        let rotate_config = load_or_default(&path).unwrap();
+        crate::cli::post_add_account(&rotate_config, &rotated_bob)
+            .await
+            .expect("the live re-login must succeed");
+
+        // Sanity: the rotation really did land on disk before the race window
+        // (the `finish_login` call below) closes.
+        let after_rotation = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            after_rotation.contains("rt-bob-ROTATED"),
+            "setup: the rotation must be on disk first: {after_rotation}"
+        );
+
+        // Now finish a THIRD account's login, live, using the STALE snapshot.
+        let name = finish_login(
+            &path,
+            LoginRoute::Live,
+            &mut client_config,
+            "charlie@example.com",
+            &tokens("at-charlie", "rt-charlie", 1_893_456_000_000),
+            profile_named("charlie@example.com"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(name, "charlie@example.com");
+
+        let final_doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let accounts = final_doc["accounts"].as_array().unwrap();
+        assert_eq!(
+            accounts.len(),
+            3,
+            "alice, rotated bob, and charlie: {final_doc}"
+        );
+        let bob = accounts
+            .iter()
+            .find(|a| a["name"] == "bob@example.com")
+            .expect("bob still on disk");
+        assert_eq!(
+            bob["refreshToken"],
+            serde_json::json!("rt-bob-ROTATED"),
+            "the live add must NOT whole-file-write a stale snapshot back over \
+             bob's rotation: {final_doc}"
+        );
+        assert!(
+            accounts.iter().any(|a| a["name"] == "charlie@example.com"),
+            "charlie was added live: {final_doc}"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// A server that answered and REFUSED us (wrong api-key) must surface,
+    /// never silently fall back to writing the file — that silent fallback is
+    /// how the two halves end up disagreeing about an account's credentials.
+    #[tokio::test]
+    async fn finish_login_live_unauthorized_does_not_fall_back_to_file() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let seed = format!(r#"{{ "proxy": {{ "port": {port}, "apiKey": "correct-key" }} }}"#);
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-live-unauthorized-{}-{port}.json",
+            std::process::id()
+        ));
+        std::fs::write(&path, &seed).unwrap();
+
+        let server_config: Config = serde_json::from_str(&seed).unwrap();
+        let manager =
+            crate::manager::Manager::with_live_refresher(server_config, Some(path.clone()));
+        tokio::spawn(async move { crate::mitm::serve(listener, manager, None).await });
+
+        // The caller's config carries the WRONG key.
+        let mut client_config: Config = serde_json::from_str(&format!(
+            r#"{{ "proxy": {{ "port": {port}, "apiKey": "wrong-key" }} }}"#
+        ))
+        .unwrap();
+        let before = std::fs::read_to_string(&path).unwrap();
+
+        let err = finish_login(
+            &path,
+            LoginRoute::Live,
+            &mut client_config,
+            "dave@example.com",
+            &tokens("at-dave", "rt-dave", 1_893_456_000_000),
+            profile_named("dave@example.com"),
+        )
+        .await
+        .expect_err("a rejected api-key must not silently write the file");
+        assert!(err.to_string().contains("api-key"), "{err}");
+
+        assert_eq!(
+            before,
+            std::fs::read_to_string(&path).unwrap(),
+            "the file must be byte-identical after a surfaced Unauthorized"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// The quiet fallback: nothing is listening at all, so there is no live
+    /// rotation to disagree with the file — `finish_login` writes it exactly
+    /// as the historical file-only path always has.
+    #[tokio::test]
+    async fn finish_login_no_server_falls_back_to_file_quietly() {
+        let dead_port = {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            listener.local_addr().unwrap().port()
+        };
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-live-noserver-{}-{dead_port}.json",
+            std::process::id()
+        ));
+        std::fs::write(
+            &path,
+            format!(r#"{{ "proxy": {{ "port": {dead_port} }}, "accounts": [] }}"#),
+        )
+        .unwrap();
+        let mut config = load_or_default(&path).unwrap();
+
+        let name = finish_login(
+            &path,
+            LoginRoute::Live,
+            &mut config,
+            "erin@example.com",
+            &tokens("at-erin", "rt-erin", 1_893_456_000_000),
+            profile_named("erin@example.com"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(name, "erin@example.com");
+
+        let doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(
+            doc["accounts"][0]["name"],
+            serde_json::json!("erin@example.com")
+        );
+        std::fs::remove_file(&path).ok();
     }
 }

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -774,9 +774,13 @@ fn login_target_port(config_path: &Path) -> u16 {
 enum LoginRoute {
     /// No live proxy on the port at all — the historical file-only login,
     /// unchanged. Also reached under `--force` when the probe could not
-    /// confirm a safe live route (no route, unauthorized, or an unusable
-    /// answer): `--force` is the escape hatch PAST A REFUSAL, never a way to
-    /// skip a live route that IS there — `Live` below takes priority over it.
+    /// confirm a safe live route (no route, or an unusable answer):
+    /// `--force` is the escape hatch PAST A REFUSAL, never a way to skip a
+    /// live route that IS there — `Live` below takes priority over it. An
+    /// api-key rejection (`AddCapability::Unauthorized`) never resolves to
+    /// this, under `--force` or otherwise: that is positive evidence the
+    /// proxy is alive, so there is no unsafe file write for `--force` to
+    /// rescue — see `login_route`'s `Unauthorized` arm.
     File,
     /// A live proxy is there and its add route is confirmed: route the
     /// finished credential through it instead of the file. Wins even against
@@ -934,10 +938,15 @@ async fn probe_add_capability(config: &Config) -> AddCapability {
 /// the probe under `--force` is exactly the bug bridge item C removed, since
 /// it is what let `--force` take the file path even when the live route was
 /// confirmed and safe. `force` only changes what happens when the probe
-/// itself cannot confirm a safe live route (unauthorized, or an unusable
-/// answer) — those cases fall back to `LoginRoute::File` under `--force`
-/// instead of erroring out, mirroring the historical "force always succeeds
-/// via the file" behaviour. Fully resolves before `login()` starts the OAuth
+/// itself produced an UNUSABLE answer (something holds the port but is not
+/// confirmed safe) — that case falls back to `LoginRoute::File` under
+/// `--force` instead of erroring out, mirroring the historical "force always
+/// succeeds via the file" behaviour. An api-key rejection (`Unauthorized`) is
+/// a DIFFERENT case, and `--force` never rescues it: it is positive evidence
+/// of a live, healthy proxy — it answered, parsed our request, and rejected
+/// the key — which makes it the worst-informed moment to whole-file-write
+/// beside it, since a live server rotating tokens is exactly what makes that
+/// write destructive. Fully resolves before `login()` starts the OAuth
 /// dance, so a user is never told to stop a server AFTER completing a full
 /// browser round-trip, and never silently falls back to the file when a live
 /// proxy answered but rejected our api-key.
@@ -949,16 +958,18 @@ async fn login_route(
 ) -> anyhow::Result<LoginRoute> {
     let config = load_or_default(config_path)?;
     match probe_add_capability(&config).await {
+        // Positive evidence the proxy is alive: it answered, parsed our
+        // request, and rejected the key. Refuses regardless of `--force` —
+        // unlike `Unusable` below, there is no unsafe-but-forceable file
+        // write to fall back to here, only a safe path one config edit away.
         AddCapability::Unauthorized => {
-            if force {
-                return Ok(LoginRoute::File);
-            }
             bail!(
                 "the proxy on :{port} rejected the api-key in {} while checking whether it \
-                 could take a live login — no browser was opened and nothing was changed. Fix \
-                 `proxy.apiKey` and retry, or re-run with --force to log in via the file \
-                 instead (this still risks the running server overwriting it on its next token \
-                 refresh).",
+                 could take a live login — no browser was opened and nothing was changed. This \
+                 refuses even under --force: a rejected api-key is proof the proxy is alive, \
+                 which makes this the worst-informed moment to write the config file beside it. \
+                 Fix `proxy.apiKey` in the config to match the running server, or stop the \
+                 server and log in offline.",
                 config_path.display()
             );
         }
@@ -2142,6 +2153,49 @@ mod tests {
 
         std::fs::remove_file(&path).ok();
         drop(listener);
+    }
+
+    /// THE OVERRULE: `--force` is the escape hatch past a wedged-port
+    /// refusal (above), but it must NOT be one past `AddCapability::
+    /// Unauthorized`. A rejected api-key is positive evidence the proxy is
+    /// alive and healthy — the worst-informed moment to fall back to a
+    /// whole-file write beside it — so `login_route` must keep refusing even
+    /// under `--force`, and nothing along the way may touch the config file.
+    #[tokio::test]
+    async fn login_route_refuses_unauthorized_even_under_force() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server_config: Config = serde_json::from_str(&format!(
+            r#"{{ "proxy": {{ "port": {port}, "apiKey": "correct-key" }} }}"#
+        ))
+        .unwrap();
+        let manager = crate::manager::Manager::with_live_refresher(server_config, None);
+        tokio::spawn(async move { crate::mitm::serve(listener, manager, None).await });
+
+        // The file `login_route` reads carries the WRONG key.
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-route-unauthorized-force-{}-{port}.json",
+            std::process::id()
+        ));
+        let seed = format!(r#"{{ "proxy": {{ "port": {port}, "apiKey": "wrong-key" }} }}"#);
+        std::fs::write(&path, &seed).unwrap();
+        let before = std::fs::read_to_string(&path).unwrap();
+
+        let err = login_route(&path, None, port, true)
+            .await
+            .expect_err("--force must not rescue a rejected api-key");
+        assert!(err.to_string().contains("api-key"), "{err}");
+        assert!(
+            err.to_string().contains("even under --force"),
+            "the message must say --force does not apply here: {err}"
+        );
+
+        assert_eq!(
+            before,
+            std::fs::read_to_string(&path).unwrap(),
+            "the file must be byte-identical — --force must not trigger a write here"
+        );
+        std::fs::remove_file(&path).ok();
     }
 
     // --- finish_login ---------------------------------------------------------

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -662,14 +662,21 @@ fn prompt_account_name(fallback: &str) -> String {
 }
 
 /// Add or update an OAuth account in `config`, keyed on `(account_uuid, org)`
-/// via [`identity::same_identity`] rather than name alone. An existing account
-/// with the same identity has its tokens refreshed in place and any absent
-/// identity field backfilled (never duplicated); otherwise a new account is
-/// appended with the next-highest priority and every identity field populated.
+/// via [`identity::resolve`] — never a loose first-match — so the legacy
+/// two-org tie ([`identity::same_identity_strict`]) is broken the same way
+/// [`config::save_account`] and [`crate::manager::Manager::add_or_update_account`]
+/// already break it, and an unbreakable tie is REFUSED rather than guessed:
+/// guessing here means stamping a fresh credential over a DIFFERENT account's
+/// single-use refresh token (see [`identity::Resolved::Many`]'s doc-comment).
+/// An existing account with the same identity has its tokens refreshed in
+/// place and any absent identity field backfilled (never duplicated);
+/// otherwise a new account is appended with the next-highest priority and
+/// every identity field populated.
 ///
 /// Backward compatible: when the probe and the stored entry both lack identity
-/// fields (today's real config), `same_identity` falls back to name equality —
-/// so a single-org re-login matches its existing entry exactly as before.
+/// fields (today's real config), `identity::resolve` falls back to name
+/// equality — so a single-org re-login matches its existing entry exactly as
+/// before.
 pub fn upsert_account(
     config: &mut Config,
     name: &str,
@@ -677,7 +684,7 @@ pub fn upsert_account(
     account_uuid: Option<String>,
     org_uuid: Option<String>,
     org_name: Option<String>,
-) {
+) -> anyhow::Result<()> {
     let probe = crate::identity::probe(
         name,
         account_uuid.clone(),
@@ -685,50 +692,65 @@ pub fn upsert_account(
         org_name.clone(),
     );
 
-    if let Some(account) = config
-        .accounts
-        .iter_mut()
-        .find(|a| crate::identity::same_identity(a, &probe))
-    {
-        account.account_type = "oauth".to_string();
-        account.access_token = tokens.access_token.clone();
-        account.refresh_token = Some(tokens.refresh_token.clone());
-        account.expires_at = Some(tokens.expires_at_ms);
-        // Backfill any identity field the stored entry was missing (e.g. a legacy
-        // pre-org entry newly profiled), without overwriting known values.
-        if account.account_uuid.is_none() {
-            account.account_uuid = account_uuid;
+    match crate::identity::resolve(config.accounts.iter().enumerate(), &probe) {
+        crate::identity::Resolved::One(index) => {
+            let account = &mut config.accounts[index];
+            account.account_type = "oauth".to_string();
+            account.access_token = tokens.access_token.clone();
+            account.refresh_token = Some(tokens.refresh_token.clone());
+            account.expires_at = Some(tokens.expires_at_ms);
+            // Backfill any identity field the stored entry was missing (e.g. a
+            // legacy pre-org entry newly profiled), without overwriting known
+            // values.
+            if account.account_uuid.is_none() {
+                account.account_uuid = account_uuid;
+            }
+            if account.org_uuid.is_none() {
+                account.org_uuid = org_uuid;
+            }
+            if account.org_name.is_none() {
+                account.org_name = org_name;
+            }
+            Ok(())
         }
-        if account.org_uuid.is_none() {
-            account.org_uuid = org_uuid;
+        crate::identity::Resolved::None => {
+            let next_priority = config
+                .accounts
+                .iter()
+                .filter_map(|a| a.priority)
+                .max()
+                .map_or(0, |max| max + 1);
+
+            config.accounts.push(Account {
+                name: name.to_string(),
+                account_type: "oauth".to_string(),
+                account_uuid,
+                org_uuid,
+                org_name,
+                access_token: tokens.access_token.clone(),
+                refresh_token: Some(tokens.refresh_token.clone()),
+                expires_at: Some(tokens.expires_at_ms),
+                priority: Some(next_priority),
+                switch_threshold: None,
+                disabled: None,
+                extra: serde_json::Map::new(),
+            });
+            Ok(())
         }
-        if account.org_name.is_none() {
-            account.org_name = org_name;
+        // Recompute the loose set for its names: `Resolved::Many` itself
+        // carries none, and this is exactly the set `resolve` drew from (same
+        // predicate, same candidates) — mirrors
+        // `Manager::add_or_update_account`'s identical recomputation.
+        crate::identity::Resolved::Many => {
+            let candidates: Vec<String> = config
+                .accounts
+                .iter()
+                .filter(|a| crate::identity::same_identity(a, &probe))
+                .map(|a| a.name.clone())
+                .collect();
+            bail!("{}", crate::cli::ambiguous_query_message(name, &candidates));
         }
-        return;
     }
-
-    let next_priority = config
-        .accounts
-        .iter()
-        .filter_map(|a| a.priority)
-        .max()
-        .map_or(0, |max| max + 1);
-
-    config.accounts.push(Account {
-        name: name.to_string(),
-        account_type: "oauth".to_string(),
-        account_uuid,
-        org_uuid,
-        org_name,
-        access_token: tokens.access_token.clone(),
-        refresh_token: Some(tokens.refresh_token.clone()),
-        expires_at: Some(tokens.expires_at_ms),
-        priority: Some(next_priority),
-        switch_threshold: None,
-        disabled: None,
-        extra: serde_json::Map::new(),
-    });
 }
 
 /// The proxy port a login must guard against — the port the running server binds.
@@ -750,13 +772,16 @@ fn login_target_port(config_path: &Path) -> u16 {
 /// `--force`. Returned by [`login_guard_refusal`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum LoginRoute {
-    /// No live proxy on the port, or `--force`: the historical file-only
-    /// login. `--force` always means this, even when the live route WAS
-    /// confirmed — it is the deliberate escape hatch past the live
-    /// coordination below, not just past the old refusal.
+    /// No live proxy on the port at all — the historical file-only login,
+    /// unchanged. Also reached under `--force` when the probe could not
+    /// confirm a safe live route (no route, unauthorized, or an unusable
+    /// answer): `--force` is the escape hatch PAST A REFUSAL, never a way to
+    /// skip a live route that IS there — `Live` below takes priority over it.
     File,
     /// A live proxy is there and its add route is confirmed: route the
-    /// finished credential through it instead of the file.
+    /// finished credential through it instead of the file. Wins even against
+    /// `--force` — forcing the unsafe file write only makes sense when the
+    /// safe live route is not available.
     Live,
     /// A live proxy is there without the route, and `--force` was not given:
     /// refuse outright with this message, unchanged from before this route
@@ -802,11 +827,17 @@ fn login_guard_refusal(
     port: u16,
     force: bool,
 ) -> LoginRoute {
-    if force {
-        return LoginRoute::File;
-    }
+    // `has_add_route` is checked BEFORE `force`, deliberately: a confirmed
+    // route wins even against the escape hatch. Checking `force` first (the
+    // pre-fix order) meant `--force` chose the file write even when the live
+    // route was confirmed safe — the exact whole-file clobber this unit
+    // exists to remove, reintroduced by the escape hatch meant to route
+    // around a REFUSAL, not around a safe route that was never refused.
     if has_add_route {
         return LoginRoute::Live;
+    }
+    if force {
+        return LoginRoute::File;
     }
     match incumbent {
         Some(incumbent) => {
@@ -828,23 +859,34 @@ fn login_guard_refusal(
 /// account add. Read from [`crate::cli::post_add_account`]'s own
 /// [`crate::cli::LiveControlError`] classification, which is itself driven by
 /// [`crate::proxy::ENDPOINT_HEADER`] — never by matching error text.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum AddCapability {
     /// The route answered (stamped, whatever the status) — a live add is
     /// possible.
     Present,
-    /// Nothing usable answered: no server, a route-less 404/405 (an older
-    /// tcr), or the probe timed out / returned something unreadable. All
-    /// three collapse to the same conservative answer: `login_guard_refusal`
-    /// treats "confirmed absent" and "could not confirm" identically, always
-    /// falling back to the historical refusal rather than guessing a route is
-    /// there.
+    /// A connection could not even be made — genuinely nothing is listening
+    /// on the port. The ONLY outcome that may resolve to `LoginRoute::File`
+    /// without `--force` and without `incumbent` separately confirming a
+    /// server: there is truly no live process to disagree with the file.
     Absent,
     /// The proxy answered and rejected our api-key. Its own condition — never
     /// folded into `Absent`: that would either wrongly read as an older proxy
     /// with no route, or let `login()` silently fall back to writing the file
     /// out from under a server that is right there, listening.
     Unauthorized,
+    /// Something holds the port and is either an older proxy answering
+    /// without the route (identified structurally, never by error text) or
+    /// accepted the connection and then produced nothing usable before the
+    /// deadline — the wedged-port shape `cli::probe_incumbent`'s own tests
+    /// document as measured and real (`a_listener_that_never_answers_is_silent_not_answering`).
+    /// Both are first-hand evidence a live process holds the port — at least
+    /// as strong as the `incumbent` pid heuristic, and stronger exactly where
+    /// that heuristic is documented to miss (an embedded host). Split out of
+    /// `Absent` because the two are NOT the same conservative answer: folding
+    /// them together let a `None` incumbent silently choose `File` beside a
+    /// real, wedged server, without `--force` ever being asked for. Carries
+    /// the probe's own account of what happened, for the refusal message.
+    Unusable(String),
 }
 
 /// Probe whether the proxy `config` points at can accept a live account add,
@@ -876,17 +918,26 @@ async fn probe_add_capability(config: &Config) -> AddCapability {
         // stamped — exactly the positive capability signal.
         Err(crate::cli::LiveControlError::Rejected(_)) => AddCapability::Present,
         Err(crate::cli::LiveControlError::Unauthorized) => AddCapability::Unauthorized,
-        Err(_) => AddCapability::Absent,
+        // A connection could not be made at all — the ONLY genuinely-absent
+        // case.
+        Err(crate::cli::LiveControlError::NoServer) => AddCapability::Absent,
+        // Everything else (`NoRoute`, `NoAnswer`, `Unusable`) is first-hand
+        // evidence something holds the port, just not usably.
+        Err(other) => AddCapability::Unusable(other.why()),
     }
 }
 
 /// Resolve which [`LoginRoute`] `login()` should take. Runs the impure HTTP
-/// capability probe UNCONDITIONALLY whenever `--force` was not given —
-/// deliberately never gated on whether [`crate::singleton::live_proxy_server`]
-/// (`incumbent`) noticed anything on the port first. That detection is a pid
-/// inference and can miss a live proxy this build's argv/owner-file matcher
-/// was never taught to recognize; the probe asks the port directly and is
-/// authoritative on its own. Fully resolves before `login()` starts the OAuth
+/// capability probe UNCONDITIONALLY — including under `--force` — deliberately
+/// never gated on whether [`crate::singleton::live_proxy_server`]
+/// (`incumbent`) noticed anything on the port first, NOR on `force`: skipping
+/// the probe under `--force` is exactly the bug bridge item C removed, since
+/// it is what let `--force` take the file path even when the live route was
+/// confirmed and safe. `force` only changes what happens when the probe
+/// itself cannot confirm a safe live route (unauthorized, or an unusable
+/// answer) — those cases fall back to `LoginRoute::File` under `--force`
+/// instead of erroring out, mirroring the historical "force always succeeds
+/// via the file" behaviour. Fully resolves before `login()` starts the OAuth
 /// dance, so a user is never told to stop a server AFTER completing a full
 /// browser round-trip, and never silently falls back to the file when a live
 /// proxy answered but rejected our api-key.
@@ -896,20 +947,41 @@ async fn login_route(
     port: u16,
     force: bool,
 ) -> anyhow::Result<LoginRoute> {
-    if force {
-        return Ok(login_guard_refusal(incumbent, false, port, force));
-    }
     let config = load_or_default(config_path)?;
     match probe_add_capability(&config).await {
-        AddCapability::Unauthorized => bail!(
-            "the proxy on :{port} rejected the api-key in {} while checking whether it could \
-             take a live login — no browser was opened and nothing was changed. Fix \
-             `proxy.apiKey` and retry, or re-run with --force to log in via the file instead \
-             (this still risks the running server overwriting it on its next token refresh).",
-            config_path.display()
-        ),
+        AddCapability::Unauthorized => {
+            if force {
+                return Ok(LoginRoute::File);
+            }
+            bail!(
+                "the proxy on :{port} rejected the api-key in {} while checking whether it \
+                 could take a live login — no browser was opened and nothing was changed. Fix \
+                 `proxy.apiKey` and retry, or re-run with --force to log in via the file \
+                 instead (this still risks the running server overwriting it on its next token \
+                 refresh).",
+                config_path.display()
+            );
+        }
         AddCapability::Present => Ok(login_guard_refusal(incumbent, true, port, force)),
         AddCapability::Absent => Ok(login_guard_refusal(incumbent, false, port, force)),
+        // Bridge item D: something holds the port but answered unusably —
+        // first-hand evidence at least as strong as `incumbent`, so this
+        // refuses REGARDLESS of what `incumbent` separately concluded, never
+        // falling through to `LoginRoute::File` the way folding this into
+        // `Absent` used to when `incumbent` was `None`.
+        AddCapability::Unusable(why) => {
+            if force {
+                return Ok(LoginRoute::File);
+            }
+            bail!(
+                "the proxy on :{port} answered but not usably ({why}) while checking whether \
+                 it could take a live login — no browser was opened and nothing was changed. \
+                 This is first-hand evidence something holds the port even though process \
+                 detection may have missed it, so the historical whole-file-write hazard still \
+                 applies. Re-run with --force to log in via the file instead (this still risks \
+                 the running server overwriting it on its next token refresh)."
+            );
+        }
     }
 }
 
@@ -985,10 +1057,50 @@ fn persist_via_file(
         profile.account_uuid,
         profile.org_uuid,
         profile.org_name,
-    );
+    )?;
     config::save(config_path, config).context("save config after login")?;
     println!("Saved account '{name}' to {}", config_path.display());
     Ok(name.to_string())
+}
+
+/// The surgical half of a live-route fallback — [`config::save_account`]'s
+/// single-account read-modify-write — used when [`probe_add_capability`]
+/// confirmed the route moments earlier but [`crate::cli::post_add_account`]
+/// itself then could not apply it (the route disappeared, or the proxy
+/// stopped answering before its 5s deadline). Bridge item A: this replaces
+/// [`persist_via_file`] on exactly those two arms of [`finish_login`].
+///
+/// Unlike `persist_via_file`, this never touches any account row but
+/// `account`'s own, and it is safe to call even though `account` was built
+/// from data gathered before this call's own async window (the profile
+/// fetch, the possible stdin prompt, the up-to-5s `post_add_account`
+/// timeout): `config::save_account` re-reads the config document FRESH from
+/// disk and resolves identity itself, rather than whole-file-saving the
+/// (possibly already-stale) in-memory `config` this process is holding — so
+/// there is no stale snapshot for it to clobber a concurrent server-side
+/// rotation with. This is the same write the server's own persist path uses.
+fn persist_via_account(config_path: &Path, account: &Account) -> anyhow::Result<String> {
+    match config::save_account(config_path, account).context("save account after login")? {
+        config::AccountWrite::Added | config::AccountWrite::Updated => {
+            println!(
+                "Saved account '{}' to {}",
+                account.name,
+                config_path.display()
+            );
+            Ok(account.name.clone())
+        }
+        config::AccountWrite::Ambiguous => bail!(
+            "'{}' matches more than one account already in {} — narrow with --org or use an \
+             exact name. Nothing was changed.",
+            account.name,
+            config_path.display()
+        ),
+        config::AccountWrite::Unwritable => bail!(
+            "the accounts key in {} is not a JSON array — refusing to write. Nothing was \
+             changed.",
+            config_path.display()
+        ),
+    }
 }
 
 /// Persist the finished OAuth credential per `route`: through the live proxy
@@ -1077,26 +1189,40 @@ async fn finish_login(
                 ),
                 // The route is missing: the capability probe said it was
                 // there and it no longer is (a race, or a downgrade mid-run).
-                // The file write is all we can do, and it is HALF a login —
-                // say so loudly, mirroring `set_enabled`'s NoRoute arm.
+                // Bridge item A: this is reached with a CONFIRMED-live server
+                // on the other end of the port, seconds after the config
+                // snapshot above was loaded (a profile fetch, possibly an
+                // unbounded stdin prompt, then this call itself came between)
+                // — so a whole-file `persist_via_file` here would revert any
+                // edit the live server made to any OTHER account in that
+                // window. `persist_via_account` writes only this one row,
+                // re-reading the file fresh instead of trusting the stale
+                // snapshot. It is still HALF a login — say so loudly,
+                // mirroring `set_enabled`'s NoRoute arm.
                 Err(crate::cli::LiveControlError::NoRoute) => {
-                    let saved = persist_via_file(config_path, config, name, tokens, profile)?;
+                    let saved = persist_via_account(config_path, &account)?;
                     eprintln!(
-                        "[tcr] WARNING: the proxy running on :{} is too old to accept a live login (no {} route), so only the config file was changed. Run `tcr restart` when a cold prompt cache is acceptable.",
+                        "[tcr] WARNING: the proxy running on :{} is too old to accept a live login (no {} route), so the account was written to {} while the proxy is running — it will not see this account until it restarts. Run `tcr restart` when a cold prompt cache is acceptable.",
                         config.proxy.port,
                         crate::proxy::ADD_ACCOUNT_PATH,
+                        config_path.display(),
                     );
                     Ok(saved)
                 }
-                // It answered something unusable, or did not answer in time.
-                // Same shape of consequence as NoRoute, different cause, and
+                // It answered something unusable, or did not answer in time
+                // (the wedged-port shape `cli::probe_incumbent`'s own tests
+                // document as measured and real — the probe confirmed the
+                // route seconds ago and `post_add_account` then hit its own
+                // 5s deadline). Same shape of consequence as `NoRoute`, same
+                // surgical write for the same reason, different cause, and
                 // equally never silent.
                 Err(other) => {
                     let why = other.why();
-                    let saved = persist_via_file(config_path, config, name, tokens, profile)?;
+                    let saved = persist_via_account(config_path, &account)?;
                     eprintln!(
-                        "[tcr] WARNING: could not apply this login to the proxy running on :{} ({why}), so only the config file was changed.",
+                        "[tcr] WARNING: could not apply this login to the proxy running on :{} ({why}), so the account was written to {} while the proxy is running — it may not see this account until it restarts.",
                         config.proxy.port,
+                        config_path.display(),
                     );
                     Ok(saved)
                 }
@@ -1336,7 +1462,8 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
 
         assert_eq!(config.accounts.len(), 1);
         let account = &config.accounts[0];
@@ -1365,7 +1492,8 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
 
         // Same account count — updated in place, not duplicated.
         assert_eq!(config.accounts.len(), 1);
@@ -1394,7 +1522,8 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
 
         assert_eq!(config.accounts.len(), 2);
         // max existing priority (3) + 1.
@@ -1413,7 +1542,8 @@ mod tests {
             Some("uuid-person".into()),
             Some("org-corp".into()),
             Some("Corp".into()),
-        );
+        )
+        .unwrap();
         upsert_account(
             &mut config,
             "me@example.com",
@@ -1421,7 +1551,8 @@ mod tests {
             Some("uuid-person".into()),
             Some("org-personal".into()),
             Some("Personal".into()),
-        );
+        )
+        .unwrap();
 
         assert_eq!(config.accounts.len(), 2, "second org is a distinct account");
         assert_eq!(config.accounts[0].access_token, "at-corp");
@@ -1448,7 +1579,8 @@ mod tests {
             Some("uuid-person".into()),
             Some("org-corp".into()),
             Some("Corp".into()),
-        );
+        )
+        .unwrap();
 
         assert_eq!(
             config.accounts.len(),
@@ -1459,6 +1591,96 @@ mod tests {
         assert_eq!(account.access_token, "new-at");
         assert_eq!(account.org_uuid.as_deref(), Some("org-corp"));
         assert_eq!(account.org_name.as_deref(), Some("Corp"));
+    }
+
+    /// THE MEASURED FAILURE bridge item B exists to fix: entries
+    /// `[{u1, org-a, at-ORG-A/rt-ORG-A}, {u1, no org, at-LEGACY/rt-LEGACY}]`
+    /// with a login identity `{u1, no org}`. Under the old `.find()`
+    /// first-match-wins, `same_identity` matches BOTH rows — a legacy no-org
+    /// entry loosely matches every org of that person — so `.find()` silently
+    /// took index 0, stamping the fresh credential over org-a's row and
+    /// destroying its single-use refresh token. `identity::resolve` exists
+    /// exactly to break this tie via `same_identity_strict`: only the legacy
+    /// row (also org-less) is a STRICT match, so the target resolves to it.
+    #[test]
+    fn upsert_resolves_the_legacy_two_org_tie_onto_the_legacy_row() {
+        let mut config: Config = serde_json::from_str(
+            r#"{ "accounts": [
+                { "name": "me@example.com", "type": "oauth", "accountUuid": "u1",
+                  "orgUuid": "org-a", "orgName": "Org A",
+                  "accessToken": "at-ORG-A", "refreshToken": "rt-ORG-A",
+                  "expiresAt": 100, "priority": 0 },
+                { "name": "me@example.com", "type": "oauth", "accountUuid": "u1",
+                  "accessToken": "at-LEGACY", "refreshToken": "rt-LEGACY",
+                  "expiresAt": 100, "priority": 1 }
+            ] }"#,
+        )
+        .unwrap();
+
+        upsert_account(
+            &mut config,
+            "me@example.com",
+            &tokens("at-NEW", "rt-NEW", 999),
+            Some("u1".to_string()),
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(config.accounts.len(), 2, "no new row appended");
+        assert_eq!(
+            config.accounts[0].access_token, "at-ORG-A",
+            "org-a's row must be untouched: {:?}",
+            config.accounts[0]
+        );
+        assert_eq!(
+            config.accounts[0].refresh_token.as_deref(),
+            Some("rt-ORG-A"),
+            "org-a's refresh token is single-use — clobbering it bricks the account"
+        );
+        assert_eq!(
+            config.accounts[1].access_token, "at-NEW",
+            "the legacy row (also org-less) is the strict match, not org-a"
+        );
+        assert_eq!(config.accounts[1].refresh_token.as_deref(), Some("rt-NEW"));
+    }
+
+    /// A genuine, unbreakable tie — two rows sharing the exact same identity —
+    /// refuses rather than guesses, and writes NOTHING: the config must be
+    /// byte-for-byte unchanged after the refusal.
+    #[test]
+    fn upsert_refuses_and_writes_nothing_on_an_unbreakable_tie() {
+        let mut config: Config = serde_json::from_str(
+            r#"{ "accounts": [
+                { "name": "me@example.com", "type": "oauth", "accountUuid": "u1",
+                  "orgUuid": "org-a", "orgName": "Org A",
+                  "accessToken": "at-1", "refreshToken": "rt-1",
+                  "expiresAt": 100, "priority": 0 },
+                { "name": "me@example.com", "type": "oauth", "accountUuid": "u1",
+                  "orgUuid": "org-a", "orgName": "Org A",
+                  "accessToken": "at-2", "refreshToken": "rt-2",
+                  "expiresAt": 100, "priority": 1 }
+            ] }"#,
+        )
+        .unwrap();
+        let before = serde_json::to_value(&config).unwrap();
+
+        let err = upsert_account(
+            &mut config,
+            "me@example.com",
+            &tokens("at-NEW", "rt-NEW", 999),
+            Some("u1".to_string()),
+            Some("org-a".to_string()),
+            Some("Org A".to_string()),
+        )
+        .expect_err("an unbreakable tie must refuse rather than guess");
+        assert!(err.to_string().contains("ambiguous"), "{err}");
+
+        assert_eq!(
+            serde_json::to_value(&config).unwrap(),
+            before,
+            "nothing was written on refusal"
+        );
     }
 
     // --- authorize URL ------------------------------------------------------
@@ -1559,6 +1781,21 @@ mod tests {
         assert_eq!(
             login_guard_refusal(None, false, 3456, false),
             LoginRoute::File
+        );
+    }
+
+    /// THE BRIDGE ITEM C FIX: `--force` overrides only the `Refuse` outcome,
+    /// never a confirmed-safe `Live` route. The pre-fix code checked `force`
+    /// BEFORE `has_add_route`, so `--force` took the file path even when the
+    /// live route was confirmed and safe — the exact bug this unit exists to
+    /// remove, self-inflicted by the escape hatch. Nobody wants the file
+    /// write *because* it is a file write; they want the login not refused.
+    #[test]
+    fn login_guard_prefers_live_over_force_when_the_route_is_confirmed() {
+        assert_eq!(
+            login_guard_refusal(incumbent(singleton::ProxyKind::Tcr), true, 3456, true),
+            LoginRoute::Live,
+            "--force must not choose the file write when the live route IS available and safe"
         );
     }
 
@@ -1715,11 +1952,15 @@ mod tests {
         assert_eq!(probe_add_capability(&config).await, AddCapability::Present);
     }
 
+    /// Bridge item D: an "older tcr" — something answers, but not on this
+    /// route at all (no `ENDPOINT_HEADER`, unlike every response this crate's
+    /// own router produces, even its 404s and 405s) — is first-hand evidence
+    /// a live process holds the port. It must NOT collapse into `Absent`
+    /// (renamed from this test's old expectation): folding it in there is
+    /// exactly what let `login_route` silently choose `File` beside a real,
+    /// answering-but-old server whenever pid detection missed it.
     #[tokio::test]
-    async fn probe_add_capability_unstamped_404_is_absent() {
-        // An "older tcr": something answers, but not on this route at all — no
-        // `ENDPOINT_HEADER`, unlike every response this crate's own router
-        // produces (even its 404s and 405s).
+    async fn probe_add_capability_unstamped_404_is_unusable_not_absent() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
         tokio::spawn(async move {
@@ -1727,7 +1968,44 @@ mod tests {
         });
         let config: Config =
             serde_json::from_str(&format!(r#"{{ "proxy": {{ "port": {port} }} }}"#)).unwrap();
+        assert!(matches!(
+            probe_add_capability(&config).await,
+            AddCapability::Unusable(_)
+        ));
+    }
+
+    /// The genuinely-absent case, for contrast with the test above: nothing
+    /// is bound to the port at all, so the connection is refused outright.
+    /// This is the ONLY shape that may still resolve to `LoginRoute::File`
+    /// without `--force` and without `incumbent` separately confirming a
+    /// server.
+    #[tokio::test]
+    async fn probe_add_capability_connection_refused_is_absent() {
+        let dead_port = {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            listener.local_addr().unwrap().port()
+        };
+        let config: Config =
+            serde_json::from_str(&format!(r#"{{ "proxy": {{ "port": {dead_port} }} }}"#)).unwrap();
         assert_eq!(probe_add_capability(&config).await, AddCapability::Absent);
+    }
+
+    /// The WEDGED shape `cli::probe_incumbent`'s own tests document as
+    /// measured and real (`a_listener_that_never_answers_is_silent_not_answering`):
+    /// bound, the connect succeeds off the kernel backlog, and nothing is
+    /// ever written back. Costs the probe's own 5s deadline by construction.
+    #[tokio::test]
+    async fn probe_add_capability_wedged_port_is_unusable() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let config: Config =
+            serde_json::from_str(&format!(r#"{{ "proxy": {{ "port": {port} }} }}"#)).unwrap();
+
+        assert!(matches!(
+            probe_add_capability(&config).await,
+            AddCapability::Unusable(_)
+        ));
+        drop(listener);
     }
 
     #[tokio::test]
@@ -1789,6 +2067,81 @@ mod tests {
             "the probe must decide this on its own, independent of incumbent detection"
         );
         std::fs::remove_file(&path).ok();
+    }
+
+    /// Bridge item C, at the `login_route` level: `--force` must still probe
+    /// and still prefer `Live` when a real server confirms the route — never
+    /// skip straight to `File` the way the pre-fix early-return did.
+    #[tokio::test]
+    async fn login_route_prefers_live_over_force_when_a_real_server_confirms_the_route() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-route-force-live-{}-{port}.json",
+            std::process::id()
+        ));
+        let seed = format!(r#"{{ "proxy": {{ "port": {port} }} }}"#);
+        std::fs::write(&path, &seed).unwrap();
+
+        let server_config: Config = serde_json::from_str(&seed).unwrap();
+        let manager = crate::manager::Manager::with_live_refresher(server_config, None);
+        tokio::spawn(async move { crate::mitm::serve(listener, manager, None).await });
+
+        let route = login_route(&path, None, port, true)
+            .await
+            .expect("a confirmed route under --force must not error");
+        assert_eq!(
+            route,
+            LoginRoute::Live,
+            "--force must still probe and prefer Live when the route is confirmed"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// Bridge item D, at the `login_route` level: a wedged port — something
+    /// answers the TCP connect and then never responds — must refuse even
+    /// when `incumbent` is `None` (pid/argv detection missed it entirely, the
+    /// TcrBar shape). Before this fix, `AddCapability::Absent` covered this
+    /// case too, and `login_guard_refusal`'s `None => LoginRoute::File` arm
+    /// let it through with no `--force` needed at all.
+    #[tokio::test]
+    async fn login_route_refuses_a_wedged_port_even_when_incumbent_detection_missed_it() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-route-wedged-{}-{port}.json",
+            std::process::id()
+        ));
+        std::fs::write(&path, format!(r#"{{ "proxy": {{ "port": {port} }} }}"#)).unwrap();
+
+        let err = login_route(&path, None, port, false)
+            .await
+            .expect_err("a wedged port must refuse, not silently choose File");
+        assert!(err.to_string().contains("--force"), "{err}");
+
+        std::fs::remove_file(&path).ok();
+        drop(listener);
+    }
+
+    /// The escape hatch still works past a wedged-port refusal: `--force`
+    /// resolves to `File` rather than erroring out.
+    #[tokio::test]
+    async fn login_route_force_resolves_to_file_past_a_wedged_port_refusal() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-route-wedged-force-{}-{port}.json",
+            std::process::id()
+        ));
+        std::fs::write(&path, format!(r#"{{ "proxy": {{ "port": {port} }} }}"#)).unwrap();
+
+        let route = login_route(&path, None, port, true)
+            .await
+            .expect("--force must still resolve past a wedged-port refusal");
+        assert_eq!(route, LoginRoute::File);
+
+        std::fs::remove_file(&path).ok();
+        drop(listener);
     }
 
     // --- finish_login ---------------------------------------------------------
@@ -2000,5 +2353,108 @@ mod tests {
             serde_json::json!("erin@example.com")
         );
         std::fs::remove_file(&path).ok();
+    }
+
+    /// THE σ5 EXPERIMENT bridge item A calls for. The WEDGED shape
+    /// `cli::probe_incumbent`'s own tests document as measured and real
+    /// (`a_listener_that_never_answers_is_silent_not_answering`): bound, the
+    /// connect succeeds off the kernel backlog, and nothing is ever written
+    /// back — reached on the `Live` route when the capability probe confirmed
+    /// the route seconds earlier and `post_add_account` then hits its own 5s
+    /// deadline.
+    ///
+    /// Reproduces the same race `finish_login_live_path_does_not_clobber_a_concurrent_rotation`
+    /// does — a stale client-side snapshot plus a write that lands on disk
+    /// AFTER that snapshot was taken — but via `config::save_account` (the
+    /// server's own persist primitive) directly, rather than a live HTTP
+    /// round-trip: the port in THIS scenario is deliberately silent for the
+    /// test's whole lifetime, so nothing can be routed through it. Before
+    /// this fix, the `NoAnswer` arm fell through to `persist_via_file`'s
+    /// WHOLE-FILE `config::save` of that now-stale snapshot, reverting
+    /// alice's rotation — the exact hazard `finish_login` exists to remove,
+    /// reintroduced in this one arm (watched failing directly: with that arm
+    /// reverted to `persist_via_file`, this test fails with `left:
+    /// "rt-alice" right: "rt-alice-ROTATED"`). Fixed, it lands through
+    /// `config::save_account`'s surgical single-row write instead, so
+    /// alice's rotated row survives and the new account is still added.
+    #[tokio::test]
+    async fn finish_login_live_timeout_does_not_clobber_other_accounts() {
+        // Bound and never accepted: connections queue in the kernel backlog
+        // and the connect succeeds, but nothing is ever written back —
+        // `post_add_account` times out at its own 5s deadline.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-live-timeout-{}-{port}.json",
+            std::process::id()
+        ));
+        let seed = format!(
+            r#"{{ "proxy": {{ "port": {port} }}, "accounts": [
+                {{ "name": "alice@example.com", "type": "oauth", "accessToken": "at-alice",
+                  "refreshToken": "rt-alice", "expiresAt": 1893456000000, "priority": 0 }}
+            ] }}"#
+        );
+        std::fs::write(&path, &seed).unwrap();
+
+        // The stale snapshot: what `login()` would have loaded before its own
+        // async window (profile fetch / stdin prompt) opened.
+        let mut client_config = load_or_default(&path).unwrap();
+
+        // A rotation lands on disk AFTER that snapshot was taken — the live
+        // server's own persist path, used directly since the port itself is
+        // silent in this scenario and cannot carry a real round-trip.
+        let rotated_alice = Account {
+            name: "alice@example.com".to_string(),
+            account_type: "oauth".to_string(),
+            account_uuid: None,
+            org_uuid: None,
+            org_name: None,
+            access_token: "at-alice-ROTATED".to_string(),
+            refresh_token: Some("rt-alice-ROTATED".to_string()),
+            expires_at: Some(1_893_456_000_000),
+            priority: None,
+            switch_threshold: None,
+            disabled: None,
+            extra: serde_json::Map::new(),
+        };
+        config::save_account(&path, &rotated_alice).expect("the rotation must land on disk");
+        let after_rotation = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            after_rotation.contains("rt-alice-ROTATED"),
+            "setup: the rotation must be on disk first: {after_rotation}"
+        );
+
+        let name = finish_login(
+            &path,
+            LoginRoute::Live,
+            &mut client_config,
+            "carol@example.com",
+            &tokens("at-carol", "rt-carol", 1_893_456_000_000),
+            profile_named("carol@example.com"),
+        )
+        .await
+        .expect("a timed-out live add must still fall back to a file write");
+        assert_eq!(name, "carol@example.com");
+
+        let final_doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let accounts = final_doc["accounts"].as_array().unwrap();
+        let alice = accounts
+            .iter()
+            .find(|a| a["name"] == "alice@example.com")
+            .expect("alice must still be on disk");
+        assert_eq!(
+            alice["refreshToken"],
+            serde_json::json!("rt-alice-ROTATED"),
+            "the timed-out live add must NOT whole-file-write a stale snapshot back over \
+             alice's rotation: {final_doc}"
+        );
+        assert!(
+            accounts.iter().any(|a| a["name"] == "carol@example.com"),
+            "carol was added: {final_doc}"
+        );
+
+        std::fs::remove_file(&path).ok();
+        drop(listener);
     }
 }

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -764,16 +764,30 @@ enum LoginRoute {
     Refuse(String),
 }
 
-/// The pure login-guard DECISION: given any live proxy server detected on the
-/// port, whether that incumbent's live account-add route was already
-/// confirmed (never probed in here — see [`probe_add_capability`]), the port,
-/// and the `--force` flag, return which [`LoginRoute`] `login()` should take.
-/// Split from the impure lsof-based detection
-/// ([`crate::singleton::live_proxy_server`]) AND from the impure HTTP
-/// capability probe so the decision itself stays unit-testable, mirroring
+/// The pure login-guard DECISION: given whether the HTTP capability probe
+/// already confirmed a live account-add route ([`probe_add_capability`], run
+/// impure and BEFORE this), any live proxy separately detected on the port
+/// (the impure lsof/owner-file detection,
+/// [`crate::singleton::live_proxy_server`]), the port, and the `--force`
+/// flag, return which [`LoginRoute`] `login()` should take. Split from both
+/// impure detectors so the decision itself stays unit-testable, mirroring
 /// singleton's pure-decision / impure-executor split.
 ///
-/// The incumbent's KIND decides the REFUSAL instruction, and it is not
+/// `has_add_route` is decided FIRST and is decisive on its own, independent
+/// of `incumbent` — including when `incumbent` is `None`. The HTTP probe is
+/// first-hand evidence that a live proxy with the route is answering on this
+/// exact port; `incumbent` is an INFERENCE from a pid, an argv string, or an
+/// owner-file claim, any of which can be stale, absent, or blind to a host
+/// application the pid/argv matcher was never taught to recognize (see
+/// `ProxyHost::Unknown`'s doc-comment). Gating the live path on `incumbent`
+/// agreeing would mean any future regression in that inference silently
+/// reintroduces the whole-file clobber this unit exists to remove — as a
+/// silent fallback rather than a loud one. So a confirmed route wins even
+/// against a `None` incumbent, and `incumbent` is consulted only to build the
+/// REFUSAL message, for the one case where the probe did NOT confirm the
+/// route.
+///
+/// The incumbent's KIND decides the refusal instruction, and it is not
 /// cosmetic. Since the owner file, detection reaches a proxy served INSIDE a
 /// host application, and the pid reported is then the HOST's. "kill {pid}"
 /// would SIGTERM a GUI process that installs no handler for it: no
@@ -781,16 +795,21 @@ enum LoginRoute {
 /// live session cold-starts its prompt cache at the next boot.
 /// `takeover_decision` and `incumbents_to_signal` are both hardened against
 /// exactly that signal; a message that ADVISES it would walk around both. So
-/// an embedded incumbent is told to be quit, not killed — whether or not it
-/// has the add route, since that's the refusal-message case regardless.
+/// an embedded incumbent is told to be quit, not killed.
 fn login_guard_refusal(
     incumbent: Option<singleton::Incumbent>,
     has_add_route: bool,
     port: u16,
     force: bool,
 ) -> LoginRoute {
+    if force {
+        return LoginRoute::File;
+    }
+    if has_add_route {
+        return LoginRoute::Live;
+    }
     match incumbent {
-        Some(incumbent) if !force && !has_add_route => {
+        Some(incumbent) => {
             let pid = incumbent.pid;
             LoginRoute::Refuse(match incumbent.kind {
                 singleton::ProxyKind::TcrEmbedded => format!(
@@ -801,8 +820,7 @@ fn login_guard_refusal(
                 ),
             })
         }
-        Some(_) if !force => LoginRoute::Live,
-        _ => LoginRoute::File,
+        None => LoginRoute::File,
     }
 }
 
@@ -862,19 +880,23 @@ async fn probe_add_capability(config: &Config) -> AddCapability {
     }
 }
 
-/// Resolve which [`LoginRoute`] `login()` should take, running the impure
-/// capability probe only when it can matter — a live incumbent is on the port
-/// and `--force` was not given. Fully resolves before `login()` starts the
-/// OAuth dance, so a user is never told to stop a server AFTER completing a
-/// full browser round-trip, and never silently falls back to the file when
-/// the incumbent answered but rejected our api-key.
+/// Resolve which [`LoginRoute`] `login()` should take. Runs the impure HTTP
+/// capability probe UNCONDITIONALLY whenever `--force` was not given —
+/// deliberately never gated on whether [`crate::singleton::live_proxy_server`]
+/// (`incumbent`) noticed anything on the port first. That detection is a pid
+/// inference and can miss a live proxy this build's argv/owner-file matcher
+/// was never taught to recognize; the probe asks the port directly and is
+/// authoritative on its own. Fully resolves before `login()` starts the OAuth
+/// dance, so a user is never told to stop a server AFTER completing a full
+/// browser round-trip, and never silently falls back to the file when a live
+/// proxy answered but rejected our api-key.
 async fn login_route(
     config_path: &Path,
     incumbent: Option<singleton::Incumbent>,
     port: u16,
     force: bool,
 ) -> anyhow::Result<LoginRoute> {
-    if force || incumbent.is_none() {
+    if force {
         return Ok(login_guard_refusal(incumbent, false, port, force));
     }
     let config = load_or_default(config_path)?;
@@ -1562,6 +1584,22 @@ mod tests {
         );
     }
 
+    /// THE CASE THE PROBE-FIRST ORDERING EXISTS FOR: the HTTP probe confirmed
+    /// the route, but pid/argv/owner-file detection found NOTHING on the port
+    /// (`incumbent: None`) — a host application `singleton::classify_proxy_server`
+    /// was never taught to recognize, or a stale/unreadable owner file. The
+    /// probe is first-hand evidence and must win on its own; requiring
+    /// `incumbent` to agree would silently fall back to `File` — the
+    /// whole-file clobber this unit exists to remove — the moment that
+    /// unrelated detection heuristic misses.
+    #[test]
+    fn login_guard_proceeds_live_on_a_confirmed_route_even_when_incumbent_detection_missed_it() {
+        assert_eq!(
+            login_guard_refusal(None, true, 3456, false),
+            LoginRoute::Live
+        );
+    }
+
     /// THE ADVICE MUST BE SURVIVABLE. `live_proxy_server` can now name the pid of
     /// the host application that serves the proxy in-process, and telling the
     /// operator to `kill` it is the one action `singleton` is hardened against
@@ -1713,6 +1751,44 @@ mod tests {
             AddCapability::Unauthorized,
             "a rejected api-key must surface as itself, never read as 'no route'"
         );
+    }
+
+    // --- login_route ----------------------------------------------------------
+
+    /// THE INTEGRATION-LEVEL VERSION of
+    /// `login_guard_proceeds_live_on_a_confirmed_route_even_when_incumbent_detection_missed_it`:
+    /// a real live server answering the real route, called with `incumbent:
+    /// None` (simulating a pid/argv/owner-file detection MISS — the TcrBar
+    /// case, where `argv[0]` ends in `/TcrBar` and
+    /// `singleton::classify_proxy_server` recognizes nothing). `login_route`
+    /// must still probe and proceed live — it must never gate the probe
+    /// itself on `incumbent.is_some()`, which is exactly the shape of bug
+    /// this test catches: skipping the probe here would fall through to
+    /// `LoginRoute::File` beside a real, answering server.
+    #[tokio::test]
+    async fn login_route_proceeds_live_even_when_incumbent_detection_missed_a_real_server() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-route-missed-incumbent-{}-{port}.json",
+            std::process::id()
+        ));
+        let seed = format!(r#"{{ "proxy": {{ "port": {port} }} }}"#);
+        std::fs::write(&path, &seed).unwrap();
+
+        let server_config: Config = serde_json::from_str(&seed).unwrap();
+        let manager = crate::manager::Manager::with_live_refresher(server_config, None);
+        tokio::spawn(async move { crate::mitm::serve(listener, manager, None).await });
+
+        let route = login_route(&path, None, port, false)
+            .await
+            .expect("a confirmed route must not error");
+        assert_eq!(
+            route,
+            LoginRoute::Live,
+            "the probe must decide this on its own, independent of incumbent detection"
+        );
+        std::fs::remove_file(&path).ok();
     }
 
     // --- finish_login ---------------------------------------------------------

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1225,26 +1225,50 @@ struct AddAccountRequest {
 
 /// The 200 body of [`ADD_ACCOUNT_PATH`]. Deserializable too — unit 3's CLI
 /// deserializes it, and both halves of a wire contract belong to one type.
+///
+/// This is a cross-BUILD wire contract — the same class as
+/// [`crate::singleton::ProxyHost::Unknown`] — because the `tcr` that
+/// deserializes a reply can be older than the `tcr` that served it. Every
+/// field below carries `#[serde(default)]` so a field a NEWER server has
+/// renamed or dropped does not fail the whole deserialize: `cli::post_add_account`
+/// maps a deserialize failure on a 2xx to `LiveControlError::Unusable`, and
+/// `oauth::probe_add_capability` reads that as `AddCapability::Absent` — a
+/// *successful* live add would then look indistinguishable from "no route
+/// here", and `tcr login` falls back to the whole-file `config::save` path
+/// beside a server that just handled the request correctly. Field
+/// ADDITIONS are already safe on their own (an older CLI just ignores a key
+/// it doesn't know); this attribute is what makes removals and renames safe
+/// too. Each default is chosen as the SAFER of the two readings, not merely
+/// the type's zero value: `persisted` defaults to `false` (never claim
+/// durability we can't confirm) and `added` defaults to `false` (never claim
+/// a fresh account was created when it might have been an in-place
+/// credential replacement) — same degrade-to-the-safer-state shape as
+/// `ProxyHost::Unknown`.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct AddAccountResponse {
     /// The account's name AS STORED. For an update this is the EXISTING row's
     /// name, which may differ from what was submitted (e.g. a bare email
     /// meeting a stored `"email (org)"` display name) — never a name that only
     /// ever existed in the request.
+    #[serde(default)]
     pub name: String,
     /// `true` when this identity had no match in the live rotation and was
     /// appended; `false` when an existing account's credentials were replaced
     /// in place. "Created" and "credentials replaced" are different facts and
     /// the operator needs to know which one they got.
+    #[serde(default)]
     pub added: bool,
     /// The account's index in the live rotation. Stable for the process
     /// lifetime — append-only, never reused, and an update never moves it.
+    #[serde(default)]
     pub index: usize,
     /// Whether the config file also carries it. `false` with a `warning` is a
     /// change that is live but will not survive a restart.
+    #[serde(default)]
     pub persisted: bool,
     /// [`AddPersist::warning`] and/or the no-refresh-token warning, joined when
     /// both apply, or `null`.
+    #[serde(default)]
     pub warning: Option<String>,
 }
 
@@ -1347,6 +1371,13 @@ async fn add_account_handler(State(manager): State<Arc<Manager>>, req: Request) 
             None,
         ));
     };
+    // LOAD-BEARING CAPABILITY SIGNAL: `oauth::probe_add_capability` deliberately
+    // POSTs a blank name to trigger exactly this branch, and reads a STAMPED
+    // 400 back as proof this route exists. Changing the status (e.g. to 422),
+    // or answering without `stamp_add_endpoint`, silently turns that read into
+    // `AddCapability::Absent` — `tcr login` then falls back to the whole-file
+    // `config::save` path beside a live server. See the seam test
+    // `probe_add_capabilitys_blank_body_is_a_stamped_400_and_mutates_nothing`.
     let Some(name) = parsed.name.filter(|n| !n.trim().is_empty()) else {
         return stamp_add_endpoint(error_response(
             StatusCode::BAD_REQUEST,
@@ -1355,6 +1386,10 @@ async fn add_account_handler(State(manager): State<Arc<Manager>>, req: Request) 
             None,
         ));
     };
+    // Same load-bearing signal as the blank-name branch above — the probe's
+    // body is ALSO blank on `accessToken`, so whichever of the two checks
+    // fires first is the one the probe actually exercises. Keep this one a
+    // stamped 400 too.
     let Some(access_token) = parsed.access_token.filter(|t| !t.trim().is_empty()) else {
         return stamp_add_endpoint(error_response(
             StatusCode::BAD_REQUEST,
@@ -5239,14 +5274,30 @@ mod tests {
             .no_proxy()
             .build()
             .expect("build client");
-        // The EXACT body `probe_add_capability` builds (oauth.rs:855-869): a
-        // blank name, a blank accessToken, `type: "oauth"`, everything else
-        // absent — serialized the same way `post_add_account` sends it
-        // (`.json(account)` over `config::Account`'s wire shape).
+        // The EXACT `Account` `probe_add_capability` builds (oauth.rs:855-869):
+        // a blank name, a blank access token, everything else absent.
+        // DERIVED, not a restated literal — a future edit to the probe's body
+        // (oauth.rs, out of this route's reach) changes this test's request
+        // too, instead of leaving a stale literal green while it tests a body
+        // nobody sends. Sent via `.json()` exactly like `post_add_account`
+        // sends it (`cli.rs:473`, `.json(account)`).
+        let probe_body = Account {
+            name: String::new(),
+            account_type: "oauth".to_string(),
+            account_uuid: None,
+            org_uuid: None,
+            org_name: None,
+            access_token: String::new(),
+            refresh_token: None,
+            expires_at: None,
+            priority: None,
+            switch_threshold: None,
+            disabled: None,
+            extra: serde_json::Map::new(),
+        };
         let resp = client
             .post(format!("http://{addr}{ADD_ACCOUNT_PATH}"))
-            .header("content-type", "application/json")
-            .body(r#"{"name":"","type":"oauth","accessToken":""}"#)
+            .json(&probe_body)
             .send()
             .await
             .expect("send the probe's blank body");

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -5203,6 +5203,80 @@ mod tests {
         }
     }
 
+    /// SEAM TEST. `oauth::probe_add_capability` (unit 3, `oauth.rs:855-881`)
+    /// decides whether `tcr login` takes the LIVE route by POSTing this exact
+    /// deliberately-blank body to `ADD_ACCOUNT_PATH` via
+    /// `cli::post_add_account` and reading whether the reply is a STAMPED
+    /// 400. Anything else — an unstamped answer, a different status, or
+    /// (worst of all) a 200 that actually appended a blank-named account to
+    /// the live fleet — reads as `AddCapability::Absent`, and `tcr login`
+    /// silently falls back to the whole-file `config::save` path while THIS
+    /// server is still running: the exact single-use-refresh-token clobber
+    /// this whole feature exists to remove, reopened as a silent fallback
+    /// rather than a loud error.
+    ///
+    /// Driven through the REAL production stack — a real `TcpListener` and
+    /// `crate::mitm::serve`, exactly how `main()` invokes it — not a
+    /// hand-built router, so a change to route registration or middleware
+    /// ordering is covered here too, not only by the in-process `oneshot`
+    /// tests above. Complements (does not replace) unit 3's own
+    /// `probe_add_capability_reads_a_stamped_400_as_present` (oauth.rs) and
+    /// `post_add_account_reads_a_stamped_400_as_rejected` (cli.rs), which
+    /// this repo's cross-file boundary keeps this route from editing.
+    #[tokio::test]
+    async fn probe_add_capabilitys_blank_body_is_a_stamped_400_and_mutates_nothing() {
+        let (manager, path) = control_manager("seam-probe", None);
+        let before = manager.snapshot(OffsetDateTime::now_utc()).accounts.len();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind seam-probe listener");
+        let addr = listener.local_addr().expect("listener addr");
+        let serving = Arc::clone(&manager);
+        tokio::spawn(async move { crate::mitm::serve(listener, serving, None).await });
+
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .expect("build client");
+        // The EXACT body `probe_add_capability` builds (oauth.rs:855-869): a
+        // blank name, a blank accessToken, `type: "oauth"`, everything else
+        // absent — serialized the same way `post_add_account` sends it
+        // (`.json(account)` over `config::Account`'s wire shape).
+        let resp = client
+            .post(format!("http://{addr}{ADD_ACCOUNT_PATH}"))
+            .header("content-type", "application/json")
+            .body(r#"{"name":"","type":"oauth","accessToken":""}"#)
+            .send()
+            .await
+            .expect("send the probe's blank body");
+
+        assert_eq!(
+            resp.status().as_u16(),
+            400,
+            "the probe body must answer a local 400 — never forwarded, never a \
+             soft-fail status the probe would misclassify"
+        );
+        assert_eq!(
+            resp.headers()
+                .get(ENDPOINT_HEADER)
+                .and_then(|v| v.to_str().ok()),
+            Some(ADD_ACCOUNT_ENDPOINT),
+            "unstamped and `probe_add_capability` reads this as Absent — `tcr login` \
+             silently falls back to the whole-file config::save path with a live \
+             server running"
+        );
+
+        assert_eq!(
+            manager.snapshot(OffsetDateTime::now_utc()).accounts.len(),
+            before,
+            "the probe's deliberately-blank body must never reach add_or_update_account"
+        );
+        assert_eq!(account_count_in_file(&path), before, "…nor the disk");
+
+        std::fs::remove_file(&path).ok();
+    }
+
     // --- rotation-bypassing relays -----------------------------------------
 
     /// What a fake upstream saw — one of these per request it received.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -37,7 +37,10 @@ use futures::StreamExt;
 use serde_json::Value;
 use time::OffsetDateTime;
 
-use crate::manager::{AccountStatus, DisablePersist, Manager, SetDisabledOutcome};
+use crate::config;
+use crate::manager::{
+    AccountStatus, AddAccountOutcome, AddPersist, DisablePersist, Manager, SetDisabledOutcome,
+};
 use crate::stats::{RequestLogEntry, SessionKind};
 
 /// Cap on a buffered request body (256 MiB) — a single-user localhost proxy has
@@ -480,6 +483,29 @@ pub const ENDPOINT_HEADER: &str = "x-tcr-endpoint";
 /// The [`ENDPOINT_HEADER`] value the account-control route stamps.
 pub const DISABLED_ENDPOINT: &str = "accounts-disabled";
 
+/// Path of the live account-ADD endpoint [`add_account_handler`] serves — `POST`
+/// only, the other route on this process that MUTATES rotation.
+///
+/// It exists because adding an account has, until now, required stopping the
+/// proxy, running `tcr login`, and starting it again — which wipes the in-memory
+/// session→account pin map, so every live session cold-starts its prompt cache
+/// on the next turn. That is the most expensive event in this system; see
+/// [`Manager::add_account`] for the append primitive this route drives and why
+/// it must never insert anywhere but the end.
+///
+/// Same shape as [`DISABLED_PATH`] and for the same reasons: registered as a
+/// real route so axum matches it exactly and BEFORE the catch-all — a `POST`
+/// here can never be rewritten onto api.anthropic.com carrying a pooled OAuth
+/// Bearer. What authorizes the mutation is [`local_endpoint_gate`] plus the
+/// `application/json` requirement, neither of which the path shape has any part
+/// in.
+pub const ADD_ACCOUNT_PATH: &str = "/_tcr/accounts";
+
+/// The [`ENDPOINT_HEADER`] value [`add_account_handler`] stamps. Distinct from
+/// [`DISABLED_ENDPOINT`] so a caller can tell which of the two mutating routes
+/// answered — the same structural discriminator [`ENDPOINT_HEADER`] documents.
+pub const ADD_ACCOUNT_ENDPOINT: &str = "accounts-add";
+
 /// Body cap for the local control route: a JSON object with three short fields.
 /// Deliberately not [`MAX_BODY_BYTES`] (256 MiB, sized for model requests) — this
 /// route buffers into memory in a credential-holding process, and nothing
@@ -796,12 +822,16 @@ pub fn app(manager: Arc<Manager>) -> Router {
             STATUS_PATH,
             axum::routing::get(status_handler).fallback(status_method_not_allowed),
         )
-        // The one MUTATING local route. Same reasoning as above, and the method
+        // The two MUTATING local routes. Same reasoning as above, and the method
         // fallback matters more here: an unregistered method must answer a local
         // 405, never fall through to `handle` and be forwarded upstream.
         .route(
             DISABLED_PATH,
             axum::routing::post(set_disabled_handler).fallback(disabled_method_not_allowed),
+        )
+        .route(
+            ADD_ACCOUNT_PATH,
+            axum::routing::post(add_account_handler).fallback(add_account_method_not_allowed),
         )
         .fallback(handle)
         .with_state(manager)
@@ -978,12 +1008,26 @@ async fn disabled_method_not_allowed() -> Response {
     ))
 }
 
-/// Add [`ENDPOINT_HEADER`] to a response the account-control route produced.
-fn stamp_endpoint(mut response: Response) -> Response {
+/// Add [`ENDPOINT_HEADER`] to a response, naming which local mutating route
+/// produced it. ONE implementation shared by both stampers below, so the two
+/// routes cannot drift on how the header is set — only on which value they set
+/// it to.
+fn stamp_endpoint_as(mut response: Response, endpoint: &'static str) -> Response {
     response
         .headers_mut()
-        .insert(ENDPOINT_HEADER, HeaderValue::from_static(DISABLED_ENDPOINT));
+        .insert(ENDPOINT_HEADER, HeaderValue::from_static(endpoint));
     response
+}
+
+/// Add [`ENDPOINT_HEADER`] to a response the account-control (disable) route
+/// produced.
+fn stamp_endpoint(response: Response) -> Response {
+    stamp_endpoint_as(response, DISABLED_ENDPOINT)
+}
+
+/// Add [`ENDPOINT_HEADER`] to a response the account-add route produced.
+fn stamp_add_endpoint(response: Response) -> Response {
+    stamp_endpoint_as(response, ADD_ACCOUNT_ENDPOINT)
 }
 
 /// The request body of [`DISABLED_PATH`].
@@ -1128,6 +1172,232 @@ async fn set_disabled_handler(State(manager): State<Arc<Manager>>, req: Request)
             headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
             headers.insert("cache-control", HeaderValue::from_static("no-store"));
             stamp_endpoint(response)
+        }
+    }
+}
+
+/// A non-`POST` on [`ADD_ACCOUNT_PATH`]. Answered locally with 405, same
+/// reasoning as [`disabled_method_not_allowed`] — the route is a command with
+/// exactly one verb, and it is stamped so a caller can tell this 405 (route
+/// exists, wrong verb) from the local 404 a tcr without the route returns.
+async fn add_account_method_not_allowed() -> Response {
+    stamp_add_endpoint(error_response(
+        StatusCode::METHOD_NOT_ALLOWED,
+        "invalid_request_error",
+        "The tcr account-add endpoint takes POST.",
+        None,
+    ))
+}
+
+/// The request body of [`ADD_ACCOUNT_PATH`].
+///
+/// Mirrors [`config::Account`]'s wire shape (camelCase, `type` for
+/// `account_type`) so a caller can build the body directly from the credentials
+/// a login already produced. `name` and `access_token` are `Option` — like
+/// [`SetDisabledRequest`]'s fields — so a body missing either gets a specific
+/// 400 naming the field instead of axum's own rejection text.
+///
+/// `priority` and `switch_threshold` are accepted for the NEW-account case only;
+/// see [`add_account_handler`]. `disabled` is deliberately not accepted at all —
+/// an account reaching this route is one the operator wants serving traffic now.
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AddAccountRequest {
+    name: Option<String>,
+    #[serde(rename = "type", default)]
+    account_type: Option<String>,
+    #[serde(default)]
+    account_uuid: Option<String>,
+    #[serde(default)]
+    org_uuid: Option<String>,
+    #[serde(default)]
+    org_name: Option<String>,
+    access_token: Option<String>,
+    #[serde(default)]
+    refresh_token: Option<String>,
+    #[serde(default)]
+    expires_at: Option<i64>,
+    #[serde(default)]
+    priority: Option<i64>,
+    #[serde(default)]
+    switch_threshold: Option<f64>,
+}
+
+/// The 200 body of [`ADD_ACCOUNT_PATH`]. Deserializable too — unit 3's CLI
+/// deserializes it, and both halves of a wire contract belong to one type.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct AddAccountResponse {
+    /// The account's name AS STORED. For an update this is the EXISTING row's
+    /// name, which may differ from what was submitted (e.g. a bare email
+    /// meeting a stored `"email (org)"` display name) — never a name that only
+    /// ever existed in the request.
+    pub name: String,
+    /// `true` when this identity had no match in the live rotation and was
+    /// appended; `false` when an existing account's credentials were replaced
+    /// in place. "Created" and "credentials replaced" are different facts and
+    /// the operator needs to know which one they got.
+    pub added: bool,
+    /// The account's index in the live rotation. Stable for the process
+    /// lifetime — append-only, never reused, and an update never moves it.
+    pub index: usize,
+    /// Whether the config file also carries it. `false` with a `warning` is a
+    /// change that is live but will not survive a restart.
+    pub persisted: bool,
+    /// [`AddPersist::warning`] and/or the no-refresh-token warning, joined when
+    /// both apply, or `null`.
+    pub warning: Option<String>,
+}
+
+/// Shown when the submitted account carries no refresh token: it will serve
+/// until its access token expires and then go dead, silently, unless the
+/// operator hears about it now.
+const NO_REFRESH_TOKEN_WARNING: &str =
+    "this account has no refresh token — it will serve until its access token expires, then go dead";
+
+/// Join whichever of the durable-persist warning and the no-refresh-token
+/// warning actually apply into the single `warning` field the response carries.
+fn combine_warnings(persist: Option<&str>, no_refresh_token: Option<&str>) -> Option<String> {
+    match (persist, no_refresh_token) {
+        (None, None) => None,
+        (Some(a), None) => Some(a.to_string()),
+        (None, Some(b)) => Some(b.to_string()),
+        (Some(a), Some(b)) => Some(format!("{a} {b}")),
+    }
+}
+
+/// Build the 200 body of [`ADD_ACCOUNT_PATH`], stamped like every response this
+/// route produces.
+fn add_account_response(
+    name: String,
+    added: bool,
+    index: usize,
+    persist: AddPersist,
+    warning: Option<String>,
+) -> Response {
+    let payload = AddAccountResponse {
+        name,
+        added,
+        index,
+        persisted: matches!(persist, AddPersist::Persisted),
+        warning,
+    };
+    let Ok(body) = serde_json::to_string(&payload) else {
+        return stamp_add_endpoint(error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "api_error",
+            "Could not serialize the account-add result.",
+            None,
+        ));
+    };
+    let mut response = Response::new(Body::from(body));
+    let headers = response.headers_mut();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    headers.insert("cache-control", HeaderValue::from_static("no-store"));
+    stamp_add_endpoint(response)
+}
+
+/// `POST /_tcr/accounts` — add an account to the LIVE rotation with no proxy
+/// restart, for a `tcr login` that should not have to stop and restart the
+/// process to take effect.
+///
+/// Gated exactly as [`set_disabled_handler`] is — [`local_endpoint_gate`], the
+/// `application/json` requirement, the same [`CONTROL_BODY_LIMIT`] — because this
+/// route carries an OAuth access token and refresh token in its body and is a
+/// write, so it is authorized no more weakly than the read routes.
+///
+/// The behaviour is [`Manager::add_or_update_account`]'s: the submitted identity
+/// resolves against the live rotation via [`crate::identity::match_one`], and
+/// either appends (nothing matched — a brand new account) or replaces an
+/// existing account's credentials in place (exactly one matched — a re-login).
+/// See that function's doc-comment for why the two cases use different
+/// resolution anchors for their durable write. An ambiguous match is a 409
+/// naming the candidates, via [`crate::cli::ambiguous_query_message`] — never
+/// guessed.
+async fn add_account_handler(State(manager): State<Arc<Manager>>, req: Request) -> Response {
+    let (parts, body) = req.into_parts();
+    if let Some(refusal) = local_endpoint_gate(&parts, &manager, "account-add") {
+        // NOT stamped — see [`set_disabled_handler`]'s identical comment: a
+        // refusal must not confirm the route exists to a caller that failed
+        // the gate.
+        return refusal;
+    }
+
+    if !is_json_content_type(&parts.headers) {
+        return stamp_add_endpoint(error_response(
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "invalid_request_error",
+            "The tcr account-add endpoint requires Content-Type: application/json.",
+            None,
+        ));
+    }
+
+    let Ok(bytes) = to_bytes(body, CONTROL_BODY_LIMIT).await else {
+        return stamp_add_endpoint(error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            "Could not read the request body.",
+            None,
+        ));
+    };
+    let Ok(parsed) = serde_json::from_slice::<AddAccountRequest>(&bytes) else {
+        return stamp_add_endpoint(error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            "Expected a JSON object: {\"name\": \"<account>\", \"accessToken\": \"<token>\", …}.",
+            None,
+        ));
+    };
+    let Some(name) = parsed.name.filter(|n| !n.trim().is_empty()) else {
+        return stamp_add_endpoint(error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            "\"name\" (string) is required and must not be empty.",
+            None,
+        ));
+    };
+    let Some(access_token) = parsed.access_token.filter(|t| !t.trim().is_empty()) else {
+        return stamp_add_endpoint(error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            "\"accessToken\" (string) is required and must not be empty.",
+            None,
+        ));
+    };
+    let refresh_token = parsed.refresh_token.filter(|t| !t.trim().is_empty());
+    let no_refresh_token_warning = refresh_token.is_none().then_some(NO_REFRESH_TOKEN_WARNING);
+
+    let account = config::Account {
+        name,
+        account_type: parsed.account_type.unwrap_or_else(|| "oauth".to_string()),
+        account_uuid: parsed.account_uuid,
+        org_uuid: parsed.org_uuid,
+        org_name: parsed.org_name,
+        access_token,
+        refresh_token,
+        expires_at: parsed.expires_at,
+        priority: parsed.priority,
+        switch_threshold: parsed.switch_threshold,
+        disabled: None,
+        extra: serde_json::Map::new(),
+    };
+    // Captured before the move below: on an ambiguous match this is the ONLY
+    // copy of what the caller actually searched for.
+    let query_name = account.name.clone();
+
+    match manager.add_or_update_account(account) {
+        AddAccountOutcome::Ambiguous(names) => stamp_add_endpoint(error_response(
+            StatusCode::CONFLICT,
+            "invalid_request_error",
+            &crate::cli::ambiguous_query_message(&query_name, &names),
+            None,
+        )),
+        AddAccountOutcome::Added { idx, name, persist } => {
+            let warning = combine_warnings(persist.warning(), no_refresh_token_warning);
+            add_account_response(name, true, idx, persist, warning)
+        }
+        AddAccountOutcome::Updated { idx, name, persist } => {
+            let warning = combine_warnings(persist.warning(), no_refresh_token_warning);
+            add_account_response(name, false, idx, persist, warning)
         }
     }
 }
@@ -3944,7 +4214,9 @@ mod tests {
     async fn an_unrouted_local_path_is_not_stamped_as_the_control_route() {
         use tower::ServiceExt as _;
         for uri in [
-            "/_tcr/accounts",
+            // NOT `/_tcr/accounts` — that is now [`ADD_ACCOUNT_PATH`], a real
+            // registered route (see the account-add tests below).
+            "/_tcr/accounts/add",
             "/_tcr/accounts/disable",
             "/_tcr/accounts/disabled/extra",
         ] {
@@ -4456,6 +4728,479 @@ mod tests {
              one yields '[:' and misroutes an IPv6 loopback client"
         );
         assert_eq!(target_host(&origin_form, &HeaderMap::new()), None);
+    }
+
+    // --- POST /_tcr/accounts (add) -------------------------------------------
+
+    /// Drive the router at [`ADD_ACCOUNT_PATH`], mirroring [`control_request`].
+    async fn add_request(
+        manager: Arc<Manager>,
+        peer: Option<SocketAddr>,
+        api_key: Option<&str>,
+        body: &str,
+    ) -> (StatusCode, HeaderMap, Bytes) {
+        use tower::ServiceExt as _;
+        let mut builder = Request::builder()
+            .method(Method::POST)
+            .uri(ADD_ACCOUNT_PATH);
+        if let Some(key) = api_key {
+            builder = builder.header("x-api-key", key);
+        }
+        let mut req = builder
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string()))
+            .expect("build request");
+        if let Some(addr) = peer {
+            req.extensions_mut().insert(ClientAddr(addr));
+        }
+        let response = app(manager).oneshot(req).await.expect("router response");
+        let status = response.status();
+        let headers = response.headers().clone();
+        let bytes = to_bytes(response.into_body(), MAX_BODY_BYTES)
+            .await
+            .expect("read body");
+        (status, headers, bytes)
+    }
+
+    fn account_in_file(path: &std::path::Path, index: usize) -> Option<serde_json::Value> {
+        let raw = std::fs::read_to_string(path).expect("read the test config");
+        let doc: serde_json::Value = serde_json::from_str(&raw).expect("valid json");
+        doc["accounts"].get(index).cloned()
+    }
+
+    fn account_count_in_file(path: &std::path::Path) -> usize {
+        let raw = std::fs::read_to_string(path).expect("read the test config");
+        let doc: serde_json::Value = serde_json::from_str(&raw).expect("valid json");
+        doc["accounts"].as_array().map_or(0, |a| a.len())
+    }
+
+    /// THE BITING TEST for the append half: a brand-new identity lands at the END
+    /// of the live rotation and is **immediately servable** — not merely
+    /// acknowledged. Every OTHER account is put in `tried`, so `select` can only
+    /// return the new one by actually finding it eligible.
+    #[tokio::test]
+    async fn add_endpoint_appends_a_new_account_and_it_is_immediately_servable() {
+        let (manager, path) = control_manager("append", None);
+        let before = manager.snapshot(OffsetDateTime::now_utc());
+        assert_eq!(before.accounts.len(), 2, "starts with alice and bob");
+
+        let (status, headers, body) = add_request(
+            Arc::clone(&manager),
+            Some(loopback_peer()),
+            None,
+            r#"{"name":"carol@example.com","accessToken":"at-carol","refreshToken":"rt-carol","expiresAt":9999999999999}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        assert_eq!(
+            headers.get(ENDPOINT_HEADER).and_then(|v| v.to_str().ok()),
+            Some(ADD_ACCOUNT_ENDPOINT),
+            "the route stamps itself so a caller can tell it from a missing route"
+        );
+
+        let payload: AddAccountResponse =
+            serde_json::from_slice(&body).expect("an account-add payload");
+        assert_eq!(payload.name, "carol@example.com");
+        assert!(
+            payload.added,
+            "a brand new identity is an APPEND, not an update"
+        );
+        assert_eq!(payload.index, 2, "appended at the END");
+        assert!(payload.persisted, "the durable half succeeded");
+        assert_eq!(payload.warning, None, "a refresh token was supplied");
+
+        // 1. THE LIVE ROTATION — present AND selectable, not merely acknowledged.
+        let after = manager.snapshot(OffsetDateTime::now_utc());
+        assert_eq!(after.accounts.len(), 3);
+        assert_eq!(after.accounts[2].name, "carol@example.com");
+        let mut tried: HashSet<usize> = HashSet::new();
+        tried.insert(0);
+        tried.insert(1);
+        assert_eq!(
+            manager.select(&tried, OffsetDateTime::now_utc(), None, None),
+            Some(2),
+            "the new account is eligible and selectable immediately, with no restart"
+        );
+
+        // 2. …and the file, so it survives one.
+        assert_eq!(account_count_in_file(&path), 3);
+        let on_disk = account_in_file(&path, 2).expect("the appended entry");
+        assert_eq!(on_disk["name"], "carol@example.com");
+        assert_eq!(on_disk["accessToken"], "at-carol");
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// THE BITING TEST for the update half: re-adding an EXISTING identity
+    /// replaces its credentials in place — same index, same account count — and
+    /// its routing state (priority) survives untouched.
+    #[tokio::test]
+    async fn add_endpoint_updates_an_existing_account_in_place_and_keeps_the_index() {
+        let (manager, path) = control_manager("update", None);
+        let before = manager.snapshot(OffsetDateTime::now_utc());
+        assert_eq!(before.accounts.len(), 2);
+        assert_eq!(before.accounts[0].name, "alice@example.com");
+        assert_eq!(before.accounts[0].priority, 0);
+
+        let (status, _headers, body) = add_request(
+            Arc::clone(&manager),
+            Some(loopback_peer()),
+            None,
+            r#"{"name":"alice@example.com","accessToken":"at-alice-fresh","refreshToken":"rt-alice-fresh","expiresAt":9999999999999}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+
+        let payload: AddAccountResponse =
+            serde_json::from_slice(&body).expect("an account-add payload");
+        assert_eq!(payload.name, "alice@example.com");
+        assert!(
+            !payload.added,
+            "an existing identity is an UPDATE, not an append"
+        );
+        assert_eq!(
+            payload.index, 0,
+            "the SAME index — never moved, never duplicated"
+        );
+        assert!(payload.persisted, "the durable half succeeded");
+
+        // 1. THE LIVE ROTATION: same count, same index, NEW credentials, and
+        // routing state (priority) untouched.
+        let after = manager.snapshot(OffsetDateTime::now_utc());
+        assert_eq!(after.accounts.len(), 2, "no duplicate appended");
+        assert_eq!(after.accounts[0].name, "alice@example.com");
+        assert_eq!(after.accounts[0].priority, 0, "routing state preserved");
+        assert_eq!(
+            manager.access_token(0).as_deref(),
+            Some("at-alice-fresh"),
+            "the credential actually changed"
+        );
+
+        // 2. …and the file: same entry, same position, new token.
+        assert_eq!(account_count_in_file(&path), 2, "no duplicate row on disk");
+        let on_disk = account_in_file(&path, 0).expect("alice's entry");
+        assert_eq!(on_disk["accessToken"], "at-alice-fresh");
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// SECURITY GUARD 1 — origin, on the account-ADD route. [`local_endpoint_gate`]
+    /// is the ONE implementation the disable and add routes both use, so this is
+    /// largely a re-proof — but on a write that carries a fresh OAuth token in its
+    /// body, a drift here would be worse.
+    #[tokio::test]
+    async fn add_endpoint_rejects_a_non_loopback_client() {
+        for (label, peer) in [
+            ("a routable peer", Some(remote_peer())),
+            ("no ClientAddr at all", None),
+        ] {
+            let (manager, path) = control_manager("add-origin", None);
+            let (status, _headers, _body) = add_request(
+                Arc::clone(&manager),
+                peer,
+                None,
+                r#"{"name":"carol@example.com","accessToken":"at-carol"}"#,
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::FORBIDDEN,
+                "{label} must be refused, got {status}"
+            );
+            assert_eq!(
+                manager.snapshot(OffsetDateTime::now_utc()).accounts.len(),
+                2,
+                "{label}: a refused caller appended an account"
+            );
+            std::fs::remove_file(&path).ok();
+        }
+    }
+
+    /// SECURITY GUARD 2 — the key, on the account-ADD route.
+    #[tokio::test]
+    async fn add_endpoint_rejects_a_bad_api_key() {
+        for (label, provided) in [("no key at all", None), ("a wrong key", Some("wrong-key"))] {
+            let (manager, path) = control_manager("add-key", Some("secret-key"));
+            let (status, _headers, _body) = add_request(
+                Arc::clone(&manager),
+                Some(loopback_peer()),
+                provided,
+                r#"{"name":"carol@example.com","accessToken":"at-carol"}"#,
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::UNAUTHORIZED,
+                "{label} must be refused, got {status}"
+            );
+            assert_eq!(
+                manager.snapshot(OffsetDateTime::now_utc()).accounts.len(),
+                2,
+                "{label}: an unauthenticated caller appended an account"
+            );
+            std::fs::remove_file(&path).ok();
+        }
+
+        // …and the right key, from loopback, is served.
+        let (manager, path) = control_manager("add-key-ok", Some("secret-key"));
+        let (status, _headers, body) = add_request(
+            Arc::clone(&manager),
+            Some(loopback_peer()),
+            Some("secret-key"),
+            r#"{"name":"carol@example.com","accessToken":"at-carol"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        assert_eq!(
+            manager.snapshot(OffsetDateTime::now_utc()).accounts.len(),
+            3
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// A non-JSON content-type is refused — this route carries an OAuth token in
+    /// its body and is a write, so the browser/CSRF defence must be no weaker
+    /// than the disable route's.
+    #[tokio::test]
+    async fn add_endpoint_requires_json_content_type() {
+        use tower::ServiceExt as _;
+        let (manager, path) = control_manager("add-ctype", None);
+        let mut req = Request::builder()
+            .method(Method::POST)
+            .uri(ADD_ACCOUNT_PATH)
+            .header(CONTENT_TYPE, "text/plain")
+            .body(Body::from(
+                r#"{"name":"carol@example.com","accessToken":"at-carol"}"#,
+            ))
+            .expect("build request");
+        req.extensions_mut().insert(ClientAddr(loopback_peer()));
+        let response = app(Arc::clone(&manager))
+            .oneshot(req)
+            .await
+            .expect("router response");
+        assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+        assert_eq!(
+            response
+                .headers()
+                .get(ENDPOINT_HEADER)
+                .and_then(|v| v.to_str().ok()),
+            Some(ADD_ACCOUNT_ENDPOINT)
+        );
+        assert_eq!(
+            manager.snapshot(OffsetDateTime::now_utc()).accounts.len(),
+            2
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// The bad-request table. None of these may half-apply anything.
+    #[tokio::test]
+    async fn add_endpoint_rejects_malformed_bodies() {
+        for (label, body) in [
+            ("an empty body", ""),
+            ("not json", "add carol"),
+            ("a json array", r#"["carol@example.com"]"#),
+            ("no accessToken field", r#"{"name":"carol@example.com"}"#),
+            ("no name field", r#"{"accessToken":"at-carol"}"#),
+            (
+                "an empty name",
+                r#"{"name":"   ","accessToken":"at-carol"}"#,
+            ),
+            (
+                "an empty accessToken",
+                r#"{"name":"carol@example.com","accessToken":"  "}"#,
+            ),
+        ] {
+            let (manager, path) = control_manager("add-badbody", None);
+            let (status, headers, response) =
+                add_request(Arc::clone(&manager), Some(loopback_peer()), None, body).await;
+            assert_eq!(
+                status,
+                StatusCode::BAD_REQUEST,
+                "{label} must be a 400, got {status}: {}",
+                String::from_utf8_lossy(&response)
+            );
+            assert_eq!(
+                headers.get(ENDPOINT_HEADER).and_then(|v| v.to_str().ok()),
+                Some(ADD_ACCOUNT_ENDPOINT),
+                "{label}: a 400 still identifies the route that produced it"
+            );
+            assert_eq!(
+                manager.snapshot(OffsetDateTime::now_utc()).accounts.len(),
+                2,
+                "{label}: a rejected body still appended an account"
+            );
+            std::fs::remove_file(&path).ok();
+        }
+    }
+
+    /// An ambiguous identity — the same email in two orgs — is a 409 naming the
+    /// candidates, never guessed. `--org` is the only fix.
+    #[tokio::test]
+    async fn add_endpoint_409s_an_ambiguous_identity_naming_the_candidates() {
+        let path = control_config_path("add-ambiguous");
+        let mut config = two_account_config(None);
+        // The same person in two orgs: one email, two rows, `--org` the only fix.
+        config.accounts[1].name = "alice@example.com".to_string();
+        crate::config::save(&path, &config).expect("write the test config");
+        let manager = Manager::with_live_refresher(config, Some(path.clone()));
+
+        let (status, headers, body) = add_request(
+            Arc::clone(&manager),
+            Some(loopback_peer()),
+            None,
+            r#"{"name":"alice@example.com","accessToken":"at-new"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(
+            headers.get(ENDPOINT_HEADER).and_then(|v| v.to_str().ok()),
+            Some(ADD_ACCOUNT_ENDPOINT)
+        );
+        let text = String::from_utf8_lossy(&body);
+        assert!(
+            text.contains("ambiguous") && text.contains("--org"),
+            "the 409 says what to do about it: {text}"
+        );
+        assert_eq!(
+            manager.snapshot(OffsetDateTime::now_utc()).accounts.len(),
+            2,
+            "an unbreakable tie changes nothing"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// A manager with no `config_path` (`tcr demo`, `tcr status --probe`, tests)
+    /// applies the change LIVE and has nothing to persist to — reported honestly
+    /// (`persisted: false`, no warning), exactly as the disable route's
+    /// equivalent case.
+    #[tokio::test]
+    async fn add_endpoint_reports_an_unpersisted_change_honestly() {
+        let manager = Manager::with_live_refresher(two_account_config(None), None);
+        let (status, _headers, body) = add_request(
+            Arc::clone(&manager),
+            Some(loopback_peer()),
+            None,
+            r#"{"name":"carol@example.com","accessToken":"at-carol","refreshToken":"rt-carol"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let payload: AddAccountResponse = serde_json::from_slice(&body).expect("payload");
+        assert!(payload.added);
+        assert_eq!(
+            manager.snapshot(OffsetDateTime::now_utc()).accounts.len(),
+            3,
+            "the live append still happened"
+        );
+        assert!(
+            !payload.persisted,
+            "…and the answer does not claim it is durable"
+        );
+        assert_eq!(
+            payload.warning, None,
+            "memory-only by design, not a failure"
+        );
+    }
+
+    /// A failed durable write still returns 200 — the live change stands — with
+    /// `persisted: false` and a warning, never swallowed. Here the config file
+    /// does not exist at all, so the write fails.
+    #[tokio::test]
+    async fn add_endpoint_surfaces_a_failed_persist() {
+        let path = control_config_path("add-nofile");
+        std::fs::remove_file(&path).ok();
+        let manager = Manager::with_live_refresher(two_account_config(None), Some(path.clone()));
+
+        let (status, _headers, body) = add_request(
+            Arc::clone(&manager),
+            Some(loopback_peer()),
+            None,
+            r#"{"name":"carol@example.com","accessToken":"at-carol","refreshToken":"rt-carol"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "the LIVE half succeeded");
+        let payload: AddAccountResponse = serde_json::from_slice(&body).expect("payload");
+        assert_eq!(
+            manager.snapshot(OffsetDateTime::now_utc()).accounts.len(),
+            3,
+            "the account is appended in the live rotation"
+        );
+        assert!(!payload.persisted, "but the file does not carry it");
+        let warning = payload.warning.expect("a NOT SAVED warning, never silence");
+        assert!(
+            warning.contains("NOT SAVED"),
+            "the warning is AddPersist::warning verbatim: {warning}"
+        );
+    }
+
+    /// The submitted account carries no refresh token — a fact the operator
+    /// needs at add time, not a hard error: it will serve now and go dead once
+    /// the access token expires.
+    #[tokio::test]
+    async fn add_endpoint_warns_when_no_refresh_token_is_supplied() {
+        let (manager, path) = control_manager("add-norefresh", None);
+        let (status, _headers, body) = add_request(
+            Arc::clone(&manager),
+            Some(loopback_peer()),
+            None,
+            r#"{"name":"carol@example.com","accessToken":"at-carol"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let payload: AddAccountResponse = serde_json::from_slice(&body).expect("payload");
+        assert!(payload.persisted);
+        let warning = payload.warning.expect("a no-refresh-token warning");
+        assert!(warning.contains("no refresh token"), "{warning}");
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// F7 — the add route is `POST`-only, same as the disable route
+    /// ([`control_endpoint_refuses_other_methods_locally`]), and had no test of
+    /// its own: a wrong method must be answered LOCALLY (never forwarded, never
+    /// able to mutate), and the 405 must still identify the route so a caller
+    /// can tell it from an older tcr that has no route at all.
+    #[tokio::test]
+    async fn add_endpoint_refuses_other_methods_locally() {
+        use tower::ServiceExt as _;
+        for method in [Method::GET, Method::PUT, Method::DELETE, Method::PATCH] {
+            let (manager, path) = control_manager("add-method", None);
+            let mut req = Request::builder()
+                .method(method.clone())
+                .uri(ADD_ACCOUNT_PATH)
+                .header(CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    r#"{"name":"carol@example.com","accessToken":"at-carol"}"#,
+                ))
+                .expect("build request");
+            req.extensions_mut().insert(ClientAddr(loopback_peer()));
+            let response = app(Arc::clone(&manager))
+                .oneshot(req)
+                .await
+                .expect("router response");
+            assert_eq!(
+                response.status(),
+                StatusCode::METHOD_NOT_ALLOWED,
+                "{method} on the add-account path is refused locally"
+            );
+            assert_ne!(
+                response.status(),
+                StatusCode::BAD_GATEWAY,
+                "{method} must never fall through to the upstream forwarder"
+            );
+            assert_eq!(
+                response
+                    .headers()
+                    .get(ENDPOINT_HEADER)
+                    .and_then(|v| v.to_str().ok()),
+                Some(ADD_ACCOUNT_ENDPOINT),
+                "{method}: the 405 identifies the route, so a caller does not read \
+                 it as a proxy too old to have one"
+            );
+            assert_eq!(
+                manager.snapshot(OffsetDateTime::now_utc()).accounts.len(),
+                2,
+                "{method} appended or changed an account"
+            );
+            std::fs::remove_file(&path).ok();
+        }
     }
 
     // --- rotation-bypassing relays -----------------------------------------
@@ -4986,15 +5731,21 @@ mod tests {
             (Method::GET, "/_tcr/"),
             (Method::GET, "/_tcr"),
             (Method::GET, "/_tcr/status?x=1&y=2/../nope"),
-            // Near-misses of the account-control route. The mutating verb makes
-            // these the rows that matter most: a `POST` that fell through the
-            // catch-all would be rewritten onto api.anthropic.com carrying a pooled
-            // OAuth Bearer, which is the shape that burned an account.
-            (Method::POST, "/_tcr/accounts"),
+            // Near-misses of the two account-control routes. The mutating verb
+            // makes these the rows that matter most: a `POST` that fell through
+            // the catch-all would be rewritten onto api.anthropic.com carrying a
+            // pooled OAuth Bearer, which is the shape that burned an account.
             (Method::POST, "/_tcr/accounts/"),
             (Method::POST, "/_tcr/accounts/disable"),
             (Method::POST, "/_tcr/accounts/disabled/extra"),
             (Method::POST, "/_tcr/accounts/priority"),
+            // The bare path IS registered (ADD_ACCOUNT_PATH) — a `GET` on it
+            // gets a local 405, not a 404 like every other row here — but it
+            // belongs in this table anyway for the assertion this table makes
+            // and `add_endpoint_refuses_other_methods_locally` does not: the
+            // hit counter, proving a wrong-verb request STILL never reaches
+            // upstream.
+            (Method::GET, "/_tcr/accounts"),
         ] {
             let manager = Manager::with_live_refresher(dummy_config(None, &upstream), None);
             let (status, body) = drive(
@@ -5008,10 +5759,18 @@ mod tests {
             .await;
             let text = String::from_utf8_lossy(&body);
             // `/_tcr/status?…` IS a registered route (the query does not change the
-            // path), so it is served; every other shape is a local 404. Neither is
-            // ever forwarded, which is the single claim this test makes.
+            // path), so it is served; the bare add-account path is registered too,
+            // wrong verb, so it is a local 405; every other shape is a local 404.
+            // None of the three is ever forwarded, which is the single claim this
+            // test makes.
             if uri.starts_with("/_tcr/status?") {
                 assert_eq!(status, StatusCode::OK, "{uri} is the real status route");
+            } else if uri == "/_tcr/accounts" {
+                assert_eq!(
+                    status,
+                    StatusCode::METHOD_NOT_ALLOWED,
+                    "{method} {uri} → the route exists, wrong verb"
+                );
             } else {
                 assert_eq!(status, StatusCode::NOT_FOUND, "{method} {uri} → local 404");
                 assert!(

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1232,17 +1232,18 @@ struct AddAccountRequest {
 /// field below carries `#[serde(default)]` so a field a NEWER server has
 /// renamed or dropped does not fail the whole deserialize: `cli::post_add_account`
 /// maps a deserialize failure on a 2xx to `LiveControlError::Unusable`, and
-/// `oauth::probe_add_capability` reads that as `AddCapability::Absent` — a
-/// *successful* live add would then look indistinguishable from "no route
-/// here", and `tcr login` falls back to the whole-file `config::save` path
-/// beside a server that just handled the request correctly. Field
-/// ADDITIONS are already safe on their own (an older CLI just ignores a key
-/// it doesn't know); this attribute is what makes removals and renames safe
-/// too. Each default is chosen as the SAFER of the two readings, not merely
-/// the type's zero value: `persisted` defaults to `false` (never claim
-/// durability we can't confirm) and `added` defaults to `false` (never claim
-/// a fresh account was created when it might have been an in-place
-/// credential replacement) — same degrade-to-the-safer-state shape as
+/// `oauth::probe_add_capability` reads that as `AddCapability::Unusable` — a
+/// *successful* live add would then look indistinguishable from a wedged or
+/// route-less proxy, and `login_route` REFUSES outright (bridge item D)
+/// instead of silently falling back to the file beside a server that just
+/// handled the request correctly. Field ADDITIONS are already safe on their
+/// own (an older CLI just ignores a key it doesn't know); this attribute is
+/// what makes removals and renames safe too. Each default is chosen as the
+/// SAFER of the two readings, not merely the type's zero value: `persisted`
+/// defaults to `false` (never claim durability we can't confirm) and `added`
+/// defaults to `false` (never claim a fresh account was created when it
+/// might have been an in-place credential replacement) — same
+/// degrade-to-the-safer-state shape as
 /// `ProxyHost::Unknown`.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct AddAccountResponse {
@@ -1375,8 +1376,10 @@ async fn add_account_handler(State(manager): State<Arc<Manager>>, req: Request) 
     // POSTs a blank name to trigger exactly this branch, and reads a STAMPED
     // 400 back as proof this route exists. Changing the status (e.g. to 422),
     // or answering without `stamp_add_endpoint`, silently turns that read into
-    // `AddCapability::Absent` — `tcr login` then falls back to the whole-file
-    // `config::save` path beside a live server. See the seam test
+    // `AddCapability::Unusable` — `login_route` then REFUSES outright (bridge
+    // item D) rather than falling back to the file, so this degrades to a
+    // needless refusal beside a server that actually has the route, not the
+    // whole-file clobber this feature exists to remove. See the seam test
     // `probe_add_capabilitys_blank_body_is_a_stamped_400_and_mutates_nothing`.
     let Some(name) = parsed.name.filter(|n| !n.trim().is_empty()) else {
         return stamp_add_endpoint(error_response(
@@ -5242,13 +5245,15 @@ mod tests {
     /// decides whether `tcr login` takes the LIVE route by POSTing this exact
     /// deliberately-blank body to `ADD_ACCOUNT_PATH` via
     /// `cli::post_add_account` and reading whether the reply is a STAMPED
-    /// 400. Anything else — an unstamped answer, a different status, or
-    /// (worst of all) a 200 that actually appended a blank-named account to
-    /// the live fleet — reads as `AddCapability::Absent`, and `tcr login`
-    /// silently falls back to the whole-file `config::save` path while THIS
-    /// server is still running: the exact single-use-refresh-token clobber
-    /// this whole feature exists to remove, reopened as a silent fallback
-    /// rather than a loud error.
+    /// 400. An unstamped answer, or a different (non-400) status, reads as
+    /// `AddCapability::Unusable` — `login_route` now REFUSES outright rather
+    /// than falling back to the whole-file `config::save` path (bridge item
+    /// D): a needless refusal beside a server that has the route, not the
+    /// single-use-refresh-token clobber this whole feature exists to remove.
+    /// Worst of all would be a 200 that actually appended a blank-named
+    /// account to the live fleet: that reads as `AddCapability::Present`
+    /// instead — a probe that is supposed to always fail silently succeeding
+    /// and mutating the live server.
     ///
     /// Driven through the REAL production stack — a real `TcpListener` and
     /// `crate::mitm::serve`, exactly how `main()` invokes it — not a
@@ -5313,9 +5318,9 @@ mod tests {
                 .get(ENDPOINT_HEADER)
                 .and_then(|v| v.to_str().ok()),
             Some(ADD_ACCOUNT_ENDPOINT),
-            "unstamped and `probe_add_capability` reads this as Absent — `tcr login` \
-             silently falls back to the whole-file config::save path with a live \
-             server running"
+            "unstamped and `probe_add_capability` reads this as Unusable — `login_route` \
+             now refuses outright instead of falling back to the whole-file config::save \
+             path with a live server running"
         );
 
         assert_eq!(


### PR DESCRIPTION

## Why

Adding an account meant stopping the proxy, running `tcr login`, and starting it
again. That restart discards the session→account pin map, so every live session
cold-starts its prompt cache on its next turn — the most expensive event in this
system.

It also carried a hazard in the other direction. `login()` loads the config and
later writes the whole file back; a proxy rotating tokens inside that window has
its fresh credentials reverted to the CLI's older snapshot. Anthropic's refresh
tokens are single-use, so a reverted write is not recoverable by retrying — the
account has to be logged in again by hand. That is why `tcr login` refused to run
beside a live server at all, and why `--force` was documented as unsafe.

Both problems have the same shape: two processes writing one file. This gives the
write to the running proxy, which already owns the equivalent mutation for
`tcr enable`/`tcr disable`.

## What changed

`POST /_tcr/accounts` adds an account to the live rotation, or replaces the
credentials of one already there. It is gated exactly as the existing
account-control route is — loopback-only, api-key with no loopback exemption,
DNS-rebind and cross-site checks, all before the body is read.

`tcr login` asks the proxy whether it can accept an account before opening the
browser, by POSTing a deliberately-invalid body and reading the reply. A response
carrying the endpoint stamp proves the route exists; the finished credential then
goes to the running proxy and the CLI never writes the config file. Against a
proxy without the route the previous refusal fires unchanged, with the same
message. With nothing listening, the previous file path runs unchanged.

That decision is made from the probe's own answer, never from process detection.
A proxy served inside a host application is invisible to the `argv[0]` matcher, so
gating on detection would silently route a live-server login back to the file
write — the failure this change exists to remove, returning as a silent fallback
rather than an error.

`--force` still probes, and still prefers the live route when it is there. It
overrides a refusal only: it will not override a confirmed live route, and it will
not override a rejected api-key, because an api-key rejection is positive evidence
that a live server is answering — the worst moment to write the file. Fix the key
or stop the server.

The remaining fallbacks write one account entry through the same surgical
read-modify-write the proxy itself uses, rather than a whole-file save. Only the
genuinely-no-server path writes the whole file, because a first login has to
create it.

Accounts are appended, never inserted or reordered: pins are held by account
index, so reordering would silently re-key live sessions onto the wrong accounts.
Logging in again as an existing account replaces its credentials in place and
keeps its index, priority, disabled flag and learned quota.

## Notes for review

Identity is resolved with `identity::resolve`/`same_identity` — the same rule
`oauth::upsert_account` and the durable config writer already use — rather than
the name-and-org query rule used for `tcr disable`. That difference is deliberate
and load-bearing: the query rule cannot compare `account_uuid` (the `Queryable`
trait does not expose it), so under it the same email in two orgs resolves onto
one row. For a reversible bench that is harmless; for a credential write it
destroys the stored account's refresh token. Both halves of the operation, live
and durable, now run the same rule.

Resolution and mutation happen under one write-lock acquisition; the durable file
write runs after the lock is released.

The capability probe's contract is now pinned from both sides: a blank body must
answer a *stamped* 400 and must leave the rotation unchanged. If that ever became
an unstamped or differently-coded response, `tcr login` would classify a healthy
route as absent and silently fall back to writing the file beside a live server —
the exact hazard this change removes, returning without an error.

`refresh_locks` was a construction-fixed `Vec` indexed by account position, and
`ensure_fresh` returned `false` with no log line when the index was out of range.
An account added after startup would have served until its first token expiry and
then gone quietly dead. The lock now lives on the account, so the mismatch is not
representable.

## Verification

`cargo test` 613 lib + 31 integration, `cargo clippy --all-targets -- -D warnings`
clean. Tests for the destructive cases were watched failing against the code
before the fix, not only passing after it.

Not covered: no live-proxy end-to-end run against a real Anthropic account. The
route is exercised against a real listener and the production router, but adding
a genuine OAuth credential to a running proxy has only been tested with
fabricated credentials.
