### PR TITLE
Close the remaining clobber windows in live account-add

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -391,12 +391,17 @@ async fn post_set_disabled(
 
     let response = match request.send().await {
         Ok(r) => r,
-        Err(e) if e.is_connect() => return Err(LiveControlError::NoServer),
+        // `is_timeout()` first: a connect TIMEOUT (a blackholed address, SYN
+        // dropped rather than refused) reports `is_connect() == true` as
+        // well, so checking `is_connect()` first would misclassify it as
+        // `NoServer` — "nothing is listening" — when the truer reading is
+        // "something is there but not answering", `NoAnswer` below.
         Err(e) if e.is_timeout() => {
             return Err(LiveControlError::NoAnswer(
                 "the server did not answer within 5s".to_string(),
             ))
         }
+        Err(e) if e.is_connect() => return Err(LiveControlError::NoServer),
         Err(e) => return Err(LiveControlError::NoAnswer(e.to_string())),
     };
 
@@ -477,12 +482,17 @@ pub(crate) async fn post_add_account(
 
     let response = match request.send().await {
         Ok(r) => r,
-        Err(e) if e.is_connect() => return Err(LiveControlError::NoServer),
+        // `is_timeout()` first: a connect TIMEOUT (a blackholed address, SYN
+        // dropped rather than refused) reports `is_connect() == true` as
+        // well, so checking `is_connect()` first would misclassify it as
+        // `NoServer` — "nothing is listening" — when the truer reading is
+        // "something is there but not answering", `NoAnswer` below.
         Err(e) if e.is_timeout() => {
             return Err(LiveControlError::NoAnswer(
                 "the server did not answer within 5s".to_string(),
             ))
         }
+        Err(e) if e.is_connect() => return Err(LiveControlError::NoServer),
         Err(e) => return Err(LiveControlError::NoAnswer(e.to_string())),
     };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1131,7 +1131,13 @@ fn find_account_entry<'a>(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AccountWrite {
     /// No entry on disk carried this identity — a new one was appended, holding
-    /// every field `account` carries (identity, credentials, and routing knobs).
+    /// every field `account` carries (identity, credentials, and routing
+    /// knobs) — with one deliberate exception: an ABSENT `priority` is filled
+    /// in as `max(existing priorities) + 1`, joining the back of the fleet,
+    /// rather than left absent (which reads as 0 at runtime and silently
+    /// promotes the new account to the primary tier). An explicit `priority`
+    /// the caller submitted is never overridden. See [`merge_account`]'s
+    /// doc-comment on the Added arm for the full rationale.
     Added,
     /// Exactly one entry carried this identity — its CREDENTIAL fields
     /// (`accessToken` / `refreshToken` / `expiresAt`) were updated in place,
@@ -1272,7 +1278,30 @@ fn merge_account(
                 // shape that was not actually verified to be an array.
                 return Ok(AccountWrite::Unwritable);
             };
-            entries.push(serde_json::to_value(account)?);
+            let mut new_entry = serde_json::to_value(account)?;
+            // An appended account with no explicit priority joins the BACK
+            // of the fleet — `max(existing priorities) + 1` — rather than
+            // being left absent. `priority` is deliberate-default here, not
+            // incidental: `skip_serializing_if` means a `None` would otherwise
+            // serialize to no key at all, and an absent `priority` reads as 0
+            // at runtime (`AccountRuntime::from_config`'s `unwrap_or(0)`),
+            // which silently promotes a freshly added account to the PRIMARY
+            // tier ahead of the established fleet. Mirrors
+            // `oauth::upsert_account`'s historical default. Skipped when the
+            // caller submitted an explicit priority (the documented
+            // new-account case — see `AddAccountRequest`'s doc-comment in
+            // `proxy.rs`), which is never overridden.
+            if account.priority.is_none() {
+                let next_priority = entries
+                    .iter()
+                    .filter_map(|e| e.get("priority").and_then(Value::as_i64))
+                    .max()
+                    .map_or(0, |max| max + 1);
+                if let Value::Object(fields) = &mut new_entry {
+                    fields.insert("priority".to_string(), Value::from(next_priority));
+                }
+            }
+            entries.push(new_entry);
             Ok(AccountWrite::Added)
         }
     }
@@ -2593,6 +2622,71 @@ mod tests {
         assert_eq!(accounts[0]["name"], json!("acct-a"));
         assert_eq!(accounts[1]["name"], json!("acct-b"));
         assert_eq!(after["warmupSeconds"], json!(900));
+        fs::remove_file(&path).ok();
+    }
+
+    /// Two pre-existing entries with real, distinct priorities — the shape
+    /// needed to prove the Added path computes MAX+1 rather than reading an
+    /// absent priority as 0.
+    const PRIORITY_SAMPLE: &str = r#"{
+      "accounts": [
+        { "name": "acct-a", "type": "oauth", "accessToken": "at-a", "priority": 0 },
+        { "name": "acct-b", "type": "oauth", "accessToken": "at-b", "priority": 1 }
+      ]
+    }"#;
+
+    /// An appended account with no explicit priority joins the BACK of the
+    /// fleet — `max(existing priorities) + 1` — never left absent. An absent
+    /// `priority` reads as 0 at runtime (`AccountRuntime::from_config`'s
+    /// `unwrap_or(0)`), which silently promotes a freshly added account to the
+    /// PRIMARY tier ahead of the established fleet. Mirrors
+    /// `oauth::upsert_account`'s historical default, which this route did not
+    /// share before this fix.
+    #[test]
+    fn save_account_added_path_assigns_max_plus_one_priority_when_none_submitted() {
+        let path = tmp_path("add-default-priority");
+        fs::write(&path, PRIORITY_SAMPLE).unwrap();
+
+        let new_account = Account {
+            priority: None,
+            ..full_account("carol@example.com", "at-carol")
+        };
+        assert_eq!(
+            save_account(&path, &new_account).unwrap(),
+            AccountWrite::Added
+        );
+
+        let after = read_json(&path);
+        let accounts = after["accounts"].as_array().expect("accounts array");
+        assert_eq!(accounts.len(), 3);
+        assert_eq!(
+            accounts[2]["priority"],
+            json!(2),
+            "an added account with no explicit priority must join the back of \
+             the fleet, not read as 0: {after}"
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    /// The max+1 default only fills an ABSENT priority — a caller that submits
+    /// one explicitly (the documented new-account case, see
+    /// `AddAccountRequest`'s doc-comment in `proxy.rs`) is never overridden.
+    #[test]
+    fn save_account_added_path_keeps_an_explicit_priority() {
+        let path = tmp_path("add-explicit-priority");
+        fs::write(&path, PRIORITY_SAMPLE).unwrap();
+
+        let new_account = Account {
+            priority: Some(99),
+            ..full_account("carol@example.com", "at-carol")
+        };
+        assert_eq!(
+            save_account(&path, &new_account).unwrap(),
+            AccountWrite::Added
+        );
+
+        let after = read_json(&path);
+        assert_eq!(after["accounts"][2]["priority"], json!(99));
         fs::remove_file(&path).ok();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,10 +160,13 @@ struct LoginArgs {
     /// Skip the refusal a running proxy would otherwise trigger, and write the
     /// login to the config file directly. Still probes the proxy first and still
     /// prefers its live account-add route when one is confirmed and safe — this
-    /// only overrides the cases login would otherwise refuse or error on (an
-    /// older proxy with no route, one that answered unusably, or a rejected
-    /// api-key). Unsafe when it takes the file path: the running server's next
-    /// token refresh can overwrite what was just written.
+    /// only overrides the cases login would otherwise refuse on: an older proxy
+    /// with no account-add route, or one that answered but not usably (wedged or
+    /// timed out). Never overrides a confirmed live route (already safe, nothing
+    /// to force) or a rejected api-key (proof the proxy is alive, so writing the
+    /// file beside it is the worst-informed moment to do it) — both still refuse
+    /// under --force. Unsafe when it takes the file path: the running server's
+    /// next token refresh can overwrite what was just written.
     #[arg(long)]
     force: bool,
 }

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -336,7 +336,11 @@ pub enum AddAccountOutcome {
     /// No account in the live rotation carried this identity — appended at the
     /// END via [`Manager::add_account`]. Pins are in-memory `(session_key,
     /// account_index)`, so appending is the only insertion that cannot re-key a
-    /// live session onto the wrong account.
+    /// live session onto the wrong account. An account with no explicit
+    /// `priority` is assigned `max(existing priorities) + 1` — deliberate,
+    /// not incidental: it joins the back of the fleet rather than reading as
+    /// 0 (the primary tier) — see the doc-comment on the Added arm inside
+    /// [`Manager::add_or_update_account`].
     Added {
         idx: usize,
         name: String,
@@ -1311,7 +1315,43 @@ impl Manager {
     /// duplicating the live row. Holding one write lock across resolve-then-
     /// mutate means the second caller's resolve runs after the first caller's
     /// append is already visible, so it finds the row and updates it instead.
-    pub fn add_or_update_account(&self, account: config::Account) -> AddAccountOutcome {
+    ///
+    /// `config_write` is held across the WHOLE function — resolve, mutate, and
+    /// persist — not just the file I/O at the end. The `self.accounts` fix
+    /// above only serializes the LIVE half: it guarantees the second of two
+    /// concurrent same-identity submissions sees the first one's row and takes
+    /// the Updated path instead of duplicating it. It said nothing about the
+    /// DURABLE half, which used to take its own `config_write` lock only
+    /// inside `persist_added`/`persist_replaced`, well after `self.accounts`
+    /// was released — so two callers' persists could still race onto
+    /// `config_write` in the OPPOSITE order from the one their live resolves
+    /// agreed on, each writing its OWN submitted credentials. The loser's
+    /// `persist_replaced` (seeing nothing on disk yet) would append a fresh
+    /// entry with ITS tokens; the winner's `persist_added` would then find
+    /// that entry and merge ITS OWN tokens over it — leaving the file holding
+    /// whichever call happened to reach `config_write` first, independent of
+    /// which one actually won the live race. Measured 2/200 over 200 rounds of
+    /// two concurrent adds of one identity. Holding this lock across both
+    /// halves makes resolve-mutate-persist one atomic unit, so the durable
+    /// write order always agrees with the live resolve order.
+    ///
+    /// This is the one place in `Manager` that holds `config_write` and
+    /// `self.accounts` at once — everywhere else they are taken sequentially,
+    /// never nested (see `set_disabled`'s and `warm_targets`'s comments on
+    /// that discipline). It is safe: `self.accounts` is held only for the
+    /// brief in-memory resolve-and-mutate inside this span, never across the
+    /// file I/O below, and no other code path holds `self.accounts` and then
+    /// reaches for `config_write` or `config` — so this adds one new,
+    /// one-directional edge (`config_write` → `self.accounts`) to the lock
+    /// order, not a cycle. `persist_added`/`persist_replaced` no longer take
+    /// `config_write` themselves — they assume the caller already holds it.
+    pub fn add_or_update_account(&self, mut account: config::Account) -> AddAccountOutcome {
+        // N2 — see above: held across resolve, mutate AND persist so this
+        // whole operation never interleaves with another concurrent call's.
+        let _writing = self
+            .config_write
+            .lock()
+            .expect("config write lock poisoned");
         let target = crate::identity::probe(
             &account.name,
             account.account_uuid.clone(),
@@ -1323,9 +1363,11 @@ impl Manager {
             && account.org_name.is_none();
 
         /// What the locked resolve-and-mutate section below produced, so the
-        /// (unlocked) durable write can run after the lock is released —
+        /// durable write can run after `self.accounts`'s lock is released —
         /// `persist_added`/`persist_replaced` do their own file I/O and must
-        /// never run under `self.accounts`'s lock.
+        /// never run under `self.accounts`'s lock (though both still run
+        /// under `config_write`, held since function entry — see the N2
+        /// doc-comment on `add_or_update_account`).
         enum Resolution {
             Added {
                 idx: usize,
@@ -1462,6 +1504,30 @@ impl Manager {
                     }
                 }
                 None => {
+                    // A follow-up regression on this arm (distinct from the
+                    // TOCTOU fix this function is named for above): an
+                    // appended account with no explicit priority must join
+                    // the BACK of the fleet — `max(existing priorities) + 1`
+                    // — not the 0 that `AccountRuntime::from_config`'s
+                    // `unwrap_or(0)` reads from an absent priority, which
+                    // would silently promote it to the PRIMARY tier ahead of
+                    // the established fleet. Computed from `accounts` (the
+                    // LIVE rotation, not the config snapshot) because this
+                    // section already holds its write lock and it is
+                    // authoritative for what is routing right now. Skipped
+                    // when the caller submitted an explicit priority (the
+                    // documented new-account case — see `AddAccountRequest`'s
+                    // doc-comment in `proxy.rs`), which is never overridden.
+                    // Mirrors the identical fix in `config::merge_account`'s
+                    // Added arm.
+                    if account.priority.is_none() {
+                        let next_priority = accounts
+                            .iter()
+                            .map(|a| a.priority)
+                            .max()
+                            .map_or(0, |max| max + 1);
+                        account.priority = Some(next_priority);
+                    }
                     let runtime = AccountRuntime::from_config(&account);
                     accounts.push(runtime);
                     Resolution::Added {
@@ -1473,8 +1539,13 @@ impl Manager {
 
         match resolution {
             Resolution::Added { idx } => {
-                // Sequential, never nested with the accounts lock above — same
-                // discipline `add_account` documents.
+                // Still sequential, never nested, with `self.accounts` (which
+                // is already released by this point) — the `self.config` lock
+                // here is a separate, short critical section, same discipline
+                // `add_account` documents. It runs nested inside
+                // `config_write` (held since function entry, see the N2
+                // doc-comment above), which is what makes this whole arm
+                // atomic with respect to another concurrent call.
                 {
                     let mut config = self.config.lock().expect("config lock poisoned");
                     config.accounts.push(account.clone());
@@ -1495,14 +1566,17 @@ impl Manager {
     /// whole `config::save_account` read-modify-write runs under
     /// `config_write`, never `self.config` — nothing here needs the in-memory
     /// snapshot, because [`Self::add_account`] already pushed `account` onto it.
+    ///
+    /// PRECONDITION: unlike every other `config_write` writer in this module,
+    /// this one does NOT take the lock itself — its only caller,
+    /// [`Self::add_or_update_account`], already holds it across the whole
+    /// resolve-mutate-persist sequence (see that function's N2 doc-comment),
+    /// and `Mutex` is not reentrant, so locking again here would deadlock.
+    /// Never call this without `config_write` already held.
     fn persist_added(&self, account: &config::Account) -> AddPersist {
         let Some(path) = &self.config_path else {
             return AddPersist::NoConfigFile;
         };
-        let _writing = self
-            .config_write
-            .lock()
-            .expect("config write lock poisoned");
         match config::save_account(path, account) {
             Ok(config::AccountWrite::Added) => {
                 tracing::info!(account = %account.name, "persisted newly added account to config");
@@ -1559,6 +1633,10 @@ impl Manager {
     /// `target` would append a fresh, un-benched entry for an account that was
     /// deliberately disabled, so it would come back into rotation on the very
     /// next restart — the exact bug `persist_disabled` exists to prevent.
+    ///
+    /// PRECONDITION: same as [`Self::persist_added`] — does NOT take
+    /// `config_write` itself; its only caller, [`Self::add_or_update_account`],
+    /// already holds it. Never call this without `config_write` already held.
     fn persist_replaced(
         &self,
         idx: usize,
@@ -1568,10 +1646,6 @@ impl Manager {
         let Some(path) = &self.config_path else {
             return AddPersist::NoConfigFile;
         };
-        let _writing = self
-            .config_write
-            .lock()
-            .expect("config write lock poisoned");
         let mut for_disk = target.clone();
         for_disk.access_token = fresh.access_token.clone();
         for_disk.refresh_token = fresh.refresh_token.clone();
@@ -5768,6 +5842,148 @@ mod tests {
         );
 
         std::fs::remove_file(&path).ok();
+    }
+
+    /// A follow-up regression on the Added path (distinct from the F3 TOCTOU
+    /// finding above, and from `config::save_account`'s identical fix on the
+    /// durable side): appending an account with no explicit priority must
+    /// join the BACK of the LIVE fleet — `max(existing priorities) + 1` — not
+    /// the 0 that `AccountRuntime::from_config`'s `unwrap_or(0)` reads from an
+    /// absent `priority`, which would silently promote a freshly added
+    /// account to the PRIMARY tier ahead of the established fleet.
+    #[test]
+    fn add_or_update_account_added_path_assigns_max_plus_one_priority_when_none_submitted() {
+        let (manager, path) = build_manager_with_disk(
+            config_with(vec![
+                account("alice@example.com", 0),
+                account("bob@example.com", 1),
+            ]),
+            "live-default-priority",
+        );
+
+        let submission = Account {
+            priority: None,
+            ..account("carol@example.com", 0)
+        };
+        let idx = match manager.add_or_update_account(submission) {
+            AddAccountOutcome::Added { idx, .. } => idx,
+            other => panic!("expected Added: {other:?}"),
+        };
+
+        {
+            let accounts = manager.accounts.read().expect("accounts lock poisoned");
+            assert_eq!(
+                accounts[idx].priority, 2,
+                "an added account with no explicit priority must join the back \
+                 of the live fleet, not the default-derived 0"
+            );
+        }
+
+        let reloaded = config::load(&path).expect("reload persisted config");
+        assert_eq!(
+            reloaded.accounts[idx].priority,
+            Some(2),
+            "the durable half must agree with the live rotation on the assigned priority"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// An explicit priority submitted on the Added path is never overridden by
+    /// the max+1 default — mirrors the durable-side test of the same name in
+    /// `config.rs`.
+    #[test]
+    fn add_or_update_account_added_path_keeps_an_explicit_priority() {
+        let (manager, path) = build_manager_with_disk(
+            config_with(vec![account("alice@example.com", 0)]),
+            "live-explicit-priority",
+        );
+
+        let submission = Account {
+            priority: Some(99),
+            ..account("carol@example.com", 0)
+        };
+        let idx = match manager.add_or_update_account(submission) {
+            AddAccountOutcome::Added { idx, .. } => idx,
+            other => panic!("expected Added: {other:?}"),
+        };
+
+        let accounts = manager.accounts.read().expect("accounts lock poisoned");
+        assert_eq!(accounts[idx].priority, 99);
+        drop(accounts);
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// The live half of a brand-new-identity race was already serialized by
+    /// the single `accounts` write-lock spanning resolve+mutate (see the
+    /// TOCTOU fix above) — but the two callers' DURABLE writes still queued on
+    /// `config_write` independently, in whatever order the OS scheduled them,
+    /// with no guarantee that order agreed with which caller actually won the
+    /// live race. Two real logins of the SAME identity racing each other (a
+    /// double-submit, a retried `tcr login`) carry genuinely DIFFERENT tokens,
+    /// so a disagreement is observable: the file could end up holding the
+    /// LOSING submission's token while the live rotation served the winner's.
+    /// Measured 2/200 over 200 rounds of two simultaneous adds of one
+    /// identity before `config_write` was widened to span the whole
+    /// resolve-mutate-persist sequence. Runs the same 200 rounds to catch it.
+    #[test]
+    fn concurrent_adds_of_one_new_identity_never_disagree_with_disk_on_the_token() {
+        use std::thread;
+        for round in 0..200 {
+            let (manager, path) = build_manager_with_disk(
+                config_with(vec![account("alice@example.com", 0)]),
+                &format!("n2-token-race-{round}"),
+            );
+
+            let base = Account {
+                account_uuid: Some("uuid-new".to_string()),
+                ..account("carol@example.com", 0)
+            };
+            let submission_a = Account {
+                access_token: "at-A".to_string(),
+                refresh_token: Some("rt-A".to_string()),
+                ..base.clone()
+            };
+            let submission_b = Account {
+                access_token: "at-B".to_string(),
+                refresh_token: Some("rt-B".to_string()),
+                ..base
+            };
+
+            let m1 = Arc::clone(&manager);
+            let m2 = Arc::clone(&manager);
+            let h1 = thread::spawn(move || m1.add_or_update_account(submission_a));
+            let h2 = thread::spawn(move || m2.add_or_update_account(submission_b));
+            h1.join().expect("adder A panicked");
+            h2.join().expect("adder B panicked");
+
+            let live_token = {
+                let accounts = manager.accounts.read().expect("accounts lock poisoned");
+                accounts
+                    .iter()
+                    .find(|a| a.name == "carol@example.com")
+                    .expect("carol's row exists live")
+                    .access_token
+                    .clone()
+            };
+            let reloaded = config::load(&path).expect("reload persisted config");
+            let disk_token = reloaded
+                .accounts
+                .iter()
+                .find(|a| a.name == "carol@example.com")
+                .expect("carol's row exists on disk")
+                .access_token
+                .clone();
+
+            assert_eq!(
+                live_token, disk_token,
+                "round {round}: live token ({live_token}) and disk token \
+                 ({disk_token}) disagree for the same identity"
+            );
+
+            std::fs::remove_file(&path).ok();
+        }
     }
 
     /// F4 — an `Error` row given fresh credentials must clear back to `Active`

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -1091,7 +1091,19 @@ fn persist_via_file(
 /// there is no stale snapshot for it to clobber a concurrent server-side
 /// rotation with. This is the same write the server's own persist path uses.
 fn persist_via_account(config_path: &Path, account: &Account) -> anyhow::Result<String> {
-    match config::save_account(config_path, account).context("save account after login")? {
+    let outcome = config::save_account(config_path, account).context("save account after login")?;
+    account_write_result(config_path, account, outcome)
+}
+
+/// Turn a [`config::AccountWrite`] outcome into `persist_via_account`'s return
+/// value, shared with [`persist_via_account_or_file`] so the two callers agree
+/// on the exact same success/refusal wording rather than drifting apart.
+fn account_write_result(
+    config_path: &Path,
+    account: &Account,
+    outcome: config::AccountWrite,
+) -> anyhow::Result<String> {
+    match outcome {
         config::AccountWrite::Added | config::AccountWrite::Updated => {
             println!(
                 "Saved account '{}' to {}",
@@ -1114,6 +1126,36 @@ fn persist_via_account(config_path: &Path, account: &Account) -> anyhow::Result<
     }
 }
 
+/// [`persist_via_account`], but falling back to [`persist_via_file`] when
+/// there is no file yet for `save_account`'s `read_document` to read —
+/// `fs::read_to_string` cannot create a missing file, and a first-ever login
+/// must still be able to. Used by `finish_login`'s `NoServer` arm, which
+/// otherwise carries the exact same clobber risk `NoRoute` and the
+/// timeout/`Unusable` arm already write surgically around: the config
+/// snapshot in `config` was taken before the profile fetch, the possible
+/// stdin prompt, and the live-add round-trip, so a whole-file write here
+/// would revert any rotation a server that exited moments ago made to any
+/// OTHER account inside that window.
+fn persist_via_account_or_file(
+    config_path: &Path,
+    config: &mut Config,
+    name: &str,
+    tokens: &Tokens,
+    profile: Profile,
+    account: &Account,
+) -> anyhow::Result<String> {
+    match config::save_account(config_path, account) {
+        Err(config::ConfigError::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
+            persist_via_file(config_path, config, name, tokens, profile)
+        }
+        result => account_write_result(
+            config_path,
+            account,
+            result.context("save account after login")?,
+        ),
+    }
+}
+
 /// Persist the finished OAuth credential per `route`: through the live proxy
 /// when it is [`LoginRoute::Live`], via [`persist_via_file`] when it is
 /// [`LoginRoute::File`]. Split out of [`login`] so WHERE the credential lands
@@ -1122,12 +1164,17 @@ fn persist_via_account(config_path: &Path, account: &Account) -> anyhow::Result<
 /// On the live path the running server owns the durable write — this must
 /// NOT also whole-file [`config::save`] the (possibly already-stale) `config`
 /// this process is holding; that write is exactly the clobber this unit
-/// exists to remove. Falls back to the file only on the quiet
-/// [`crate::cli::LiveControlError::NoServer`] case, mirroring
-/// [`crate::cli::set_enabled`]'s discipline: a server that answered and
-/// REFUSED us (`Unauthorized`, `Rejected`) must surface, never silently write
-/// the file instead, because the two halves would then disagree about what
-/// the account's credentials are.
+/// exists to remove. The quiet [`crate::cli::LiveControlError::NoServer`]
+/// case carries that SAME clobber risk, not a lesser one: the proxy the
+/// earlier capability probe confirmed alive can have exited any time in the
+/// profile-fetch / stdin-prompt / round-trip window since, so any OTHER
+/// account it rotated in that window is still on disk waiting to be
+/// reverted. It therefore routes through [`persist_via_account_or_file`]'s
+/// surgical write exactly like `NoRoute`/`Unusable` below, never straight to
+/// a whole-file one. A server that answered and REFUSED us (`Unauthorized`,
+/// `Rejected`) must surface, never silently write the file instead, because
+/// the two halves would then disagree about what the account's credentials
+/// are.
 async fn finish_login(
     config_path: &Path,
     route: LoginRoute,
@@ -1174,11 +1221,21 @@ async fn finish_login(
                     Ok(applied.name)
                 }
                 // Nothing is listening any more (it exited between the probe
-                // and here): the quiet fallback, same discipline as
-                // `set_enabled`.
-                Err(crate::cli::LiveControlError::NoServer) => {
-                    persist_via_file(config_path, config, name, tokens, profile)
-                }
+                // and here). NOT the safe "offline the whole time" case
+                // `persist_via_file` is for: a proxy WAS confirmed alive
+                // moments ago, and it can have rotated any OTHER account's
+                // tokens on disk any time in the profile-fetch / stdin-prompt
+                // / round-trip window since. Same surgical write as
+                // `NoRoute`/`Unusable` below, falling back to a whole-file
+                // write only when there is no file yet at all.
+                Err(crate::cli::LiveControlError::NoServer) => persist_via_account_or_file(
+                    config_path,
+                    config,
+                    name,
+                    tokens,
+                    profile,
+                    &account,
+                ),
                 // The proxy rejected our api-key. Writing the file here would
                 // be the clobber this unit exists to remove, in a new place:
                 // the running server keeps whatever it already had while the
@@ -2510,5 +2567,236 @@ mod tests {
 
         std::fs::remove_file(&path).ok();
         drop(listener);
+    }
+
+    /// THE σ5 EXPERIMENT for the `NoServer` arm specifically — same shape as
+    /// `finish_login_live_path_does_not_clobber_a_concurrent_rotation` and
+    /// `finish_login_live_timeout_does_not_clobber_other_accounts`, but for
+    /// the arm those two do not reach: the proxy the capability probe found
+    /// alive has exited entirely by the time `post_add_account` connects, so
+    /// the connection is refused outright (`is_connect()`, not `is_timeout()`
+    /// or a 404/405). Before this fix, this arm alone still called
+    /// `persist_via_file` directly regardless of what any other test in this
+    /// file exercises — a stale client-side snapshot whole-file-written over
+    /// a rotation that landed on disk in the profile-fetch / stdin-prompt /
+    /// round-trip window. Watched failing directly: with the `NoServer` arm
+    /// reverted to `persist_via_file`, this test fails with `left:
+    /// "rt-alice" right: "rt-alice-ROTATED"`.
+    #[tokio::test]
+    async fn finish_login_no_server_does_not_clobber_a_concurrent_rotation() {
+        // Bind to grab a free port, then drop the listener immediately: it
+        // was live a moment ago (mirroring the capability probe having
+        // confirmed it), but by the time `finish_login` runs, nothing is
+        // listening and a connect is refused outright.
+        let dead_port = {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            listener.local_addr().unwrap().port()
+        };
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-live-noserver-clobber-{}-{dead_port}.json",
+            std::process::id()
+        ));
+        let seed = format!(
+            r#"{{ "proxy": {{ "port": {dead_port} }}, "accounts": [
+                {{ "name": "alice@example.com", "type": "oauth", "accessToken": "at-alice",
+                  "refreshToken": "rt-alice", "expiresAt": 1893456000000, "priority": 0 }}
+            ] }}"#
+        );
+        std::fs::write(&path, &seed).unwrap();
+
+        // The stale snapshot: what `login()` would have loaded before its own
+        // async window (profile fetch / stdin prompt) opened.
+        let mut client_config = load_or_default(&path).unwrap();
+
+        // A rotation lands on disk AFTER that snapshot was taken — the
+        // (now-gone) server's own persist path, used directly since the port
+        // is silent for the whole test and cannot carry a real round-trip.
+        let rotated_alice = Account {
+            name: "alice@example.com".to_string(),
+            account_type: "oauth".to_string(),
+            account_uuid: None,
+            org_uuid: None,
+            org_name: None,
+            access_token: "at-alice-ROTATED".to_string(),
+            refresh_token: Some("rt-alice-ROTATED".to_string()),
+            expires_at: Some(1_893_456_000_000),
+            priority: None,
+            switch_threshold: None,
+            disabled: None,
+            extra: serde_json::Map::new(),
+        };
+        config::save_account(&path, &rotated_alice).expect("the rotation must land on disk");
+        let after_rotation = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            after_rotation.contains("rt-alice-ROTATED"),
+            "setup: the rotation must be on disk first: {after_rotation}"
+        );
+
+        let name = finish_login(
+            &path,
+            LoginRoute::Live,
+            &mut client_config,
+            "carol@example.com",
+            &tokens("at-carol", "rt-carol", 1_893_456_000_000),
+            profile_named("carol@example.com"),
+        )
+        .await
+        .expect("a NoServer live add must still fall back to a surgical write");
+        assert_eq!(name, "carol@example.com");
+
+        let final_doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let accounts = final_doc["accounts"].as_array().unwrap();
+        let alice = accounts
+            .iter()
+            .find(|a| a["name"] == "alice@example.com")
+            .expect("alice must still be on disk");
+        assert_eq!(
+            alice["refreshToken"],
+            serde_json::json!("rt-alice-ROTATED"),
+            "the NoServer live add must NOT whole-file-write a stale snapshot back over \
+             alice's rotation: {final_doc}"
+        );
+        assert!(
+            accounts.iter().any(|a| a["name"] == "carol@example.com"),
+            "carol was added: {final_doc}"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// A direct exercise of `finish_login`'s `NoRoute` arm. Before this test
+    /// it was covered only by inference — every existing clobber test in
+    /// this file drives either `Live`'s success path, `NoServer`, or the
+    /// timeout/`Unusable` catch-all (`Err(other)`), never the specific
+    /// unstamped-404 shape `NoRoute` is. Same "older tcr" server as
+    /// `probe_add_capability_unstamped_404_is_unusable_not_absent`: an empty
+    /// axum router answers every path, so `post_add_account` sees a 404 with
+    /// no `ENDPOINT_HEADER` and classifies it structurally as `NoRoute`
+    /// rather than `Unusable`.
+    #[tokio::test]
+    async fn finish_login_no_route_does_not_clobber_other_accounts() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, axum::Router::new()).await;
+        });
+
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-live-noroute-{}-{port}.json",
+            std::process::id()
+        ));
+        let seed = format!(
+            r#"{{ "proxy": {{ "port": {port} }}, "accounts": [
+                {{ "name": "alice@example.com", "type": "oauth", "accessToken": "at-alice",
+                  "refreshToken": "rt-alice", "expiresAt": 1893456000000, "priority": 0 }}
+            ] }}"#
+        );
+        std::fs::write(&path, &seed).unwrap();
+
+        // The stale snapshot: what `login()` would have loaded before its own
+        // async window (profile fetch / stdin prompt) opened.
+        let mut client_config = load_or_default(&path).unwrap();
+
+        // A rotation lands on disk AFTER that snapshot was taken — this
+        // "older tcr" has no add-account route to have produced it, standing
+        // in for any other writer that touched the file in the window, same
+        // as every sibling clobber test in this file.
+        let rotated_alice = Account {
+            name: "alice@example.com".to_string(),
+            account_type: "oauth".to_string(),
+            account_uuid: None,
+            org_uuid: None,
+            org_name: None,
+            access_token: "at-alice-ROTATED".to_string(),
+            refresh_token: Some("rt-alice-ROTATED".to_string()),
+            expires_at: Some(1_893_456_000_000),
+            priority: None,
+            switch_threshold: None,
+            disabled: None,
+            extra: serde_json::Map::new(),
+        };
+        config::save_account(&path, &rotated_alice).expect("the rotation must land on disk");
+
+        let name = finish_login(
+            &path,
+            LoginRoute::Live,
+            &mut client_config,
+            "dana@example.com",
+            &tokens("at-dana", "rt-dana", 1_893_456_000_000),
+            profile_named("dana@example.com"),
+        )
+        .await
+        .expect("a NoRoute live add must still fall back to a surgical write");
+        assert_eq!(name, "dana@example.com");
+
+        let final_doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let accounts = final_doc["accounts"].as_array().unwrap();
+        let alice = accounts
+            .iter()
+            .find(|a| a["name"] == "alice@example.com")
+            .expect("alice must still be on disk");
+        assert_eq!(
+            alice["refreshToken"],
+            serde_json::json!("rt-alice-ROTATED"),
+            "the NoRoute live add must NOT whole-file-write a stale snapshot back over \
+             alice's rotation: {final_doc}"
+        );
+        assert!(
+            accounts.iter().any(|a| a["name"] == "dana@example.com"),
+            "dana was added: {final_doc}"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// `persist_via_account_or_file`'s NotFound guard: `config::save_account`'s
+    /// `read_document` opens the file with `fs::read_to_string`, which cannot
+    /// create one that is not there — so a `NoServer` result reached with NO
+    /// config file on disk at all must still fall back to `persist_via_file`
+    /// (the same whole-file write `LoginRoute::File` always used) instead of
+    /// bailing on the read error. A first-ever login must be able to create
+    /// the file exactly as it always has.
+    #[tokio::test]
+    async fn finish_login_no_server_creates_the_file_when_none_exists() {
+        let dead_port = {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            listener.local_addr().unwrap().port()
+        };
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-live-noserver-nofile-{}-{dead_port}.json",
+            std::process::id()
+        ));
+        std::fs::remove_file(&path).ok();
+        assert!(!path.exists(), "setup: no config file must exist yet");
+
+        // In-memory only — no file backs this, mirroring what `login()` would
+        // hold when there is nothing on disk yet. Must carry `dead_port`
+        // explicitly: leaving `proxy.port` at its serde default would send
+        // this test's request to whatever real port 3456 happens to hold.
+        let mut client_config: Config =
+            serde_json::from_str(&format!(r#"{{ "proxy": {{ "port": {dead_port} }} }}"#)).unwrap();
+
+        let name = finish_login(
+            &path,
+            LoginRoute::Live,
+            &mut client_config,
+            "frank@example.com",
+            &tokens("at-frank", "rt-frank", 1_893_456_000_000),
+            profile_named("frank@example.com"),
+        )
+        .await
+        .expect("a NoServer live add with no file yet must still create one");
+        assert_eq!(name, "frank@example.com");
+
+        let doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(
+            doc["accounts"][0]["name"],
+            serde_json::json!("frank@example.com")
+        );
+
+        std::fs::remove_file(&path).ok();
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -5241,7 +5241,7 @@ mod tests {
         }
     }
 
-    /// SEAM TEST. `oauth::probe_add_capability` (unit 3, `oauth.rs:855-881`)
+    /// SEAM TEST. `oauth::probe_add_capability` (unit 3, `oauth.rs:901-932`)
     /// decides whether `tcr login` takes the LIVE route by POSTing this exact
     /// deliberately-blank body to `ADD_ACCOUNT_PATH` via
     /// `cli::post_add_account` and reading whether the reply is a STAMPED
@@ -5279,13 +5279,13 @@ mod tests {
             .no_proxy()
             .build()
             .expect("build client");
-        // The EXACT `Account` `probe_add_capability` builds (oauth.rs:855-869):
+        // The EXACT `Account` `probe_add_capability` builds (oauth.rs:902-915):
         // a blank name, a blank access token, everything else absent.
         // DERIVED, not a restated literal — a future edit to the probe's body
         // (oauth.rs, out of this route's reach) changes this test's request
         // too, instead of leaving a stale literal green while it tests a body
         // nobody sends. Sent via `.json()` exactly like `post_add_account`
-        // sends it (`cli.rs:473`, `.json(account)`).
+        // sends it (`cli.rs:478`, `.json(account)`).
         let probe_body = Account {
             name: String::new(),
             account_type: "oauth".to_string(),


### PR DESCRIPTION
## Why

Follow-ups to #75, all found by adversarial review of the merged code rather than
by CI. Three of the four are the same defect class as the one #75 set out to
remove — a whole-file config write beside a live proxy — surviving on paths the
original fix did not reach.

## What changed

**The last whole-file-write clobber window.** `finish_login`'s `NoServer` arm
still wrote the entire config file. It is reachable after the probe has already
confirmed a live proxy: the snapshot loads, then a profile fetch, a possibly
unbounded name prompt and the browser round-trip, and if the proxy rotates a
token and then exits in that window — quitting the host application does exactly
this, on every update — the add is refused, the arm fires, and the pre-rotation
snapshot lands on disk. Refresh tokens are single-use, so the reverted account
needs a hand re-auth. It now takes the same surgical single-row write as the
other arms, falling back to a whole-file write only when the file does not exist
yet, which is the one case the surgical path cannot serve.

The test that should have caught this seeded an empty account list, so there was
nothing to clobber and it could not fail.

**`upsert_account` resolved by first match.** It used the loose identity
comparison and took whichever entry sat earlier in the array, where
`identity::resolve` exists to break exactly that tie and to refuse an unbreakable
one. On the legacy shape — an entry stored before org UUIDs, carrying a UUID and
no org — it could write a fresh credential onto a different account's row and
destroy that account's refresh token. It now resolves like every other path and
refuses an ambiguous match rather than guessing.

**`--force` help contradicted the code.** It stated that `--force` overrides a
rejected api-key; the code refuses that case before `force` is read.

**A connect timeout was classified as "nothing is listening"**, because
`is_connect()` was matched before `is_timeout()`. Hardening — the reachability
was not demonstrated on loopback.

**A new account's priority.** The surgical write left it unset, which reads as 0
and puts a freshly added account in the primary tier ahead of the established
fleet, while the file path assigned max+1. Every path now assigns max+1 when no
priority is submitted, and an explicitly submitted one is left alone.

**Live and durable halves of an add are now one atomic unit.** The live half was
serialized, but the two durable writes still raced onto `config_write`, so the
file could end up holding whichever call reached it first rather than the one
that won the live race — measured 2 in 200 concurrent rounds of two adds of one
identity.

## Notes for review

The lock now spans resolve, mutate and persist. That adds one directed edge,
`config_write` → `accounts`, and no path anywhere creates the reverse edge, so
the graph stays acyclic. This was checked by building a 13-thread race harness,
injecting a deliberate reverse edge to confirm the harness detects the class — it
wedged at one completed operation — and then running the real code clean for 25
seconds. The lock window grew by ~3%; 97% of it is the file write that already
ran under that lock.

Known and deliberate: a submission carrying no identity fields still matches by
name alone. That is the documented `same_identity` fallback and `upsert_account`
behaves the same way; changing it is a crate-wide policy decision, not a fix.
