### PR TITLE
fix: observe truncated streams, and stop one connection fault killing the fleet

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -755,8 +755,9 @@ pub fn render_accounts(
                 a.cache_read_tokens as f64 / a.input_tokens as f64 * 100.0
             )
         };
-        // In-band SSE `error` events this account's streams carried (decayed
-        // window). A truncated 200 books as a clean serve, so this is the only
+        // Stream failures this account's streams carried (decayed window): an
+        // in-band SSE `error` event, or a stream that hit EOF without Anthropic's
+        // `message_stop` terminator (recorded as `"truncated"`). This is the only
         // place that class of failure is visible at all.
         //
         // `n/a` — never `0` — on an OFFLINE snapshot, for the same reason
@@ -909,8 +910,9 @@ fn render_accounts_json(
                 },
                 "probeStatus": a.probe_status.as_str(),
                 "probeError": a.probe_error,
-                // Decayed count of in-band SSE `error` events — a truncated 200
-                // that books as a clean serve. `null`, NEVER 0, on the offline
+                // Decayed count of stream failures — an in-band SSE `error` event,
+                // or a stream that hit EOF without `message_stop` (recorded as
+                // `"truncated"`). `null`, NEVER 0, on the offline
                 // path: the counter lives in the serving process, so a fresh one
                 // is structurally zero, and an unmeasured `0` on an ERROR counter
                 // publishes an all-clear nobody measured. Same "not measured"

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -79,6 +79,7 @@ fn base(name: &str, priority: i64) -> AccountRuntime {
         stream_error_times_ms: std::collections::VecDeque::new(),
         last_stream_error: None,
         refresh_lock: Arc::new(AsyncMutex::new(())),
+        http: crate::manager::build_serving_client(),
     }
 }
 

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -60,6 +60,7 @@ fn base(name: &str, priority: i64) -> AccountRuntime {
         quota_known: true,
         consecutive_probe_failures: 0,
         consecutive_warms_without_evidence: 0,
+        warm_evidence_retry_after_ms: None,
         input_tokens: 0,
         output_tokens: 0,
         cache_read_tokens: 0,

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -59,6 +59,7 @@ fn base(name: &str, priority: i64) -> AccountRuntime {
         // a permanently un-warmable account.
         quota_known: true,
         consecutive_probe_failures: 0,
+        consecutive_warms_without_evidence: 0,
         input_tokens: 0,
         output_tokens: 0,
         cache_read_tokens: 0,

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -141,7 +141,30 @@ const PROBE_FAILURES_BEFORE_WARMING_UNPROBED: u32 = 3;
 /// misses is a hiccup, not a verdict) but bounds the opposite direction: that one
 /// bounds a WAIT before warming starts; this one bounds a REPEAT once warming
 /// itself stops producing evidence.
+///
+/// Crossing this excludes the account from [`Manager::warm_targets`] — but that
+/// exclusion must itself be recoverable without a restart, or a transient
+/// upstream condition that strips the 5h headers for a few minutes sidelines the
+/// account for the life of the process. [`AccountRuntime::warm_evidence_retry_after_ms`]
+/// is that recovery: a flat cooldown, not a per-response reset — an EARLIER
+/// version of this fix reset the counter on every successful background probe,
+/// which reopened exactly the loop this constant bounds (`probeable_indices`
+/// probes an excluded account regardless of `warm_targets` membership, so a
+/// probe-triggered reset re-armed a full burst of [`WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT`]
+/// warms every probe cycle — worse than the original unbounded-warm bug).
 const WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT: u32 = 3;
+
+/// Flat cooldown before a keep-warm-excluded account (see
+/// [`WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT`]) is retried. An hour: two orders of
+/// magnitude cheaper than retrying every probe cycle (probe cadence defaults to
+/// minutes, not hours — see [`crate::probe::DEFAULT_PROBE_SECONDS`]) while still
+/// recovering well inside a restart's cost. Deliberately a flat wait, not
+/// exponential backoff like [`AccountRuntime::error_backoff_ms`]: a header-less
+/// warm response is not evidence the account is unhealthy (unlike a rejected
+/// refresh token), so there is no reason to believe the NEXT retry is less
+/// likely to work than this one, and a flat interval keeps the recovery time
+/// bound simple to state.
+const WARM_EVIDENCE_RETRY_COOLDOWN_MS: i64 = 3_600_000;
 
 /// Decay window for [`AccountRuntime::stream_error_times_ms`] — how far back a
 /// stream error still counts toward the operator-facing decayed count. An hour:
@@ -236,17 +259,25 @@ pub struct AccountRuntime {
     pub consecutive_probe_failures: u32,
     /// Consecutive keep-warm requests ([`Manager::warm_account`]) that succeeded
     /// but carried none of the unified 5h rate-limit headers — a 200 that latched
-    /// no evidence. Reset to `0` by ANY response (warm or served) whose headers DO
-    /// carry the 5h window — see [`Manager::update_quota`] — and also by a
-    /// SUCCESSFUL background probe of this account's usage endpoint — see
-    /// [`Manager::apply_usage`]. The probe reset is what makes the exclusion below
-    /// recoverable without a restart: the prober reaches every
-    /// [`Manager::probeable_indices`] account on its own schedule regardless of
-    /// `warm_targets` membership, so it is the one path that still reaches an
-    /// account this counter has excluded from keep-warm and that never gets
-    /// picked to serve. Bounds [`Manager::warm_targets`]'s otherwise-unbounded
-    /// repeat; see [`WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT`].
+    /// no evidence. Reset to `0` only by a response (warm or served) whose
+    /// headers DO carry the 5h window — see [`Manager::update_quota`].
+    /// Deliberately NOT reset by a successful background probe
+    /// ([`Manager::apply_usage`]): see that function's doc-comment for why a
+    /// probe read is not the evidence this counter is bounding. Bounds
+    /// [`Manager::warm_targets`]'s otherwise-unbounded repeat; see
+    /// [`WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT`]. The exclusion this drives is
+    /// recovered by [`Self::warm_evidence_retry_after_ms`] instead, once its
+    /// cooldown elapses.
     pub consecutive_warms_without_evidence: u32,
+    /// Set by [`Manager::record_warm_without_evidence`] once
+    /// `consecutive_warms_without_evidence` reaches
+    /// [`WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT`]: the wall-clock instant (epoch
+    /// ms) at or after which [`Manager::warm_targets`] treats this account as
+    /// eligible again despite the counter still being at or over the limit —
+    /// one bounded retry per [`WARM_EVIDENCE_RETRY_COOLDOWN_MS`], not one per
+    /// probe cycle. `None` when the account is not currently excluded, or once
+    /// a header-bearing response clears it (see [`Manager::update_quota`]).
+    pub warm_evidence_retry_after_ms: Option<i64>,
     pub input_tokens: u64,
     pub output_tokens: u64,
     /// Cache-read input tokens (a SUBSET of `input_tokens`, not additional quota).
@@ -498,6 +529,7 @@ impl AccountRuntime {
             quota_known: false,
             consecutive_probe_failures: 0,
             consecutive_warms_without_evidence: 0,
+            warm_evidence_retry_after_ms: None,
             input_tokens: 0,
             output_tokens: 0,
             cache_read_tokens: 0,
@@ -6618,25 +6650,73 @@ mod tests {
         );
     }
 
+    /// A follow-up regression on the bound above: it must not be defeatable by
+    /// the background prober. A first cut of the recovery fix reset
+    /// `consecutive_warms_without_evidence` on every successful `apply_usage`
+    /// call — but `probeable_indices` (unlike `warm_targets`) does not check
+    /// that counter, so the prober keeps visiting an excluded account on its
+    /// OWN schedule regardless of exclusion. That reset would reopen the gate
+    /// every probe cycle and hand back a full burst of
+    /// `WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT` header-less warms each time —
+    /// MORE spend than the original unbounded-warm bug, not less. Drives an
+    /// account past the limit, then feeds it several successful
+    /// no-5h-bucket probes (several "probe cycles") and asserts it stays
+    /// excluded throughout — recovery must come from the cooldown, not from
+    /// probe traffic.
+    #[tokio::test]
+    async fn repeated_probe_cycles_do_not_reopen_a_warm_exclusion() {
+        let refresher = Arc::new(CountingRefresher {
+            calls: Arc::new(AtomicUsize::new(0)),
+        });
+        let warmer = Arc::new(HeaderlessWarmer);
+        let manager =
+            build_manager_with_warmer(config_with(vec![account("cold", 0)]), refresher, warmer);
+        mark_all_probed(&manager); // isolate from the never-probed boot gate
+        assert_eq!(manager.warm_targets(), vec![0]);
+
+        for _ in 0..50 {
+            manager.warm_account(0).await;
+        }
+        assert!(
+            !manager.warm_targets().contains(&0),
+            "setup: the account must be excluded before the probe-cycle check runs"
+        );
+
+        let headerless_probe = crate::probe::Usage {
+            five_hour: None,
+            seven_day: None,
+            seven_day_oi: None,
+        };
+        for cycle in 0..5 {
+            manager.apply_usage(0, &headerless_probe);
+            assert!(
+                !manager.warm_targets().contains(&0),
+                "probe cycle {cycle}: a successful probe that reads no 5h bucket \
+                 must not, by itself, reopen a warm exclusion — recovery is the \
+                 cooldown, not probe traffic"
+            );
+        }
+    }
+
     /// The recovery half of the bound above. `consecutive_warms_without_evidence`
     /// is a ONE-WAY latch with a single writer (`record_warm_without_evidence`)
-    /// and, before this fix, a single reset (`update_quota`, on a header-bearing
-    /// served or warmed response) — but an account excluded from `warm_targets`
-    /// is never picked to SERVE either, so it can never earn one of those. Left
-    /// that way, a transient upstream condition that strips the 5h headers for a
-    /// few minutes would exclude the account from keep-warm for the life of the
+    /// and only one reset (`update_quota`, on a header-bearing served or warmed
+    /// response) — but an account excluded from `warm_targets` is never picked
+    /// to SERVE either, so it can never earn one of those on its own. Left that
+    /// way, a transient upstream condition that strips the 5h headers for a few
+    /// minutes would exclude the account from keep-warm for the life of the
     /// process, recoverable only by a restart (this repo's most expensive event
     /// — a full cold prompt-cache prefix for every live session).
     ///
-    /// The fix is `apply_usage` also resetting the counter: the background
-    /// prober reaches every `probeable_indices` account on its own schedule
-    /// (`schedule::run`'s `Job::Probe` arm), which does NOT check this counter,
-    /// so it is the one path that still reaches an idle, excluded account. This
-    /// drives an account past the limit, then feeds it a successful probe (no 5h
-    /// bucket at all, so `update_quota` never runs — isolating the probe path as
-    /// the thing that recovers it) and asserts it is a warm target again.
+    /// The fix is `warm_evidence_retry_after_ms`'s flat cooldown, set by
+    /// `record_warm_without_evidence` once the account crosses the limit. This
+    /// drives an account past the limit, confirms it is excluded, fast-forwards
+    /// the cooldown by writing a past deadline directly (the same pattern this
+    /// module's other `_until_ms`/`_after_ms` cooldown tests use — a real sleep
+    /// of `WARM_EVIDENCE_RETRY_COOLDOWN_MS` is not a reasonable thing to do in a
+    /// unit test), and asserts the account is a warm target again.
     #[tokio::test]
-    async fn a_successful_probe_recovers_an_account_the_warm_latch_excluded() {
+    async fn warm_evidence_retry_cooldown_recovers_an_excluded_account() {
         let refresher = Arc::new(CountingRefresher {
             calls: Arc::new(AtomicUsize::new(0)),
         });
@@ -6653,23 +6733,23 @@ mod tests {
             !manager.warm_targets().contains(&0),
             "setup: the account must be excluded before recovery is exercised"
         );
+        {
+            let accounts = manager.accounts.read().expect("accounts lock poisoned");
+            assert!(
+                accounts[0].warm_evidence_retry_after_ms.is_some(),
+                "setup: crossing the limit must arm a retry cooldown"
+            );
+        }
 
-        // A successful probe that reports NO 5h bucket at all — still evidence
-        // (see `apply_usage`'s doc-comment), and deliberately not routed through
-        // `update_quota`/`warm_account`, so this isolates the probe path.
-        manager.apply_usage(
-            0,
-            &crate::probe::Usage {
-                five_hour: None,
-                seven_day: None,
-                seven_day_oi: None,
-            },
-        );
+        {
+            let mut accounts = manager.accounts.write().expect("accounts lock poisoned");
+            accounts[0].warm_evidence_retry_after_ms = Some(crate::now_ms() - 1);
+        }
 
         assert!(
             manager.warm_targets().contains(&0),
-            "a successful probe must recover an account the warm latch excluded, \
-             without a restart"
+            "an elapsed retry cooldown must recover an account the warm latch \
+             excluded, without a restart"
         );
     }
 

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -301,6 +301,59 @@ pub struct AccountRuntime {
     /// cannot be missing one — the desync it replaces made `ensure_fresh` a silent
     /// no-op (no log, no status change) until the initial token expired.
     pub refresh_lock: Arc<AsyncMutex<()>>,
+    /// This account's OWN upstream-forwarding client — never shared with any
+    /// other account. `hyper-util`'s pool keys a connection on `(scheme,
+    /// authority)` alone (`PoolKey`, `client/legacy/client.rs`), with nothing in
+    /// that key touching the Bearer token or account identity — so a single
+    /// `reqwest::Client` reused across the fleet collapses every account's
+    /// traffic onto ONE pooled connection, and that connection's death (an h2
+    /// `PROTOCOL_ERROR` reset, observed live spanning 2-3 distinct accounts at
+    /// once) takes every account down with it, defeating rotation and failover
+    /// at the connection layer no matter how healthy any individual account is.
+    /// Built once per account by [`build_serving_client`] (never rebuilt on
+    /// every request — that would throw away the warm pool this exists to
+    /// keep) and wrapped in `Arc` so [`Manager::http_client`] can hand out
+    /// cheap clones while still letting a test prove two accounts' clients are
+    /// genuinely distinct instances via `Arc::ptr_eq`.
+    pub http: Arc<reqwest::Client>,
+}
+
+/// Build one upstream-forwarding HTTP client. Called once per account (see
+/// [`AccountRuntime::http`]) so every account's client is configured
+/// identically and differs from every other account's only in the connection
+/// pool it privately owns.
+pub(crate) fn build_serving_client() -> Arc<reqwest::Client> {
+    // no_proxy(): reqwest honors HTTPS_PROXY/HTTP_PROXY by default. We ARE the
+    // proxy — routing our upstream through an ambient proxy (e.g. the JS
+    // teamclaude on :3456) loops us through the thing we replace and every
+    // request dies as "upstream unreachable". Always reach Anthropic directly.
+    Arc::new(
+        reqwest::Client::builder()
+            .no_proxy()
+            // Cap only the CONNECT phase. A blackholed route (no RST, no reply)
+            // otherwise stalls the attempt until the OS TCP timeout, and with a
+            // retry budget of `account_count * 2 + 4` that is many minutes of a
+            // hung request. `oauth.rs` and `probe.rs` both already set one.
+            //
+            // DELIBERATELY NOT a total `.timeout(...)`, and do not add one: these
+            // responses are long-lived SSE streams that legitimately run longer
+            // than any bound worth setting, and a total timeout would truncate
+            // them mid-stream. `connect_timeout` cannot — it applies only before
+            // the response headers arrive, so once a stream is flowing it is out
+            // of the picture.
+            .connect_timeout(std::time::Duration::from_secs(10))
+            // Keep the single HTTP/2 connection to Anthropic warm across
+            // interactive think-time pauses. reqwest reaps idle connections
+            // after 90s by default, but a coding session routinely pauses
+            // longer — so the next request would pay a fresh TCP+TLS handshake
+            // (~100-300ms). h2 keep-alive PINGs + a 5-min idle timeout hold the
+            // connection open so a post-pause request skips the reconnect.
+            .http2_keep_alive_interval(std::time::Duration::from_secs(30))
+            .http2_keep_alive_while_idle(true)
+            .pool_idle_timeout(std::time::Duration::from_secs(300))
+            .build()
+            .expect("build reqwest client"),
+    )
 }
 
 /// A rotation slot answers a user's account query by the same three fields a
@@ -426,6 +479,7 @@ impl AccountRuntime {
             stream_error_times_ms: VecDeque::new(),
             last_stream_error: None,
             refresh_lock: Arc::new(AsyncMutex::new(())),
+            http: build_serving_client(),
         }
     }
 }
@@ -571,9 +625,6 @@ pub struct Manager {
     /// ONLY on the false→true `quota_known` flip, which happens at most once per
     /// account per process, so it can never become a self-feeding loop of sweeps.
     warm_wake: Notify,
-    /// Client used for upstream forwarding — deliberately no total timeout so
-    /// long SSE streams are never cut (an idle guard belongs on the read side).
-    http: reqwest::Client,
     /// The persisted config, kept so token refreshes can be written back with
     /// every unmodelled field intact.
     config: Mutex<Config>,
@@ -772,35 +823,6 @@ impl Manager {
             warmer,
             warm_in_flight: AtomicBool::new(false),
             warm_wake: Notify::new(),
-            // no_proxy(): reqwest honors HTTPS_PROXY/HTTP_PROXY by default. We ARE the
-            // proxy — routing our upstream through an ambient proxy (e.g. the JS
-            // teamclaude on :3456) loops us through the thing we replace and every
-            // request dies as "upstream unreachable". Always reach Anthropic directly.
-            http: reqwest::Client::builder()
-                .no_proxy()
-                // Cap only the CONNECT phase. A blackholed route (no RST, no reply)
-                // otherwise stalls the attempt until the OS TCP timeout, and with a
-                // retry budget of `account_count * 2 + 4` that is many minutes of a
-                // hung request. `oauth.rs` and `probe.rs` both already set one.
-                //
-                // DELIBERATELY NOT a total `.timeout(...)`, and do not add one: these
-                // responses are long-lived SSE streams that legitimately run longer
-                // than any bound worth setting, and a total timeout would truncate
-                // them mid-stream. `connect_timeout` cannot — it applies only before
-                // the response headers arrive, so once a stream is flowing it is out
-                // of the picture.
-                .connect_timeout(std::time::Duration::from_secs(10))
-                // Keep the single HTTP/2 connection to Anthropic warm across
-                // interactive think-time pauses. reqwest reaps idle connections
-                // after 90s by default, but a coding session routinely pauses
-                // longer — so the next request would pay a fresh TCP+TLS handshake
-                // (~100-300ms). h2 keep-alive PINGs + a 5-min idle timeout hold the
-                // connection open so a post-pause request skips the reconnect.
-                .http2_keep_alive_interval(std::time::Duration::from_secs(30))
-                .http2_keep_alive_while_idle(true)
-                .pool_idle_timeout(std::time::Duration::from_secs(300))
-                .build()
-                .expect("build reqwest client"),
             config: Mutex::new(config),
             config_write: Mutex::new(()),
             config_path,
@@ -5232,9 +5254,56 @@ mod tests {
             "reqwest no longer reports a total timeout in Debug — this guard needs rewriting"
         );
 
+        let accounts = manager.accounts.read().expect("accounts lock poisoned");
         assert!(
-            !format!("{:?}", manager.http).contains("TotalTimeout"),
+            !format!("{:?}", accounts[0].http).contains("TotalTimeout"),
             "the serving client grew a total timeout; it will truncate SSE streams"
+        );
+    }
+
+    /// The connection-pool isolation this whole module exists for: two accounts
+    /// must never be handed the SAME client. `hyper-util` keys its pool on
+    /// `(scheme, authority)` alone — nothing about the Bearer token or account
+    /// identity — so a client shared across accounts collapses every account
+    /// onto one pooled connection, and that connection's death takes every
+    /// account down with it regardless of how healthy any individual account is
+    /// (see [`AccountRuntime::http`]'s doc comment for the measured incident).
+    ///
+    /// This is an IN-PROCESS identity check, not a live network measurement —
+    /// `Arc::ptr_eq` proves two accounts never share the same client instance
+    /// (and thus never share its connection pool), and that repeated lookups of
+    /// the SAME account keep returning the SAME instance rather than a fresh
+    /// one that would throw away its warm pool. It does not, and cannot, prove
+    /// two real TCP connections were opened — that would need an actual
+    /// upstream to observe.
+    #[test]
+    fn different_accounts_never_share_a_serving_client() {
+        let refresher = Arc::new(CountingRefresher {
+            calls: Arc::new(AtomicUsize::new(0)),
+        });
+        let manager = build_manager(
+            config_with(vec![account("a", 0), account("b", 0)]),
+            refresher,
+        );
+
+        let client_a = manager.http_client(0).expect("account 0 exists");
+        let client_b = manager.http_client(1).expect("account 1 exists");
+        assert!(
+            !Arc::ptr_eq(&client_a, &client_b),
+            "two different accounts were handed the same client — a dead \
+             connection on one account's pool would take every other account \
+             down with it"
+        );
+
+        // The SAME account, looked up again, must return the SAME instance —
+        // a fresh client per lookup would defeat the whole point (a cold pool
+        // on every single request), even though it would still pass the
+        // distinctness assertion above.
+        let client_a_again = manager.http_client(0).expect("account 0 exists");
+        assert!(
+            Arc::ptr_eq(&client_a, &client_a_again),
+            "the same account's client must be stable across lookups, not \
+             rebuilt per call"
         );
     }
 

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -237,9 +237,15 @@ pub struct AccountRuntime {
     /// Consecutive keep-warm requests ([`Manager::warm_account`]) that succeeded
     /// but carried none of the unified 5h rate-limit headers — a 200 that latched
     /// no evidence. Reset to `0` by ANY response (warm or served) whose headers DO
-    /// carry the 5h window — see [`Manager::update_quota`]. Bounds
-    /// [`Manager::warm_targets`]'s otherwise-unbounded repeat; see
-    /// [`WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT`].
+    /// carry the 5h window — see [`Manager::update_quota`] — and also by a
+    /// SUCCESSFUL background probe of this account's usage endpoint — see
+    /// [`Manager::apply_usage`]. The probe reset is what makes the exclusion below
+    /// recoverable without a restart: the prober reaches every
+    /// [`Manager::probeable_indices`] account on its own schedule regardless of
+    /// `warm_targets` membership, so it is the one path that still reaches an
+    /// account this counter has excluded from keep-warm and that never gets
+    /// picked to serve. Bounds [`Manager::warm_targets`]'s otherwise-unbounded
+    /// repeat; see [`WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT`].
     pub consecutive_warms_without_evidence: u32,
     pub input_tokens: u64,
     pub output_tokens: u64,
@@ -327,11 +333,34 @@ pub struct AccountRuntime {
     pub http: Arc<reqwest::Client>,
 }
 
+// Test-only fault injection for `build_serving_client`: set via
+// `fail_next_client_build`, consumed (and cleared) by the next call on this
+// thread. Exists to prove — with a real panic, not a hypothetical one — that
+// `Manager::add_or_update_account`'s Added path builds its runtime BEFORE
+// taking `self.accounts`'s write lock: a panic here that happens UNDER that
+// lock poisons it for every other `.expect("accounts lock poisoned")` call
+// site in this module; one that happens before the lock is taken does not.
+#[cfg(test)]
+thread_local! {
+    static FAIL_NEXT_CLIENT_BUILD: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Arm [`FAIL_NEXT_CLIENT_BUILD`] so the next call to `build_serving_client` on
+/// this thread panics instead of building. Test-only.
+#[cfg(test)]
+pub(crate) fn fail_next_client_build() {
+    FAIL_NEXT_CLIENT_BUILD.with(|f| f.set(true));
+}
+
 /// Build one upstream-forwarding HTTP client. Called once per account (see
 /// [`AccountRuntime::http`]) so every account's client is configured
 /// identically and differs from every other account's only in the connection
 /// pool it privately owns.
 pub(crate) fn build_serving_client() -> Arc<reqwest::Client> {
+    #[cfg(test)]
+    if FAIL_NEXT_CLIENT_BUILD.with(|f| f.replace(false)) {
+        panic!("build reqwest client (test-injected failure)");
+    }
     // no_proxy(): reqwest honors HTTPS_PROXY/HTTP_PROXY by default. We ARE the
     // proxy — routing our upstream through an ambient proxy (e.g. the JS
     // teamclaude on :3456) loops us through the thing we replace and every
@@ -1415,6 +1444,23 @@ impl Manager {
             && account.org_uuid.is_none()
             && account.org_name.is_none();
 
+        // Built SPECULATIVELY, before `self.accounts`'s write lock below —
+        // `AccountRuntime::from_config` ends in `build_serving_client()`'s
+        // `.expect("build reqwest client")`, and a panic while that lock's write
+        // guard is held poisons it for every other caller (`http_client`,
+        // `select`, `snapshot`, `record_stream_error`, ~97 sites total all
+        // `.expect` the same lock). Every field `from_config` derives from
+        // `account` is already final at this point except possibly `priority`
+        // (only mutated below, under the lock, and only on the Added path) — so
+        // if resolution lands on Added, the `priority` field is patched on this
+        // already-built value instead of rebuilding. If it lands on Updated,
+        // this is simply dropped unused. Mirrors what `add_account` already
+        // does (build before the lock); `add_or_update_account` isn't a hot
+        // path (`POST /_tcr/accounts`, driven by login/config-reload, not by
+        // served traffic), so building one extra idle client on the Updated
+        // path costs nothing worth avoiding.
+        let mut speculative_runtime = AccountRuntime::from_config(&account);
+
         /// What the locked resolve-and-mutate section below produced, so the
         /// durable write can run after `self.accounts`'s lock is released —
         /// `persist_added`/`persist_replaced` do their own file I/O and must
@@ -1580,9 +1626,14 @@ impl Manager {
                             .max()
                             .map_or(0, |max| max + 1);
                         account.priority = Some(next_priority);
+                        // The speculative build above ran before `next_priority`
+                        // was known — patch it in rather than rebuilding (which
+                        // would call `build_serving_client()` again, under this
+                        // same lock, resurrecting exactly the bug this comment
+                        // block exists to avoid).
+                        speculative_runtime.priority = next_priority;
                     }
-                    let runtime = AccountRuntime::from_config(&account);
-                    accounts.push(runtime);
+                    accounts.push(speculative_runtime);
                     Resolution::Added {
                         idx: accounts.len() - 1,
                     }
@@ -6028,6 +6079,40 @@ mod tests {
         std::fs::remove_file(&path).ok();
     }
 
+    /// Before this fix, the Added path's `AccountRuntime::from_config(&account)`
+    /// ran INSIDE the `self.accounts.write()` block — meaning
+    /// `build_serving_client`'s `.expect("build reqwest client")` executed while
+    /// the write guard was held. A panic there poisons the `RwLock` for every
+    /// other caller in this module: `http_client`, `select`, `snapshot`,
+    /// `record_stream_error` and ~93 more all `.expect("accounts lock
+    /// poisoned")`, so one recoverable client-build failure would take down the
+    /// whole proxy. Uses the `#[cfg(test)]` fault-injection seam on
+    /// `build_serving_client` to make that failure real rather than
+    /// hypothetical, on a submission guaranteed to resolve Added (an empty
+    /// fleet, so nothing can match), and asserts the lock survives.
+    #[test]
+    fn add_or_update_account_added_path_does_not_poison_the_accounts_lock_on_a_client_build_panic()
+    {
+        let manager = build_manager(config_with(vec![]), lock_refresher());
+        let submission = account("brand-new@example.com", 0);
+
+        fail_next_client_build();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            manager.add_or_update_account(submission)
+        }));
+        assert!(
+            result.is_err(),
+            "setup: the injected client-build failure must actually panic"
+        );
+
+        assert!(
+            manager.accounts.read().is_ok(),
+            "a client-build panic in add_or_update_account must not poison the \
+             accounts lock — every other .expect(\"accounts lock poisoned\") \
+             call site would panic in turn"
+        );
+    }
+
     /// The live half of a brand-new-identity race was already serialized by
     /// the single `accounts` write-lock spanning resolve+mutate (see the
     /// TOCTOU fix above) — but the two callers' DURABLE writes still queued on
@@ -6530,6 +6615,61 @@ mod tests {
         assert!(
             !manager.warm_targets().contains(&0),
             "a warm that never latches evidence must not remain an eligible target forever"
+        );
+    }
+
+    /// The recovery half of the bound above. `consecutive_warms_without_evidence`
+    /// is a ONE-WAY latch with a single writer (`record_warm_without_evidence`)
+    /// and, before this fix, a single reset (`update_quota`, on a header-bearing
+    /// served or warmed response) — but an account excluded from `warm_targets`
+    /// is never picked to SERVE either, so it can never earn one of those. Left
+    /// that way, a transient upstream condition that strips the 5h headers for a
+    /// few minutes would exclude the account from keep-warm for the life of the
+    /// process, recoverable only by a restart (this repo's most expensive event
+    /// — a full cold prompt-cache prefix for every live session).
+    ///
+    /// The fix is `apply_usage` also resetting the counter: the background
+    /// prober reaches every `probeable_indices` account on its own schedule
+    /// (`schedule::run`'s `Job::Probe` arm), which does NOT check this counter,
+    /// so it is the one path that still reaches an idle, excluded account. This
+    /// drives an account past the limit, then feeds it a successful probe (no 5h
+    /// bucket at all, so `update_quota` never runs — isolating the probe path as
+    /// the thing that recovers it) and asserts it is a warm target again.
+    #[tokio::test]
+    async fn a_successful_probe_recovers_an_account_the_warm_latch_excluded() {
+        let refresher = Arc::new(CountingRefresher {
+            calls: Arc::new(AtomicUsize::new(0)),
+        });
+        let warmer = Arc::new(HeaderlessWarmer);
+        let manager =
+            build_manager_with_warmer(config_with(vec![account("cold", 0)]), refresher, warmer);
+        mark_all_probed(&manager); // isolate from the never-probed boot gate
+        assert_eq!(manager.warm_targets(), vec![0]);
+
+        for _ in 0..50 {
+            manager.warm_account(0).await;
+        }
+        assert!(
+            !manager.warm_targets().contains(&0),
+            "setup: the account must be excluded before recovery is exercised"
+        );
+
+        // A successful probe that reports NO 5h bucket at all — still evidence
+        // (see `apply_usage`'s doc-comment), and deliberately not routed through
+        // `update_quota`/`warm_account`, so this isolates the probe path.
+        manager.apply_usage(
+            0,
+            &crate::probe::Usage {
+                five_hour: None,
+                seven_day: None,
+                seven_day_oi: None,
+            },
+        );
+
+        assert!(
+            manager.warm_targets().contains(&0),
+            "a successful probe must recover an account the warm latch excluded, \
+             without a restart"
         );
     }
 

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -287,14 +287,23 @@ pub struct AccountRuntime {
     pub probe_status: ProbeStatus,
     pub last_probe_ms: Option<i64>,
     pub probe_error: Option<String>,
-    /// Wall-clock ms of each in-band SSE `error` event observed on a stream this
-    /// account served (see [`Manager::record_stream_error`]), pruned to
-    /// [`STREAM_ERROR_WINDOW_MS`] and hard-capped at [`STREAM_ERROR_CAP`] entries
-    /// on BOTH insert and read, so it cannot grow unbounded. OBSERVABILITY ONLY —
-    /// nothing in `select.rs` reads this field; see that module's gates for why.
+    /// Wall-clock ms of each stream failure observed on a stream this account
+    /// served (see [`Manager::record_stream_error`]): an in-band SSE `error`
+    /// event, or a stream that hit EOF without Anthropic's `message_stop`
+    /// terminator — recorded with the fixed kind `"truncated"`, which covers a
+    /// mid-stream transport death and the malformed/utf8 break alike. An
+    /// `error` event takes precedence: EOF without `message_stop` is only
+    /// counted as `"truncated"` when no more specific `error` was already
+    /// recorded. Pruned to [`STREAM_ERROR_WINDOW_MS`] and hard-capped at
+    /// [`STREAM_ERROR_CAP`] entries on BOTH insert and read, so it cannot grow
+    /// unbounded. OBSERVABILITY ONLY — nothing in `select.rs` reads this
+    /// field; see that module's gates for why.
     pub stream_error_times_ms: VecDeque<i64>,
-    /// The most recent stream error's `error.type` (e.g. `"overloaded_error"`),
-    /// alongside the decayed count above.
+    /// The most recent stream failure's kind: an Anthropic `error.type` (e.g.
+    /// `"overloaded_error"`) from an in-band SSE `error` event, or the fixed
+    /// string `"truncated"` when the stream hit EOF without `message_stop` and
+    /// no more specific `error` was already recorded, alongside the decayed
+    /// count above.
     pub last_stream_error: Option<String>,
     /// Coalescing gate for THIS account's OAuth refresh. Lives on the account rather
     /// than in a parallel Vec indexed by position, so an account added after startup

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -129,6 +129,20 @@ const ERROR_REPROBE_CAP_MS: i64 = 30 * 60_000;
 /// here at all.
 const PROBE_FAILURES_BEFORE_WARMING_UNPROBED: u32 = 3;
 
+/// Bound on consecutive keep-warm requests that succeeded (200) but carried NONE
+/// of the `anthropic-ratelimit-unified-5h-*` headers — a response that latches no
+/// evidence (see [`Manager::update_quota`]'s doc-comment: "a response WITHOUT the
+/// header latches nothing"). Left unbounded, such an account would stay a
+/// [`Manager::warm_targets`] member forever — its 5h window never gets folded, so
+/// `live_reset` never fires — and get re-warmed every cadence at real upstream
+/// cost for nothing.
+///
+/// Mirrors [`PROBE_FAILURES_BEFORE_WARMING_UNPROBED`] in shape (three consecutive
+/// misses is a hiccup, not a verdict) but bounds the opposite direction: that one
+/// bounds a WAIT before warming starts; this one bounds a REPEAT once warming
+/// itself stops producing evidence.
+const WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT: u32 = 3;
+
 /// Decay window for [`AccountRuntime::stream_error_times_ms`] — how far back a
 /// stream error still counts toward the operator-facing decayed count. An hour:
 /// long enough to show a persistent pattern, short enough that a stale blip from
@@ -220,6 +234,13 @@ pub struct AccountRuntime {
     /// probe fails forever, so gating on it unconditionally makes keep-warm
     /// structurally dark. See [`PROBE_FAILURES_BEFORE_WARMING_UNPROBED`].
     pub consecutive_probe_failures: u32,
+    /// Consecutive keep-warm requests ([`Manager::warm_account`]) that succeeded
+    /// but carried none of the unified 5h rate-limit headers — a 200 that latched
+    /// no evidence. Reset to `0` by ANY response (warm or served) whose headers DO
+    /// carry the 5h window — see [`Manager::update_quota`]. Bounds
+    /// [`Manager::warm_targets`]'s otherwise-unbounded repeat; see
+    /// [`WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT`].
+    pub consecutive_warms_without_evidence: u32,
     pub input_tokens: u64,
     pub output_tokens: u64,
     /// Cache-read input tokens (a SUBSET of `input_tokens`, not additional quota).
@@ -385,6 +406,7 @@ impl AccountRuntime {
             // every account's quota is genuinely unread.
             quota_known: false,
             consecutive_probe_failures: 0,
+            consecutive_warms_without_evidence: 0,
             input_tokens: 0,
             output_tokens: 0,
             cache_read_tokens: 0,
@@ -2110,6 +2132,19 @@ mod tests {
                 );
                 Ok(h)
             })
+        }
+    }
+
+    /// A warmer that succeeds (never a `WarmError`) but returns EMPTY headers — no
+    /// `anthropic-ratelimit-unified-5h-*` at all. Models a 200 response that
+    /// carries none of the unified rate-limit headers (an intermediary that
+    /// strips them, or a response shape the warm endpoint does not always emit):
+    /// the "silence" case [`Manager::update_quota`]'s doc-comment distinguishes
+    /// from evidence — a warm that latches nothing.
+    struct HeaderlessWarmer;
+    impl AccountWarmer for HeaderlessWarmer {
+        fn warm(&self, _access_token: String, _upstream: String) -> WarmFuture {
+            Box::pin(async { Ok(reqwest::header::HeaderMap::new()) })
         }
     }
 
@@ -6383,6 +6418,40 @@ mod tests {
         assert!(
             manager.warm_targets().is_empty(),
             "a freshly-warmed account is no longer a target"
+        );
+    }
+
+    /// **THE truncation guard.** `warm_targets`' own doc-comment calls a warm that
+    /// latches no evidence "self-limiting", on the strength of `warm_account`
+    /// folding the response's rate-limit headers back into the account's quota. A
+    /// 200 that carries none of the `anthropic-ratelimit-unified-5h-*` headers
+    /// folds NOTHING (`Quota::update_from_headers`'s own doc-comment: "a response
+    /// without the header latches nothing") — so the account's 5h window stays
+    /// blank, `live_reset` stays `None`, and it stays a `warm_targets` member
+    /// forever, warmed again every cadence at real upstream cost. This asserts the
+    /// promise in `warm_targets`' doc-comment actually holds: a warm that never
+    /// latches evidence must not repeat without limit.
+    #[tokio::test]
+    async fn warm_account_without_evidence_headers_does_not_repeat_forever() {
+        let refresher = Arc::new(CountingRefresher {
+            calls: Arc::new(AtomicUsize::new(0)),
+        });
+        let warmer = Arc::new(HeaderlessWarmer);
+        let manager =
+            build_manager_with_warmer(config_with(vec![account("cold", 0)]), refresher, warmer);
+        mark_all_probed(&manager); // isolate from the never-probed boot gate
+        assert_eq!(manager.warm_targets(), vec![0]);
+
+        // A generous number of cadence-driven warms, standing in for "forever" —
+        // if the account is STILL a target after this many header-less 200s, the
+        // loop has no bound at all.
+        for _ in 0..50 {
+            manager.warm_account(0).await;
+        }
+
+        assert!(
+            !manager.warm_targets().contains(&0),
+            "a warm that never latches evidence must not remain an eligible target forever"
         );
     }
 

--- a/src/manager/state.rs
+++ b/src/manager/state.rs
@@ -107,8 +107,17 @@ impl Manager {
         self.proxy_api_key.as_deref()
     }
 
-    pub fn http_client(&self) -> reqwest::Client {
-        self.http.clone()
+    /// Account `idx`'s OWN upstream-forwarding client — see
+    /// [`AccountRuntime::http`] for why every account carries its own. `None`
+    /// only if `idx` is stale (accounts are appended, never removed, so this is
+    /// never observed on the live serving path — it exists for the same reason
+    /// [`Self::access_token`] and [`Self::account_name`] return `Option`).
+    pub fn http_client(&self, idx: usize) -> Option<Arc<reqwest::Client>> {
+        self.accounts
+            .read()
+            .expect("accounts lock poisoned")
+            .get(idx)
+            .map(|a| a.http.clone())
     }
 
     /// The access token to inject for account `idx` (a clone — the request

--- a/src/manager/usage.rs
+++ b/src/manager/usage.rs
@@ -92,6 +92,19 @@ impl Manager {
     /// the account's keep-warm eligibility) untouched. Note it latches even when the
     /// endpoint reported no 5h bucket at all: "we have read this account's quota" is
     /// about the READ, not about which windows came back.
+    ///
+    /// Also resets [`AccountRuntime::consecutive_warms_without_evidence`], for the
+    /// same reason [`Manager::update_quota`] does on a header-bearing response: a
+    /// successful probe is ITSELF a first-hand read of this account's quota, so it
+    /// is evidence too, regardless of whether a 5h bucket came back. This is the
+    /// recovery path for [`WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT`]'s exclusion: the
+    /// background prober visits every [`Manager::probeable_indices`] account on its
+    /// own schedule (`schedule::run`'s `Job::Probe` arm), which does NOT check this
+    /// counter — so it is the one path that still reaches an account keep-warm has
+    /// given up on and that never gets picked to serve (and so never earns a
+    /// header-bearing response of its own). Without this reset, an account excluded
+    /// here would stay excluded for the life of the process even after the upstream
+    /// condition that caused the miss streak clears.
     pub fn apply_usage(&self, idx: usize, usage: &Usage) {
         let newly_known = {
             let mut accounts = self.accounts.write().expect("accounts lock poisoned");
@@ -100,6 +113,7 @@ impl Manager {
                     account.quota.apply_usage(usage);
                     let flipped = !account.quota_known;
                     account.quota_known = true;
+                    account.consecutive_warms_without_evidence = 0;
                     flipped
                 }
                 None => false,

--- a/src/manager/usage.rs
+++ b/src/manager/usage.rs
@@ -43,8 +43,11 @@ impl Manager {
                     // account is not stuck returning header-less responses —
                     // resets keep-warm's miss counter regardless of whether this
                     // particular update was the warm path or a served request.
+                    // Also clears the cooldown timestamp so no stale retry-after
+                    // lingers on a row that just proved it does not need one.
                     if read_five_hour {
                         account.consecutive_warms_without_evidence = 0;
+                        account.warm_evidence_retry_after_ms = None;
                     }
                     (flipped, read_five_hour)
                 }
@@ -93,18 +96,22 @@ impl Manager {
     /// endpoint reported no 5h bucket at all: "we have read this account's quota" is
     /// about the READ, not about which windows came back.
     ///
-    /// Also resets [`AccountRuntime::consecutive_warms_without_evidence`], for the
-    /// same reason [`Manager::update_quota`] does on a header-bearing response: a
-    /// successful probe is ITSELF a first-hand read of this account's quota, so it
-    /// is evidence too, regardless of whether a 5h bucket came back. This is the
-    /// recovery path for [`WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT`]'s exclusion: the
-    /// background prober visits every [`Manager::probeable_indices`] account on its
-    /// own schedule (`schedule::run`'s `Job::Probe` arm), which does NOT check this
-    /// counter — so it is the one path that still reaches an account keep-warm has
-    /// given up on and that never gets picked to serve (and so never earns a
-    /// header-bearing response of its own). Without this reset, an account excluded
-    /// here would stay excluded for the life of the process even after the upstream
-    /// condition that caused the miss streak clears.
+    /// Deliberately does NOT reset [`AccountRuntime::consecutive_warms_without_evidence`],
+    /// even though this can latch [`AccountRuntime::quota_known`] just like a
+    /// header-bearing served response does. A first cut of this fix reset it
+    /// here unconditionally and reopened the exact loop the counter exists to
+    /// close: `probeable_indices` (unlike [`Self::warm_targets`]) does not check
+    /// this counter, so the background prober keeps visiting an excluded account
+    /// on its OWN schedule — reset it on every successful probe and a
+    /// persistently header-less account gets re-warmed once per probe cycle
+    /// forever, worse than the original unbounded-warm bug this counter fixed.
+    /// A probe finding no 5h bucket also says nothing about whether the next
+    /// WARM response would carry one — it is a different, zero-spend endpoint,
+    /// not a rehearsal of the warm request the counter is bounding. Recovery
+    /// from the exclusion is [`Manager::record_warm_without_evidence`]'s
+    /// [`AccountRuntime::warm_evidence_retry_after_ms`] cooldown instead — a
+    /// flat wall-clock wait, decoupled from probe cadence, so the retry rate is
+    /// bounded by policy rather than by how often the fleet happens to probe.
     pub fn apply_usage(&self, idx: usize, usage: &Usage) {
         let newly_known = {
             let mut accounts = self.accounts.write().expect("accounts lock poisoned");
@@ -113,7 +120,6 @@ impl Manager {
                     account.quota.apply_usage(usage);
                     let flipped = !account.quota_known;
                     account.quota_known = true;
-                    account.consecutive_warms_without_evidence = 0;
                     flipped
                 }
                 None => false,

--- a/src/manager/usage.rs
+++ b/src/manager/usage.rs
@@ -21,17 +21,34 @@ impl Manager {
     ///
     /// `probe_status` is deliberately still untouched here — that field is about
     /// probe HEALTH, which a served response says nothing about.
-    pub fn update_quota(&self, idx: usize, headers: &reqwest::header::HeaderMap) {
-        let newly_known = {
+    ///
+    /// Returns whether THIS response's headers carried the 5h window — the same
+    /// signal [`crate::quota::Quota::update_from_headers`] returns, passed through
+    /// so a caller like [`Manager::warm_account`] can tell "evidence read" apart
+    /// from "silence" on this specific response, not just the account's
+    /// once-ever `quota_known` latch. Deliberately NOT `#[must_use]`: most
+    /// callers (every served-response path in `proxy.rs`, most existing tests)
+    /// only care about the side effect of folding the headers in, and forcing
+    /// every one of them to consume the bool would be pure churn unrelated to
+    /// this fix.
+    pub fn update_quota(&self, idx: usize, headers: &reqwest::header::HeaderMap) -> bool {
+        let (newly_known, read_five_hour) = {
             let mut accounts = self.accounts.write().expect("accounts lock poisoned");
             match accounts.get_mut(idx) {
                 Some(account) => {
                     let read_five_hour = account.quota.update_from_headers(headers);
                     let flipped = read_five_hour && !account.quota_known;
                     account.quota_known |= read_five_hour;
-                    flipped
+                    // Any response that DOES carry the 5h window is proof this
+                    // account is not stuck returning header-less responses —
+                    // resets keep-warm's miss counter regardless of whether this
+                    // particular update was the warm path or a served request.
+                    if read_five_hour {
+                        account.consecutive_warms_without_evidence = 0;
+                    }
+                    (flipped, read_five_hour)
                 }
-                None => false,
+                None => (false, false),
             }
         };
         // Edge-triggered, with the accounts lock RELEASED — identical to
@@ -39,6 +56,7 @@ impl Manager {
         if newly_known {
             self.warm_wake.notify_one();
         }
+        read_five_hour
     }
 
     /// Add token usage to account `idx` (the true serving account — bug #3).

--- a/src/manager/usage.rs
+++ b/src/manager/usage.rs
@@ -143,10 +143,12 @@ impl Manager {
         }
     }
 
-    /// Record that account `idx` served a stream that carried an in-band SSE
-    /// `error` event (`kind` is `error.error.type`, e.g. `"overloaded_error"`) —
-    /// a truncated turn the client saw as a 200 that must not read as a clean
-    /// serve. OBSERVABILITY ONLY: this warns and updates a decayed counter and
+    /// Record that account `idx` served a stream that failed to complete cleanly
+    /// (`kind` is either an Anthropic `error.error.type`, e.g. `"overloaded_error"`,
+    /// from an in-band SSE `error` event, or the fixed string `"truncated"` for a
+    /// stream that hit EOF without Anthropic's `message_stop` terminator) — a
+    /// turn the client saw as a 200 that must not read as a clean serve.
+    /// OBSERVABILITY ONLY: this warns and updates a decayed counter and
     /// the account's last-error label; it deliberately does NOT call
     /// `mark_error` (that condemns terminally — see its doc comment on the 2026-07-17
     /// incident) or `mark_rate_limited` (an overloaded account is not over quota —
@@ -162,7 +164,7 @@ impl Manager {
                 account = %account.name,
                 index = idx,
                 error_type = kind,
-                "SSE stream carried an in-band error event — truncated turn, not a clean serve"
+                "stream failed to complete cleanly — truncated turn, not a clean serve"
             );
             account.stream_error_times_ms.push_back(now_ms);
             prune_stream_errors(&mut account.stream_error_times_ms, now_ms);

--- a/src/manager/warm.rs
+++ b/src/manager/warm.rs
@@ -46,10 +46,13 @@ impl Manager {
     ///    warm on stale information — the wait must be BOUNDED, or gating on
     ///    `quota_known` is a silent kill switch whenever the probe stays broken.
     ///
-    /// State 3 is self-limiting, which is what makes it safe: `warm_account` folds
-    /// the warm response's own rate-limit headers back in, so one warm request per
-    /// account produces the evidence the gate wanted and states 1/2 take over
-    /// again. It cannot become a repeating burst.
+    /// State 3 is self-limiting IF the warm response actually carries the 5h
+    /// headers: `warm_account` folds them back in, so one warm request per account
+    /// produces the evidence the gate wanted and states 1/2 take over again. When
+    /// it does NOT — a 200 with none of the unified headers — nothing is folded
+    /// and the account would stay a target forever; that half of the bound is
+    /// [`WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT`] below, not this doc-comment's
+    /// promise alone.
     ///
     /// The predicate is NOT `probe_status`: `record_probe` stamps
     /// `Error`/`Timeout`/`RateLimited` on a FAILED probe, which leaves
@@ -91,6 +94,11 @@ impl Manager {
                     && !a
                         .quota
                         .is_near(a.switch_threshold.unwrap_or(self.global_threshold), now)
+                    // Repeated warms that never latch a 5h window are not
+                    // self-limiting on their own (see the doc-comment above) — cap
+                    // the repeat so a header-less upstream response cannot spend
+                    // real quota on this account every cadence forever.
+                    && a.consecutive_warms_without_evidence < WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT
             })
             .map(|(idx, _)| idx)
             .collect()
@@ -101,6 +109,13 @@ impl Manager {
     /// rate-limit headers so the just-started window is immediately visible (which
     /// suppresses a re-warm on the next sweep). A warm FAILURE is non-fatal —
     /// logged at `warn` and stepped over, never a crash of the loop.
+    ///
+    /// A warm that comes back 200 but carries none of the unified 5h headers is a
+    /// THIRD outcome, distinct from both: not a failure (nothing to log at `warn`
+    /// as broken), but not evidence either (`update_quota` returns `false` — see
+    /// its doc-comment). Claiming "started 5h window" there would be false, so
+    /// this logs what actually happened and bumps the miss counter
+    /// [`Self::warm_targets`] gates on, so the repeat is bounded.
     pub async fn warm_account(&self, idx: usize) {
         self.ensure_fresh(idx).await;
         let Some(token) = self.access_token(idx) else {
@@ -112,8 +127,24 @@ impl Manager {
             Ok(headers) => {
                 // Fold the now-live 5h window into the account's quota so the next
                 // sweep sees it as already warm (REQUIRED — suppresses re-warm).
-                self.update_quota(idx, &headers);
-                tracing::info!(account = %name, index = idx, "keep-warm: started 5h window");
+                if self.update_quota(idx, &headers) {
+                    tracing::info!(account = %name, index = idx, "keep-warm: started 5h window");
+                } else {
+                    let gave_up = self.record_warm_without_evidence(idx);
+                    tracing::warn!(
+                        account = %name,
+                        index = idx,
+                        "keep-warm: request succeeded but the response carried no 5h window — no evidence latched"
+                    );
+                    if gave_up {
+                        tracing::warn!(
+                            account = %name,
+                            index = idx,
+                            attempts = WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT,
+                            "keep-warm: giving up on this account — repeated warms have never returned a 5h window"
+                        );
+                    }
+                }
             }
             Err(err) => {
                 tracing::warn!(
@@ -124,6 +155,21 @@ impl Manager {
                 );
             }
         }
+    }
+
+    /// Bump account `idx`'s consecutive miss counter after a warm that succeeded
+    /// but latched no evidence (see [`Self::warm_account`]). Returns whether this
+    /// call just CROSSED [`WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT`], so the caller
+    /// logs the give-up once rather than every cadence — mirrors
+    /// [`Manager::record_probe`]'s crossing-log pattern for the same reason.
+    fn record_warm_without_evidence(&self, idx: usize) -> bool {
+        let mut accounts = self.accounts.write().expect("accounts lock poisoned");
+        let Some(account) = accounts.get_mut(idx) else {
+            return false;
+        };
+        account.consecutive_warms_without_evidence =
+            account.consecutive_warms_without_evidence.saturating_add(1);
+        account.consecutive_warms_without_evidence == WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT
     }
 
     /// Warm ONE account, if it is still eligible at this instant.

--- a/src/manager/warm.rs
+++ b/src/manager/warm.rs
@@ -52,7 +52,11 @@ impl Manager {
     /// it does NOT — a 200 with none of the unified headers — nothing is folded
     /// and the account would stay a target forever; that half of the bound is
     /// [`WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT`] below, not this doc-comment's
-    /// promise alone.
+    /// promise alone. Once that limit excludes the account, the exclusion is
+    /// itself bounded by [`AccountRuntime::warm_evidence_retry_after_ms`] (see
+    /// the filter below) rather than being permanent — see that field's
+    /// doc-comment for why the recovery is a flat wall-clock cooldown and not a
+    /// reset on the next successful background probe.
     ///
     /// The predicate is NOT `probe_status`: `record_probe` stamps
     /// `Error`/`Timeout`/`RateLimited` on a FAILED probe, which leaves
@@ -67,6 +71,7 @@ impl Manager {
     /// to wait for and no failure count to accrue either.
     pub fn warm_targets(&self) -> Vec<usize> {
         let now = OffsetDateTime::now_utc();
+        let now_ms = crate::now_ms();
         // Read the probe cadence BEFORE taking the accounts lock: this touches the
         // config lock, and holding both at once here would invert the order
         // `set_disabled` takes them in (accounts, then config).
@@ -97,8 +102,12 @@ impl Manager {
                     // Repeated warms that never latch a 5h window are not
                     // self-limiting on their own (see the doc-comment above) — cap
                     // the repeat so a header-less upstream response cannot spend
-                    // real quota on this account every cadence forever.
-                    && a.consecutive_warms_without_evidence < WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT
+                    // real quota on this account every cadence forever. Past the
+                    // cap the account is STILL excluded unless its cooldown has
+                    // elapsed — this is the recovery half, bounded by
+                    // WARM_EVIDENCE_RETRY_COOLDOWN_MS rather than left permanent.
+                    && (a.consecutive_warms_without_evidence < WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT
+                        || a.warm_evidence_retry_after_ms.is_some_and(|until| now_ms >= until))
             })
             .map(|(idx, _)| idx)
             .collect()
@@ -162,6 +171,14 @@ impl Manager {
     /// call just CROSSED [`WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT`], so the caller
     /// logs the give-up once rather than every cadence — mirrors
     /// [`Manager::record_probe`]'s crossing-log pattern for the same reason.
+    ///
+    /// At or past the limit, (re-)arms [`AccountRuntime::warm_evidence_retry_after_ms`]
+    /// to `now + `[`WARM_EVIDENCE_RETRY_COOLDOWN_MS`] — including on a MISS that
+    /// happens during the one retry the cooldown just granted, which is what
+    /// keeps the retry rate at one attempt per cooldown rather than one per
+    /// scheduled warm tick once the account is past the limit: without
+    /// re-arming here, the very next scheduled warm would see the (now past)
+    /// old deadline and immediately re-qualify.
     fn record_warm_without_evidence(&self, idx: usize) -> bool {
         let mut accounts = self.accounts.write().expect("accounts lock poisoned");
         let Some(account) = accounts.get_mut(idx) else {
@@ -169,7 +186,13 @@ impl Manager {
         };
         account.consecutive_warms_without_evidence =
             account.consecutive_warms_without_evidence.saturating_add(1);
-        account.consecutive_warms_without_evidence == WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT
+        let crossed =
+            account.consecutive_warms_without_evidence == WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT;
+        if account.consecutive_warms_without_evidence >= WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT {
+            account.warm_evidence_retry_after_ms =
+                Some(crate::now_ms() + WARM_EVIDENCE_RETRY_COOLDOWN_MS);
+        }
+        crossed
     }
 
     /// Warm ONE account, if it is still eligible at this instant.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -2223,7 +2223,9 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
             method: method.to_string(),
             path: path_and_query.clone(),
             status: status.as_u16(),
-            account: account_name.unwrap_or_default(),
+            // Cloned, not moved: the streaming arm below still needs
+            // `account_name` to log a mid-stream transport failure by name.
+            account: account_name.clone().unwrap_or_default(),
         });
 
         let is_stream = up_headers
@@ -2279,13 +2281,32 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
                 // `&` reference forces edition-2021 precise capture to take the guard by
                 // value; an unmentioned capture would be elided and dropped early.
                 let _anchor = &_in_flight;
-                if let Ok(bytes) = &chunk {
-                    // Best-effort tee: `try_send` never blocks the passthrough. A
-                    // full channel (slow/starved parser) or a dropped receiver
-                    // drops the chunk for the PARSER only — usage counting becomes
-                    // best-effort under backpressure; the client stream forwards
-                    // untouched. Intentional discard, hence `let _`.
-                    let _ = tx.try_send(bytes.clone());
+                match &chunk {
+                    Ok(bytes) => {
+                        // Best-effort tee: `try_send` never blocks the passthrough. A
+                        // full channel (slow/starved parser) or a dropped receiver
+                        // drops the chunk for the PARSER only — usage counting becomes
+                        // best-effort under backpressure; the client stream forwards
+                        // untouched. Intentional discard, hence `let _`.
+                        let _ = tx.try_send(bytes.clone());
+                    }
+                    Err(err) => {
+                        // The transport died AFTER headers were already forwarded —
+                        // this `Err` is what silently reached the client as a
+                        // severed connection while the request was already booked
+                        // as a clean 200 upstream response. Nothing else observes
+                        // a body-level transport failure, so this is the only place
+                        // it is ever logged. Same field shape as the pre-header
+                        // transport-failure ladder above, so both halves of a
+                        // request's lifecycle log alike.
+                        tracing::warn!(
+                            account_index = idx,
+                            account = account_name.as_deref().unwrap_or("?"),
+                            error = ?err,
+                            "upstream transport failure mid-stream — forwarding the \
+                             severed connection to the client"
+                        );
+                    }
                 }
                 chunk
             });
@@ -2819,6 +2840,15 @@ fn usage_from_json(bytes: &[u8]) -> ParsedUsage {
 /// as a template, and the `event: error` fixture below) — that is a truncated,
 /// failed turn, not usage to add to the quota. First `error` event wins; a
 /// second is ignored, so multi-event streams still name their root cause.
+///
+/// `message_stop` is Anthropic's ONLY marker for "this turn completed" — it
+/// does not appear anywhere else in this crate (grepped: zero hits before this
+/// function existed). A stream that ends without one — the transport dying
+/// mid-body, or the malformed/utf8 `break` above — is exactly as truncated as
+/// one that carries an in-band `error` event, so it gets the same treatment:
+/// `stream_error` is set, this time to the fixed kind `"truncated"`, UNLESS an
+/// `error` event already explained the failure (that one names a root cause;
+/// this one only names the absence of proof the turn finished).
 async fn parse_sse_usage<S, B, E>(stream: S) -> (ParsedUsage, Option<String>)
 where
     S: futures::Stream<Item = Result<B, E>>,
@@ -2829,6 +2859,7 @@ where
 
     let mut parsed = ParsedUsage::default();
     let mut stream_error: Option<String> = None;
+    let mut saw_message_stop = false;
     while let Some(item) = events.next().await {
         let Ok(event) = item else {
             break; // malformed/utf8/transport error — stop parsing, keep totals
@@ -2858,6 +2889,9 @@ where
                     parsed.output = out;
                 }
             }
+            Some("message_stop") => {
+                saw_message_stop = true;
+            }
             // First `error` event wins — a later one is ignored (guard skips the
             // arm rather than nesting an `if` inside it, per clippy).
             Some("error") if stream_error.is_none() => {
@@ -2871,6 +2905,12 @@ where
             }
             _ => {}
         }
+    }
+    // The loop exited — either the upstream closed cleanly after `message_stop`,
+    // or it stopped short. No terminator and no more specific error already
+    // recorded means the turn's ending was never observed: that IS truncation.
+    if !saw_message_stop && stream_error.is_none() {
+        stream_error = Some("truncated".to_string());
     }
     (parsed, stream_error)
 }
@@ -3329,6 +3369,8 @@ mod tests {
             "\"cache_read_input_tokens\":1000,\"output_tokens\":1}}}\n\n",
             "event: message_delta\n",
             "data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":42}}\n\n",
+            "event: message_stop\n",
+            "data: {\"type\":\"message_stop\"}\n\n",
         );
         // Split mid-way through the first event's data line.
         let split = 60usize;
@@ -3337,7 +3379,10 @@ mod tests {
             Ok::<Bytes, Infallible>(Bytes::copy_from_slice(&full.as_bytes()[split..])),
         ];
         let (parsed, stream_error) = parse_sse_usage(futures::stream::iter(chunks)).await;
-        assert_eq!(stream_error, None, "a clean stream has no error event");
+        assert_eq!(
+            stream_error, None,
+            "a stream that reaches message_stop has no error event"
+        );
         // R1: the quota sum is byte-identical to before.
         assert_eq!(
             parsed.input_total, 1110,
@@ -3361,10 +3406,14 @@ mod tests {
             "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}}\n\n",
             "event: message_delta\ndata: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":20}}\n\n",
             "event: message_delta\ndata: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":37}}\n\n",
+            "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
         );
         let stream = futures::stream::iter(vec![Ok::<Bytes, Infallible>(Bytes::from(full))]);
         let (parsed, stream_error) = parse_sse_usage(stream).await;
-        assert_eq!(stream_error, None, "a clean stream has no error event");
+        assert_eq!(
+            stream_error, None,
+            "a stream that reaches message_stop has no error event"
+        );
         assert_eq!(parsed.input_total, 5);
         assert_eq!(parsed.output, 37, "final cumulative output, not 20 + 37");
         // No cache tokens in this fixture → both stay zero.
@@ -6486,12 +6535,18 @@ mod tests {
         );
     }
 
-    /// NEGATIVE CONTROL: a clean 200 SSE stream (normal `message_start` /
-    /// `message_delta`, no `error` event) must record NO stream error. Uses the
-    /// same bounded-poll discipline as the positive case — asserting absence
-    /// after a trivially-passing zero-wait would be vacuous.
+    /// THE OTHER BUG this fix closes: a stream that ends after `message_start` /
+    /// `message_delta` with no `message_stop` is not a clean serve — it is
+    /// indistinguishable, from inside `parse_sse_usage`, from a connection that
+    /// was severed mid-turn. Anthropic's ONLY marker that a turn actually
+    /// finished is `message_stop`; a complete turn carries one, and anything
+    /// that reaches EOF without one — this fixture included — is truncated.
+    /// Before this fix this test asserted `stream_error_count == 0` under the
+    /// docstring "a clean 200 SSE stream" for exactly this fixture — the
+    /// assertion WAS the bug, encoded as the contract. It is inverted here to
+    /// assert the truncation IS detected.
     #[tokio::test]
-    async fn sse_clean_stream_records_no_stream_error() {
+    async fn sse_stream_without_message_stop_is_recorded_as_truncated() {
         let upstream = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let up_addr = upstream.local_addr().unwrap();
         tokio::spawn(async move {
@@ -6508,6 +6563,81 @@ mod tests {
                         "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}}\n\n",
                         "event: message_delta\n",
                         "data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":9}}\n\n",
+                    );
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = sock.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+
+        let manager =
+            Manager::with_live_refresher(dummy_config(None, &format!("http://{up_addr}")), None);
+
+        let proxy = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = proxy.local_addr().unwrap();
+        let served = Arc::clone(&manager);
+        tokio::spawn(async move {
+            let _ = axum::serve(proxy, app(served)).await;
+        });
+
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let resp = client
+            .post(format!("http://{proxy_addr}/v1/messages"))
+            .body("{}")
+            .send()
+            .await
+            .unwrap();
+        let _ = resp.bytes().await.unwrap();
+
+        let (seen, polls) = poll_stream_error_count(&manager, 1).await;
+        assert_eq!(
+            seen, 1,
+            "polled {polls} times, stream-error count stayed {seen} — a stream that \
+             ends without message_stop must be recorded as truncated, not booked as \
+             a clean serve"
+        );
+
+        // The tee task updates usage BEFORE it records the stream error (see the
+        // spawned task above `parse_sse_usage` is awaited in), so by the time the
+        // poll above observes the error count, usage from `message_start` has
+        // already landed too — truncation detection does not cost the quota
+        // accounting anything.
+        assert_eq!(
+            manager.snapshot(OffsetDateTime::now_utc()).accounts[0].input_tokens,
+            5,
+            "usage already parsed before the stream was found truncated must still count"
+        );
+    }
+
+    /// POSITIVE CONTROL for the truncation detector above: the identical
+    /// fixture, this time WITH `message_stop`, must record NO stream error.
+    /// Without this, the detector could not be told apart from one that fires
+    /// unconditionally — this is what proves it discriminates on the
+    /// terminator rather than on the mere absence of an in-band `error` event.
+    #[tokio::test]
+    async fn sse_stream_with_message_stop_records_no_stream_error() {
+        let upstream = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let up_addr = upstream.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = upstream.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut buf = [0u8; 1024];
+                    let _ = sock.read(&mut buf).await;
+                    let body = concat!(
+                        "event: message_start\n",
+                        "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}}\n\n",
+                        "event: message_delta\n",
+                        "data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":9}}\n\n",
+                        "event: message_stop\n",
+                        "data: {\"type\":\"message_stop\"}\n\n",
                     );
                     let response = format!(
                         "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
@@ -6556,7 +6686,7 @@ mod tests {
         assert_eq!(
             manager.snapshot(OffsetDateTime::now_utc()).accounts[0].stream_error_count,
             0,
-            "a clean SSE stream must record no stream error"
+            "a stream that reaches message_stop must record no stream error"
         );
     }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -22,6 +22,8 @@
 use std::collections::{HashMap, HashSet};
 use std::convert::Infallible;
 use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -39,7 +41,8 @@ use time::OffsetDateTime;
 
 use crate::config;
 use crate::manager::{
-    AccountStatus, AddAccountOutcome, AddPersist, DisablePersist, Manager, SetDisabledOutcome,
+    AccountStatus, AddAccountOutcome, AddPersist, DisablePersist, InFlightGuard, Manager,
+    SetDisabledOutcome,
 };
 use crate::stats::{RequestLogEntry, SessionKind};
 
@@ -52,6 +55,13 @@ const MAX_BODY_BYTES: usize = 256 * 1024 * 1024;
 /// the parser (usage counting becomes best-effort) rather than letting the buffer
 /// grow without bound or gating the client passthrough on the parser.
 const SSE_TEE_CAPACITY: usize = 256;
+/// The fixed `stream_error` kind [`parse_sse_usage`] synthesizes when a stream
+/// ends without Anthropic's `message_stop` terminator and no more specific
+/// in-band `error` event already explained why. Named so the proxy handler's
+/// classifier can tell "we witnessed an explicit error" (always trustworthy)
+/// apart from "we never saw the terminator" (trustworthy only when we also
+/// know we saw everything there was to see — see the handler's use of this).
+const TRUNCATED_STREAM_ERROR_KIND: &str = "truncated";
 /// A transient `429` whose `retry-after` is within this bound is waited out
 /// inline on the same account; anything longer throttles + rotates instead of
 /// tying up the client connection.
@@ -2251,7 +2261,30 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
             // channel; `try_send` on the passthrough side keeps that bound from
             // ever applying backpressure to the client — see below.
             let (tx, rx) = tokio::sync::mpsc::channel::<Bytes>(SSE_TEE_CAPACITY);
+            // Distinguishes WHY the tee ends. A plain `.map()` over the upstream
+            // stream (this passthrough's previous shape) only ever sees `Some`
+            // items — it cannot observe `Ready(None)`/the stream being dropped,
+            // so a client hitting Esc mid-turn (axum drops the response body,
+            // dropping everything the passthrough owns) looked IDENTICAL, from
+            // inside the parser, to the upstream finishing the stream itself.
+            // This oneshot is consumed exactly once, the moment `TeeState` (below)
+            // observes the WRAPPED stream reach a genuine terminal state — clean
+            // EOF or a transport error, both real signals ABOUT THE UPSTREAM. If
+            // `TeeState` is dropped before either happens (client walked away),
+            // the sender drops unfired and `ended_rx` resolves to `Err` — the
+            // signal for "we never learned how the stream would have ended,"
+            // which must never be booked as truncation.
+            let (ended_tx, ended_rx) = tokio::sync::oneshot::channel::<()>();
+            // Set the instant a teed chunk is dropped by the bounded channel
+            // below (full channel or a dead receiver). A dropped chunk might
+            // have been the one carrying `message_stop` — from that point on,
+            // "no message_stop was observed" no longer means "the turn was
+            // truncated", it means "we don't know", so the classifier abstains
+            // instead of guessing.
+            let evidence_dropped = Arc::new(AtomicBool::new(false));
+            let evidence_dropped_reader = Arc::clone(&evidence_dropped);
             let manager_side = manager.clone();
+            let status_is_success = status.is_success();
             tokio::spawn(async move {
                 let byte_stream = futures::stream::unfold(rx, |mut rx| async move {
                     rx.recv()
@@ -2274,50 +2307,128 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
                 // (a truncated stream booked as a clean serve). Called ONCE per
                 // stream, after the parse loop ends, never per event — a
                 // per-event call on a long erroring stream is a log-flood vector.
-                if let Some(kind) = stream_error {
-                    manager_side.record_stream_error(idx, &kind);
+                //
+                // A forwarded 3xx/4xx/5xx SSE body never had a `message_stop`
+                // contract to begin with — it is an error response, not a
+                // truncated turn — so nothing is classified unless the upstream
+                // actually answered 2xx.
+                if status_is_success {
+                    if let Some(kind) = stream_error {
+                        // An in-band `error` event is a POSITIVE observation —
+                        // we directly read those bytes off the wire, so it is
+                        // recorded regardless of how the tee itself ended. The
+                        // synthesized `TRUNCATED_STREAM_ERROR_KIND` is an
+                        // ABSENCE (no `message_stop` seen) rather than a
+                        // positive observation, and an absence is only
+                        // evidence when we know we saw everything there was to
+                        // see — hence the extra gate below, which the positive
+                        // case skips entirely.
+                        if kind == TRUNCATED_STREAM_ERROR_KIND {
+                            let ended_naturally = ended_rx.await.is_ok();
+                            let dropped = evidence_dropped_reader.load(Ordering::SeqCst);
+                            if ended_naturally && !dropped {
+                                manager_side.record_stream_error(idx, &kind);
+                            } else {
+                                tracing::debug!(
+                                    account_index = idx,
+                                    ended_naturally,
+                                    evidence_dropped = dropped,
+                                    "SSE stream ended without message_stop but the tee \
+                                     cannot prove why — abstaining rather than recording \
+                                     a fabricated truncation"
+                                );
+                            }
+                        } else {
+                            manager_side.record_stream_error(idx, &kind);
+                        }
+                    }
                 }
             });
-            let passthrough = resp.bytes_stream().map(move |chunk| {
-                // Anchor the in-flight guard to THIS streamed body. Returning
-                // `Body::from_stream(..)` drops every handler-local, but axum polls
-                // the body AFTER the handler returns — so a handler-local guard would
-                // decrement `in_flight` at response-headers while the stream keeps
-                // flowing for seconds. Moving the OWNED guard into this `move` closure
-                // makes the closure (hence the stream body) own it, so its Drop — the
-                // account's `in_flight` decrement — fires at stream completion / client
-                // disconnect / body drop, which is when pacing must count the load. The
-                // `&` reference forces edition-2021 precise capture to take the guard by
-                // value; an unmentioned capture would be elided and dropped early.
-                let _anchor = &_in_flight;
-                match &chunk {
-                    Ok(bytes) => {
-                        // Best-effort tee: `try_send` never blocks the passthrough. A
-                        // full channel (slow/starved parser) or a dropped receiver
-                        // drops the chunk for the PARSER only — usage counting becomes
-                        // best-effort under backpressure; the client stream forwards
-                        // untouched. Intentional discard, hence `let _`.
-                        let _ = tx.try_send(bytes.clone());
+
+            // Threads the tee's mutable state — the wrapped byte stream, the
+            // side-channel sender, the dropped-evidence flag, the `ended`
+            // oneshot, and the `_in_flight` RAII guard — through
+            // `stream::unfold` so all of it lives exactly as long as the
+            // passthrough stream does and drops in ONE place, together. That
+            // single drop site is what lets `ended` (this arm's job: tell the
+            // parser task client-abandonment from upstream-completion) and
+            // `_in_flight` (unrelated: pacing's load counter) each fire exactly
+            // once, at real completion — clean EOF, transport error, OR client
+            // disconnect — rather than at response-headers. See the long-form
+            // comment this replaced for why `_in_flight` cannot just be a
+            // handler-local.
+            struct TeeState {
+                inner: Pin<Box<dyn futures::Stream<Item = reqwest::Result<Bytes>> + Send>>,
+                tx: tokio::sync::mpsc::Sender<Bytes>,
+                evidence_dropped: Arc<AtomicBool>,
+                ended: Option<tokio::sync::oneshot::Sender<()>>,
+                account_index: usize,
+                account_name: Option<String>,
+                _in_flight: InFlightGuard,
+            }
+            let state = TeeState {
+                inner: Box::pin(resp.bytes_stream()),
+                tx,
+                evidence_dropped,
+                ended: Some(ended_tx),
+                account_index: idx,
+                account_name: account_name.clone(),
+                _in_flight,
+            };
+            let passthrough = futures::stream::unfold(state, |mut state| async move {
+                match state.inner.next().await {
+                    Some(Ok(bytes)) => {
+                        // Best-effort tee: `try_send` never blocks the
+                        // passthrough. A full channel (slow/starved parser) or
+                        // a dropped receiver drops the chunk for the PARSER
+                        // only — usage counting becomes best-effort under
+                        // backpressure; the client stream forwards untouched.
+                        // Unlike before, the drop is no longer silent: it
+                        // flips `evidence_dropped` so the parser task can tell
+                        // "no message_stop" apart from "no message_stop THAT
+                        // WE COULD SEE".
+                        if state.tx.try_send(bytes.clone()).is_err() {
+                            state.evidence_dropped.store(true, Ordering::SeqCst);
+                        }
+                        Some((Ok(bytes), state))
                     }
-                    Err(err) => {
-                        // The transport died AFTER headers were already forwarded —
-                        // this `Err` is what silently reached the client as a
-                        // severed connection while the request was already booked
-                        // as a clean 200 upstream response. Nothing else observes
-                        // a body-level transport failure, so this is the only place
-                        // it is ever logged. Same field shape as the pre-header
+                    Some(Err(err)) => {
+                        // The transport died AFTER headers were already
+                        // forwarded — this `Err` is what silently reached the
+                        // client as a severed connection while the request was
+                        // already booked as a clean 200 upstream response.
+                        // Nothing else observes a body-level transport
+                        // failure, so this is the only place it is ever
+                        // logged. Same field shape as the pre-header
                         // transport-failure ladder above, so both halves of a
-                        // request's lifecycle log alike.
+                        // request's lifecycle log alike. It is ALSO a genuine
+                        // observation about the upstream, not a client
+                        // abandonment — fire `ended` before returning it.
                         tracing::warn!(
-                            account_index = idx,
-                            account = account_name.as_deref().unwrap_or("?"),
+                            account_index = state.account_index,
+                            account = state.account_name.as_deref().unwrap_or("?"),
                             error = ?err,
                             "upstream transport failure mid-stream — forwarding the \
                              severed connection to the client"
                         );
+                        if let Some(ended) = state.ended.take() {
+                            let _ = ended.send(());
+                        }
+                        Some((Err(err), state))
+                    }
+                    None => {
+                        // Clean EOF — the upstream itself closed the stream.
+                        // Also a genuine observation. Client abandonment never
+                        // reaches this arm at all: axum drops the response
+                        // body (hence this whole stream, mid-poll) instead of
+                        // ever seeing it reach `None`, which drops `state` —
+                        // and `state.ended` along with it — unfired.
+                        if let Some(ended) = state.ended.take() {
+                            let _ = ended.send(());
+                        }
+                        None
                     }
                 }
-                chunk
             });
             return build_response(
                 status,
@@ -2855,9 +2966,13 @@ fn usage_from_json(bytes: &[u8]) -> ParsedUsage {
 /// function existed). A stream that ends without one — the transport dying
 /// mid-body, or the malformed/utf8 `break` above — is exactly as truncated as
 /// one that carries an in-band `error` event, so it gets the same treatment:
-/// `stream_error` is set, this time to the fixed kind `"truncated"`, UNLESS an
-/// `error` event already explained the failure (that one names a root cause;
-/// this one only names the absence of proof the turn finished).
+/// `stream_error` is set, this time to the fixed kind [`TRUNCATED_STREAM_ERROR_KIND`],
+/// UNLESS an `error` event already explained the failure (that one names a
+/// root cause; this one only names the absence of proof the turn finished) —
+/// OR `message_start` never arrived either, because then this was never
+/// observed to be a Messages turn in the first place (a non-2xx SSE error
+/// body or a non-Messages endpoint that happens to share the content-type has
+/// no `message_stop` contract to begin with, so its absence proves nothing).
 async fn parse_sse_usage<S, B, E>(stream: S) -> (ParsedUsage, Option<String>)
 where
     S: futures::Stream<Item = Result<B, E>>,
@@ -2868,6 +2983,7 @@ where
 
     let mut parsed = ParsedUsage::default();
     let mut stream_error: Option<String> = None;
+    let mut saw_message_start = false;
     let mut saw_message_stop = false;
     while let Some(item) = events.next().await {
         let Ok(event) = item else {
@@ -2881,6 +2997,7 @@ where
         };
         match value.get("type").and_then(Value::as_str) {
             Some("message_start") => {
+                saw_message_start = true;
                 if let Some(usage) = value.get("message").and_then(|m| m.get("usage")) {
                     parsed.input_total = sum_input_tokens(usage);
                     (parsed.cache_read, parsed.cache_creation) = cache_breakdown(usage);
@@ -2917,9 +3034,12 @@ where
     }
     // The loop exited — either the upstream closed cleanly after `message_stop`,
     // or it stopped short. No terminator and no more specific error already
-    // recorded means the turn's ending was never observed: that IS truncation.
-    if !saw_message_stop && stream_error.is_none() {
-        stream_error = Some("truncated".to_string());
+    // recorded means the turn's ending was never observed: that IS truncation
+    // — but only for a stream that was ever confirmed to BE a Messages turn.
+    // Without `saw_message_start`, "no message_stop" is not evidence of
+    // anything (see the doc comment above).
+    if saw_message_start && !saw_message_stop && stream_error.is_none() {
+        stream_error = Some(TRUNCATED_STREAM_ERROR_KIND.to_string());
     }
     (parsed, stream_error)
 }
@@ -3428,6 +3548,27 @@ mod tests {
         // No cache tokens in this fixture → both stay zero.
         assert_eq!(parsed.cache_read, 0);
         assert_eq!(parsed.cache_creation, 0);
+    }
+
+    /// FALSE-POSITIVE case #3 (contract-derived, not a path allowlist): a
+    /// stream that never sent `message_start` was never confirmed to BE a
+    /// Messages turn in the first place — a forwarded 3xx/4xx/5xx SSE error
+    /// body, a HEAD response, or a future non-Messages endpoint that happens
+    /// to share `text/event-stream` all look like this from inside
+    /// `parse_sse_usage`. Before the `saw_message_start` gate, the absence of
+    /// `message_stop` alone was enough to synthesize `"truncated"` here; an
+    /// empty stream would have been misclassified on every such request.
+    #[tokio::test]
+    async fn sse_stream_with_no_message_start_records_no_stream_error() {
+        let stream = futures::stream::iter(Vec::<Result<Bytes, Infallible>>::new());
+        let (parsed, stream_error) = parse_sse_usage(stream).await;
+        assert_eq!(parsed, ParsedUsage::default());
+        assert_eq!(
+            stream_error, None,
+            "a stream that never confirmed itself as a Messages turn (no \
+             message_start) must not be classified as truncated just because \
+             it also has no message_stop"
+        );
     }
 
     /// Non-stream JSON path also sums the cache tokens into `input`.
@@ -6696,6 +6837,209 @@ mod tests {
             manager.snapshot(OffsetDateTime::now_utc()).accounts[0].stream_error_count,
             0,
             "a stream that reaches message_stop must record no stream error"
+        );
+    }
+
+    /// FALSE-POSITIVE case #1 (the worst of the set): a CLIENT abandoning the
+    /// connection mid-turn — exactly what happens when a user hits Esc in
+    /// Claude Code — must record NOTHING, not `"truncated"`. Before the
+    /// `ended`/`evidence_dropped` machinery, `tx` was owned by the `.map()`
+    /// closure over `resp.bytes_stream()`; axum dropping the response body on
+    /// client disconnect dropped that closure, hence `tx`, and `rx.recv()`
+    /// returning `None` was INDISTINGUISHABLE from the upstream finishing the
+    /// stream itself. The fake upstream here sends `message_start` and then
+    /// hangs forever (never sends `message_stop`, never closes) — the ONLY
+    /// way this stream ever ends is the test client dropping it, so any
+    /// `stream_error` this test observes was fabricated from an interrupt,
+    /// not from anything upstream actually did.
+    ///
+    /// Also covers the overwrite half of the same bug: a genuine PRIOR
+    /// `last_stream_error` is seeded before the interrupted request, and must
+    /// survive it untouched — `record_stream_error` always overwrites the
+    /// label (see its doc comment), so a false "truncated" here would have
+    /// erased real evidence of the account being `overloaded_error`.
+    #[tokio::test]
+    async fn client_abort_mid_stream_records_no_stream_error() {
+        let upstream = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let up_addr = upstream.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = upstream.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut buf = [0u8; 1024];
+                    let _ = sock.read(&mut buf).await;
+                    let event = concat!(
+                        "event: message_start\n",
+                        "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}}\n\n",
+                    );
+                    // Chunked, not content-length: a real Messages turn's
+                    // length isn't known up front. One chunk, then HANG —
+                    // never a terminating "0\r\n\r\n" chunk, never a close.
+                    // If the client does not abandon this connection, this
+                    // handler simply blocks forever and the test times out —
+                    // which is the point: nothing here ever produces
+                    // `message_stop` or EOF on its own.
+                    let headers = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ntransfer-encoding: chunked\r\n\r\n";
+                    let chunk = format!("{:x}\r\n{event}\r\n", event.len());
+                    let _ = sock.write_all(headers.as_bytes()).await;
+                    let _ = sock.write_all(chunk.as_bytes()).await;
+                    tokio::time::sleep(Duration::from_secs(3600)).await;
+                });
+            }
+        });
+
+        let manager =
+            Manager::with_live_refresher(dummy_config(None, &format!("http://{up_addr}")), None);
+        // Seed a genuine prior error BEFORE the interrupted request — the
+        // overwrite-on-abandonment bug would clobber this.
+        manager.record_stream_error(0, "overloaded_error");
+
+        let proxy = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = proxy.local_addr().unwrap();
+        let served = Arc::clone(&manager);
+        tokio::spawn(async move {
+            let _ = axum::serve(proxy, app(served)).await;
+        });
+
+        tokio::time::timeout(Duration::from_secs(10), async {
+            let client = reqwest::Client::builder().no_proxy().build().unwrap();
+            let resp = client
+                .post(format!("http://{proxy_addr}/v1/messages"))
+                .body("{}")
+                .send()
+                .await
+                .unwrap();
+            let mut body = resp.bytes_stream();
+            // Read the ONE chunk the fake upstream ever sends, proving the
+            // tee actually started, THEN abandon — mirrors a client that
+            // received partial output before the user hit Esc.
+            let first = body.next().await;
+            assert!(first.is_some(), "expected the message_start chunk");
+            drop(body);
+        })
+        .await
+        .expect("client-abort scenario must not hang the server");
+
+        // Positive, waitable signal that the tee's parse loop drained the one
+        // chunk it got: usage from `message_start` lands regardless of how
+        // the stream ends (see `sse_stream_without_message_stop_...` above).
+        let (input_tokens, polls) = {
+            let mut polls = 0u32;
+            let mut seen = manager.snapshot(OffsetDateTime::now_utc()).accounts[0].input_tokens;
+            while seen == 0 && polls < 200 {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                seen = manager.snapshot(OffsetDateTime::now_utc()).accounts[0].input_tokens;
+                polls += 1;
+            }
+            (seen, polls)
+        };
+        assert_eq!(
+            input_tokens, 5,
+            "polled {polls} times waiting for usage to land"
+        );
+
+        // No positive signal exists for "the classifier decided to abstain" —
+        // silence IS the pass condition — so flat-wait comfortably past the
+        // `ended`/`evidence_dropped` decision (a local oneshot + atomic load,
+        // never network-bound) before asserting nothing changed.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        let snapshot = manager.snapshot(OffsetDateTime::now_utc());
+        assert_eq!(
+            snapshot.accounts[0].stream_error_count, 1,
+            "count must stay at the ONE seeded error — the client abandoning \
+             the connection must add nothing"
+        );
+        assert_eq!(
+            snapshot.accounts[0].last_stream_error.as_deref(),
+            Some("overloaded_error"),
+            "the genuine prior error label must survive a client abandoning \
+             a later stream — record_stream_error unconditionally overwrites \
+             this field, so a fabricated \"truncated\" here would erase real \
+             evidence"
+        );
+    }
+
+    /// FALSE-POSITIVE case #3: a forwarded non-2xx response never had a
+    /// `message_stop` contract — it is an error response, not a truncated
+    /// turn. The fixture is deliberately the SAME shape that would have been
+    /// misclassified as truncated before this fix (a `message_start` with no
+    /// `message_stop`), on a 400 instead of a 200, to prove the status gate
+    /// — not the message_start gate above — is what suppresses it here.
+    #[tokio::test]
+    async fn non_2xx_sse_body_records_no_stream_error() {
+        let upstream = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let up_addr = upstream.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = upstream.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut buf = [0u8; 1024];
+                    let _ = sock.read(&mut buf).await;
+                    let body = concat!(
+                        "event: message_start\n",
+                        "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}}\n\n",
+                    );
+                    let response = format!(
+                        "HTTP/1.1 400 Bad Request\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = sock.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+
+        let manager =
+            Manager::with_live_refresher(dummy_config(None, &format!("http://{up_addr}")), None);
+
+        let proxy = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = proxy.local_addr().unwrap();
+        let served = Arc::clone(&manager);
+        tokio::spawn(async move {
+            let _ = axum::serve(proxy, app(served)).await;
+        });
+
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let resp = client
+            .post(format!("http://{proxy_addr}/v1/messages"))
+            .body("{}")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), reqwest::StatusCode::BAD_REQUEST);
+        let _ = resp.bytes().await.unwrap();
+
+        // record_served fires on the terminal outcome regardless of status
+        // (same as the in-band-error test above) — a waitable positive
+        // signal that the request was actually processed before we check for
+        // the absence of a stream error.
+        let mut polls = 0u32;
+        let mut requests = manager.snapshot(OffsetDateTime::now_utc()).accounts[0].requests;
+        while requests == 0 && polls < 200 {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            requests = manager.snapshot(OffsetDateTime::now_utc()).accounts[0].requests;
+            polls += 1;
+        }
+        assert_eq!(
+            requests, 1,
+            "polled {polls} times waiting for the request to be booked"
+        );
+
+        // Flat-wait past where the tee task would have recorded a stream
+        // error had the status gate not suppressed it — same rationale as
+        // the client-abort test above (silence is the pass condition).
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert_eq!(
+            manager.snapshot(OffsetDateTime::now_utc()).accounts[0].stream_error_count,
+            0,
+            "a forwarded 400 body missing message_stop is an error response, \
+             not a truncated Messages turn — it must not be classified"
         );
     }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1620,7 +1620,6 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
 
     // 3. Selection + rotation loop.
     let account_count = manager.account_count();
-    let http = manager.http_client();
     let mut tried: HashSet<usize> = HashSet::new();
     // Accounts that already got their one force-refresh on a 401.
     let mut forced_401: HashSet<usize> = HashSet::new();
@@ -1850,6 +1849,16 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
             continue;
         }
         let Some(token) = manager.access_token(idx) else {
+            tried.insert(idx);
+            continue;
+        };
+        // This account's OWN client — fetched INSIDE the loop, keyed on the idx
+        // this iteration is actually about to serve. Hoisting this above the
+        // loop (as it used to be) reused whichever account was selected FIRST
+        // for every later rotation attempt too, which is the bug
+        // `AccountRuntime::http` exists to fix: every account collapsing onto
+        // one shared connection pool regardless of which one is serving.
+        let Some(http) = manager.http_client(idx) else {
             tried.insert(idx);
             continue;
         };

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -124,9 +124,15 @@ pub struct AccountSnapshot {
     /// (`Login`/`Disabled`), or when a gating window has no known reset (unknown —
     /// we cannot promise a time).
     pub free_at: Option<OffsetDateTime>,
-    /// Count of in-band SSE `error` events this account's streams carried within
-    /// the decay window (see `STREAM_ERROR_WINDOW_MS` in `manager/mod.rs`) — a
-    /// truncated 200 that got booked as a clean serve before this field existed.
+    /// Count of stream failures this account's streams carried within the decay
+    /// window (see `STREAM_ERROR_WINDOW_MS` in `manager/mod.rs`): an in-band SSE
+    /// `error` event, or a stream that hit EOF without Anthropic's `message_stop`
+    /// terminator — recorded with the fixed kind `"truncated"`, which covers a
+    /// mid-stream transport death and the malformed/utf8 break alike. An `error`
+    /// event takes precedence: EOF without `message_stop` is only counted as
+    /// `"truncated"` when no more specific `error` was already recorded. Before
+    /// that check existed, a truncated 200 with no in-band `error` event was
+    /// booked as a clean serve and never reached this field at all.
     /// OBSERVABILITY ONLY: nothing in `select.rs` reads it, so it never gates
     /// rotation. On the wire deliberately (see `status.rs`'s module doc): it
     /// carries no credential material, and `tcr status --json` is how an
@@ -140,10 +146,12 @@ pub struct AccountSnapshot {
     /// — if a future change drops either renderer, delete the claim with it rather
     /// than leaving a rationale the code no longer earns.
     pub stream_error_count: usize,
-    /// The most recent stream error's `error.type` (e.g. `"overloaded_error"`),
-    /// alongside the count above. Same on-the-wire decision as `stream_error_count`,
-    /// and surfaced by the same two renderers (`lastStreamError` in JSON, the
-    /// `last_stream_error=` token in text).
+    /// The most recent stream failure's kind: an Anthropic `error.type` (e.g.
+    /// `"overloaded_error"`) from an in-band SSE `error` event, or the fixed
+    /// string `"truncated"` when the stream hit EOF without `message_stop` and
+    /// no more specific `error` was already recorded. Same on-the-wire decision
+    /// as `stream_error_count`, and surfaced by the same two renderers
+    /// (`lastStreamError` in JSON, the `last_stream_error=` token in text).
     pub last_stream_error: Option<String>,
 }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -147,8 +147,10 @@ pub struct AccountStatus {
     /// The account's effective switch threshold on the SERVER (its own
     /// `switchThreshold`, else the global one).
     pub threshold: f64,
-    /// Decayed count of in-band SSE `error` events (see
-    /// [`AccountSnapshot::stream_error_count`]). Put ON the wire deliberately —
+    /// Decayed count of stream failures — an in-band SSE `error` event, or a
+    /// stream that hit EOF without Anthropic's `message_stop` terminator
+    /// (recorded as `"truncated"`); see [`AccountSnapshot::stream_error_count`].
+    /// Put ON the wire deliberately —
     /// it carries no credential material and `tcr status --json` is how an
     /// operator sees the fleet (`tcr status --json | jq '.[].streamErrorCount'`);
     /// see this module's doc comment on the no-secret invariant.

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -585,8 +585,10 @@ fn render_accounts(
                         )),
                         output,
                         last,
-                        // In-band SSE `error` events (decayed count), observability
-                        // only — never a routing input. `-` when none observed.
+                        // Stream failures — in-band SSE `error` events plus streams
+                        // that hit EOF without `message_stop` (decayed count),
+                        // observability only — never a routing input. `-` when none
+                        // observed.
                         Cell::from(if account.stream_error_count > 0 {
                             account.stream_error_count.to_string()
                         } else {


### PR DESCRIPTION
This proxy could not tell a finished response from a severed one, and a single upstream connection fault took the whole fleet down with it. Four related changes.

## The proxy had no concept of a completed turn

`message_stop` — Anthropic's only completion marker — appeared nowhere in this repository. Nothing could distinguish *finished* from *stopped*, so a connection that died mid-stream was booked as a clean HTTP 200: the retry ladder is entirely pre-header, `record_served` and `push_log` both fire at header time, and `RequestLogEntry` has no field capable of recording otherwise. The usage tee was typed `Ok<Bytes, Infallible>`, so a transport error could not reach the parser even in principle, and the passthrough had no `Err` arm at all.

The passthrough is now a `stream::unfold` over an explicit state struct rather than a `.map()`, because `.map()` can only observe items — never termination — and termination is precisely the fact needed here. A record is written only when **all four** of these hold:

- the response was 2xx (a forwarded 4xx/5xx SSE-shaped body is not a truncated turn);
- the stream actually began a Messages turn (`message_start` was seen), derived from the stream's own content rather than a path allowlist that would rot on the next beta endpoint;
- the upstream genuinely terminated — either clean EOF or a transport error — signalled explicitly, so a **client disconnect cannot masquerade as upstream failure**. Without this, every Esc keypress would book a fake error against a healthy account and overwrite a real `overloaded_error`;
- no evidence was discarded. The bounded tee drops chunks under backpressure by design (that is what keeps the parser from ever applying backpressure to the client), and a dropped chunk may be the one carrying the terminator. When that happens the classifier abstains rather than guessing, and the abstention is logged with its reason — "decided not to classify" and "nothing happened" must not be the same bytes.

An in-band `error` event bypasses these gates: it is a positive observation, not an inferred absence.

This widens what `stream_error_count` means, so every surface describing it was corrected in the same change — including a `tracing::warn!` whose text asserted "in-band error event", which would have been false on every truncation.

**Three pre-existing tests asserted the old behaviour was correct.** Two unit fixtures ended at `message_delta` and asserted `stream_error == None` with the message "a clean stream has no error event"; the integration test fed a terminator-less stream, closed the connection, and asserted `stream_error_count == 0`, its docstring calling that "a clean 200 SSE stream". The fixtures now carry a `message_stop` so their real subject is tested on well-formed input; the integration test is inverted and renamed.

Routing is unchanged. `stream_error_count` remains observability-only — nothing in `select.rs` reads it.

## One upstream connection served every account

`hyper-util` keys its connection pool on `(Scheme, Authority)`. Nothing in that key touches headers, the bearer token, or account identity, so every account's traffic to the same origin collapsed onto one pooled connection — and `is_open()` for H2 is capacity-blind, so an over-capacity stream queues rather than opening a second. In this proxy's own logs, sub-millisecond `Http2 Reset(StreamId(N), PROTOCOL_ERROR, Remote)` clusters span two and three distinct accounts. Rotation and failover therefore bought nothing against a connection-level fault: the next send rode the same connection.

Each `AccountRuntime` now owns its client, built in `from_config` so every insertion path gets one without parallel bookkeeping. The credential-replace path leaves the client alone, so rotating a credential keeps that account's warm pool. `Manager.http` is gone; `http_client` is keyed by index.

Scope of the claim: separate clients have separate pools by construction, and the test asserts two accounts never share a client instance. That is an in-process identity check, not an observation of two TCP connections on the wire. The cost bought deliberately: N pools means N handshakes rather than one; `pool_idle_timeout` is protocol-agnostic and keeps them warm.

## Keep-warm could repeat forever, then could stop forever

`warm_account` logged "started 5h window" on any successful warm, but `update_quota` latches nothing when the response carries no rate-limit headers. A header-less 200 left the account an eligible warm target indefinitely, re-warmed every cadence at real upstream cost — while `warm_targets`' own doc-comment asserted this "cannot become a repeating burst". It was never caught because the only warm fixture always returned headers with a live window, so the invariant could not fail in test.

Bounding the repeat then creates the opposite hazard: an account excluded after N evidence-free warms is never warmed again, and an idle account is never *served* either, so nothing ever resets it — it contributes zero capacity until a process restart, which costs a cold prompt-cache prefix on every live session. The exclusion therefore expires on a flat cooldown: one bounded retry burst per hour per excluded account, versus one per probe cycle if recovery were driven off probes, which would spend more than the original bug did.

## Verification

Every new or inverted assertion was watched failing before being trusted, per CONTRIBUTING. `cargo fmt --all --check`, `cargo clippy --all-targets --locked -- -D warnings` and `cargo test --all --locked` all exit 0 against the branch tip; 671 tests pass.

Known gap, stated rather than papered over: the discarded-evidence path is implemented and gates the classifier identically to client-abandonment, but has no automated test — deterministically overflowing the bounded channel needs a producer/consumer race that would be flaky. Covered by tests: client abort, non-2xx body, absent `message_start`, genuine truncation, and the clean case.
