### PR TITLE
fix: close the five defects #78 introduced in its own fixes

### DIFF
--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -836,6 +836,15 @@ fn short_session_id(key: u64) -> String {
     format!("{:06x}", ((key ^ (key >> 40)) & 0xFF_FFFF))
 }
 
+/// Whether a wall-clock cooldown deadline (epoch ms) has elapsed as of `now_ms`.
+/// `None` (no cooldown armed) reads as "not held back by this gate" — the same
+/// shape [`Manager::probeable_indices`]'s `error_retry_after_ms` check and
+/// [`Manager::warm_targets`]'s `warm_evidence_retry_after_ms` check both need,
+/// factored out so the two don't drift on the `>=` vs `>` boundary.
+fn cooldown_elapsed(deadline_ms: Option<i64>, now_ms: i64) -> bool {
+    deadline_ms.is_some_and(|until| now_ms >= until)
+}
+
 impl Manager {
     /// Build a manager over `config`, using `refresher` for token refresh,
     /// `prober` for background usage reads, and persisting refreshes to
@@ -1459,13 +1468,19 @@ impl Manager {
     /// one-directional edge (`config_write` → `self.accounts`) to the lock
     /// order, not a cycle. `persist_added`/`persist_replaced` no longer take
     /// `config_write` themselves — they assume the caller already holds it.
+    ///
+    /// A resolution that lands on Added needs a freshly-built
+    /// [`AccountRuntime`] (a `reqwest::Client`) to push, and building one must
+    /// never happen while EITHER lock is held — a panic mid-build would
+    /// poison it for every other `.expect(...)` site on that lock,
+    /// `config_write` included (`persist_tokens`, `persist_now`'s shutdown
+    /// flush, this function's own next call). So `config_write` is held
+    /// across each ATTEMPT's resolve/mutate/persist, not necessarily across
+    /// the whole call: an attempt that resolves Added with no runtime ready
+    /// yet mutates NOTHING, drops both locks, builds, and retries — see the
+    /// loop inside the function body for why at most one retry is ever
+    /// needed and why it cannot reopen the TOCTOU above.
     pub fn add_or_update_account(&self, mut account: config::Account) -> AddAccountOutcome {
-        // N2 — see above: held across resolve, mutate AND persist so this
-        // whole operation never interleaves with another concurrent call's.
-        let _writing = self
-            .config_write
-            .lock()
-            .expect("config write lock poisoned");
         let target = crate::identity::probe(
             &account.name,
             account.account_uuid.clone(),
@@ -1476,28 +1491,11 @@ impl Manager {
             && account.org_uuid.is_none()
             && account.org_name.is_none();
 
-        // Built SPECULATIVELY, before `self.accounts`'s write lock below —
-        // `AccountRuntime::from_config` ends in `build_serving_client()`'s
-        // `.expect("build reqwest client")`, and a panic while that lock's write
-        // guard is held poisons it for every other caller (`http_client`,
-        // `select`, `snapshot`, `record_stream_error`, ~97 sites total all
-        // `.expect` the same lock). Every field `from_config` derives from
-        // `account` is already final at this point except possibly `priority`
-        // (only mutated below, under the lock, and only on the Added path) — so
-        // if resolution lands on Added, the `priority` field is patched on this
-        // already-built value instead of rebuilding. If it lands on Updated,
-        // this is simply dropped unused. Mirrors what `add_account` already
-        // does (build before the lock); `add_or_update_account` isn't a hot
-        // path (`POST /_tcr/accounts`, driven by login/config-reload, not by
-        // served traffic), so building one extra idle client on the Updated
-        // path costs nothing worth avoiding.
-        let mut speculative_runtime = AccountRuntime::from_config(&account);
-
         /// What the locked resolve-and-mutate section below produced, so the
         /// durable write can run after `self.accounts`'s lock is released —
         /// `persist_added`/`persist_replaced` do their own file I/O and must
         /// never run under `self.accounts`'s lock (though both still run
-        /// under `config_write`, held since function entry — see the N2
+        /// under `config_write`, held since this attempt's start — see the N2
         /// doc-comment on `add_or_update_account`).
         enum Resolution {
             Added {
@@ -1513,186 +1511,225 @@ impl Manager {
                 /// clippy flags the size gap between variants otherwise.
                 target: Box<config::Account>,
             },
+            /// The resolve below landed on Added, but there is no
+            /// already-built [`AccountRuntime`] to push yet — see the loop
+            /// below, which built nothing here on purpose.
+            NeedsBuild,
         }
 
-        let resolution = {
-            let mut accounts = self.accounts.write().expect("accounts lock poisoned");
+        // Built on demand, never while a lock is held — see the doc-comment
+        // above `add_or_update_account`. `None` until the first attempt
+        // below discovers it actually needs one.
+        let mut speculative_runtime: Option<AccountRuntime> = None;
 
-            let probes: Vec<(usize, config::Account)> = accounts
-                .iter()
-                .enumerate()
-                .map(|(i, a)| {
-                    (
-                        i,
-                        crate::identity::probe(
-                            &a.name,
-                            a.account_uuid.clone(),
-                            a.org_uuid.clone(),
-                            a.org_name.clone(),
-                        ),
-                    )
-                })
-                .collect();
+        loop {
+            // N2 — see above: held across THIS ATTEMPT's resolve, mutate and
+            // persist so it never interleaves with another concurrent call's.
+            // Dropped early, before any mutation, on an attempt that turns out
+            // to need a client it doesn't have yet (`NeedsBuild` below).
+            let _writing = self
+                .config_write
+                .lock()
+                .expect("config write lock poisoned");
 
-            let matched =
-                match crate::identity::resolve(probes.iter().map(|(i, p)| (*i, p)), &target) {
-                    crate::identity::Resolved::One(idx) => Some(idx),
-                    crate::identity::Resolved::Many => {
-                        // Recompute the loose set for its names: `Resolved::Many`
-                        // itself carries none, and this is exactly the set
-                        // `resolve` drew from (same predicate, same candidates).
-                        let names = accounts
-                            .iter()
-                            .filter(|a| {
-                                crate::identity::same_identity(
-                                    &target,
-                                    &crate::identity::probe(
-                                        &a.name,
-                                        a.account_uuid.clone(),
-                                        a.org_uuid.clone(),
-                                        a.org_name.clone(),
-                                    ),
-                                )
-                            })
-                            .map(|a| a.name.clone())
-                            .collect();
-                        return AddAccountOutcome::Ambiguous(names);
-                    }
-                    crate::identity::Resolved::None if bare_identity => {
-                        match crate::identity::match_one(&accounts[..], &account.name, None) {
-                            crate::identity::Match::One(idx) => Some(idx),
-                            crate::identity::Match::None => None,
-                            crate::identity::Match::Ambiguous(names) => {
-                                return AddAccountOutcome::Ambiguous(names);
+            let resolution = {
+                let mut accounts = self.accounts.write().expect("accounts lock poisoned");
+
+                let probes: Vec<(usize, config::Account)> = accounts
+                    .iter()
+                    .enumerate()
+                    .map(|(i, a)| {
+                        (
+                            i,
+                            crate::identity::probe(
+                                &a.name,
+                                a.account_uuid.clone(),
+                                a.org_uuid.clone(),
+                                a.org_name.clone(),
+                            ),
+                        )
+                    })
+                    .collect();
+
+                let matched =
+                    match crate::identity::resolve(probes.iter().map(|(i, p)| (*i, p)), &target) {
+                        crate::identity::Resolved::One(idx) => Some(idx),
+                        crate::identity::Resolved::Many => {
+                            // Recompute the loose set for its names: `Resolved::Many`
+                            // itself carries none, and this is exactly the set
+                            // `resolve` drew from (same predicate, same candidates).
+                            let names = accounts
+                                .iter()
+                                .filter(|a| {
+                                    crate::identity::same_identity(
+                                        &target,
+                                        &crate::identity::probe(
+                                            &a.name,
+                                            a.account_uuid.clone(),
+                                            a.org_uuid.clone(),
+                                            a.org_name.clone(),
+                                        ),
+                                    )
+                                })
+                                .map(|a| a.name.clone())
+                                .collect();
+                            return AddAccountOutcome::Ambiguous(names);
+                        }
+                        crate::identity::Resolved::None if bare_identity => {
+                            match crate::identity::match_one(&accounts[..], &account.name, None) {
+                                crate::identity::Match::One(idx) => Some(idx),
+                                crate::identity::Match::None => None,
+                                crate::identity::Match::Ambiguous(names) => {
+                                    return AddAccountOutcome::Ambiguous(names);
+                                }
                             }
                         }
-                    }
-                    crate::identity::Resolved::None => None,
-                };
-
-            match matched {
-                Some(idx) => {
-                    let row = accounts
-                        .get_mut(idx)
-                        .expect("idx was just resolved against this same vec");
-                    row.access_token = account.access_token.clone();
-                    row.refresh_token = account.refresh_token.clone();
-                    row.expires_at_ms = account.expires_at.map(oauth::normalize_expires_at);
-                    // F4: fresh credentials clear a stuck error — `eligible`
-                    // hard-gates on `status == Error` — but do NOT clear a
-                    // rate-limit hold. That hold expires on its own
-                    // (`MAX_RATE_LIMIT_HOLD_SECONDS`) and the next 429 re-arms
-                    // it; clearing it here bought nothing but the ability to
-                    // race a genuinely-still-limited account back into
-                    // rotation early.
-                    if row.status == AccountStatus::Error {
-                        row.status = AccountStatus::Active;
-                    }
-                    // F6: the submitted type always wins — this route only
-                    // ever carries a real credential, so a row whose stored
-                    // type was stale (e.g. `"api"`) is corrected, or
-                    // `refresh_plan` silently never refreshes it again.
-                    // Identity fields are BACKFILLED — filled in only where
-                    // the row does not already carry a value — mirroring
-                    // `oauth::upsert_account`. Backfilling (rather than
-                    // ignoring) is what permanently closes the split-brain
-                    // trigger: once a legacy no-org row's org is filled in,
-                    // it stops being loosely matched by every org variant of
-                    // that person and starts requiring an exact org match,
-                    // like any other fully-known account.
-                    row.account_type = account.account_type.clone();
-                    if row.account_uuid.is_none() {
-                        row.account_uuid = account.account_uuid.clone();
-                    }
-                    if row.org_uuid.is_none() {
-                        row.org_uuid = account.org_uuid.clone();
-                    }
-                    if row.org_name.is_none() {
-                        row.org_name = account.org_name.clone();
-                    }
-                    // F5: carry the row's REAL routing state, not
-                    // `identity::probe`'s None placeholders — see
-                    // `persist_replaced`'s doc-comment for the restart-un-bench
-                    // this replaces.
-                    let target = config::Account {
-                        name: row.name.clone(),
-                        account_type: row.account_type.clone(),
-                        account_uuid: row.account_uuid.clone(),
-                        org_uuid: row.org_uuid.clone(),
-                        org_name: row.org_name.clone(),
-                        access_token: String::new(),
-                        refresh_token: None,
-                        expires_at: None,
-                        priority: Some(row.priority),
-                        switch_threshold: row.switch_threshold,
-                        disabled: row.disabled.then_some(true),
-                        extra: serde_json::Map::new(),
+                        crate::identity::Resolved::None => None,
                     };
-                    Resolution::Updated {
-                        idx,
-                        name: row.name.clone(),
-                        target: Box::new(target),
-                    }
-                }
-                None => {
-                    // A follow-up regression on this arm (distinct from the
-                    // TOCTOU fix this function is named for above): an
-                    // appended account with no explicit priority must join
-                    // the BACK of the fleet — `max(existing priorities) + 1`
-                    // — not the 0 that `AccountRuntime::from_config`'s
-                    // `unwrap_or(0)` reads from an absent priority, which
-                    // would silently promote it to the PRIMARY tier ahead of
-                    // the established fleet. Computed from `accounts` (the
-                    // LIVE rotation, not the config snapshot) because this
-                    // section already holds its write lock and it is
-                    // authoritative for what is routing right now. Skipped
-                    // when the caller submitted an explicit priority (the
-                    // documented new-account case — see `AddAccountRequest`'s
-                    // doc-comment in `proxy.rs`), which is never overridden.
-                    // Mirrors the identical fix in `config::merge_account`'s
-                    // Added arm.
-                    if account.priority.is_none() {
-                        let next_priority = accounts
-                            .iter()
-                            .map(|a| a.priority)
-                            .max()
-                            .map_or(0, |max| max + 1);
-                        account.priority = Some(next_priority);
-                        // The speculative build above ran before `next_priority`
-                        // was known — patch it in rather than rebuilding (which
-                        // would call `build_serving_client()` again, under this
-                        // same lock, resurrecting exactly the bug this comment
-                        // block exists to avoid).
-                        speculative_runtime.priority = next_priority;
-                    }
-                    accounts.push(speculative_runtime);
-                    Resolution::Added {
-                        idx: accounts.len() - 1,
-                    }
-                }
-            }
-        };
 
-        match resolution {
-            Resolution::Added { idx } => {
-                // Still sequential, never nested, with `self.accounts` (which
-                // is already released by this point) — the `self.config` lock
-                // here is a separate, short critical section, same discipline
-                // `add_account` documents. It runs nested inside
-                // `config_write` (held since function entry, see the N2
-                // doc-comment above), which is what makes this whole arm
-                // atomic with respect to another concurrent call.
-                {
-                    let mut config = self.config.lock().expect("config lock poisoned");
-                    config.accounts.push(account.clone());
+                match matched {
+                    Some(idx) => {
+                        let row = accounts
+                            .get_mut(idx)
+                            .expect("idx was just resolved against this same vec");
+                        row.access_token = account.access_token.clone();
+                        row.refresh_token = account.refresh_token.clone();
+                        row.expires_at_ms = account.expires_at.map(oauth::normalize_expires_at);
+                        // F4: fresh credentials clear a stuck error — `eligible`
+                        // hard-gates on `status == Error` — but do NOT clear a
+                        // rate-limit hold. That hold expires on its own
+                        // (`MAX_RATE_LIMIT_HOLD_SECONDS`) and the next 429 re-arms
+                        // it; clearing it here bought nothing but the ability to
+                        // race a genuinely-still-limited account back into
+                        // rotation early.
+                        if row.status == AccountStatus::Error {
+                            row.status = AccountStatus::Active;
+                        }
+                        // F6: the submitted type always wins — this route only
+                        // ever carries a real credential, so a row whose stored
+                        // type was stale (e.g. `"api"`) is corrected, or
+                        // `refresh_plan` silently never refreshes it again.
+                        // Identity fields are BACKFILLED — filled in only where
+                        // the row does not already carry a value — mirroring
+                        // `oauth::upsert_account`. Backfilling (rather than
+                        // ignoring) is what permanently closes the split-brain
+                        // trigger: once a legacy no-org row's org is filled in,
+                        // it stops being loosely matched by every org variant of
+                        // that person and starts requiring an exact org match,
+                        // like any other fully-known account.
+                        row.account_type = account.account_type.clone();
+                        if row.account_uuid.is_none() {
+                            row.account_uuid = account.account_uuid.clone();
+                        }
+                        if row.org_uuid.is_none() {
+                            row.org_uuid = account.org_uuid.clone();
+                        }
+                        if row.org_name.is_none() {
+                            row.org_name = account.org_name.clone();
+                        }
+                        // F5: carry the row's REAL routing state, not
+                        // `identity::probe`'s None placeholders — see
+                        // `persist_replaced`'s doc-comment for the restart-un-bench
+                        // this replaces.
+                        let target = config::Account {
+                            name: row.name.clone(),
+                            account_type: row.account_type.clone(),
+                            account_uuid: row.account_uuid.clone(),
+                            org_uuid: row.org_uuid.clone(),
+                            org_name: row.org_name.clone(),
+                            access_token: String::new(),
+                            refresh_token: None,
+                            expires_at: None,
+                            priority: Some(row.priority),
+                            switch_threshold: row.switch_threshold,
+                            disabled: row.disabled.then_some(true),
+                            extra: serde_json::Map::new(),
+                        };
+                        Resolution::Updated {
+                            idx,
+                            name: row.name.clone(),
+                            target: Box::new(target),
+                        }
+                    }
+                    None => match speculative_runtime.take() {
+                        // No runtime ready yet — mutate nothing, report it, and
+                        // let the loop below build one with no lock held before
+                        // retrying. Safe to abandon this attempt outright: it
+                        // has not touched `accounts`, `self.config`, or disk.
+                        None => Resolution::NeedsBuild,
+                        Some(mut runtime) => {
+                            // A follow-up regression on this arm (distinct from the
+                            // TOCTOU fix this function is named for above): an
+                            // appended account with no explicit priority must join
+                            // the BACK of the fleet — `max(existing priorities) + 1`
+                            // — not the 0 that `AccountRuntime::from_config`'s
+                            // `unwrap_or(0)` reads from an absent priority, which
+                            // would silently promote it to the PRIMARY tier ahead of
+                            // the established fleet. Computed from `accounts` (the
+                            // LIVE rotation, not the config snapshot) because this
+                            // section already holds its write lock and it is
+                            // authoritative for what is routing right now. Skipped
+                            // when the caller submitted an explicit priority (the
+                            // documented new-account case — see `AddAccountRequest`'s
+                            // doc-comment in `proxy.rs`), which is never overridden.
+                            // Mirrors the identical fix in `config::merge_account`'s
+                            // Added arm.
+                            if account.priority.is_none() {
+                                let next_priority = accounts
+                                    .iter()
+                                    .map(|a| a.priority)
+                                    .max()
+                                    .map_or(0, |max| max + 1);
+                                account.priority = Some(next_priority);
+                                // Built on the PRIOR attempt, before `next_priority`
+                                // was known — patch it in rather than rebuilding
+                                // (which would call `build_serving_client()` again,
+                                // under this same lock, resurrecting exactly the bug
+                                // the loop above exists to avoid).
+                                runtime.priority = next_priority;
+                            }
+                            accounts.push(runtime);
+                            Resolution::Added {
+                                idx: accounts.len() - 1,
+                            }
+                        }
+                    },
                 }
-                let name = account.name.clone();
-                let persist = self.persist_added(&account);
-                AddAccountOutcome::Added { idx, name, persist }
-            }
-            Resolution::Updated { idx, name, target } => {
-                let persist = self.persist_replaced(idx, &target, &account);
-                AddAccountOutcome::Updated { idx, name, persist }
+            };
+
+            match resolution {
+                Resolution::NeedsBuild => {
+                    // Both locks are released here (self.accounts already went
+                    // out of scope above; config_write is dropped explicitly)
+                    // before the one call that can panic — see the doc-comment
+                    // above `add_or_update_account`. Nothing was mutated on this
+                    // attempt, so retrying from scratch is safe; the next
+                    // attempt is guaranteed to have a runtime ready, so it
+                    // cannot hit this arm again.
+                    drop(_writing);
+                    speculative_runtime = Some(AccountRuntime::from_config(&account));
+                    continue;
+                }
+                Resolution::Added { idx } => {
+                    // Still sequential, never nested, with `self.accounts` (which
+                    // is already released by this point) — the `self.config` lock
+                    // here is a separate, short critical section, same discipline
+                    // `add_account` documents. It runs nested inside
+                    // `config_write` (held since this attempt's start, see the N2
+                    // doc-comment above), which is what makes this whole arm
+                    // atomic with respect to another concurrent call.
+                    {
+                        let mut config = self.config.lock().expect("config lock poisoned");
+                        config.accounts.push(account.clone());
+                    }
+                    let name = account.name.clone();
+                    let persist = self.persist_added(&account);
+                    return AddAccountOutcome::Added { idx, name, persist };
+                }
+                Resolution::Updated { idx, name, target } => {
+                    let persist = self.persist_replaced(idx, &target, &account);
+                    return AddAccountOutcome::Updated { idx, name, persist };
+                }
             }
         }
     }
@@ -6111,20 +6148,29 @@ mod tests {
         std::fs::remove_file(&path).ok();
     }
 
-    /// Before this fix, the Added path's `AccountRuntime::from_config(&account)`
+    /// Before the first fix, the Added path's `AccountRuntime::from_config(&account)`
     /// ran INSIDE the `self.accounts.write()` block — meaning
     /// `build_serving_client`'s `.expect("build reqwest client")` executed while
     /// the write guard was held. A panic there poisons the `RwLock` for every
     /// other caller in this module: `http_client`, `select`, `snapshot`,
     /// `record_stream_error` and ~93 more all `.expect("accounts lock
     /// poisoned")`, so one recoverable client-build failure would take down the
-    /// whole proxy. Uses the `#[cfg(test)]` fault-injection seam on
-    /// `build_serving_client` to make that failure real rather than
-    /// hypothetical, on a submission guaranteed to resolve Added (an empty
-    /// fleet, so nothing can match), and asserts the lock survives.
+    /// whole proxy.
+    ///
+    /// A second round moved the build OUTSIDE `self.accounts`'s lock but left
+    /// it inside `config_write` (held from function entry in that version) —
+    /// so the SAME panic instead poisoned `config_write`, which is arguably
+    /// worse: `persist_tokens` and `persist_now`'s shutdown flush both
+    /// `.expect()` it, so a poisoned `config_write` stops rotated refresh
+    /// tokens from ever reaching disk again, on top of every future call to
+    /// this very function panicking at its own `config_write.lock()`.
+    ///
+    /// Uses the `#[cfg(test)]` fault-injection seam on `build_serving_client`
+    /// to make that failure real rather than hypothetical, on a submission
+    /// guaranteed to resolve Added (an empty fleet, so nothing can match),
+    /// and asserts BOTH locks survive.
     #[test]
-    fn add_or_update_account_added_path_does_not_poison_the_accounts_lock_on_a_client_build_panic()
-    {
+    fn add_or_update_account_added_path_does_not_poison_either_lock_on_a_client_build_panic() {
         let manager = build_manager(config_with(vec![]), lock_refresher());
         let submission = account("brand-new@example.com", 0);
 
@@ -6142,6 +6188,51 @@ mod tests {
             "a client-build panic in add_or_update_account must not poison the \
              accounts lock — every other .expect(\"accounts lock poisoned\") \
              call site would panic in turn"
+        );
+        assert!(
+            manager.config_write.lock().is_ok(),
+            "a client-build panic in add_or_update_account must not poison the \
+             config_write lock either — persist_tokens and persist_now's \
+             shutdown flush both .expect() it, and this function itself takes \
+             it again on its very next call"
+        );
+    }
+
+    /// The Added-only half of the fix above: an ordinary re-auth of an
+    /// EXISTING account (the common case this route serves — every token
+    /// refresh's re-login goes through `POST /_tcr/accounts`, not just a
+    /// first-time add) must resolve Updated on its FIRST locked attempt and
+    /// never reach `build_serving_client` at all. A version that built the
+    /// runtime unconditionally before resolving (fixing the poisoning bug
+    /// above but not this one) would waste a client build on every re-auth
+    /// and widen the panic surface to a call that never needed one. Arms the
+    /// SAME fault-injection seam on a submission guaranteed to resolve
+    /// Updated (an existing row with a matching bare identity) — if the
+    /// build were ever reached the injected panic would fire, so a normal
+    /// return proves it was not.
+    #[test]
+    fn add_or_update_account_updated_path_never_builds_a_client() {
+        let existing = account("alice@example.com", 0);
+        let manager = build_manager(config_with(vec![existing.clone()]), lock_refresher());
+        let mut resubmission = existing.clone();
+        resubmission.access_token = "at-alice-rotated".to_string();
+
+        fail_next_client_build();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            manager.add_or_update_account(resubmission)
+        }));
+
+        let outcome = result.unwrap_or_else(|_| {
+            panic!(
+                "add_or_update_account must never reach build_serving_client on \
+                 the Updated path — the injected client-build failure should \
+                 not have fired at all"
+            )
+        });
+        assert!(
+            matches!(outcome, AddAccountOutcome::Updated { .. }),
+            "setup: the resubmission must resolve against the existing row, \
+             not append a new one"
         );
     }
 
@@ -6750,6 +6841,62 @@ mod tests {
             manager.warm_targets().contains(&0),
             "an elapsed retry cooldown must recover an account the warm latch \
              excluded, without a restart"
+        );
+    }
+
+    /// The failing half of the recovery above. `record_warm_without_evidence`
+    /// only re-arms `warm_evidence_retry_after_ms` from the Ok-but-header-less
+    /// branch of `warm_account` — a warm that FAILS outright takes the `Err`
+    /// arm instead, which (before this fix) never touched the deadline. Once
+    /// the cooldown had elapsed, a FAILING retry left the now-past deadline in
+    /// place, and `warm_targets`' `cooldown_elapsed` check re-admitted the
+    /// account on every subsequent pass rather than once per cooldown — the
+    /// "one bounded retry burst per hour" property collapsing back to "every
+    /// tick" on the failure path specifically, which is the unbounded-repeat
+    /// bug this whole latch exists to bound. Drives an account past the limit
+    /// and elapses its cooldown directly (this test is about the `Err` arm's
+    /// re-arm, not about repeating `warm_account` 50 times to get there), then
+    /// feeds it ONE failing warm (`NoWarmer` always returns `Err`) and asserts
+    /// the deadline moved back into the future — and the account is excluded
+    /// again immediately, not just eventually.
+    #[tokio::test]
+    async fn a_failing_retry_does_not_reset_the_warm_evidence_cooldown() {
+        let refresher = Arc::new(CountingRefresher {
+            calls: Arc::new(AtomicUsize::new(0)),
+        });
+        let manager = build_manager_with_warmer(
+            config_with(vec![account("cold", 0)]),
+            refresher,
+            Arc::new(NoWarmer),
+        );
+        mark_all_probed(&manager); // isolate from the never-probed boot gate
+
+        {
+            let mut accounts = manager.accounts.write().expect("accounts lock poisoned");
+            accounts[0].consecutive_warms_without_evidence = WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT;
+            accounts[0].warm_evidence_retry_after_ms = Some(crate::now_ms() - 1);
+        }
+        assert!(
+            manager.warm_targets().contains(&0),
+            "setup: an elapsed cooldown must make the account a target again"
+        );
+
+        manager.warm_account(0).await; // NoWarmer always returns Err
+
+        let deadline = {
+            let accounts = manager.accounts.read().expect("accounts lock poisoned");
+            accounts[0].warm_evidence_retry_after_ms
+        };
+        assert!(
+            deadline.is_some_and(|until| until > crate::now_ms()),
+            "a FAILING retry must re-arm the cooldown into the future too, not \
+             just an Ok-but-header-less one — otherwise the account is \
+             re-admitted on every subsequent tick instead of once per cooldown"
+        );
+        assert!(
+            !manager.warm_targets().contains(&0),
+            "immediately after a failing retry the account must be excluded \
+             again, not left eligible on a stale past deadline"
         );
     }
 

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -366,11 +366,14 @@ pub struct AccountRuntime {
 
 // Test-only fault injection for `build_serving_client`: set via
 // `fail_next_client_build`, consumed (and cleared) by the next call on this
-// thread. Exists to prove — with a real panic, not a hypothetical one — that
-// `Manager::add_or_update_account`'s Added path builds its runtime BEFORE
-// taking `self.accounts`'s write lock: a panic here that happens UNDER that
-// lock poisons it for every other `.expect("accounts lock poisoned")` call
-// site in this module; one that happens before the lock is taken does not.
+// thread. Exists to prove — with a real panic, not a hypothetical one — two
+// properties of `Manager::add_or_update_account`: its Added path builds the
+// runtime with NEITHER `self.accounts` nor `config_write` held, so a panic
+// here poisons neither lock — every other `.expect(...)` call site on either
+// one in this module would otherwise go down with it — and its Updated path
+// never reaches this function at all. See
+// `add_or_update_account_added_path_does_not_poison_either_lock_on_a_client_build_panic`
+// and `add_or_update_account_updated_path_never_builds_a_client`.
 #[cfg(test)]
 thread_local! {
     static FAIL_NEXT_CLIENT_BUILD: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };

--- a/src/manager/probing.rs
+++ b/src/manager/probing.rs
@@ -91,7 +91,7 @@ impl Manager {
                     && a.refresh_token.is_some()
                     && !a.disabled
                     && (a.status != AccountStatus::Error
-                        || a.error_retry_after_ms.is_some_and(|until| now_ms >= until))
+                        || cooldown_elapsed(a.error_retry_after_ms, now_ms))
             })
             .map(|(idx, _)| idx)
             .collect()

--- a/src/manager/warm.rs
+++ b/src/manager/warm.rs
@@ -2,6 +2,25 @@
 
 use super::*;
 
+/// Re-arm [`AccountRuntime::warm_evidence_retry_after_ms`] if this account is
+/// currently AT OR PAST [`WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT`] — shared by
+/// [`Manager::record_warm_without_evidence`] (a warm that succeeded but
+/// latched no evidence) and [`Manager::record_warm_failure`] (a warm that
+/// failed outright). Either one, if it happens during the one retry the
+/// cooldown just granted, must push the deadline forward again: the deadline
+/// this replaces is already in the PAST by the time a retry runs (that is
+/// what made the account eligible again — see [`Manager::warm_targets`]), so
+/// leaving it alone after a failing retry keeps `warm_targets` re-admitting
+/// the account on EVERY subsequent pass instead of once per cooldown —
+/// exactly the unbounded-repeat bug this latch exists to bound, just entered
+/// from the failure path instead of the header-less-200 path.
+fn rearm_warm_evidence_cooldown_if_excluded(account: &mut AccountRuntime) {
+    if account.consecutive_warms_without_evidence >= WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT {
+        account.warm_evidence_retry_after_ms =
+            Some(crate::now_ms() + WARM_EVIDENCE_RETRY_COOLDOWN_MS);
+    }
+}
+
 impl Manager {
     /// The account indices eligible for a keep-warm request. Starts from the same
     /// base as [`Self::probeable_indices`] (an OAuth account with a refresh token
@@ -107,7 +126,7 @@ impl Manager {
                     // elapsed — this is the recovery half, bounded by
                     // WARM_EVIDENCE_RETRY_COOLDOWN_MS rather than left permanent.
                     && (a.consecutive_warms_without_evidence < WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT
-                        || a.warm_evidence_retry_after_ms.is_some_and(|until| now_ms >= until))
+                        || cooldown_elapsed(a.warm_evidence_retry_after_ms, now_ms))
             })
             .map(|(idx, _)| idx)
             .collect()
@@ -156,6 +175,17 @@ impl Manager {
                 }
             }
             Err(err) => {
+                // A failed warm is not "succeeded without evidence" — it does not
+                // bump `consecutive_warms_without_evidence`, which specifically
+                // counts a 200 that latched nothing. But if the account is
+                // already PAST the limit, this failure just consumed the one
+                // retry `warm_evidence_retry_after_ms`'s cooldown granted, and
+                // that deadline must move forward again — see
+                // `rearm_warm_evidence_cooldown_if_excluded`'s doc-comment for
+                // why leaving it alone reopens the unbounded-repeat bug this
+                // whole latch exists to bound, just on the failure path instead
+                // of the header-less-200 path.
+                self.record_warm_failure(idx);
                 tracing::warn!(
                     account = %name,
                     index = idx,
@@ -172,13 +202,10 @@ impl Manager {
     /// logs the give-up once rather than every cadence — mirrors
     /// [`Manager::record_probe`]'s crossing-log pattern for the same reason.
     ///
-    /// At or past the limit, (re-)arms [`AccountRuntime::warm_evidence_retry_after_ms`]
-    /// to `now + `[`WARM_EVIDENCE_RETRY_COOLDOWN_MS`] — including on a MISS that
-    /// happens during the one retry the cooldown just granted, which is what
-    /// keeps the retry rate at one attempt per cooldown rather than one per
-    /// scheduled warm tick once the account is past the limit: without
-    /// re-arming here, the very next scheduled warm would see the (now past)
-    /// old deadline and immediately re-qualify.
+    /// Re-arms the retry cooldown once at/past the limit via
+    /// [`rearm_warm_evidence_cooldown_if_excluded`] — see that function's
+    /// doc-comment for why a MISS that happens during the one retry the
+    /// cooldown just granted must re-arm it too.
     fn record_warm_without_evidence(&self, idx: usize) -> bool {
         let mut accounts = self.accounts.write().expect("accounts lock poisoned");
         let Some(account) = accounts.get_mut(idx) else {
@@ -188,11 +215,23 @@ impl Manager {
             account.consecutive_warms_without_evidence.saturating_add(1);
         let crossed =
             account.consecutive_warms_without_evidence == WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT;
-        if account.consecutive_warms_without_evidence >= WARM_ATTEMPTS_WITHOUT_EVIDENCE_LIMIT {
-            account.warm_evidence_retry_after_ms =
-                Some(crate::now_ms() + WARM_EVIDENCE_RETRY_COOLDOWN_MS);
-        }
+        rearm_warm_evidence_cooldown_if_excluded(account);
         crossed
+    }
+
+    /// The failure-path twin of [`Self::record_warm_without_evidence`]: a warm
+    /// that came back `Err` (see [`Self::warm_account`]) rather than a
+    /// header-less `Ok`. Does NOT bump `consecutive_warms_without_evidence` —
+    /// that counter's doc-comment defines it as "succeeded but carried no
+    /// evidence", and an outright failure is neither — but still re-arms the
+    /// cooldown when the account is already excluded, via
+    /// [`rearm_warm_evidence_cooldown_if_excluded`].
+    fn record_warm_failure(&self, idx: usize) {
+        let mut accounts = self.accounts.write().expect("accounts lock poisoned");
+        let Some(account) = accounts.get_mut(idx) else {
+            return;
+        };
+        rearm_warm_evidence_cooldown_if_excluded(account);
     }
 
     /// Warm ONE account, if it is still eligible at this instant.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1450,15 +1450,31 @@ async fn add_account_handler(State(manager): State<Arc<Manager>>, req: Request) 
 }
 
 /// Whether a dropped SSE tee chunk represents genuine evidence loss for the
-/// truncation classifier. `Full` means the bounded channel could not keep up
-/// with the parser — those bytes were never seen, so "no `message_stop`" is
-/// no longer trustworthy and the classifier must abstain. `Closed` means the
-/// RECEIVING side (the parser task's own `rx`-backed stream) already ended —
-/// it does not want any more bytes — which is not evidence loss at all, and
-/// treating it as such was a coverage regression: a `Closed` `try_send`
-/// (e.g. right as the parser's stream reaches its own end) used to latch
-/// `evidence_dropped` and make the classifier abstain on turns it had, in
-/// fact, fully observed.
+/// truncation classifier. This is a SEMANTIC distinction, not a defensive
+/// one: `evidence_dropped` exists to answer exactly one question — did bytes
+/// arrive from UPSTREAM that the parser never got to see? `Full` answers
+/// yes: the bounded channel could not keep up, those bytes were dropped, and
+/// "no `message_stop`" is no longer trustworthy. `Closed` answers a
+/// different question entirely — the CONSUMER (the parser task's own
+/// `rx`-backed stream) went away — and a consumer going away can never be
+/// evidence that upstream data was lost, so it must never latch the same
+/// flag. Treating it as such was a coverage regression: a `Closed`
+/// `try_send` used to make the classifier abstain on turns it had, in fact,
+/// fully observed.
+///
+/// Reachability today, read directly from the pinned `eventsource-stream`
+/// 0.2.3 source rather than assumed: its `Utf8Stream` never surfaces a UTF-8
+/// error mid-stream (an unresolved tail is buffered, not rejected, until the
+/// underlying byte stream itself reaches EOF), so `parse_sse_usage`'s
+/// malformed-frame `break` cannot fire before `rx` would have closed on its
+/// own — the specific "malformed frame closes `rx` early while upstream
+/// keeps sending" scenario this was first written to guard is not
+/// constructible through today's wiring. The predicate stays correct
+/// regardless: it guards CONSUMER-side death generally, and a parser task
+/// that exits early for some reason added later — a read timeout, an
+/// explicit cancellation, an abort at runtime shutdown — would drop `rx`
+/// while the passthrough is still actively forwarding upstream bytes, which
+/// IS reachable and hits exactly this path.
 fn is_genuine_evidence_loss<T>(err: &tokio::sync::mpsc::error::TrySendError<T>) -> bool {
     matches!(err, tokio::sync::mpsc::error::TrySendError::Full(_))
 }
@@ -3693,16 +3709,13 @@ mod tests {
     /// The other half of the malformed-frame property: `evidence_dropped`
     /// must latch on `Full` (a real dropped chunk — genuine evidence loss)
     /// and NOT on `Closed` (the parser's own `rx`-side stream already ended —
-    /// not evidence loss). Exercised directly against the extracted
-    /// predicate rather than a live race: `rx` can only close once `tx` (the
-    /// tee sender, owned by the passthrough) is already dropped, and dropping
-    /// `tx` is itself the passthrough's own terminal action — so by the time
-    /// a real `Closed` could ever be observed, the producer that would hit it
-    /// has already stopped calling `try_send`. That makes the live race this
-    /// predicate defends against effectively unreachable through today's
-    /// wiring; the predicate is still the correct, defensive contract for any
-    /// future path that closes `rx` independently, and this is what is
-    /// actually verified — not a network-level reproduction of the race.
+    /// not evidence loss). See [`is_genuine_evidence_loss`]'s doc comment for
+    /// why this is semantic, not defensive, and for why today's wiring
+    /// specifically cannot reach `Closed` via the malformed-frame path (it
+    /// remains reachable via a future consumer-side early exit — a timeout,
+    /// a cancellation, a shutdown abort). Exercised directly against the
+    /// extracted predicate rather than a network-level reproduction of a
+    /// race that this exact code path cannot currently trigger.
     #[test]
     fn evidence_loss_predicate_distinguishes_full_from_closed() {
         use tokio::sync::mpsc::error::TrySendError;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1450,31 +1450,26 @@ async fn add_account_handler(State(manager): State<Arc<Manager>>, req: Request) 
 }
 
 /// Whether a dropped SSE tee chunk represents genuine evidence loss for the
-/// truncation classifier. This is a SEMANTIC distinction, not a defensive
-/// one: `evidence_dropped` exists to answer exactly one question — did bytes
-/// arrive from UPSTREAM that the parser never got to see? `Full` answers
-/// yes: the bounded channel could not keep up, those bytes were dropped, and
-/// "no `message_stop`" is no longer trustworthy. `Closed` answers a
-/// different question entirely — the CONSUMER (the parser task's own
-/// `rx`-backed stream) went away — and a consumer going away can never be
-/// evidence that upstream data was lost, so it must never latch the same
-/// flag. Treating it as such was a coverage regression: a `Closed`
-/// `try_send` used to make the classifier abstain on turns it had, in fact,
-/// fully observed.
+/// truncation classifier. `evidence_dropped` asserts exactly one thing: that
+/// bytes arrived from UPSTREAM which the parser never got to see. `Full`
+/// answers yes — the bounded channel could not keep up, those bytes are
+/// gone, and "no `message_stop`" is no longer trustworthy. `Closed` answers
+/// a different question: the CONSUMER (the parser task's own `rx`-backed
+/// stream) went away. A consumer going away is never evidence that upstream
+/// data was lost, so it must not latch the same flag — the distinction holds
+/// no matter why `rx` closed, including a parser that later gains a read
+/// timeout, an explicit cancellation, or has its task aborted at shutdown.
 ///
-/// Reachability today, read directly from the pinned `eventsource-stream`
-/// 0.2.3 source rather than assumed: its `Utf8Stream` never surfaces a UTF-8
-/// error mid-stream (an unresolved tail is buffered, not rejected, until the
-/// underlying byte stream itself reaches EOF), so `parse_sse_usage`'s
-/// malformed-frame `break` cannot fire before `rx` would have closed on its
-/// own — the specific "malformed frame closes `rx` early while upstream
-/// keeps sending" scenario this was first written to guard is not
-/// constructible through today's wiring. The predicate stays correct
-/// regardless: it guards CONSUMER-side death generally, and a parser task
-/// that exits early for some reason added later — a read timeout, an
-/// explicit cancellation, an abort at runtime shutdown — would drop `rx`
-/// while the passthrough is still actively forwarding upstream bytes, which
-/// IS reachable and hits exactly this path.
+/// `eventsource-stream`'s `Utf8Stream` never surfaces a UTF-8 error
+/// mid-stream — an unresolved tail is buffered, not rejected, until the
+/// underlying byte stream itself reaches EOF — so `parse_sse_usage`'s
+/// malformed-frame `break` cannot close `rx` while the upstream is still
+/// sending; that specific race is not constructible through real TCP
+/// behavior. What IS reachable: a parser-side panic drops `rx` while the
+/// upstream keeps streaming, and without this split every subsequent
+/// `try_send` on that request would latch `evidence_dropped`, making the
+/// classifier silently abstain on a turn whose evidence it never actually
+/// lost — an unrelated bug quietly disabling this feature.
 fn is_genuine_evidence_loss<T>(err: &tokio::sync::mpsc::error::TrySendError<T>) -> bool {
     matches!(err, tokio::sync::mpsc::error::TrySendError::Full(_))
 }
@@ -3708,14 +3703,12 @@ mod tests {
 
     /// The other half of the malformed-frame property: `evidence_dropped`
     /// must latch on `Full` (a real dropped chunk — genuine evidence loss)
-    /// and NOT on `Closed` (the parser's own `rx`-side stream already ended —
-    /// not evidence loss). See [`is_genuine_evidence_loss`]'s doc comment for
-    /// why this is semantic, not defensive, and for why today's wiring
-    /// specifically cannot reach `Closed` via the malformed-frame path (it
-    /// remains reachable via a future consumer-side early exit — a timeout,
-    /// a cancellation, a shutdown abort). Exercised directly against the
-    /// extracted predicate rather than a network-level reproduction of a
-    /// race that this exact code path cannot currently trigger.
+    /// and NOT on `Closed` (the consumer went away — never evidence about
+    /// upstream data). See [`is_genuine_evidence_loss`]'s doc comment for why
+    /// that distinction holds independent of the malformed-frame path
+    /// specifically. Exercised directly against the extracted predicate
+    /// rather than a network-level reproduction of the race, which the
+    /// malformed-frame path alone cannot trigger.
     #[test]
     fn evidence_loss_predicate_distinguishes_full_from_closed() {
         use tokio::sync::mpsc::error::TrySendError;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -22,7 +22,6 @@
 use std::collections::{HashMap, HashSet};
 use std::convert::Infallible;
 use std::net::SocketAddr;
-use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -1450,6 +1449,20 @@ async fn add_account_handler(State(manager): State<Arc<Manager>>, req: Request) 
     }
 }
 
+/// Whether a dropped SSE tee chunk represents genuine evidence loss for the
+/// truncation classifier. `Full` means the bounded channel could not keep up
+/// with the parser — those bytes were never seen, so "no `message_stop`" is
+/// no longer trustworthy and the classifier must abstain. `Closed` means the
+/// RECEIVING side (the parser task's own `rx`-backed stream) already ended —
+/// it does not want any more bytes — which is not evidence loss at all, and
+/// treating it as such was a coverage regression: a `Closed` `try_send`
+/// (e.g. right as the parser's stream reaches its own end) used to latch
+/// `evidence_dropped` and make the classifier abstain on turns it had, in
+/// fact, fully observed.
+fn is_genuine_evidence_loss<T>(err: &tokio::sync::mpsc::error::TrySendError<T>) -> bool {
+    matches!(err, tokio::sync::mpsc::error::TrySendError::Full(_))
+}
+
 /// The catch-all proxy handler.
 async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
     let (parts, body) = req.into_parts();
@@ -2310,20 +2323,22 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
                 //
                 // A forwarded 3xx/4xx/5xx SSE body never had a `message_stop`
                 // contract to begin with — it is an error response, not a
-                // truncated turn — so nothing is classified unless the upstream
-                // actually answered 2xx.
-                if status_is_success {
-                    if let Some(kind) = stream_error {
-                        // An in-band `error` event is a POSITIVE observation —
-                        // we directly read those bytes off the wire, so it is
-                        // recorded regardless of how the tee itself ended. The
-                        // synthesized `TRUNCATED_STREAM_ERROR_KIND` is an
-                        // ABSENCE (no `message_stop` seen) rather than a
-                        // positive observation, and an absence is only
-                        // evidence when we know we saw everything there was to
-                        // see — hence the extra gate below, which the positive
-                        // case skips entirely.
-                        if kind == TRUNCATED_STREAM_ERROR_KIND {
+                // truncated turn — so the SYNTHESIZED verdict below only fires
+                // once the upstream actually answered 2xx. That status gate
+                // must scope to the synthesized branch ALONE: a genuine in-band
+                // `error` event is a positive observation read directly off
+                // the wire, independent of the response's status line, and
+                // wrapping it in the same `if` too was a coverage regression —
+                // a real error on a forwarded non-2xx body went unrecorded.
+                if let Some(kind) = stream_error {
+                    if kind == TRUNCATED_STREAM_ERROR_KIND {
+                        // The synthesized verdict is an ABSENCE (no
+                        // `message_stop` seen) rather than a positive
+                        // observation, and an absence is only evidence when we
+                        // know we saw everything there was to see — hence the
+                        // status gate plus the ended/evidence checks below,
+                        // which the positive case in the `else` skips entirely.
+                        if status_is_success {
                             let ended_naturally = ended_rx.await.is_ok();
                             let dropped = evidence_dropped_reader.load(Ordering::SeqCst);
                             if ended_naturally && !dropped {
@@ -2338,9 +2353,13 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
                                      a fabricated truncation"
                                 );
                             }
-                        } else {
-                            manager_side.record_stream_error(idx, &kind);
                         }
+                    } else {
+                        // An in-band `error` event is a POSITIVE observation —
+                        // we directly read those bytes off the wire, so it is
+                        // recorded regardless of the response status and
+                        // regardless of how the tee itself ended.
+                        manager_side.record_stream_error(idx, &kind);
                     }
                 }
             });
@@ -2357,8 +2376,12 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
             // disconnect — rather than at response-headers. See the long-form
             // comment this replaced for why `_in_flight` cannot just be a
             // handler-local.
-            struct TeeState {
-                inner: Pin<Box<dyn futures::Stream<Item = reqwest::Result<Bytes>> + Send>>,
+            // Generic over the concrete upstream stream type rather than boxed
+            // as `dyn Stream` — there is exactly one call site (below), so a
+            // trait object bought nothing but a v-table indirection and a heap
+            // allocation on every streamed response.
+            struct TeeState<S> {
+                inner: S,
                 tx: tokio::sync::mpsc::Sender<Bytes>,
                 evidence_dropped: Arc<AtomicBool>,
                 ended: Option<tokio::sync::oneshot::Sender<()>>,
@@ -2367,28 +2390,36 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
                 _in_flight: InFlightGuard,
             }
             let state = TeeState {
-                inner: Box::pin(resp.bytes_stream()),
+                inner: resp.bytes_stream(),
                 tx,
                 evidence_dropped,
                 ended: Some(ended_tx),
                 account_index: idx,
-                account_name: account_name.clone(),
+                // Moved, not cloned: this is the last use of `account_name` in
+                // this iteration — the retry loop above already re-fetches its
+                // own copy from `manager.account_name(idx)` on the next pass.
+                account_name,
                 _in_flight,
             };
             let passthrough = futures::stream::unfold(state, |mut state| async move {
                 match state.inner.next().await {
                     Some(Ok(bytes)) => {
                         // Best-effort tee: `try_send` never blocks the
-                        // passthrough. A full channel (slow/starved parser) or
-                        // a dropped receiver drops the chunk for the PARSER
-                        // only — usage counting becomes best-effort under
-                        // backpressure; the client stream forwards untouched.
-                        // Unlike before, the drop is no longer silent: it
-                        // flips `evidence_dropped` so the parser task can tell
-                        // "no message_stop" apart from "no message_stop THAT
-                        // WE COULD SEE".
-                        if state.tx.try_send(bytes.clone()).is_err() {
-                            state.evidence_dropped.store(true, Ordering::SeqCst);
+                        // passthrough. A FULL channel (slow/starved parser)
+                        // drops the chunk for the PARSER only — usage counting
+                        // becomes best-effort under backpressure; the client
+                        // stream forwards untouched. That drop is genuine
+                        // evidence loss and flips `evidence_dropped` so the
+                        // parser task can tell "no message_stop" apart from
+                        // "no message_stop THAT WE COULD SEE". A CLOSED
+                        // receiver is a different thing entirely — the parser
+                        // task's own `rx`-side stream already ended and it does
+                        // not want any more bytes — so it must not poison the
+                        // verdict the same way; see [`is_genuine_evidence_loss`].
+                        if let Err(err) = state.tx.try_send(bytes.clone()) {
+                            if is_genuine_evidence_loss(&err) {
+                                state.evidence_dropped.store(true, Ordering::SeqCst);
+                            }
                         }
                         Some((Ok(bytes), state))
                     }
@@ -2968,11 +2999,23 @@ fn usage_from_json(bytes: &[u8]) -> ParsedUsage {
 /// one that carries an in-band `error` event, so it gets the same treatment:
 /// `stream_error` is set, this time to the fixed kind [`TRUNCATED_STREAM_ERROR_KIND`],
 /// UNLESS an `error` event already explained the failure (that one names a
-/// root cause; this one only names the absence of proof the turn finished) —
-/// OR `message_start` never arrived either, because then this was never
-/// observed to be a Messages turn in the first place (a non-2xx SSE error
-/// body or a non-Messages endpoint that happens to share the content-type has
-/// no `message_stop` contract to begin with, so its absence proves nothing).
+/// root cause; this one only names the absence of proof the turn finished).
+///
+/// The remaining case is a stream that never saw `message_start` — this used
+/// to suppress the verdict unconditionally, on the theory that such a stream
+/// was "never confirmed to be a Messages turn" (a non-2xx SSE error body, a
+/// HEAD response, or a future non-Messages endpoint sharing the content-type).
+/// That conflated two shapes that are NOT the same: a stream cut off before
+/// its first parseable event (zero events observed at all — `!saw_any_event`)
+/// and a stream that genuinely produced OTHER events but none of them
+/// `message_start` (`saw_any_event && !saw_message_start`). Only the second
+/// one is evidence the stream was never a Messages turn; the first is
+/// indistinguishable from a Messages turn severed before `message_start` ever
+/// arrived — the single worst case this classifier exists to catch, since it
+/// otherwise records nothing at all. So the verdict fires when `message_start`
+/// was seen (truncated mid-turn) OR nothing was ever seen (severed before the
+/// first event) — and stays silent only when events arrived that affirmatively
+/// were not `message_start`.
 async fn parse_sse_usage<S, B, E>(stream: S) -> (ParsedUsage, Option<String>)
 where
     S: futures::Stream<Item = Result<B, E>>,
@@ -2983,6 +3026,7 @@ where
 
     let mut parsed = ParsedUsage::default();
     let mut stream_error: Option<String> = None;
+    let mut saw_any_event = false;
     let mut saw_message_start = false;
     let mut saw_message_stop = false;
     while let Some(item) = events.next().await {
@@ -2992,6 +3036,7 @@ where
         if event.data.is_empty() {
             continue;
         }
+        saw_any_event = true;
         let Ok(value) = serde_json::from_str::<Value>(&event.data) else {
             continue;
         };
@@ -3034,11 +3079,16 @@ where
     }
     // The loop exited — either the upstream closed cleanly after `message_stop`,
     // or it stopped short. No terminator and no more specific error already
-    // recorded means the turn's ending was never observed: that IS truncation
-    // — but only for a stream that was ever confirmed to BE a Messages turn.
-    // Without `saw_message_start`, "no message_stop" is not evidence of
-    // anything (see the doc comment above).
-    if saw_message_start && !saw_message_stop && stream_error.is_none() {
+    // recorded means the turn's ending was never observed: that IS truncation,
+    // for either of two shapes — `message_start` was seen (a confirmed Messages
+    // turn that never reached its terminator) or NOTHING was ever seen at all
+    // (`!saw_any_event`, severed before the stream produced a single event —
+    // indistinguishable from a Messages turn cut off before `message_start`,
+    // so it gets the same verdict rather than a silent pass). The one case
+    // that stays silent is events having arrived that affirmatively were not
+    // `message_start` — that is the actual proof this was never a Messages
+    // turn (see the doc comment above).
+    if !saw_message_stop && stream_error.is_none() && (saw_message_start || !saw_any_event) {
         stream_error = Some(TRUNCATED_STREAM_ERROR_KIND.to_string());
     }
     (parsed, stream_error)
@@ -3551,23 +3601,118 @@ mod tests {
     }
 
     /// FALSE-POSITIVE case #3 (contract-derived, not a path allowlist): a
-    /// stream that never sent `message_start` was never confirmed to BE a
-    /// Messages turn in the first place — a forwarded 3xx/4xx/5xx SSE error
-    /// body, a HEAD response, or a future non-Messages endpoint that happens
-    /// to share `text/event-stream` all look like this from inside
-    /// `parse_sse_usage`. Before the `saw_message_start` gate, the absence of
-    /// `message_stop` alone was enough to synthesize `"truncated"` here; an
-    /// empty stream would have been misclassified on every such request.
+    /// stream that PRODUCED events but none of them `message_start` was
+    /// never confirmed to BE a Messages turn in the first place — a future
+    /// non-Messages endpoint that happens to share `text/event-stream` looks
+    /// exactly like this from inside `parse_sse_usage`. This is the only
+    /// shape that earns the exemption. A round-4 fix (see the sibling test
+    /// below) narrowed this from "no message_start" to "no message_start
+    /// AND at least one other event arrived" — a stream with ZERO events is
+    /// a different, indistinguishable-from-severed-early shape and must NOT
+    /// share this exemption; conflating the two was exactly the round-4 bug.
     #[tokio::test]
-    async fn sse_stream_with_no_message_start_records_no_stream_error() {
-        let stream = futures::stream::iter(Vec::<Result<Bytes, Infallible>>::new());
+    async fn sse_stream_with_non_message_events_records_no_stream_error() {
+        // A heartbeat-shaped event, never `message_start` — stands in for a
+        // non-Messages endpoint that happens to emit `text/event-stream`.
+        let full = concat!("event: heartbeat\n", "data: {\"type\":\"heartbeat\"}\n\n",);
+        let stream = futures::stream::iter(vec![Ok::<Bytes, Infallible>(Bytes::from(full))]);
         let (parsed, stream_error) = parse_sse_usage(stream).await;
         assert_eq!(parsed, ParsedUsage::default());
         assert_eq!(
             stream_error, None,
-            "a stream that never confirmed itself as a Messages turn (no \
-             message_start) must not be classified as truncated just because \
-             it also has no message_stop"
+            "a stream that produced events but none of them message_start \
+             was genuinely never a Messages turn — it must not be classified \
+             as truncated just because it also has no message_stop"
+        );
+    }
+
+    /// THE SEVEREST case this classifier exists to catch (round-4 fix): a
+    /// stream cut off BEFORE its first parseable event ever arrives. Before
+    /// this fix, `saw_message_start` gated the verdict on its own, so this
+    /// looked IDENTICAL to the sibling test above — zero events either way —
+    /// and a 2xx Messages turn severed before `message_start` recorded
+    /// NOTHING: zero content delivered to the client, `tcr status` showing a
+    /// perfectly healthy account. That is precisely "a truncated turn booked
+    /// as a clean serve," the bug this whole feature exists to catch. The
+    /// fix keys on `saw_any_event` instead of `saw_message_start` alone: zero
+    /// events is indistinguishable from a Messages turn severed early, so it
+    /// gets the SAME verdict as the confirmed-truncated case, not the
+    /// not-a-Messages-turn exemption above.
+    #[tokio::test]
+    async fn sse_stream_severed_before_any_event_records_truncation() {
+        let stream = futures::stream::iter(Vec::<Result<Bytes, Infallible>>::new());
+        let (parsed, stream_error) = parse_sse_usage(stream).await;
+        assert_eq!(parsed, ParsedUsage::default());
+        assert_eq!(
+            stream_error.as_deref(),
+            Some(TRUNCATED_STREAM_ERROR_KIND),
+            "a stream that produced ZERO parseable events before ending must \
+             be treated as truncated, not silently passed — it is \
+             indistinguishable from a Messages turn severed before \
+             message_start ever arrived"
+        );
+    }
+
+    /// MUST-RECORD: "a malformed/utf8 frame that ends parsing mid-turn ⇒
+    /// truncation, not abstention." `eventsource-stream` 0.2.3's `Utf8Stream`
+    /// never surfaces a UTF-8 error MID-stream (it buffers an unresolved
+    /// tail hoping the next chunk completes it) — the error only surfaces
+    /// once the underlying byte stream ends with that tail still unresolved
+    /// (verified by reading `utf8_stream.rs`: mid-stream `Ok` is returned
+    /// unconditionally; `Err` is only constructed in the `Poll::Ready(None)`
+    /// arm). So "malformed frame" and "stream end" are the same moment here
+    /// — this fixture reproduces that: a confirmed `message_start`, then one
+    /// byte (`0xFF`) that can never resolve into valid UTF-8 no matter what
+    /// follows, and nothing follows. `parse_sse_usage`'s `break` on that `Err`
+    /// must still leave `saw_message_start` set, so the post-loop check
+    /// classifies it exactly like the ordinary "no message_stop" case.
+    #[tokio::test]
+    async fn sse_stream_with_malformed_utf8_after_message_start_records_truncation() {
+        let head = concat!(
+            "event: message_start\n",
+            "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\
+             \"input_tokens\":5,\"output_tokens\":1}}}\n\n",
+        );
+        let chunks = vec![
+            Ok::<Bytes, Infallible>(Bytes::from(head)),
+            Ok::<Bytes, Infallible>(Bytes::copy_from_slice(&[0xFFu8])),
+        ];
+        let (parsed, stream_error) = parse_sse_usage(futures::stream::iter(chunks)).await;
+        assert_eq!(
+            parsed.input_total, 5,
+            "usage from message_start is retained even though the stream ends malformed"
+        );
+        assert_eq!(
+            stream_error.as_deref(),
+            Some(TRUNCATED_STREAM_ERROR_KIND),
+            "a confirmed Messages turn that ends on an unresolvable malformed \
+             byte must be treated as truncated, not silently abstained"
+        );
+    }
+
+    /// The other half of the malformed-frame property: `evidence_dropped`
+    /// must latch on `Full` (a real dropped chunk — genuine evidence loss)
+    /// and NOT on `Closed` (the parser's own `rx`-side stream already ended —
+    /// not evidence loss). Exercised directly against the extracted
+    /// predicate rather than a live race: `rx` can only close once `tx` (the
+    /// tee sender, owned by the passthrough) is already dropped, and dropping
+    /// `tx` is itself the passthrough's own terminal action — so by the time
+    /// a real `Closed` could ever be observed, the producer that would hit it
+    /// has already stopped calling `try_send`. That makes the live race this
+    /// predicate defends against effectively unreachable through today's
+    /// wiring; the predicate is still the correct, defensive contract for any
+    /// future path that closes `rx` independently, and this is what is
+    /// actually verified — not a network-level reproduction of the race.
+    #[test]
+    fn evidence_loss_predicate_distinguishes_full_from_closed() {
+        use tokio::sync::mpsc::error::TrySendError;
+        assert!(
+            is_genuine_evidence_loss(&TrySendError::Full(())),
+            "a full channel is genuine evidence loss — the parser never saw those bytes"
+        );
+        assert!(
+            !is_genuine_evidence_loss(&TrySendError::Closed(())),
+            "a closed receiver is the parser's own exit, not evidence loss"
         );
     }
 
@@ -7040,6 +7185,146 @@ mod tests {
             0,
             "a forwarded 400 body missing message_stop is an error response, \
              not a truncated Messages turn — it must not be classified"
+        );
+    }
+
+    /// End-to-end version of `sse_stream_severed_before_any_event_records_truncation`
+    /// above: a 2xx `text/event-stream` response that closes with an EMPTY
+    /// body — no bytes at all, so `parse_sse_usage` sees zero events — must
+    /// be recorded as truncated through the FULL pipeline, including the
+    /// `status_is_success` / `ended_naturally` / `evidence_dropped` gates the
+    /// unit-level test above never exercises. This is the severest live
+    /// regression named in the round-4 review: before the fix, this exact
+    /// shape recorded NOTHING — zero content delivered to the client, and
+    /// the account looked perfectly healthy.
+    #[tokio::test]
+    async fn sse_stream_severed_before_message_start_is_recorded_as_truncated_e2e() {
+        let upstream = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let up_addr = upstream.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = upstream.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut buf = [0u8; 1024];
+                    let _ = sock.read(&mut buf).await;
+                    // Headers claim an SSE body, then the connection closes
+                    // having sent NOT ONE byte of it — severed before the
+                    // stream could ever produce its first parseable event.
+                    let response = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: 0\r\nconnection: close\r\n\r\n";
+                    let _ = sock.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+
+        let manager =
+            Manager::with_live_refresher(dummy_config(None, &format!("http://{up_addr}")), None);
+
+        let proxy = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = proxy.local_addr().unwrap();
+        let served = Arc::clone(&manager);
+        tokio::spawn(async move {
+            let _ = axum::serve(proxy, app(served)).await;
+        });
+
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let resp = client
+            .post(format!("http://{proxy_addr}/v1/messages"))
+            .body("{}")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+        let _ = resp.bytes().await.unwrap();
+
+        let (seen, polls) = poll_stream_error_count(&manager, 1).await;
+        assert_eq!(
+            seen, 1,
+            "polled {polls} times, stream-error count stayed {seen} — a 2xx \
+             SSE stream severed before its first event must be recorded as \
+             truncated, not booked as a clean serve"
+        );
+        assert_eq!(
+            manager.snapshot(OffsetDateTime::now_utc()).accounts[0]
+                .last_stream_error
+                .as_deref(),
+            Some(TRUNCATED_STREAM_ERROR_KIND)
+        );
+    }
+
+    /// MUST-RECORD: "an in-band `error` event, at ANY status, always." This is
+    /// the live regression from `status_is_success` wrapping BOTH the
+    /// synthesized-truncation branch and the positive-observation branch: a
+    /// genuine `error` event forwarded inside a NON-2xx body used to be
+    /// silently dropped, a coverage regression versus before the truncation
+    /// feature existed at all. Same fixture shape as
+    /// `sse_error_event_is_observed_not_counted_as_clean_serve` (a 200), this
+    /// time on a 400 — proving the status gate no longer reaches the positive
+    /// case.
+    #[tokio::test]
+    async fn in_band_error_on_non_2xx_is_recorded_regardless_of_status() {
+        let upstream = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let up_addr = upstream.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = upstream.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut buf = [0u8; 1024];
+                    let _ = sock.read(&mut buf).await;
+                    let body = concat!(
+                        "event: error\n",
+                        "data: {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"bad\"}}\n\n",
+                    );
+                    let response = format!(
+                        "HTTP/1.1 400 Bad Request\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = sock.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+
+        let manager =
+            Manager::with_live_refresher(dummy_config(None, &format!("http://{up_addr}")), None);
+
+        let proxy = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = proxy.local_addr().unwrap();
+        let served = Arc::clone(&manager);
+        tokio::spawn(async move {
+            let _ = axum::serve(proxy, app(served)).await;
+        });
+
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let resp = client
+            .post(format!("http://{proxy_addr}/v1/messages"))
+            .body("{}")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), reqwest::StatusCode::BAD_REQUEST);
+        let _ = resp.bytes().await.unwrap();
+
+        let (seen, polls) = poll_stream_error_count(&manager, 1).await;
+        assert_eq!(
+            seen, 1,
+            "polled {polls} times, stream-error count stayed {seen} — an \
+             in-band SSE error event must be observed on a forwarded non-2xx \
+             body too, not just on 200"
+        );
+        assert_eq!(
+            manager.snapshot(OffsetDateTime::now_utc()).accounts[0]
+                .last_stream_error
+                .as_deref(),
+            Some("invalid_request_error"),
+            "the recorded kind must be the POSITIVE observation read off the \
+             wire, never the synthesized \"truncated\" kind — this path must \
+             not go anywhere near the status_is_success gate"
         );
     }
 


### PR DESCRIPTION
Follow-up to #78. That PR's five changes each introduced a defect of the same shape: a fix that closed its reported symptom and reopened it one level out, with a test that proved the fix worked and did not re-check the property next to it. This closes all five.

## The truncation classifier suppressed the cases it exists to catch

Three gates added in #78 to remove false positives went too far.

`saw_message_start` deleted detection of the **severest** case — a 2xx SSE stream severed before any parseable event, where the client gets nothing at all and the account reads as perfectly healthy. The gate conflated "severed before the first event" with "never a Messages turn"; both looked like zero events. These are distinguishable and now are: a severed stream produces **zero** events, while a non-Messages stream produces events that simply are not `message_start`. The condition is now `saw_message_start || !saw_any_event`.

`status_is_success` wrapped both branches, so a genuine in-band `error` event on a forwarded non-2xx body was discarded — worse coverage than before the feature existed, while the comment beside it claimed positive observations were "recorded regardless". It now gates only the synthesized truncation verdict; a positive observation read off the wire is recorded at any status.

`evidence_dropped` latched on any `try_send` failure including `Closed`. `Full` means upstream bytes were lost and the classifier must abstain; `Closed` means the consumer went away, which can never answer that question. Split via `is_genuine_evidence_loss`.

One existing test had to change, and the reason is worth stating: `sse_stream_with_no_message_start_records_no_stream_error` fed an **empty** stream — exactly the shape that must now record truncation. It encoded the bug. It is rewritten with a non-`message_start` event, the correct fixture for that exemption, with a sibling test covering the severed case so the two shapes stay apart.

## The lock-poisoning fix had moved the poison, not removed it

#78 moved the client build out of the `accounts` write lock. But `add_or_update_account` takes `config_write` at entry, and the build sat inside it — so a `build_serving_client()` panic poisoned `config_write` instead. That is the worse of the two: `persist_tokens` and `persist_now` both take it, so rotated refresh tokens would stop reaching disk and every later login would panic before doing any work. The test asserted only that the `accounts` lock survived — it checked the lock that was fixed, not the one the problem moved to.

`add_or_update_account` is now a bounded two-attempt loop. Attempt one resolves under both locks and, if the account is new and no runtime is ready, mutates **nothing** and reports that a build is needed. Both guards are then released, the runtime is built holding no lock, and attempt two resolves again from scratch. An ordinary re-auth resolves Updated on the first attempt and never builds a client at all.

This preserves the module's N2 guarantee: the winning attempt still holds `config_write` unbroken across resolve → mutate → persist, and a bailed attempt is a pure read whose only carry-over is the built client, every field of which derives from the submitted account rather than from fleet state. The two pre-existing 200-round N2 stress tests exercise this new path deterministically — a brand-new identity always takes the bail — and both pass.

The test now asserts **both** locks survive an injected build panic.

## The warm cooldown was defeated on the failure path

The retry cooldown was armed only from the succeeded-without-evidence branch. A warm that outright failed left an already-elapsed deadline in place, so the account was re-admitted on every pass and the "one bounded retry per cooldown" property collapsed back to "every tick" — the unbounded repeat it was added to prevent. A failing retry now re-arms the cooldown without bumping the evidence-miss counter, which means something narrower.

## Verification

Every new assertion was watched failing first, with the fix reverted in isolation to confirm the failure was the expected one. `cargo fmt --all --check`, `cargo clippy --all-targets --locked -- -D warnings`, `cargo test --all --locked` all exit 0; 678 tests pass.

Known gaps, stated rather than papered over: no test runs concurrent adds of two **distinct** new identities comparing live order against on-disk order (order agreement holds by mutual exclusion, and affinity persists identities rather than indices, so the consequence is small); and the discarded-evidence path is covered by a predicate-level test rather than by overflowing the real channel, which would be flaky.
