### PR TITLE
fix: make dead-credential accounts legible and re-login targetable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaude-rs"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -635,11 +635,32 @@ struct AccountRow: View {
     /// it is the normal state of twelve of thirteen rows, and colouring the
     /// unremarkable case would spend the panel's colour budget on it. Colour
     /// stays with quota, which is the thing worth scanning for.
+    ///
+    /// This pill answers ONE question — can this account be picked for
+    /// traffic — and there are two independent ways for the answer to be no:
+    /// `disabled` (an operator's own choice) and `account.health ==
+    /// .needsRelogin` (`src/manager/select.rs:931` hard-excludes an
+    /// `AccountStatus::Error` account from selection exactly like a disabled
+    /// one, even though `disabled` itself reads false). Drawing "rotating" on
+    /// a broken row would assert the opposite of the NEEDS RE-LOGIN pill
+    /// drawn beside it — precisely the "misread as its own opposite" defect
+    /// this pill exists to kill, just with the second cause substituted for
+    /// the first.
+    ///
+    /// A broken row draws NEITHER "rotating" nor "parked": "parked" claims an
+    /// operator decision that never happened, and "rotating" claims traffic
+    /// can land here, which `select.rs` refuses. Silence is the case this
+    /// pill was rewritten to avoid, but the reason silence used to be
+    /// dangerous was that nothing nearby said the row could not serve — here
+    /// the red NEEDS RE-LOGIN pill already says exactly that, unambiguously,
+    /// so a second pill would only have two ways left to be wrong.
     @ViewBuilder
     private var rotationPill: some View {
         if account.disabled {
             StatusPill("parked", tint: Tok.disabled)
                 .help("Out of the rotation — `tcr` sends this account no traffic.")
+        } else if account.health == .needsRelogin {
+            EmptyView()
         } else {
             StatusPill("rotating", tint: Tok.inkFaint)
                 .help("In the rotation — this account can be picked for traffic.")
@@ -657,8 +678,20 @@ struct AccountRow: View {
         var parts = [account.name]
         // Spoken in both directions, for the same reason the pill is drawn in
         // both: silence is not a state, and a VoiceOver user has even less to
-        // infer it from than a sighted one.
-        parts.append(account.disabled ? "parked, out of rotation" : "rotating")
+        // infer it from than a sighted one. A broken row says neither
+        // "rotating" nor "parked" — same reason `rotationPill` draws neither:
+        // `disabled` reads false, so "parked" would claim an operator
+        // decision that never happened, and "rotating" would claim traffic
+        // can land here, which `src/manager/select.rs:931` refuses exactly
+        // like a disabled account. The detail below already names the real
+        // cause, so this element is not left silent either.
+        if account.disabled {
+            parts.append("parked, out of rotation")
+        } else if account.health == .needsRelogin {
+            parts.append("not in rotation")
+        } else {
+            parts.append("rotating")
+        }
         // Mirrors the pill's three cases. A VoiceOver user hearing "never
         // probed" about an account whose probe errored is told the same wrong
         // cause a sighted user was, with less to correct it from.
@@ -667,8 +700,7 @@ struct AccountRow: View {
         // is the same wrong cause a sighted user was told, with less to correct
         // it from.
         if account.health == .needsRelogin {
-            parts.append(
-                "needs re-login, refresh token rejected, out of rotation until re-login")
+            parts.append("refresh token rejected, re-login to restore traffic")
         } else if account.hasQuotaEvidence {
             parts.append("\(account.quotaState.token), \(QuotaFormat.percent(account.quota)) used")
         } else if account.probeStatus.isFailure {

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -912,15 +912,17 @@ struct AccountRow: View {
         }
     }
 
-    /// Hands `tcr login` to a Terminal window, hinting at this account's name.
-    /// Drawn on a `.needsRelogin` row only, beside ``toggleButton``.
+    /// Hands `tcr login --account <name>` to a Terminal window, targeting THIS
+    /// row's account. Drawn on a `.needsRelogin` row only, beside
+    /// ``toggleButton``.
     ///
-    /// `tcr login` takes no account argument — it upserts by the profile
-    /// identity the browser hands back — so this cannot re-authenticate the
-    /// row directly; it only opens the same flow ``addAccount()`` does, with a
-    /// name in the Terminal echo so the operator knows which browser account
-    /// to pick. `.accessibilityLabel` says exactly that, not "Re-login" alone,
-    /// which would promise more than a click here can do.
+    /// `--account` (`src/main.rs` / `src/oauth.rs`'s `login_hint`) requests
+    /// that specific identity and refuses to write anything if the browser
+    /// hands back a different one — this app used to say `tcr login` could
+    /// not be targeted at all, which stopped being true the moment that flag
+    /// shipped. Untargeted, the row's click could authenticate as whichever
+    /// account happened to be signed into the browser; targeted, a mismatch
+    /// refuses rather than overwriting the wrong account's credentials.
     private var reloginButton: some View {
         Button("Re-login…") { onRelogin() }
             .buttonStyle(.bordered)
@@ -928,9 +930,9 @@ struct AccountRow: View {
             .font(Tok.detailFont)
             .accessibilityLabel("Re-login \(account.name)")
             .help(
-                "Opens `tcr login` in a Terminal window for this account. The "
-                    + "browser account you choose is what actually gets logged in — "
-                    + "`tcr login` takes no account argument."
+                "Opens `tcr login --account` in a Terminal window, requesting "
+                    + "this exact account. `tcr` refuses to save if the browser "
+                    + "hands back a different one."
             )
     }
 

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -602,15 +602,57 @@ struct AccountRow: View {
     /// `.needsRelogin` row.
     let onRelogin: () -> Void
 
-    /// The single tint for this row's quota evidence. The pill and the bar both
-    /// read it, so the two can never disagree about whether a quota is known.
+    /// The single tint for this row's quota evidence. The bar and the
+    /// percentage run both read it, so the two can never disagree about
+    /// whether a quota is known — or, now, about whether it is still LIVE.
     ///
     /// `Tok.unmeasured`, not `Tok.unknown`: `FleetTally.Kind` documents these as
     /// deliberately separate — "a quota state this build cannot name" is not the
     /// same fact as "no quota state at all", and colouring them alike re-merges
     /// exactly what the optional model exists to keep apart.
+    ///
+    /// `.needsRelogin` is checked FIRST, ahead of `hasQuotaEvidence`, for a
+    /// reason that is not cosmetic. A broken account that died AFTER being
+    /// probed keeps its last-learned `quota` and `quotaState` — often `.ok` —
+    /// so `Tok.color(for: .ok)` would draw the SAME green a genuinely healthy
+    /// row draws. Green in this palette means "you can work right now"; this
+    /// account's apparent headroom is unreachable until re-login
+    /// (`src/manager/select.rs:931` sends it nothing), so drawing it green
+    /// overclaims exactly the way an unfilled bar overclaims for a nil
+    /// reading — the same reason `QuotaBar`'s own doc-comment makes a nil
+    /// draw DASHED rather than empty. Stale-versus-live is that distinction
+    /// one step over, and this row already committed to the principle.
+    ///
+    /// Neither existing hue fits the stale case. `Tok.unmeasured` is spoken
+    /// for by "never probed" — reusing it re-merges the two causes this
+    /// branch spent three rounds separating. Dashed/`Tok.unknown` would claim
+    /// no reading exists, which misattributes the cause exactly like the grey
+    /// `unmeasured` pill did before this branch started. Red (`Tok.spent`,
+    /// already worn by the pill and the status word on this row) would claim
+    /// the quota is EXHAUSTED, a different and equally false fact — the
+    /// number is real and is not zero. `Tok.disabled` is the closest existing
+    /// token in MEANING ("this row is not in play") even though its literal
+    /// cause (an operator's own choice) is not this row's cause; it is reused
+    /// rather than adding a colour, since this repo's palette is generated
+    /// and gated on WCAG contrast, and a new token is a heavier change than
+    /// muting a stale reading needs.
     private var quotaTint: Color {
-        account.hasQuotaEvidence ? Tok.color(for: account.quotaState) : Tok.unmeasured
+        if hasStaleQuotaReading { return Tok.disabled }
+        return account.hasQuotaEvidence ? Tok.color(for: account.quotaState) : Tok.unmeasured
+    }
+
+    /// True for exactly the shape this whole round exists to demote: a
+    /// broken account that has a REAL last-learned quota reading, not an
+    /// absent one. Gated on `hasQuotaEvidence` as well as `health`, not
+    /// `health` alone — a broken account that was NEVER probed (the `04b`
+    /// scene) has nothing filled to overclaim with: its bar is already the
+    /// dashed "no reading" outline, unambiguous regardless of colour, and
+    /// its percentage already reads "n/a". Recolouring either would be a
+    /// change with nothing behind it, and `04b` stays byte-identical because
+    /// this stays false for it. Shared by `quotaTint`, the bar's `.help`, and
+    /// the two percentage runs, so all four demote together or not at all.
+    private var hasStaleQuotaReading: Bool {
+        account.health == .needsRelogin && account.hasQuotaEvidence
     }
 
     /// Whether this account is in the rotation, said in BOTH directions.
@@ -714,7 +756,24 @@ struct AccountRow: View {
         // is the same wrong cause a sighted user was told, with less to correct
         // it from.
         if account.health == .needsRelogin {
-            parts.append("refresh token rejected, re-login to restore traffic")
+            // The spoken half of the same fix as `quotaTint`: dropping the
+            // number here (as an earlier round of this did) under-informs a
+            // VoiceOver user exactly where a sighted one still sees a muted
+            // bar and grey digits — deleting real information rather than
+            // demoting it. `hasQuotaEvidence` is false on the never-probed
+            // shape (the `04b` scene), where there truly is no number to
+            // qualify, so only the probed-then-broken shape (`04c`) gets the
+            // longer phrase.
+            if account.hasQuotaEvidence {
+                parts.append(
+                    "refresh token rejected, re-login to restore traffic. Last "
+                        + "reading before rejection: \(account.quotaState.token), "
+                        + "\(QuotaFormat.percent(account.quota)) used — unreachable "
+                        + "until re-login"
+                )
+            } else {
+                parts.append("refresh token rejected, re-login to restore traffic")
+            }
         } else if account.hasQuotaEvidence {
             parts.append("\(account.quotaState.token), \(QuotaFormat.percent(account.quota)) used")
         } else if account.probeStatus.isFailure {
@@ -826,16 +885,34 @@ struct AccountRow: View {
                 }
             }
             QuotaBar(fraction: account.quota, tint: quotaTint)
+                // Sighted-hover half of the same fix `quotaTint` makes for the
+                // fill colour: a muted bar alone can still read as "just a
+                // dim healthy bar" rather than "not live" without a word
+                // saying so on hover.
+                .help(
+                    hasStaleQuotaReading
+                        ? "The last reading taken before the credential was rejected. "
+                            + "This headroom is unreachable until you re-login."
+                        : ""
+                )
             HStack(spacing: Tok.tightSpacing) {
                 Text(QuotaFormat.percent(account.quota))
                     .font(Tok.secondaryDigitFont)
-                    .foregroundStyle(.secondary)
+                    // Demoted alongside the bar, not left `.secondary`: the
+                    // eye should group these digits as historical rather than
+                    // live, the same distinction `quotaTint` draws for the
+                    // fill. The number itself is unchanged — it is still
+                    // true, just no longer reachable.
+                    .foregroundStyle(hasStaleQuotaReading ? Tok.disabled : .secondary)
                 Text(
                     "· 5h \(QuotaFormat.percent(account.fiveHour)) "
                         + "· 7d \(QuotaFormat.percent(account.sevenDay))"
                 )
                 .font(Tok.secondaryDigitFont)
-                .foregroundStyle(.secondary)
+                // Same demotion as the leading percentage — one run reading
+                // live and the other historical would be its own new
+                // contradiction inside a single line.
+                .foregroundStyle(hasStaleQuotaReading ? Tok.disabled : .secondary)
                 Spacer()
                 // `status` is the account's own field and it keeps saying
                 // "active" while `disabled` is true — verified against live

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -290,7 +290,7 @@ struct FleetView: View {
             // Used to be disabled while a proxy served the port, enforcing a
             // `tcr login` refusal that stopped existing 2026-08-11 (`a385f0f`,
             // "feat: route tcr login through a live proxy instead of
-            // refusing"): `login_route` (src/oauth.rs:953-997) now probes the
+            // refusing"): `login_route` (src/oauth.rs:966-1010) now probes the
             // running proxy and, when it is a modern build, routes the
             // finished credential *through* the server instead of refusing.
             // Gil runs a modern proxy, so the gate this button enforced no
@@ -637,23 +637,32 @@ struct AccountRow: View {
     /// stays with quota, which is the thing worth scanning for.
     ///
     /// This pill answers ONE question — can this account be picked for
-    /// traffic — and there are two independent ways for the answer to be no:
-    /// `disabled` (an operator's own choice) and `account.health ==
+    /// traffic — and there are at least THREE independent ways for the
+    /// answer to be no, only two of which this build can currently see:
+    /// `disabled` (an operator's own choice), `account.health ==
     /// .needsRelogin` (`src/manager/select.rs:931` hard-excludes an
     /// `AccountStatus::Error` account from selection exactly like a disabled
-    /// one, even though `disabled` itself reads false). Drawing "rotating" on
-    /// a broken row would assert the opposite of the NEEDS RE-LOGIN pill
-    /// drawn beside it — precisely the "misread as its own opposite" defect
-    /// this pill exists to kill, just with the second cause substituted for
-    /// the first.
+    /// one, even though `disabled` itself reads false), and a THIRD gate this
+    /// pill cannot yet name: `select.rs:809-822` also excludes an account
+    /// whose `quota.status == Some("rejected")` — Anthropic's own verdict —
+    /// while the snapshot `status` this app decodes stays `"active"`
+    /// (`snapshot.rs:142-153` only ever rewrites `Throttled`). Drawing
+    /// "rotating" on THAT row is the same "misread as its own opposite"
+    /// defect the first two gates were fixed for, and TcrBar currently has no
+    /// way to catch it: `tcr status --json` emits no gate field at all. A
+    /// server-side `GateReason` in the status payload is the fix, tracked
+    /// through the lead rather than added here — decode it as an OPTIONAL
+    /// field when it lands, so an older server (absent field) degrades to
+    /// today's behaviour and never to a false claim in either direction.
     ///
-    /// A broken row draws NEITHER "rotating" nor "parked": "parked" claims an
-    /// operator decision that never happened, and "rotating" claims traffic
-    /// can land here, which `select.rs` refuses. Silence is the case this
-    /// pill was rewritten to avoid, but the reason silence used to be
-    /// dangerous was that nothing nearby said the row could not serve — here
-    /// the red NEEDS RE-LOGIN pill already says exactly that, unambiguously,
-    /// so a second pill would only have two ways left to be wrong.
+    /// A row broken by the SECOND gate draws NEITHER "rotating" nor "parked":
+    /// "parked" claims an operator decision that never happened, and
+    /// "rotating" claims traffic can land here, which `select.rs` refuses.
+    /// Silence is the case this pill was rewritten to avoid, but the reason
+    /// silence used to be dangerous was that nothing nearby said the row
+    /// could not serve — here the red NEEDS RE-LOGIN pill already says
+    /// exactly that, unambiguously, so a second pill would only have two ways
+    /// left to be wrong.
     @ViewBuilder
     private var rotationPill: some View {
         if account.disabled {
@@ -663,7 +672,12 @@ struct AccountRow: View {
             EmptyView()
         } else {
             StatusPill("rotating", tint: Tok.inkFaint)
-                .help("In the rotation — this account can be picked for traffic.")
+                .help(
+                    "In the rotation — this account can be picked for traffic, as "
+                        + "far as this build can tell. A quota rejection from "
+                        + "Anthropic can also exclude an account without changing "
+                        + "its status; TcrBar cannot see that gate yet."
+                )
         }
     }
 

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -199,7 +199,8 @@ struct FleetView: View {
                     account: account,
                     countersAreStructural: fleet.source.countersAreStructural,
                     accounts: accounts,
-                    onChanged: { await poller.pollOnce() }
+                    onChanged: { await poller.pollOnce() },
+                    onRelogin: { reloginAccount(account.name) }
                 )
             }
         }
@@ -286,33 +287,28 @@ struct FleetView: View {
                 Button("Start server") { server.start() }
             }
             Button("Refresh") { Task { await poller.pollOnce() } }
-            // Disabled while a proxy is serving, for the same reason
-            // "Take over port…" is disabled while we supervise one: the click
-            // cannot succeed, so offering it is a promise the panel cannot keep.
+            // Used to be disabled while a proxy served the port, enforcing a
+            // `tcr login` refusal that stopped existing 2026-08-11 (`a385f0f`,
+            // "feat: route tcr login through a live proxy instead of
+            // refusing"): `login_route` (src/oauth.rs:953-997) now probes the
+            // running proxy and, when it is a modern build, routes the
+            // finished credential *through* the server instead of refusing.
+            // Gil runs a modern proxy, so the gate this button enforced no
+            // longer applies to the only case that matters here — and a
+            // disabled button in front of a working flow is a worse defect
+            // than an occasional refusal from an older `tcr`.
             //
-            // `tcr login` refuses outright when something holds the port — the
-            // server's next token refresh would overwrite the credentials the
-            // login just wrote. That refusal is correct. What was wrong is that
-            // the panel offered the button anyway, with the reason in a `.help`
-            // tooltip nobody hovers before clicking, so the flow was: click,
-            // watch a Terminal open, read an error, work out the remedy
-            // yourself. Reported from live use, which is the only way it
-            // surfaces — the button renders identically either way, so no
-            // screenshot and no `--render-states` scene could show it.
-            //
-            // The remedy is two clicks away and both are in this footer, so the
-            // help names them rather than describing the failure.
+            // An older proxy still refuses, but it does so BEFORE any browser
+            // opens, and its message names the remedy — which is useful only
+            // if a human can read it, which is exactly what the Terminal
+            // hand-off gives them.
             Button("Add account…") { addAccount() }
-                .disabled(proxyHoldsThePort)
                 .help(
-                    proxyHoldsThePort
-                        ? "A proxy is serving on the port. `tcr login` refuses "
-                            + "while that is true, because the server's next token "
-                            + "refresh would overwrite the new credentials. Stop "
-                            + "the server, add the account, then start it again."
-                        : "Opens `tcr login` in a Terminal window. It needs one: it "
-                            + "prompts for a name, may ask for a pasted code, and "
-                            + "refuses while a proxy is holding the port."
+                    "Opens `tcr login` in a Terminal window. It needs one: it "
+                        + "prompts for a name and may ask for a pasted code. A "
+                        + "modern proxy takes the login live even while serving; "
+                        + "an older one refuses before any browser opens and "
+                        + "prints how to recover."
                 )
             Spacer()
         }
@@ -436,22 +432,6 @@ struct FleetView: View {
         }
     }
 
-    /// True when a proxy is actually serving the port — the condition under
-    /// which `tcr login` refuses.
-    ///
-    /// The case alone is NOT the test. An offline read also decodes to
-    /// ``PollState/loaded(_:)``: `tcr status` answers from config with no
-    /// server up, which is precisely the state where adding an account
-    /// *works*. Keying on `.loaded` would disable the button exactly when it is
-    /// usable, and the panel already distinguishes the two — `source` is why
-    /// `offlineNotice` exists.
-    private var proxyHoldsThePort: Bool {
-        if case .loaded(let fleet) = poller.state {
-            return !fleet.source.countersAreStructural
-        }
-        return false
-    }
-
     /// Hand `tcr login` to a Terminal window.
     ///
     /// Deliberately a hand-off, not an in-app flow. `tcr login` refuses while a
@@ -460,6 +440,23 @@ struct FleetView: View {
     /// in the label is doing real work: this opens something.
     private func addAccount() {
         if case .failure(let why) = LoginLauncher.launch() {
+            switch why {
+            case .toolMissing(let searched):
+                loginError = "tcr not found (searched \(searched.count) locations)."
+            case .couldNotWriteScript(let message):
+                loginError = "Could not open Terminal: \(message)"
+            }
+        } else {
+            loginError = nil
+        }
+    }
+
+    /// Same hand-off as ``addAccount()``, with the account name threaded
+    /// through so the Terminal script can name it. Surfaces a failure the same
+    /// way — a button that silently does nothing is worse than one that says
+    /// why.
+    private func reloginAccount(_ name: String) {
+        if case .failure(let why) = LoginLauncher.launch(reloggingIn: name) {
             switch why {
             case .toolMissing(let searched):
                 loginError = "tcr not found (searched \(searched.count) locations)."
@@ -601,6 +598,9 @@ struct AccountRow: View {
     /// computed against — reading the poller's published `state` afterwards could
     /// pick up a different, later poll.
     let onChanged: () async -> PollState
+    /// Hands `tcr login` to a Terminal window for THIS account. Only drawn on a
+    /// `.needsRelogin` row.
+    let onRelogin: () -> Void
 
     /// The single tint for this row's quota evidence. The pill and the bar both
     /// read it, so the two can never disagree about whether a quota is known.
@@ -662,7 +662,14 @@ struct AccountRow: View {
         // Mirrors the pill's three cases. A VoiceOver user hearing "never
         // probed" about an account whose probe errored is told the same wrong
         // cause a sighted user was, with less to correct it from.
-        if account.hasQuotaEvidence {
+        // Broken beats the probe-based cases: a rejected refresh token is a
+        // known cause with a known remedy, and speaking "never probed" over it
+        // is the same wrong cause a sighted user was told, with less to correct
+        // it from.
+        if account.health == .needsRelogin {
+            parts.append(
+                "needs re-login, refresh token rejected, out of rotation until re-login")
+        } else if account.hasQuotaEvidence {
             parts.append("\(account.quotaState.token), \(QuotaFormat.percent(account.quota)) used")
         } else if account.probeStatus.isFailure {
             parts.append("quota probe \(account.probeStatus.token), quota unknown")
@@ -683,13 +690,35 @@ struct AccountRow: View {
     }
 
     var body: some View {
-        HStack(alignment: .top, spacing: Tok.tightSpacing) {
-            information
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel(rowAccessibilityLabel)
-            toggleButton
+        // A broken row draws its two buttons on their OWN line, below the name
+        // and pills, rather than beside `information` the way `toggleButton`
+        // alone sits for every other row. Measured, not assumed: beside
+        // `information`, `ROTATING` + `NEEDS RE-LOGIN` + `Re-login…` +
+        // `Disable` do not fit in the row's 356pt (`fleetActions`'s own
+        // truncation bug, documented above, is exactly this failure mode) —
+        // the name collapsed to a single truncated character. Every other row
+        // keeps the original layout unchanged, because it already fits.
+        if account.health == .needsRelogin {
+            VStack(alignment: .leading, spacing: Tok.tightSpacing) {
+                information
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(rowAccessibilityLabel)
+                HStack(spacing: Tok.tightSpacing) {
+                    Spacer()
+                    reloginButton
+                    toggleButton
+                }
+            }
+            .padding(.vertical, Tok.rowPaddingV)
+        } else {
+            HStack(alignment: .top, spacing: Tok.tightSpacing) {
+                information
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(rowAccessibilityLabel)
+                toggleButton
+            }
+            .padding(.vertical, Tok.rowPaddingV)
         }
-        .padding(.vertical, Tok.rowPaddingV)
     }
 
     private var information: some View {
@@ -719,7 +748,18 @@ struct AccountRow: View {
                 // palette reserves for *never probed* — telling the operator to
                 // wait for a sweep that had already run and failed. Observed
                 // live: a row reading UNMEASURED beside a status of `error`.
-                if account.hasQuotaEvidence {
+                // Broken beats every other case, including a stale
+                // "never probed" read: `status == "error"` paired with
+                // `probeStatus == .never` is the case actually occurring on
+                // the live fleet, and it is a known cause with a known remedy,
+                // not an absence of information.
+                if account.health == .needsRelogin {
+                    StatusPill("needs re-login", tint: Tok.spent)
+                        .help(
+                            "The refresh token was rejected — this account is out "
+                                + "of rotation and serves no traffic until you re-login."
+                        )
+                } else if account.hasQuotaEvidence {
                     StatusPill(account.quotaState.token, tint: quotaTint)
                 } else if account.probeStatus.isFailure {
                     // The probe's own word, so the row names the cause rather
@@ -760,7 +800,11 @@ struct AccountRow: View {
                 if !account.disabled {
                     Text(account.status)
                         .font(Tok.secondaryFont)
-                        .foregroundStyle(.secondary)
+                        // `active` and `error` must not be pixel-identical: an
+                        // `error` account is what the UNMEASURED pill used to
+                        // wear too, and the raw word alone drew in the same
+                        // grey as a healthy account right above it.
+                        .foregroundStyle(account.health == .needsRelogin ? Tok.spent : .secondary)
                         .lineLimit(1)
                 }
             }
@@ -834,6 +878,28 @@ struct AccountRow: View {
         // `Tok.ok`, which is the clean case's alone.
         case .spokeUp: return Tok.near
         }
+    }
+
+    /// Hands `tcr login` to a Terminal window, hinting at this account's name.
+    /// Drawn on a `.needsRelogin` row only, beside ``toggleButton``.
+    ///
+    /// `tcr login` takes no account argument — it upserts by the profile
+    /// identity the browser hands back — so this cannot re-authenticate the
+    /// row directly; it only opens the same flow ``addAccount()`` does, with a
+    /// name in the Terminal echo so the operator knows which browser account
+    /// to pick. `.accessibilityLabel` says exactly that, not "Re-login" alone,
+    /// which would promise more than a click here can do.
+    private var reloginButton: some View {
+        Button("Re-login…") { onRelogin() }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .font(Tok.detailFont)
+            .accessibilityLabel("Re-login \(account.name)")
+            .help(
+                "Opens `tcr login` in a Terminal window for this account. The "
+                    + "browser account you choose is what actually gets logged in — "
+                    + "`tcr login` takes no account argument."
+            )
     }
 
     /// `tcr enable <name>` / `tcr disable <name>`, keyed off the account's own

--- a/apps/macos/Sources/TcrBar/RenderStates.swift
+++ b/apps/macos/Sources/TcrBar/RenderStates.swift
@@ -66,6 +66,7 @@ enum RenderStates {
             ("02-mixed-thirteen", .loaded(fleet(mixedJSON)), false),
             ("03-zero-capacity", .loaded(fleet(exhaustedJSON)), false),
             ("04-unmeasured-row", .loaded(fleet(unmeasuredJSON)), false),
+            ("04b-needs-relogin-row", .loaded(fleet(needsReloginJSON)), false),
             ("05-unreadable-row", .loaded(partiallyUnreadableFleet()), false),
             ("06-offline-source", .loaded(fleet(offlineJSON)), false),
             ("07-empty-fleet", .loaded(fleet("[]")), false),
@@ -221,10 +222,11 @@ enum RenderStates {
         disabled: Bool = false,
         probe: String = "ok",
         held: String = "[]",
-        source: String = "live"
+        source: String = "live",
+        status: String = "active"
     ) -> String {
         """
-        {"name":"\(name)","priority":0,"status":"active","disabled":\(disabled),
+        {"name":"\(name)","priority":0,"status":"\(status)","disabled":\(disabled),
          "quota":\(quota),"quotaState":"\(state)","fiveHour":\(quota),
          "sevenDay":\(quota),"sevenDayOi":0.0,"held":\(held),
          "requests":102,"inputTokens":8781926,"outputTokens":31860,
@@ -269,5 +271,18 @@ enum RenderStates {
 
     private static var offlineJSON: String {
         "[\(account("alice@example.com", quota: "0.12", state: "ok", source: "offline"))]"
+    }
+
+    /// The bug this whole scene set exists for: a dead-credential account
+    /// (`status:"error"`, `probeStatus:"never"`) beside a healthy one, so the
+    /// pill, the status word's tint, the row order and the header clause are
+    /// all reviewable together. The Re-login button draws as a placeholder —
+    /// `ImageRenderer` cannot rasterise AppKit controls — but its presence
+    /// beside Disable still shows in the row's width.
+    private static var needsReloginJSON: String {
+        let alice = account("alice@example.com", quota: "0.12", state: "ok")
+        let dave = account(
+            "dave@example.com", quota: "null", state: "ok", probe: "never", status: "error")
+        return "[\(alice),\(dave)]"
     }
 }

--- a/apps/macos/Sources/TcrBar/RenderStates.swift
+++ b/apps/macos/Sources/TcrBar/RenderStates.swift
@@ -67,6 +67,7 @@ enum RenderStates {
             ("03-zero-capacity", .loaded(fleet(exhaustedJSON)), false),
             ("04-unmeasured-row", .loaded(fleet(unmeasuredJSON)), false),
             ("04b-needs-relogin-row", .loaded(fleet(needsReloginJSON)), false),
+            ("04c-probed-then-broken-row", .loaded(fleet(probedThenBrokenJSON)), false),
             ("05-unreadable-row", .loaded(partiallyUnreadableFleet()), false),
             ("06-offline-source", .loaded(fleet(offlineJSON)), false),
             ("07-empty-fleet", .loaded(fleet("[]")), false),
@@ -284,5 +285,23 @@ enum RenderStates {
         let dave = account(
             "dave@example.com", quota: "null", state: "ok", probe: "never", status: "error")
         return "[\(alice),\(dave)]"
+    }
+
+    /// The blind spot an adversarial review found: `04b` above is the OTHER
+    /// way an account breaks — never probed, `quota: null`. This is the shape
+    /// that actually happens in production: a credential that dies AFTER
+    /// being probed keeps its last-learned `quota` and a real `probeStatus`
+    /// (`probe_account`, `src/manager/probing.rs:128-139`, early-returns on
+    /// an `Error` row instead of clearing anything; `refresh.rs:93-101` sets
+    /// only `status`). `carol@example.com` here carries `status:"error"` WITH
+    /// `quota:0.12` and `probeStatus:"ok"` — a real prior reading, not an
+    /// absent one — sat beside a genuinely healthy account so the header's
+    /// arithmetic ("1 of 2 ready · 1 need re-login", not "2 of 2 ready") is
+    /// reviewable in the same frame this scene renders.
+    private static var probedThenBrokenJSON: String {
+        let alice = account("alice@example.com", quota: "0.12", state: "ok")
+        let carol = account(
+            "carol@example.com", quota: "0.12", state: "ok", probe: "ok", status: "error")
+        return "[\(alice),\(carol)]"
     }
 }

--- a/apps/macos/Sources/TcrBar/Tokens.swift
+++ b/apps/macos/Sources/TcrBar/Tokens.swift
@@ -295,6 +295,11 @@ public enum Tok {
         case .near: return near
         case .spent: return spent
         case .unknown: return unknown
+        // Reuses `spent`, not a new token: a broken account is known-cannot-
+        // serve, the same certainty `spent` already carries, and this repo's
+        // colour palette is generated — a new token drags in a regeneration
+        // and two blocking gates for a fact this one already covers.
+        case .needsRelogin: return spent
         case .unmeasured: return unmeasured
         case .disabled: return disabled
         }

--- a/apps/macos/Sources/TcrBarCore/FleetStatus.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetStatus.swift
@@ -406,8 +406,18 @@ public struct Account: Decodable, Equatable, Identifiable, Sendable {
     /// Worst-first ordering key. A disabled account is not an alarm — it is an
     /// operator decision — so it sorts below a spent one. This does *not* drive
     /// the menu-bar glyph; see ``Fleet/capacityGlyphState``.
+    ///
+    /// `needsRelogin` is checked explicitly, not left to fall through to
+    /// `quotaState.severity`: a broken account's `quotaState` is Rust's
+    /// `#[default]` `"ok"` (the same default a never-probed account carries),
+    /// so falling through would have scored it `1` — tied with `disabled`,
+    /// the one case this property's own doc-comment names as deliberately
+    /// NOT an alarm. A dead credential earns the opposite ranking: worse than
+    /// `spent`, since a spent account recovers on its own reset and a broken
+    /// one does not without operator action.
     public var severity: Int {
         if disabled { return 1 }
+        if health == .needsRelogin { return QuotaState.spent.severity + 2 }
         return quotaState.severity + 1
     }
 

--- a/apps/macos/Sources/TcrBarCore/FleetStatus.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetStatus.swift
@@ -353,6 +353,28 @@ public struct Account: Decodable, Equatable, Identifiable, Sendable {
     public let status: String
     public let disabled: Bool
 
+    /// The Rust side's `AccountStatus` (src/manager/mod.rs:182-198), decoded.
+    /// `.other` keeps an unknown future variant readable instead of asserting a
+    /// meaning this build cannot support.
+    public enum AccountHealth: Equatable, Sendable {
+        case active, throttled, needsRelogin
+        case other(String)
+    }
+
+    /// Computed from `status`, exact match, lowercase — never a substitute for
+    /// the raw field, which stays displayed verbatim elsewhere. `"error"` maps
+    /// to `.needsRelogin` rather than to a case named after Rust's own word: an
+    /// `error` account is what the UNMEASURED pill wears too, and the panel must
+    /// not use one word to mean two different facts.
+    public var health: AccountHealth {
+        switch status.lowercased() {
+        case "active": return .active
+        case "throttled": return .throttled
+        case "error": return .needsRelogin
+        default: return .other(status)
+        }
+    }
+
     /// The gating window — the most-spent of `5h`, `7d`, `7d_oi`. `null` on the
     /// wire, and `nil` here, when nothing has been learned about this account
     /// yet. Never render it as `0`.
@@ -400,14 +422,21 @@ public struct Account: Decodable, Equatable, Identifiable, Sendable {
     /// come first and the operator's own parked accounts sink to the bottom.
     /// `unmeasured` sits below `near` because an unprobed account is not capacity,
     /// and above `spent` because it is not known to be exhausted either.
+    ///
+    /// `needsRelogin` sits between `unknown` and `unmeasured`: it is actionable —
+    /// there is a real remedy, a click away — so it belongs above the other
+    /// non-serving rows and below anything that can still serve. `disabled` is
+    /// checked FIRST: a parked account is an operator decision, not a request for
+    /// action, so it always sinks to the bottom regardless of its health.
     public var displayOrder: Int {
-        if disabled { return 5 }
-        if !hasQuotaEvidence { return 3 }
+        if disabled { return 6 }
+        if health == .needsRelogin { return 3 }
+        if !hasQuotaEvidence { return 4 }
         switch quotaState {
         case .ok: return 0
         case .near: return 1
         case .unknown: return 2
-        case .spent: return 4
+        case .spent: return 5
         }
     }
 
@@ -458,6 +487,12 @@ public struct FleetTally: Equatable, Sendable {
         case near
         case spent
         case unknown
+        /// The refresh token was rejected — `AccountHealth.needsRelogin`. Its
+        /// own bucket, checked BEFORE `hasQuotaEvidence` in `init(account:)`:
+        /// these accounts also have no quota reading, and folding them into
+        /// `.unmeasured` would tell the operator to wait for a sweep that will
+        /// never fix a dead credential.
+        case needsRelogin
         /// Enabled, but nothing has ever been measured about it. Its own bucket
         /// because folding it into `ok` is precisely the overclaim this exists
         /// to stop, and folding it into `unknown` would conflate "a quota state
@@ -471,6 +506,7 @@ public struct FleetTally: Equatable, Sendable {
             case .near: return "near"
             case .spent: return "spent"
             case .unknown: return "unknown"
+            case .needsRelogin: return "need re-login"
             case .unmeasured: return "unmeasured"
             case .disabled: return "disabled"
             }
@@ -488,9 +524,16 @@ public struct FleetTally: Equatable, Sendable {
 
         /// The bucket an *enabled* account falls into, measurement included.
         /// An unmeasured account's `quotaState` is a default, so it never
-        /// reaches the quota-state mapping at all.
+        /// reaches the quota-state mapping at all. Health is checked BEFORE
+        /// `hasQuotaEvidence` — a broken account has no quota reading either,
+        /// and checking evidence first would land every one of them back in
+        /// `.unmeasured`.
         init(account: Account) {
-            self = account.hasQuotaEvidence ? Kind(quotaState: account.quotaState) : .unmeasured
+            if account.health == .needsRelogin {
+                self = .needsRelogin
+            } else {
+                self = account.hasQuotaEvidence ? Kind(quotaState: account.quotaState) : .unmeasured
+            }
         }
     }
 
@@ -649,8 +692,21 @@ public struct Fleet: Equatable, Sendable {
     /// Enabled accounts nothing is known about. Reported next to `readyCount`
     /// rather than folded into it: "unknown" and "not ready" are different
     /// answers and lead to different next actions.
+    ///
+    /// EXCLUDES `needsReloginCount`. A broken account also has no quota
+    /// reading, but "unmeasured" tells the operator to wait for a sweep that
+    /// will never fix a dead credential — this must stay a property of the
+    /// evidence a *live* account is missing, not a catch-all for "no reading".
     public var unmeasuredCount: Int {
-        enabledAccounts.filter { !$0.hasQuotaEvidence }.count
+        enabledAccounts.filter { !$0.hasQuotaEvidence && $0.health != .needsRelogin }.count
+    }
+
+    /// Enabled accounts whose refresh token was rejected — dead credentials,
+    /// hard-excluded from selection (`src/manager/select.rs:814`, `:931`).
+    /// Reported on the same footing as `unmeasuredCount`: both are reasons an
+    /// account is not ready, but they lead to different remedies.
+    public var needsReloginCount: Int {
+        enabledAccounts.filter { $0.health == .needsRelogin }.count
     }
 
     /// The denominator of the headline: accounts that *could* serve.
@@ -675,16 +731,17 @@ public struct Fleet: Equatable, Sendable {
     public var capacitySummary: String {
         if enabledAccounts.isEmpty { return "No enabled accounts" }
         let unmeasured = unmeasuredCount > 0 ? " · \(unmeasuredCount) unmeasured" : ""
-        if readyCount > 0 { return "\(readyCount) of \(enabledCount) ready\(unmeasured)" }
+        let needsRelogin = needsReloginCount > 0 ? " · \(needsReloginCount) need re-login" : ""
+        if readyCount > 0 { return "\(readyCount) of \(enabledCount) ready\(unmeasured)\(needsRelogin)" }
         if unmeasuredCount > 0 {
             guard let next = soonestRecovery else {
-                return "No confirmed capacity\(unmeasured)"
+                return "No confirmed capacity\(unmeasured)\(needsRelogin)"
             }
-            return "No confirmed capacity\(unmeasured) · next in "
+            return "No confirmed capacity\(unmeasured)\(needsRelogin) · next in "
                 + HeldWindow.duration(minutes: next.minutesUntilReset)
         }
-        guard let next = soonestRecovery else { return "No capacity" }
-        return "No capacity · next in \(HeldWindow.duration(minutes: next.minutesUntilReset))"
+        guard let next = soonestRecovery else { return "No capacity\(needsRelogin)" }
+        return "No capacity\(needsRelogin) · next in \(HeldWindow.duration(minutes: next.minutesUntilReset))"
     }
 
     /// Which tint the capacity line wears. Near-binary: there is capacity, there
@@ -736,7 +793,9 @@ public struct Fleet: Equatable, Sendable {
             counts[FleetTally.Kind(account: account), default: 0] += 1
         }
         counts[.disabled] = disabledCount
-        let order: [FleetTally.Kind] = [.ok, .near, .spent, .unknown, .unmeasured, .disabled]
+        let order: [FleetTally.Kind] = [
+            .ok, .near, .spent, .unknown, .needsRelogin, .unmeasured, .disabled,
+        ]
         return order.compactMap { kind in
             guard let count = counts[kind], count > 0 else { return nil }
             return FleetTally(kind: kind, count: count)

--- a/apps/macos/Sources/TcrBarCore/FleetStatus.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetStatus.swift
@@ -480,8 +480,20 @@ public struct Account: Decodable, Equatable, Identifiable, Sendable {
     /// an unmeasured account reports `quotaState == .ok` by default, so without
     /// it, enabling a never-probed account makes the fleet claim capacity that
     /// nothing has ever verified.
+    ///
+    /// The fourth clause exists for a credential that dies AFTER being
+    /// probed, not before. `probe_account` (`src/manager/probing.rs:128-139`)
+    /// early-returns on an `Error` row instead of clearing anything, and
+    /// `refresh.rs:93-101` only ever sets `status` — so a rejected refresh
+    /// token leaves the LAST-LEARNED `quota` and `probeStatus: .ok` sitting
+    /// there unchanged. Without this clause `hasQuotaEvidence` stays true,
+    /// `quotaState` reads whatever it last measured (often `.ok`), and the
+    /// row reports READY for an account `src/manager/select.rs:931`
+    /// hard-excludes and will serve zero requests — the header could then
+    /// read "1 of 1 ready · 1 need re-login" in the same frame, the panel
+    /// contradicting itself.
     public var isReady: Bool {
-        !disabled && quotaState == .ok && hasQuotaEvidence
+        !disabled && health != .needsRelogin && quotaState == .ok && hasQuotaEvidence
     }
 }
 
@@ -715,6 +727,14 @@ public struct Fleet: Equatable, Sendable {
     /// hard-excluded from selection (`src/manager/select.rs:814`, `:931`).
     /// Reported on the same footing as `unmeasuredCount`: both are reasons an
     /// account is not ready, but they lead to different remedies.
+    ///
+    /// That "not ready" claim is enforced by ``Account/isReady``'s own
+    /// `health != .needsRelogin` clause, not merely implied by this count
+    /// existing — a credential that dies AFTER being probed keeps its
+    /// last-learned `quota` and `quotaState`, so without that clause on
+    /// `isReady` an account counted here could ALSO count in `readyCount`,
+    /// the exact contradiction ("1 of 1 ready · 1 need re-login") this whole
+    /// change exists to rule out.
     public var needsReloginCount: Int {
         enabledAccounts.filter { $0.health == .needsRelogin }.count
     }
@@ -787,7 +807,17 @@ public struct Fleet: Equatable, Sendable {
     public var capacityGlyphState: QuotaState {
         if enabledAccounts.isEmpty { return .unknown("empty") }
         if readyCount > 0 { return .ok }
-        if enabledAccounts.contains(where: { $0.hasQuotaEvidence && $0.quotaState == .near }) {
+        // `health != .needsRelogin` is load-bearing here too, not just on
+        // `isReady`: a credential that dies AFTER being probed keeps its
+        // LAST-LEARNED `quotaState`, which can be `.near` — Rust never resets
+        // it, `probe_account` (`src/manager/probing.rs:128-139`) early-returns
+        // on an `Error` row and `refresh.rs:93-101` only ever sets `status`.
+        // Without the health check, a broken account that used to be close to
+        // its threshold would amber the glyph for capacity that has since
+        // gone to zero, not "close".
+        if enabledAccounts.contains(where: {
+            $0.hasQuotaEvidence && $0.quotaState == .near && $0.health != .needsRelogin
+        }) {
             return .near
         }
         if unmeasuredCount > 0 { return .unknown("unmeasured") }

--- a/apps/macos/Sources/TcrBarCore/LoginLauncher.swift
+++ b/apps/macos/Sources/TcrBarCore/LoginLauncher.swift
@@ -29,6 +29,16 @@ import Foundation
 ///
 /// `--force` is never passed. `tcr` documents it as unsafe, and a GUI silently
 /// forcing past a guard the CLI put up is exactly the wrong use of a button.
+///
+/// A re-login (``script(forExecutableAt:reloggingIn:)`` with a name) passes
+/// `--account <name>`, added by `src/main.rs` / `src/oauth.rs`'s `login_hint`.
+/// This app used to describe `tcr login` as taking no account argument at
+/// all, upserting by whatever identity the browser handed back — true when
+/// this file said so, and false as of that change: an untargeted re-login can
+/// authenticate as whichever account happens to be signed into the browser,
+/// and `--account` is what makes the button actually target the row it was
+/// clicked from, with `tcr` refusing to write on a mismatch rather than
+/// silently overwriting the wrong account's credentials.
 public enum LoginLauncher {
 
     public enum Failure: Error, Equatable {
@@ -43,35 +53,48 @@ public enum LoginLauncher {
     ///
     /// `reloggingIn` is an optional account-name hint, `nil` by default so the
     /// existing add-account call site is unchanged. When present, the script
-    /// echoes which account this re-login is for — honestly: `tcr login` takes
-    /// no account argument, it upserts by the profile identity the browser hands
-    /// back, so the label says the browser choice is what actually selects the
-    /// account, rather than implying this script can steer it there.
+    /// passes it as `--account <name>` (`src/main.rs`, `LoginArgs::account`;
+    /// `src/oauth.rs`, `login_hint`): `tcr` requests that specific identity and
+    /// refuses to write anything if the browser hands back a different one —
+    /// measured live, not theoretical: a re-login meant for one account
+    /// authenticated as a different one that happened to be signed into the
+    /// browser, and the mismatch assertion is the only reason the config was
+    /// not overwritten. Echoing the name without passing it would have been
+    /// that failure with no seatbelt, landing on whichever account the
+    /// browser happened to be signed into.
     ///
-    /// Shell-quoted exactly like the path just below — POSIX `'\''` — because an
-    /// account name is attacker-adjacent input in principle, and unquoted
-    /// interpolation into a `.command` file is injection.
+    /// Both the path and the name are shell-quoted the same POSIX way —
+    /// `'\''` — because both are now going onto the COMMAND LINE, not just
+    /// into an `echo`: an account name is attacker-adjacent input in
+    /// principle, and unquoted interpolation into a `.command` file is
+    /// injection.
     public static func script(forExecutableAt path: String, reloggingIn name: String? = nil) -> String {
         // Single-quote the path and escape any embedded single quote the POSIX
         // way ('\'') so the shell receives exactly one argument whatever the path
         // contains.
         let quoted = "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
         let hint: String
+        let accountArgument: String
         if let name {
             // The WHOLE message is the single-quoted argument, not the name
             // alone inside a double-quoted one — a double-quoted echo still
             // expands `$`, backticks and `\`, so quoting only the name would
             // leave the rest of the line open to exactly the injection this
             // quoting exists to close.
-            let message = "Re-logging in \(name) — choose that account in the browser."
+            let message =
+                "Re-logging in \(name) — tcr requests that account, and refuses "
+                + "to save if the browser hands back a different one."
             let quotedMessage = "'" + message.replacingOccurrences(of: "'", with: "'\\''") + "'"
             hint = """
                 echo \(quotedMessage)
                 echo
 
                 """
+            let quotedName = "'" + name.replacingOccurrences(of: "'", with: "'\\''") + "'"
+            accountArgument = " --account \(quotedName)"
         } else {
             hint = ""
+            accountArgument = ""
         }
         return """
             #!/bin/sh
@@ -81,7 +104,7 @@ public enum LoginLauncher {
             # refuses outright while a proxy is holding the port.
             echo "Running tcr login — follow the prompts below."
             echo
-            \(hint)exec \(quoted) login
+            \(hint)exec \(quoted) login\(accountArgument)
             """
     }
 

--- a/apps/macos/Sources/TcrBarCore/LoginLauncher.swift
+++ b/apps/macos/Sources/TcrBarCore/LoginLauncher.swift
@@ -9,15 +9,18 @@ import Foundation
 /// independent reasons, and both are in `tcr`'s own source rather than guesswork:
 ///
 ///  1. **An older `tcr` refuses while a server holds the port.** That used to be
-///     universal (`src/oauth.rs:752-757`, superseded), but `a385f0f`
-///     (2026-08-11, "feat: route tcr login through a live proxy instead of
-///     refusing") added a live route: `login_route` (`src/oauth.rs:953-997`)
-///     probes the running proxy and, on `AddCapability::Present`, takes the
-///     login live through the server instead of refusing. A modern proxy — the
-///     only kind this button needs to assume — accepts a login while serving.
-///     An old one still refuses, before any browser opens, and its message
-///     names the pid and the stop-login-restart sequence — which is useful
-///     only if a human can read it.
+///     universal — refusing outright whenever a proxy held the port, no
+///     exceptions — but `a385f0f` (2026-08-11, "feat: route tcr login
+///     through a live proxy instead of refusing") added a live route:
+///     `login_route` (`src/oauth.rs:966-1010`) probes the running proxy and,
+///     on `AddCapability::Present`, takes the login live through the server
+///     instead of refusing. A modern proxy — the only kind this button needs
+///     to assume — accepts a login while serving. An old one still refuses,
+///     before any browser opens, and its message names the pid and the
+///     stop-login-restart sequence — which is useful only if a human can
+///     read it. (Line numbers move; verified against `src/oauth.rs` as of
+///     `9fc4fe8`, not carried forward from memory — re-check before trusting
+///     them again.)
 ///  2. **It is interactive.** It prompts for an account name on stdin
 ///     (`src/oauth.rs:645`) and can take a pasted authorization code
 ///     (`src/oauth.rs:450`). With no TTY those prompts go nowhere and stdin hits
@@ -113,9 +116,20 @@ public enum LoginLauncher {
     /// A `.command` file opened via LaunchServices starts Terminal directly. The
     /// alternative — an AppleScript `do script` — needs Automation permission and
     /// would put a consent dialog between the operator and a login they asked for.
+    ///
+    /// The filename carries a UUID (`uuid`, injectable for tests), not a fixed
+    /// `tcr-login.command`. Before `--account` shipped every invocation wrote
+    /// IDENTICAL bytes, so a fixed path was harmless — two clicks in quick
+    /// succession just overwrote the file with the same script. It is a
+    /// correctness surface now: the content is per-account, so two Re-login
+    /// clicks in quick succession could overwrite the file before the first
+    /// Terminal window reads it, letting window A run window B's
+    /// `--account`. A unique path per invocation makes that race structurally
+    /// impossible rather than merely unlikely.
     @discardableResult
     public static func launch(
         reloggingIn name: String? = nil,
+        uuid: () -> UUID = UUID.init,
         resolve: () -> Result<URL, TcrTool.NotFound> = { TcrTool.resolve() },
         open: (URL) -> Void = { NSWorkspace.shared.open($0) }
     ) -> Result<URL, Failure> {
@@ -127,7 +141,7 @@ public enum LoginLauncher {
 
         let script = script(forExecutableAt: executable.path, reloggingIn: name)
         let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("tcr-login.command")
+            .appendingPathComponent("tcr-login-\(uuid().uuidString).command")
 
         do {
             try script.write(to: url, atomically: true, encoding: .utf8)

--- a/apps/macos/Sources/TcrBarCore/LoginLauncher.swift
+++ b/apps/macos/Sources/TcrBarCore/LoginLauncher.swift
@@ -8,11 +8,16 @@ import Foundation
 /// `tcr login` cannot run as a background subprocess of a GUI app, for two
 /// independent reasons, and both are in `tcr`'s own source rather than guesswork:
 ///
-///  1. **It refuses while a server holds the port** (`src/oauth.rs:752-757`):
-///     logging in then would be overwritten by the server's next token refresh.
-///     TcrBar exists because a proxy is always running, so that refusal is the
-///     normal case here, not an edge case. Its message names the pid and the
-///     stop-login-restart sequence — which is useful only if a human can read it.
+///  1. **An older `tcr` refuses while a server holds the port.** That used to be
+///     universal (`src/oauth.rs:752-757`, superseded), but `a385f0f`
+///     (2026-08-11, "feat: route tcr login through a live proxy instead of
+///     refusing") added a live route: `login_route` (`src/oauth.rs:953-997`)
+///     probes the running proxy and, on `AddCapability::Present`, takes the
+///     login live through the server instead of refusing. A modern proxy — the
+///     only kind this button needs to assume — accepts a login while serving.
+///     An old one still refuses, before any browser opens, and its message
+///     names the pid and the stop-login-restart sequence — which is useful
+///     only if a human can read it.
 ///  2. **It is interactive.** It prompts for an account name on stdin
 ///     (`src/oauth.rs:645`) and can take a pasted authorization code
 ///     (`src/oauth.rs:450`). With no TTY those prompts go nowhere and stdin hits
@@ -35,19 +40,48 @@ public enum LoginLauncher {
     ///
     /// Split out and pure so the quoting is testable: an install path containing a
     /// space or a quote must not become a broken or, worse, an injectable command.
-    public static func script(forExecutableAt path: String) -> String {
+    ///
+    /// `reloggingIn` is an optional account-name hint, `nil` by default so the
+    /// existing add-account call site is unchanged. When present, the script
+    /// echoes which account this re-login is for — honestly: `tcr login` takes
+    /// no account argument, it upserts by the profile identity the browser hands
+    /// back, so the label says the browser choice is what actually selects the
+    /// account, rather than implying this script can steer it there.
+    ///
+    /// Shell-quoted exactly like the path just below — POSIX `'\''` — because an
+    /// account name is attacker-adjacent input in principle, and unquoted
+    /// interpolation into a `.command` file is injection.
+    public static func script(forExecutableAt path: String, reloggingIn name: String? = nil) -> String {
         // Single-quote the path and escape any embedded single quote the POSIX
         // way ('\'') so the shell receives exactly one argument whatever the path
         // contains.
         let quoted = "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        let hint: String
+        if let name {
+            // The WHOLE message is the single-quoted argument, not the name
+            // alone inside a double-quoted one — a double-quoted echo still
+            // expands `$`, backticks and `\`, so quoting only the name would
+            // leave the rest of the line open to exactly the injection this
+            // quoting exists to close.
+            let message = "Re-logging in \(name) — choose that account in the browser."
+            let quotedMessage = "'" + message.replacingOccurrences(of: "'", with: "'\\''") + "'"
+            hint = """
+                echo \(quotedMessage)
+                echo
+
+                """
+        } else {
+            hint = ""
+        }
         return """
             #!/bin/sh
             # Opened by TcrBar. `tcr login` needs a terminal: it prompts for an
-            # account name and may ask you to paste an authorization code, and it
+            # account name and may ask you to paste an authorization code. A
+            # modern proxy takes the login live even while serving; an older one
             # refuses outright while a proxy is holding the port.
             echo "Running tcr login — follow the prompts below."
             echo
-            exec \(quoted) login
+            \(hint)exec \(quoted) login
             """
     }
 
@@ -58,6 +92,7 @@ public enum LoginLauncher {
     /// would put a consent dialog between the operator and a login they asked for.
     @discardableResult
     public static func launch(
+        reloggingIn name: String? = nil,
         resolve: () -> Result<URL, TcrTool.NotFound> = { TcrTool.resolve() },
         open: (URL) -> Void = { NSWorkspace.shared.open($0) }
     ) -> Result<URL, Failure> {
@@ -67,7 +102,7 @@ public enum LoginLauncher {
         case .failure(let missing): return .failure(.toolMissing(searched: missing.searched))
         }
 
-        let script = script(forExecutableAt: executable.path)
+        let script = script(forExecutableAt: executable.path, reloggingIn: name)
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("tcr-login.command")
 

--- a/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
@@ -256,6 +256,25 @@ final class AccountHealthTests: XCTestCase {
         XCTAssertEqual(fleet.needsReloginCount, 0)
         XCTAssertEqual(fleet.unmeasuredCount, 1)
     }
+
+    /// `severity` used to fall through to `quotaState.severity` for a broken,
+    /// enabled account — and a broken account's `quotaState` is the same Rust
+    /// `#[default]` `"ok"` a never-probed one carries, so it scored `1`, tied
+    /// with `disabled`, which this same property's doc-comment names as
+    /// deliberately NOT an alarm. A dead credential is the opposite: worse
+    /// than `spent`, not on par with an operator's own parked account.
+    func testBrokenAccountOutranksSpentAndIsNotTiedWithDisabled() {
+        let broken = brokenAccount("dave@example.com")
+        let spent = account("erin@example.com", state: .spent)
+        let disabled = account("off@example.com", state: .ok, disabled: true)
+
+        XCTAssertGreaterThan(broken.severity, spent.severity)
+        XCTAssertNotEqual(
+            broken.severity, disabled.severity,
+            "a dead credential is an alarm; a parked account is an operator's own choice"
+        )
+        XCTAssertEqual(Fleet(accounts: [spent, broken]).worst?.name, "dave@example.com")
+    }
 }
 
 /// The invariant this whole change restores: a broken account is not

--- a/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
@@ -187,7 +187,7 @@ private func account(
 }
 
 /// A dead-credential account: `status:"error"`, never probed — the live shape
-/// (`src/manager/refresh.rs:92-101` rejects the refresh token and sets
+/// (`src/manager/refresh.rs:93-101` rejects the refresh token and sets
 /// `AccountStatus::Error`), not a hand-picked one. `quotaState` stays the
 /// Rust-side default `ok` and `quota` stays `nil`, exactly as `hasQuotaEvidence`
 /// expects for an account that has never been probed.
@@ -218,12 +218,84 @@ private func brokenAccount(_ name: String, disabled: Bool = false) -> Account {
     )
 }
 
+/// A credential that died AFTER being probed — the shape a review of the
+/// original fix found every existing test blind to. `probe_account`
+/// (`src/manager/probing.rs:128-139`) early-returns on an `Error` row instead
+/// of clearing anything, and `refresh.rs:93-101` sets only `status` — so the
+/// LAST-LEARNED `quota`, `quotaState` and `probeStatus: .ok` stay exactly as
+/// they were the moment before the refresh token was rejected. `brokenAccount`
+/// above (`probeStatus: .never, quota: nil`) cannot express this: it is the
+/// OTHER way a broken account arrives, and the two are not interchangeable —
+/// `hasQuotaEvidence` reads true here and false there.
+private func probedThenBrokenAccount(
+    _ name: String,
+    quota: Double = 0.12,
+    quotaState: QuotaState = .ok,
+    disabled: Bool = false
+) -> Account {
+    Account(
+        name: name,
+        priority: 1,
+        status: "error",
+        disabled: disabled,
+        quota: quota,
+        quotaState: quotaState,
+        fiveHour: quota,
+        sevenDay: quota,
+        sevenDayOi: 0,
+        held: [],
+        requests: 102,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheHitRatio: nil,
+        probeStatus: .ok,
+        probeError: nil,
+        lastStreamError: nil,
+        streamErrorCount: 0,
+        source: .live,
+        serverSha: "abc1234",
+        serverDirty: false
+    )
+}
+
 /// The bug this whole change fixes: `status == "error"` paired with
 /// `probeStatus == .never` — a rejected refresh token, not an absence of
 /// probing — decoded and counted correctly.
 final class AccountHealthTests: XCTestCase {
     func testErrorStatusIsNeedsRelogin() {
         XCTAssertEqual(brokenAccount("dave@example.com").health, .needsRelogin)
+    }
+
+    /// Nothing pins the `"error"` token across the Rust/Swift boundary except
+    /// this test. `Account.health`'s `case "error": return .needsRelogin` is a
+    /// bare string match against `AccountStatus::as_str` (`src/manager/mod.rs`)
+    /// — a rename there degrades SILENTLY to `.other` here (by design, for a
+    /// genuinely unrecognised future status), and every row would quietly
+    /// revert to the pre-fix wrong pill with no red build to catch it.
+    /// `testUnknownFutureStatusDecodesToOtherAndChangesNoCount` proves graceful
+    /// degradation; this proves the token that degradation is silently hiding
+    /// hasn't disappeared. Reads the Rust source directly rather than
+    /// hardcoding a duplicate assumption about it, so a rename fails THIS
+    /// test loudly instead of the panel failing silently in production.
+    func testAccountStatusErrorTokenStillExistsInRustSource() throws {
+        let thisFile = URL(fileURLWithPath: #filePath)
+        let repoRoot =
+            thisFile
+            .deletingLastPathComponent()  // FleetStatusTests.swift -> TcrBarTests
+            .deletingLastPathComponent()  // TcrBarTests -> Tests
+            .deletingLastPathComponent()  // Tests -> apps/macos
+            .deletingLastPathComponent()  // apps/macos -> apps
+            .deletingLastPathComponent()  // apps -> repo root
+        let rustSource = repoRoot.appendingPathComponent("src/manager/mod.rs")
+        let contents = try String(contentsOf: rustSource, encoding: .utf8)
+        XCTAssertTrue(
+            contents.contains(#"AccountStatus::Error => "error","#),
+            "the \"error\" token FleetStatus.swift's Account.health decodes as "
+                + ".needsRelogin has moved or been renamed in \(rustSource.path) "
+                + "— update the case in FleetStatus.swift to match, or every "
+                + "broken-account row silently reverts to the pre-fix wrong pill"
+        )
     }
 
     func testActiveAndThrottledDecodeToTheirOwnCases() {
@@ -373,6 +445,87 @@ final class FleetNeedsReloginTests: XCTestCase {
                 "erin@example.com", "parked@example.com",
             ]
         )
+    }
+}
+
+/// The bug an adversarial review found: every test above exercises only
+/// `brokenAccount` — never-probed, `quota: nil`. The shape that actually
+/// happens in production is `probedThenBrokenAccount`: a credential that
+/// dies AFTER being probed keeps its last-learned `quota`/`quotaState`, so
+/// `hasQuotaEvidence` reads TRUE. `isReady` originally checked
+/// `!disabled && quotaState == .ok && hasQuotaEvidence` with no health
+/// clause, so this exact shape read READY — counted in `readyCount`, turned
+/// `capacityState`/the glyph green, and the header could say
+/// "1 of 1 ready · 1 need re-login" in the same frame.
+final class FleetProbedThenBrokenTests: XCTestCase {
+    func testProbedThenBrokenAccountIsNotReady() {
+        let broken = probedThenBrokenAccount("dave@example.com")
+        XCTAssertTrue(
+            broken.hasQuotaEvidence,
+            "the shape under test: this account DOES have a last-learned reading"
+        )
+        XCTAssertEqual(broken.quotaState, .ok, "and that reading says ok, same as a healthy account")
+        XCTAssertFalse(
+            broken.isReady,
+            "hasQuotaEvidence + quotaState == .ok is not enough — health must gate isReady too"
+        )
+    }
+
+    func testProbedThenBrokenAccountIsExcludedFromReadyCount() {
+        let fleet = Fleet(accounts: [
+            account("alice@example.com", state: .ok),
+            probedThenBrokenAccount("dave@example.com"),
+        ])
+        XCTAssertEqual(fleet.readyCount, 1, "only alice; dave's stale ok reading must not count")
+        XCTAssertEqual(fleet.needsReloginCount, 1)
+        XCTAssertEqual(fleet.unmeasuredCount, 0, "dave has evidence — just not usable evidence")
+    }
+
+    func testCapacitySummaryDoesNotDoubleCountAProbedThenBrokenAccountAsReady() {
+        let fleet = Fleet(accounts: [probedThenBrokenAccount("dave@example.com")])
+        XCTAssertEqual(fleet.capacitySummary, "No capacity · 1 need re-login")
+        XCTAssertFalse(
+            fleet.capacitySummary.contains("of 1 ready"),
+            "the exact contradiction the review found: \"1 of 1 ready\" beside \"1 need re-login\""
+        )
+    }
+
+    func testCapacityStateIsSpentNotOkForAProbedThenBrokenAccount() {
+        let fleet = Fleet(accounts: [probedThenBrokenAccount("dave@example.com")])
+        XCTAssertEqual(fleet.capacityState, .spent)
+        XCTAssertEqual(fleet.capacityGlyphState, .spent)
+    }
+
+    /// The `.near` glyph branch reads `quotaState` directly, not through
+    /// `isReady` — a broken account whose LAST reading was `.near` (it was
+    /// close to its threshold before the credential died) must not amber the
+    /// glyph for capacity that has since gone to zero, not merely "close".
+    func testCapacityGlyphIgnoresANearReadingFromABrokenAccount() {
+        let fleet = Fleet(accounts: [
+            probedThenBrokenAccount("dave@example.com", quota: 0.94, quotaState: .near)
+        ])
+        XCTAssertEqual(
+            fleet.capacityGlyphState, .spent,
+            "a broken account's stale .near reading must not amber the glyph"
+        )
+    }
+
+    func testProbedThenBrokenAccountGetsTheNeedsReloginBreakdownBucketNotOk() {
+        let fleet = Fleet(accounts: [
+            account("alice@example.com", state: .ok),
+            probedThenBrokenAccount("dave@example.com"),
+        ])
+        XCTAssertEqual(fleet.breakdownLabel, "1 ok · 1 need re-login")
+    }
+
+    /// Same class, different quota state: a spent-then-broken account must
+    /// also land in `needsRelogin`, not `spent` — the bucket answers "why is
+    /// this not ready", and the answer is the credential, not the quota.
+    func testSpentThenBrokenAccountAlsoBucketsAsNeedsReloginNotSpent() {
+        let fleet = Fleet(accounts: [
+            probedThenBrokenAccount("dave@example.com", quota: 1.0, quotaState: .spent)
+        ])
+        XCTAssertEqual(fleet.breakdownLabel, "1 need re-login")
     }
 }
 

--- a/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
@@ -186,6 +186,177 @@ private func account(
     )
 }
 
+/// A dead-credential account: `status:"error"`, never probed — the live shape
+/// (`src/manager/refresh.rs:92-101` rejects the refresh token and sets
+/// `AccountStatus::Error`), not a hand-picked one. `quotaState` stays the
+/// Rust-side default `ok` and `quota` stays `nil`, exactly as `hasQuotaEvidence`
+/// expects for an account that has never been probed.
+private func brokenAccount(_ name: String, disabled: Bool = false) -> Account {
+    Account(
+        name: name,
+        priority: 1,
+        status: "error",
+        disabled: disabled,
+        quota: nil,
+        quotaState: .ok,
+        fiveHour: nil,
+        sevenDay: nil,
+        sevenDayOi: nil,
+        held: [],
+        requests: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheHitRatio: nil,
+        probeStatus: .never,
+        probeError: nil,
+        lastStreamError: nil,
+        streamErrorCount: 0,
+        source: .live,
+        serverSha: "abc1234",
+        serverDirty: false
+    )
+}
+
+/// The bug this whole change fixes: `status == "error"` paired with
+/// `probeStatus == .never` — a rejected refresh token, not an absence of
+/// probing — decoded and counted correctly.
+final class AccountHealthTests: XCTestCase {
+    func testErrorStatusIsNeedsRelogin() {
+        XCTAssertEqual(brokenAccount("dave@example.com").health, .needsRelogin)
+    }
+
+    func testActiveAndThrottledDecodeToTheirOwnCases() {
+        XCTAssertEqual(account("alice@example.com", state: .ok).health, .active)
+        let throttled = Account(
+            name: "bob@example.com", priority: 1, status: "throttled", disabled: false,
+            quota: 0.9, quotaState: .near, fiveHour: 0.9, sevenDay: 0.9, sevenDayOi: 0,
+            held: [], requests: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0,
+            cacheHitRatio: nil, probeStatus: .ok, probeError: nil, lastStreamError: nil,
+            streamErrorCount: 0, source: .live, serverSha: nil, serverDirty: nil
+        )
+        XCTAssertEqual(throttled.health, .throttled)
+    }
+
+    /// A future status this build has never seen degrades to `.other`, exactly
+    /// like `QuotaState.unknown` and `ProbeState.unknown` do — never a decode
+    /// failure, and it must not silently change any count.
+    func testUnknownFutureStatusDecodesToOtherAndChangesNoCount() {
+        let weird = Account(
+            name: "eve@example.com", priority: 1, status: "quarantined", disabled: false,
+            quota: nil, quotaState: .ok, fiveHour: nil, sevenDay: nil, sevenDayOi: nil,
+            held: [], requests: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0,
+            cacheHitRatio: nil, probeStatus: .never, probeError: nil, lastStreamError: nil,
+            streamErrorCount: 0, source: .live, serverSha: nil, serverDirty: nil
+        )
+        XCTAssertEqual(weird.health, .other("quarantined"))
+        let fleet = Fleet(accounts: [weird])
+        // Not needs-relogin, so it falls through to the ordinary unmeasured
+        // path — an unrecognised status must not invent a new remedy.
+        XCTAssertEqual(fleet.needsReloginCount, 0)
+        XCTAssertEqual(fleet.unmeasuredCount, 1)
+    }
+}
+
+/// The invariant this whole change restores: a broken account is not
+/// "unmeasured" — it is a known, certain fact with its own bucket, its own
+/// count and a glyph that reflects the certainty rather than backing off to
+/// `.unknown`.
+final class FleetNeedsReloginTests: XCTestCase {
+    func testBrokenAccountIsNotCountedAsUnmeasured() {
+        let fleet = Fleet(accounts: [
+            account("alice@example.com", state: .ok),
+            brokenAccount("dave@example.com"),
+        ])
+        XCTAssertEqual(fleet.unmeasuredCount, 0, "an error account is not merely unprobed")
+        XCTAssertEqual(fleet.needsReloginCount, 1)
+    }
+
+    func testBrokenAccountGetsItsOwnBreakdownBucket() {
+        let fleet = Fleet(accounts: [
+            account("alice@example.com", state: .ok),
+            brokenAccount("dave@example.com"),
+            brokenAccount("erin@example.com"),
+        ])
+        XCTAssertEqual(fleet.breakdownLabel, "1 ok · 2 need re-login")
+    }
+
+    func testCapacitySummaryNamesTheBrokenAccounts() {
+        let fleet = Fleet(accounts: [
+            account("alice@example.com", state: .ok),
+            brokenAccount("dave@example.com"),
+        ])
+        XCTAssertEqual(fleet.capacitySummary, "1 of 2 ready · 1 need re-login")
+    }
+
+    /// The case that used to say "No confirmed capacity · 5 unmeasured" for a
+    /// fleet where nothing was actually unmeasured — five accounts were dead
+    /// credentials, a fact the fleet already knew and could have said.
+    func testCapacitySummaryOnAllBrokenFleetDoesNotClaimUnconfirmed() {
+        let fleet = Fleet(accounts: [
+            brokenAccount("dave@example.com"),
+            brokenAccount("erin@example.com"),
+        ])
+        XCTAssertEqual(fleet.capacitySummary, "No capacity · 2 need re-login")
+        XCTAssertFalse(
+            fleet.capacitySummary.contains("unmeasured"),
+            "nothing here is unmeasured — every account has a known, rejected credential"
+        )
+    }
+
+    /// The certainty a broken account earns: `.spent`, not `.unknown`. An
+    /// unprobed account still forces `.unknown`, because that one really is a
+    /// question mark — the two must not collapse into the same glyph.
+    func testGlyphIsSpentNotUnknownWhenOnlyBrokenAccountsAreNotReady() {
+        let brokenOnly = Fleet(accounts: [
+            brokenAccount("dave@example.com"),
+            brokenAccount("erin@example.com"),
+        ])
+        XCTAssertEqual(brokenOnly.capacityGlyphState, .spent)
+        XCTAssertEqual(brokenOnly.capacityState, .spent)
+
+        let unmeasuredOnly = Fleet(accounts: [
+            Account(
+                name: "frank@example.com", priority: 1, status: "active", disabled: false,
+                quota: nil, quotaState: .ok, fiveHour: nil, sevenDay: nil, sevenDayOi: nil,
+                held: [], requests: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0,
+                cacheHitRatio: nil, probeStatus: .never, probeError: nil, lastStreamError: nil,
+                streamErrorCount: 0, source: .live, serverSha: nil, serverDirty: nil
+            )
+        ])
+        XCTAssertEqual(
+            unmeasuredOnly.capacityGlyphState, .unknown("unmeasured"),
+            "a genuinely never-probed account must still read as unknown, not spent"
+        )
+    }
+
+    /// Row order: usable first, broken above the merely-unmeasured and the
+    /// spent, parked last regardless of health.
+    func testDisplayOrderPutsBrokenAboveUnmeasuredAndBelowReady() {
+        let ready = account("alice@example.com", state: .ok)
+        let broken = brokenAccount("dave@example.com")
+        let neverProbed = Account(
+            name: "frank@example.com", priority: 1, status: "active", disabled: false,
+            quota: nil, quotaState: .ok, fiveHour: nil, sevenDay: nil, sevenDayOi: nil,
+            held: [], requests: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0,
+            cacheHitRatio: nil, probeStatus: .never, probeError: nil, lastStreamError: nil,
+            streamErrorCount: 0, source: .live, serverSha: nil, serverDirty: nil
+        )
+        let spent = account("erin@example.com", state: .spent)
+        let parkedBroken = brokenAccount("parked@example.com", disabled: true)
+
+        let fleet = Fleet(accounts: [parkedBroken, spent, neverProbed, broken, ready])
+        let order = fleet.rowsInDisplayOrder.map(\.name)
+        XCTAssertEqual(
+            order,
+            [
+                "alice@example.com", "dave@example.com", "frank@example.com",
+                "erin@example.com", "parked@example.com",
+            ]
+        )
+    }
+}
+
 final class FleetCapacitySummaryTests: XCTestCase {
     func testHealthyFleetReadsAsAllOk() {
         let fleet = Fleet(accounts: (1...12).map { account("a\($0)@example.com", state: .ok) })

--- a/apps/macos/Tests/TcrBarTests/LoginLauncherTests.swift
+++ b/apps/macos/Tests/TcrBarTests/LoginLauncherTests.swift
@@ -61,39 +61,86 @@ final class LoginLauncherTests: XCTestCase {
         XCTAssertNil(opened, "nothing should be opened when tcr was never found")
     }
 
-    /// The re-login hint is honest that the browser choice — not this script —
-    /// is what selects the account: `tcr login` takes no account argument.
-    func testReloginHintNamesTheAccountAndDefersToTheBrowser() {
+    /// The re-login hint is honest about what actually targets the account:
+    /// `--account` requests that identity and `tcr` refuses to save on a
+    /// mismatch — not "choose that account in the browser", which was true
+    /// before `--account` shipped and is not any more.
+    func testReloginHintNamesTheAccountAndTheMismatchGuard() {
         let script = LoginLauncher.script(
             forExecutableAt: "/opt/homebrew/bin/tcr", reloggingIn: "alice@example.com")
         XCTAssertTrue(
             script.contains(
-                "echo 'Re-logging in alice@example.com — choose that account in the browser.'"),
+                "echo 'Re-logging in alice@example.com — tcr requests that account, "
+                    + "and refuses to save if the browser hands back a different one.'"
+            ),
             script
         )
     }
 
-    /// Omitting the hint must leave the existing add-account script unchanged.
-    func testNoHintByDefault() {
-        let script = LoginLauncher.script(forExecutableAt: "/opt/homebrew/bin/tcr")
-        XCTAssertFalse(script.contains("Re-logging in"), script)
+    /// The part that makes the button actually target the row it was clicked
+    /// from, not merely narrate it: `login --account <name>` on the exec line.
+    /// `src/main.rs` / `src/oauth.rs`'s `login_hint` refuses to write when the
+    /// browser hands back a different identity — measured live, a re-login
+    /// meant for one account authenticated as a different one signed into the
+    /// browser, and this flag is the only reason nothing was overwritten.
+    func testReloginPassesAccountFlagOnTheExecLine() {
+        let script = LoginLauncher.script(
+            forExecutableAt: "/opt/homebrew/bin/tcr", reloggingIn: "alice@example.com")
+        XCTAssertTrue(
+            script.contains("exec '/opt/homebrew/bin/tcr' login --account 'alice@example.com'"),
+            script
+        )
     }
 
-    /// The injection case for the account name: a single quote must not escape
-    /// the quoting and let anything after it run as its own command. Mirrors
-    /// ``testSingleQuoteInPathCannotEscapeTheQuoting`` for the path.
-    func testSingleQuoteInReloginNameCannotEscapeTheQuoting() {
+    /// Omitting the hint must leave the existing add-account script unchanged
+    /// — no echoed name, and no `--account` flag it cannot satisfy.
+    func testNoHintOrAccountFlagByDefault() {
+        let script = LoginLauncher.script(forExecutableAt: "/opt/homebrew/bin/tcr")
+        XCTAssertFalse(script.contains("Re-logging in"), script)
+        XCTAssertFalse(script.contains("--account"), script)
+        // The exec line ends at `login`, whole-line, not merely a substring —
+        // an `--account` this build failed to append would otherwise slip
+        // past a plain `.contains("login")` check.
+        let execLine = script.split(separator: "\n").first { $0.hasPrefix("exec ") }
+        XCTAssertEqual(
+            execLine.map(String.init), "exec '/opt/homebrew/bin/tcr' login",
+            "the add-account path must not grow an --account it cannot satisfy"
+        )
+    }
+
+    /// The injection case for the account name in the ECHO: a single quote
+    /// must not escape the quoting and let anything after it run as its own
+    /// command. Mirrors ``testSingleQuoteInPathCannotEscapeTheQuoting`` for
+    /// the path.
+    func testSingleQuoteInReloginNameCannotEscapeTheEchoQuoting() {
         let script = LoginLauncher.script(
             forExecutableAt: "/opt/homebrew/bin/tcr", reloggingIn: "ev'il@example.com")
         XCTAssertTrue(
             script.contains(
-                #"echo 'Re-logging in ev'\''il@example.com — choose that account in the browser.'"#),
+                #"echo 'Re-logging in ev'\''il@example.com — tcr requests that account, "#
+                    + #"and refuses to save if the browser hands back a different one.'"#
+            ),
             "a quote in the name must be escaped POSIX-style, got: \(script)"
         )
         // The whole message is one shell argument to `echo` — nothing after
         // the closing quote on that line.
         let echoLine = script.split(separator: "\n").first { $0.hasPrefix("echo 'Re-logging in") }
-        XCTAssertEqual(echoLine?.hasSuffix("browser.'"), true, "trailing text after the quoted message")
+        XCTAssertEqual(echoLine?.hasSuffix("different one.'"), true, "trailing text after the quoted message")
+    }
+
+    /// The injection case for the account name on the COMMAND LINE — the part
+    /// that is now load-bearing rather than cosmetic, since this text becomes
+    /// an actual shell argument to `tcr`, not just something `echo` prints.
+    func testSingleQuoteInReloginNameCannotEscapeTheAccountFlagQuoting() {
+        let script = LoginLauncher.script(
+            forExecutableAt: "/opt/homebrew/bin/tcr", reloggingIn: "ev'il@example.com")
+        XCTAssertTrue(
+            script.contains(#"login --account 'ev'\''il@example.com'"#),
+            "a quote in the name must be escaped POSIX-style on the exec line, got: \(script)"
+        )
+        // Nothing may follow the quoted account name except the end of the line.
+        let execLine = script.split(separator: "\n").first { $0.hasPrefix("exec ") }
+        XCTAssertEqual(execLine?.hasSuffix("'"), true, "trailing text after the quoted account name")
     }
 
     func testSuccessWritesAnExecutableScriptAndOpensIt() throws {

--- a/apps/macos/Tests/TcrBarTests/LoginLauncherTests.swift
+++ b/apps/macos/Tests/TcrBarTests/LoginLauncherTests.swift
@@ -143,6 +143,40 @@ final class LoginLauncherTests: XCTestCase {
         XCTAssertEqual(execLine?.hasSuffix("'"), true, "trailing text after the quoted account name")
     }
 
+    /// The race this fixes: before `--account`, every invocation wrote
+    /// identical bytes to a FIXED path, so two overlapping Re-login clicks
+    /// were harmless. The content is per-account now, so two clicks in quick
+    /// succession could overwrite the file before the first Terminal window
+    /// reads it — window A running window B's `--account`. Two real (default
+    /// `UUID.init`) launches must land at two different paths.
+    func testTwoLaunchesGetDifferentPaths() throws {
+        var opened: [URL] = []
+        for _ in 0..<2 {
+            let result = LoginLauncher.launch(
+                resolve: { .success(URL(fileURLWithPath: "/usr/local/bin/tcr")) },
+                open: { opened.append($0) }
+            )
+            guard case .success = result else { return XCTFail("expected success") }
+        }
+        XCTAssertEqual(opened.count, 2)
+        XCTAssertNotEqual(opened[0], opened[1], "two launches must not race on one shared path")
+    }
+
+    /// The path is deterministic under an injected UUID, which is what makes
+    /// the uniqueness above testable without depending on real randomness.
+    func testPathIncorporatesTheInjectedUUID() throws {
+        let fixed = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+        var opened: URL?
+        let result = LoginLauncher.launch(
+            uuid: { fixed },
+            resolve: { .success(URL(fileURLWithPath: "/usr/local/bin/tcr")) },
+            open: { opened = $0 }
+        )
+        guard case .success(let url) = result else { return XCTFail("expected success") }
+        XCTAssertEqual(opened, url)
+        XCTAssertEqual(url.lastPathComponent, "tcr-login-\(fixed.uuidString).command")
+    }
+
     func testSuccessWritesAnExecutableScriptAndOpensIt() throws {
         var opened: URL?
         let result = LoginLauncher.launch(

--- a/apps/macos/Tests/TcrBarTests/LoginLauncherTests.swift
+++ b/apps/macos/Tests/TcrBarTests/LoginLauncherTests.swift
@@ -61,6 +61,41 @@ final class LoginLauncherTests: XCTestCase {
         XCTAssertNil(opened, "nothing should be opened when tcr was never found")
     }
 
+    /// The re-login hint is honest that the browser choice — not this script —
+    /// is what selects the account: `tcr login` takes no account argument.
+    func testReloginHintNamesTheAccountAndDefersToTheBrowser() {
+        let script = LoginLauncher.script(
+            forExecutableAt: "/opt/homebrew/bin/tcr", reloggingIn: "alice@example.com")
+        XCTAssertTrue(
+            script.contains(
+                "echo 'Re-logging in alice@example.com — choose that account in the browser.'"),
+            script
+        )
+    }
+
+    /// Omitting the hint must leave the existing add-account script unchanged.
+    func testNoHintByDefault() {
+        let script = LoginLauncher.script(forExecutableAt: "/opt/homebrew/bin/tcr")
+        XCTAssertFalse(script.contains("Re-logging in"), script)
+    }
+
+    /// The injection case for the account name: a single quote must not escape
+    /// the quoting and let anything after it run as its own command. Mirrors
+    /// ``testSingleQuoteInPathCannotEscapeTheQuoting`` for the path.
+    func testSingleQuoteInReloginNameCannotEscapeTheQuoting() {
+        let script = LoginLauncher.script(
+            forExecutableAt: "/opt/homebrew/bin/tcr", reloggingIn: "ev'il@example.com")
+        XCTAssertTrue(
+            script.contains(
+                #"echo 'Re-logging in ev'\''il@example.com — choose that account in the browser.'"#),
+            "a quote in the name must be escaped POSIX-style, got: \(script)"
+        )
+        // The whole message is one shell argument to `echo` — nothing after
+        // the closing quote on that line.
+        let echoLine = script.split(separator: "\n").first { $0.hasPrefix("echo 'Re-logging in") }
+        XCTAssertEqual(echoLine?.hasSuffix("browser.'"), true, "trailing text after the quoted message")
+    }
+
     func testSuccessWritesAnExecutableScriptAndOpensIt() throws {
         var opened: URL?
         let result = LoginLauncher.launch(

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -117,29 +117,42 @@ Runs the browser OAuth flow and adds the resulting account to the pool.
 |---|---|---|---|
 | `--config <path>` | path | `~/.config/teamclaude.json` | config to write into |
 | `--force` | bool | `false` | override a refusal and write the config file anyway — never overrides a confirmed live route or a rejected api-key |
-| `--account <name>` | string | none | re-login a specific existing account, and refuse to write anything unless the identity that comes back matches it |
+| `--account <name>` | string | none | re-login a specific existing account, and refuse to write anything unless the identity that comes back resolves to it |
+| `--org <name-or-uuid>` | string | none | narrow an ambiguous `--account` match to a single org — same flag `tcr enable`/`tcr disable`/`tcr remove`/`tcr priority` take |
 
-**`--account <name>` targets one existing account and refuses to fix the wrong one.**
-Without it, `login` upserts by whatever identity the browser hands back — a
+**`--account <name> [--org <org>]` targets one existing account and refuses to fix the
+wrong one.** Without it, `login` upserts by whatever identity the browser hands back — a
 default-browser OAuth flow carries whatever claude.ai session is already signed in, so
 re-logging in a dead account can silently refresh a *different*, already-healthy one and
-report success while the broken account stays broken. `--account` resolves `<name>`
-against the config with the same exact-name-then-exact-email rule `tcr enable`/`tcr
-disable` use (case-sensitive, no substrings; `--account` itself takes no `--org`, so an
-ambiguous email across two orgs is an error naming the candidates). It also passes the
-resolved account's email as OAuth's `login_hint`, which pre-selects that address on a
-clean login page — this part is ergonomics only, not a guarantee: it is unverified
-whether the hint overrides a browser that is *already* signed in as someone else, which
-is exactly the case the default-browser flow produces. The correctness guarantee is a
-separate check, after the browser round trip and before anything is written: the
-identity that came back (preferring `account_uuid`, since an email can be reused across
-orgs but a uuid cannot) must match the resolved account, or **nothing is written** — the
-config is left byte-identical — and the error names both the account that was requested
-and the one the browser actually authenticated as. A profile with neither an email nor a
-uuid (a failed profile fetch) is refused the same way, never treated as a pass. Omitting
-`--account` behaves exactly as before: no identity check runs, and a fresh login is
-free to land on whatever account the browser returns — that is the add-a-new-account
-path.
+report success while the broken account stays broken. `--account`/`--org` resolve
+`<name>` against the config with the same rule `tcr enable`/`tcr disable` use
+(case-sensitive, no substrings; `--org` narrows an otherwise-ambiguous email match by org
+name or org uuid). It also passes the resolved account's email as OAuth's `login_hint`,
+which pre-selects that address on a clean login page — this part is ergonomics only, not
+a guarantee: it is unverified whether the hint overrides a browser that is *already*
+signed in as someone else, which is exactly the case the default-browser flow produces.
+The hint is only ever sent when the resolved account's name is address-shaped; an
+account named e.g. `work` never produces `login_hint=work`.
+
+The correctness guarantee is a separate check, after the browser round trip and before
+anything is written. **An account UUID alone identifies the *person*, not the account**:
+the same person routinely holds more than one organization (a corporate Pro org and a
+personal Max org), each with its own token and quota, so a UUID can be identical on two
+different rows in the config. The check therefore resolves the identity that came back
+the same way a write would — UUID *and* org together, through the same resolution
+`upsert_account` uses — and only a resolution landing on the SAME row as `--account`
+counts as a match. Two rows sharing a UUID but a different org (Corp vs. Personal) are
+correctly treated as different accounts, and a re-login intended for one can never be
+silently written onto the other. On any other outcome — a different row, an ambiguous
+resolution, or an unresolvable one — **nothing is written**, the config is left
+byte-identical, and the error names both the account that was requested and the identity
+the browser actually authenticated as. A profile with neither an email nor a uuid (a
+failed profile fetch) is refused the same way, never treated as a pass. An account with
+no stored UUID *and* a non-email display name (e.g. `work`) has nothing on file to check
+a returned identity against at all; that case is refused too, with a message that says so
+plainly instead of suggesting a browser sign-out that could not help. Omitting `--account`
+behaves exactly as before: no identity check runs, and a fresh login is free to land on
+whatever account the browser returns — that is the add-a-new-account path.
 
 **A running proxy no longer has to be stopped.** Before opening the browser, `tcr login`
 asks the proxy on the configured port whether it can take an account live, by POSTing a

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -117,6 +117,29 @@ Runs the browser OAuth flow and adds the resulting account to the pool.
 |---|---|---|---|
 | `--config <path>` | path | `~/.config/teamclaude.json` | config to write into |
 | `--force` | bool | `false` | override a refusal and write the config file anyway — never overrides a confirmed live route or a rejected api-key |
+| `--account <name>` | string | none | re-login a specific existing account, and refuse to write anything unless the identity that comes back matches it |
+
+**`--account <name>` targets one existing account and refuses to fix the wrong one.**
+Without it, `login` upserts by whatever identity the browser hands back — a
+default-browser OAuth flow carries whatever claude.ai session is already signed in, so
+re-logging in a dead account can silently refresh a *different*, already-healthy one and
+report success while the broken account stays broken. `--account` resolves `<name>`
+against the config with the same exact-name-then-exact-email rule `tcr enable`/`tcr
+disable` use (case-sensitive, no substrings; `--account` itself takes no `--org`, so an
+ambiguous email across two orgs is an error naming the candidates). It also passes the
+resolved account's email as OAuth's `login_hint`, which pre-selects that address on a
+clean login page — this part is ergonomics only, not a guarantee: it is unverified
+whether the hint overrides a browser that is *already* signed in as someone else, which
+is exactly the case the default-browser flow produces. The correctness guarantee is a
+separate check, after the browser round trip and before anything is written: the
+identity that came back (preferring `account_uuid`, since an email can be reused across
+orgs but a uuid cannot) must match the resolved account, or **nothing is written** — the
+config is left byte-identical — and the error names both the account that was requested
+and the one the browser actually authenticated as. A profile with neither an email nor a
+uuid (a failed profile fetch) is refused the same way, never treated as a pass. Omitting
+`--account` behaves exactly as before: no identity check runs, and a fresh login is
+free to land on whatever account the browser returns — that is the add-a-new-account
+path.
 
 **A running proxy no longer has to be stopped.** Before opening the browser, `tcr login`
 asks the proxy on the configured port whether it can take an account live, by POSTing a

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -885,6 +885,19 @@ fn render_accounts_json(
                 "disabled": a.disabled,
                 "quota": quota,
                 "quotaState": quota_state_token(a.quota_state),
+                // The server's own terminal-gate verdict
+                // (`Manager::account_terminal_gate`/`account_gate`), including the
+                // one TcrBar could not otherwise see: `rejected` (Anthropic's own
+                // `anthropic-ratelimit-unified-status: rejected` header). Before
+                // this field existed, `status` was rewritten only for `Throttled`
+                // (see `snapshot.rs`), so a rejected account still read `status:
+                // "active"` and the panel drew it as eligible when the router will
+                // never select it. Kebab-case values ("ok", "hold", "five-hour",
+                // "seven-day", "fable-weekly", "standard", "login", "rejected",
+                // "disabled") via `GateReason`'s own `Serialize`. New field, so an
+                // older reader on either end is unaffected: a client built before
+                // this shipped simply never looks at it.
+                "gate": a.gate,
                 "fiveHour": a.five_hour,
                 "sevenDay": a.seven_day,
                 "sevenDayOi": a.seven_day_oi,

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,6 +173,10 @@ struct LoginArgs {
     /// match, or nothing is written.
     #[arg(long)]
     account: Option<String>,
+    /// Narrow an ambiguous `--account` match to a single org (name or uuid) —
+    /// the same flag `tcr enable`/`tcr disable`/`tcr remove`/`tcr priority` take.
+    #[arg(long)]
+    org: Option<String>,
 }
 
 #[derive(clap::Args)]
@@ -513,9 +517,14 @@ fn apply_capability_defaults(cmd: &mut std::process::Command) {
 /// in [`oauth::login`]; this just resolves the config path and reports.
 async fn run_login(args: LoginArgs) -> anyhow::Result<()> {
     let config_path = args.config.clone().unwrap_or_else(config::default_path);
-    let name = oauth::login(&config_path, args.force, args.account.as_deref())
-        .await
-        .context("OAuth login failed")?;
+    let name = oauth::login(
+        &config_path,
+        args.force,
+        args.account.as_deref(),
+        args.org.as_deref(),
+    )
+    .await
+    .context("OAuth login failed")?;
     println!("Logged in as '{name}'.");
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,6 +169,10 @@ struct LoginArgs {
     /// next token refresh can overwrite what was just written.
     #[arg(long)]
     force: bool,
+    /// Re-login a specific existing account. The identity that comes back must
+    /// match, or nothing is written.
+    #[arg(long)]
+    account: Option<String>,
 }
 
 #[derive(clap::Args)]
@@ -509,7 +513,7 @@ fn apply_capability_defaults(cmd: &mut std::process::Command) {
 /// in [`oauth::login`]; this just resolves the config path and reports.
 async fn run_login(args: LoginArgs) -> anyhow::Result<()> {
     let config_path = args.config.clone().unwrap_or_else(config::default_path);
-    let name = oauth::login(&config_path, args.force)
+    let name = oauth::login(&config_path, args.force, args.account.as_deref())
         .await
         .context("OAuth login failed")?;
     println!("Logged in as '{name}'.");

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -1026,6 +1026,7 @@ pub async fn login(
     config_path: &Path,
     force: bool,
     account: Option<&str>,
+    org: Option<&str>,
 ) -> anyhow::Result<String> {
     let port = login_target_port(config_path);
     let incumbent = singleton::live_proxy_server(port);
@@ -1042,8 +1043,20 @@ pub async fn login(
     let hint = match account {
         Some(query) => {
             let probe_config = load_or_default(config_path)?;
-            let idx = crate::cli::resolve_account(&probe_config.accounts, query, None)?;
-            Some(crate::identity::email_of(&probe_config.accounts[idx].name).to_string())
+            let idx = crate::cli::resolve_account(&probe_config.accounts, query, org)?;
+            let email = crate::identity::email_of(&probe_config.accounts[idx].name);
+            // Only ever send something address-shaped: a non-email display
+            // name (e.g. an account named "work") produces `login_hint=work`
+            // otherwise — an unvalidated non-address value on an endpoint
+            // this crate already knows is picky about param shape (the
+            // 32-byte-state note above). Skipping it there costs nothing:
+            // the hint is ergonomics only (see this function's doc-comment),
+            // never the source of truth.
+            if looks_like_email(email) {
+                Some(email.to_string())
+            } else {
+                None
+            }
         }
         None => None,
     };
@@ -1086,14 +1099,33 @@ pub async fn login(
         &tokens,
         profile,
         account,
+        org,
     )
     .await
+}
+
+/// Whether `s` is plausibly an email address — no whitespace, and exactly one
+/// `@` with at least one character on each side. Deliberately not a full RFC
+/// 5322 validator: this only ever gates whether a value is safe to hand to
+/// `login_hint` (see `build_login_flow`'s doc-comment), where the failure mode
+/// of being too strict is "no pre-fill" and the failure mode of being too
+/// loose is an unvalidated string on an endpoint already known to reject
+/// malformed params outright.
+fn looks_like_email(s: &str) -> bool {
+    if s.contains(char::is_whitespace) {
+        return false;
+    }
+    match s.split_once('@') {
+        Some((local, domain)) => !local.is_empty() && !domain.is_empty() && !domain.contains('@'),
+        None => false,
+    }
 }
 
 /// [`finish_login`], but first asserting the requested `--account` identity
 /// when one was given. Split out so the assertion + write sequence `login()`
 /// runs is directly testable without a real browser or network round trip —
 /// exactly the reason [`finish_login`] itself was split from [`login`].
+#[allow(clippy::too_many_arguments)]
 async fn finish_login_checked(
     config_path: &Path,
     route: LoginRoute,
@@ -1102,32 +1134,46 @@ async fn finish_login_checked(
     tokens: &Tokens,
     profile: Profile,
     requested_account: Option<&str>,
+    requested_org: Option<&str>,
 ) -> anyhow::Result<String> {
     if let Some(query) = requested_account {
-        assert_requested_identity(config, query, &profile)?;
+        assert_requested_identity(config, query, requested_org, &profile)?;
     }
     finish_login(config_path, route, config, name, tokens, profile).await
 }
 
-/// The load-bearing half of `tcr login --account <query>`: resolve `query`
-/// against `config` via [`crate::cli::resolve_account`] — the exact
-/// exact-name-then-email-then-org rule `tcr enable`/`tcr disable` and TcrBar's
-/// row buttons already rely on, not a second copy of it — and refuse to
-/// proceed unless the identity that came back from `fetch_profile` is the
-/// SAME account. `account_uuid` is preferred when both sides have one (an
-/// email can be reused across orgs, a UUID cannot); otherwise email is
-/// compared. Called strictly BEFORE any write path
+/// The load-bearing half of `tcr login --account <query> [--org <org>]`:
+/// resolve `query`/`org` against `config` via [`crate::cli::resolve_account`]
+/// — the exact rule `tcr enable`/`tcr disable` and TcrBar's row buttons
+/// already rely on, not a second copy of it — then refuse to proceed unless
+/// the identity that came back from `fetch_profile` resolves, through
+/// [`crate::identity::resolve`], to that SAME row.
+///
+/// Deliberately reuses `identity::resolve`/`identity::probe` — the exact
+/// functions [`upsert_account`] writes through — rather than a hand-rolled
+/// comparison: an account UUID alone identifies the *person*, not the
+/// account. The same person routinely holds more than one organization (a
+/// corporate Pro org and a personal Max org), each with its own token and
+/// quota (`src/identity.rs:3-8`), so a `uuid`-only check cannot tell those
+/// apart — it would happily confirm a re-login intended for the Corp row
+/// against a browser session signed into Personal, because both carry the
+/// same `uuid`. `identity::resolve` folds the org discriminator in on top of
+/// the uuid, which is why it — not a second copy of only half its logic — is
+/// what both the check and the write need to agree on.
+///
+/// Called strictly BEFORE any write path
 /// ([`finish_login`]/[`persist_via_file`]/[`persist_via_account`]): on
-/// mismatch, or on an unresolvable requested account, or on a profile that
-/// carries neither an email nor a uuid (`fetch_profile`'s all-`None` failure
-/// return, `src/oauth.rs:589-592` above — an assertion that cannot be
+/// mismatch, on an unresolvable/ambiguous requested account, or on a profile
+/// that carries neither an email nor a uuid (`fetch_profile`'s all-`None`
+/// failure return, `src/oauth.rs:649-654` — an assertion that cannot be
 /// evaluated must fail closed, not pass by default), nothing is written.
 fn assert_requested_identity(
     config: &Config,
     query: &str,
+    org: Option<&str>,
     profile: &Profile,
 ) -> anyhow::Result<()> {
-    let idx = crate::cli::resolve_account(&config.accounts, query, None)?;
+    let idx = crate::cli::resolve_account(&config.accounts, query, org)?;
     let requested = &config.accounts[idx];
 
     if profile.email.is_none() && profile.account_uuid.is_none() {
@@ -1138,22 +1184,61 @@ fn assert_requested_identity(
         );
     }
 
-    let matches = match (&requested.account_uuid, &profile.account_uuid) {
-        (Some(want), Some(got)) => want == got,
-        _ => {
-            let want_email = crate::identity::email_of(&requested.name);
-            profile
-                .email
-                .as_deref()
-                .is_some_and(|got| got == want_email)
-        }
+    // The identity a fresh login resolves to, computed the SAME way
+    // `upsert_account` resolves one for a write: build a probe carrying only
+    // what the browser told us, and resolve it against the WHOLE fleet, not
+    // just `requested`. Comparing against the whole fleet (rather than just
+    // asking "does `requested` match the probe?") is what makes the org
+    // discriminator load-bearing: a uuid-only local comparison against
+    // `requested` alone would still pass when Corp was requested and the
+    // browser returned Personal, because it never looks at whether that
+    // identity actually belongs to a DIFFERENT row.
+    let probe_name = profile.email.as_deref().unwrap_or(&requested.name);
+    let probe = crate::identity::probe(
+        probe_name,
+        profile.account_uuid.clone(),
+        profile.org_uuid.clone(),
+        profile.org_name.clone(),
+    );
+    let resolved = crate::identity::resolve(config.accounts.iter().enumerate(), &probe);
+    let resolved_idx = match resolved {
+        crate::identity::Resolved::One(i) => Some(i),
+        crate::identity::Resolved::None | crate::identity::Resolved::Many => None,
     };
 
-    if !matches {
-        let got = profile
-            .email
-            .as_deref()
-            .unwrap_or("an account with no email in its profile");
+    if resolved_idx != Some(idx) {
+        let got = match resolved_idx {
+            // The identity resolved cleanly, just to a DIFFERENT existing
+            // row — name that row, it is the actionable fact.
+            Some(other) => config.accounts[other].name.clone(),
+            None if requested.account_uuid.is_none() && !requested.name.contains('@') => {
+                // `requested` has no stored account id, and its own display
+                // name isn't email-shaped (e.g. an account named "work"), so
+                // there is no stored fact to compare the browser's identity
+                // against at all — this is not "wrong browser session", it
+                // is "nothing on file to check against". Telling the
+                // operator to sign out cannot help here; say so honestly.
+                bail!(
+                    "'{}' has no stored account id, and its name is not an email address, so \
+                     `--account` cannot confirm the browser authenticated as the right person — \
+                     there is nothing on file to compare against. Nothing was written. Run `tcr \
+                     login` once WITHOUT --account, confirm from the printed email that it is the \
+                     account you intended, then either rename this entry to that email or use \
+                     that email with --account from now on.",
+                    requested.name
+                );
+            }
+            None => {
+                let email = profile
+                    .email
+                    .as_deref()
+                    .unwrap_or("an account with no email in its profile");
+                match profile.org_name.as_deref().or(profile.org_uuid.as_deref()) {
+                    Some(org) => format!("{email} (org {org})"),
+                    None => email.to_string(),
+                }
+            }
+        };
         bail!(
             "requested re-login for '{}', but the browser authenticated as '{got}' instead — \
              nothing was written. Sign out of that account in the browser first, or use a \
@@ -2393,6 +2478,19 @@ mod tests {
         }
     }
 
+    // --- `login_hint` value validation --------------------------------------
+
+    #[test]
+    fn looks_like_email_accepts_and_rejects() {
+        assert!(looks_like_email("alice@example.com"));
+        assert!(!looks_like_email("work"), "a bare display name, no '@'");
+        assert!(!looks_like_email("personal-max"), "no '@'");
+        assert!(!looks_like_email("@example.com"), "empty local part");
+        assert!(!looks_like_email("alice@"), "empty domain");
+        assert!(!looks_like_email("alice @example.com"), "whitespace");
+        assert!(!looks_like_email("alice@b@c"), "two '@'s");
+    }
+
     // --- `--account` identity assertion (`tcr login --account`) ------------
 
     fn two_account_seed() -> String {
@@ -2428,6 +2526,7 @@ mod tests {
             &tokens("at-new", "rt-new", 1_893_456_000_000),
             profile_named("mallory@example.com"),
             Some("alice@example.com"),
+            None,
         )
         .await
         .unwrap_err();
@@ -2463,6 +2562,7 @@ mod tests {
             &tokens("at-fresh", "rt-fresh", 1_893_456_000_000),
             profile_named("alice@example.com"),
             Some("alice@example.com"),
+            None,
         )
         .await
         .unwrap();
@@ -2477,7 +2577,7 @@ mod tests {
         std::fs::remove_file(&path).ok();
     }
 
-    /// `fetch_profile`'s all-`None` failure return (`src/oauth.rs:589-592`)
+    /// `fetch_profile`'s all-`None` failure return (`src/oauth.rs:649-654`)
     /// must refuse rather than pass by default — an assertion that cannot be
     /// evaluated is not evidence of a match.
     #[tokio::test]
@@ -2506,6 +2606,7 @@ mod tests {
             &tokens("at-new", "rt-new", 1_893_456_000_000),
             all_none,
             Some("alice@example.com"),
+            None,
         )
         .await
         .unwrap_err();
@@ -2554,6 +2655,7 @@ mod tests {
             &tokens("at-new", "rt-new", 1_893_456_000_000),
             profile_named("dup@example.com"),
             Some("dup@example.com"),
+            None,
         )
         .await
         .unwrap_err();
@@ -2566,6 +2668,269 @@ mod tests {
 
         let after = std::fs::read_to_string(&path).unwrap();
         assert_eq!(before, after, "an ambiguous query must not guess and write");
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// The remedy `ambiguous_query_message` advises ("narrow with --org") must
+    /// actually be followable: `--org` plumbed through resolves the same
+    /// otherwise-ambiguous query to exactly one row.
+    #[tokio::test]
+    async fn finish_login_checked_org_disambiguates_a_duplicate_email() {
+        let seed = r#"{ "accounts": [
+            { "name": "dup@example.com", "type": "oauth", "accessToken": "at-1",
+              "refreshToken": "rt-1", "expiresAt": 1893456000000, "priority": 0,
+              "accountUuid": "uuid-dup", "orgUuid": "org-a", "orgName": "Corp A" },
+            { "name": "dup@example.com", "type": "oauth", "accessToken": "at-2",
+              "refreshToken": "rt-2", "expiresAt": 1893456000000, "priority": 1,
+              "accountUuid": "uuid-dup", "orgUuid": "org-b", "orgName": "Corp B" }
+        ] }"#;
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-account-org-disambig-{}-{}.json",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(&path, seed).unwrap();
+        let mut config = load_or_default(&path).unwrap();
+
+        let name = finish_login_checked(
+            &path,
+            LoginRoute::File,
+            &mut config,
+            "dup@example.com",
+            &tokens("at-new", "rt-new", 1_893_456_000_000),
+            profile_with_identity(
+                "dup@example.com",
+                Some("uuid-dup"),
+                Some("org-a"),
+                Some("Corp A"),
+            ),
+            Some("dup@example.com"),
+            Some("org-a"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(name, "dup@example.com");
+
+        let after: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let corp_a = after["accounts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|a| a["orgUuid"] == "org-a")
+            .expect("Corp A row still present");
+        assert_eq!(
+            corp_a["refreshToken"],
+            serde_json::json!("rt-new"),
+            "the disambiguated row must be the one that was written: {after}"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// A [`Profile`] carrying an account uuid and org — the branch the plain
+    /// email-only [`profile_named`] can never exercise, and the one the review
+    /// found untested (`identity::resolve`'s uuid+org comparison, not merely
+    /// its name-equality fallback).
+    fn profile_with_identity(
+        email: &str,
+        account_uuid: Option<&str>,
+        org_uuid: Option<&str>,
+        org_name: Option<&str>,
+    ) -> Profile {
+        Profile {
+            email: Some(email.to_string()),
+            account_uuid: account_uuid.map(str::to_string),
+            org_uuid: org_uuid.map(str::to_string),
+            org_name: org_name.map(str::to_string),
+        }
+    }
+
+    /// THE CANONICAL FAILURE the review found: `account_uuid` alone cannot
+    /// distinguish a person's two orgs. Config holds the SAME person
+    /// (`uuid-person`) in both a Corp row and a Personal row, each with its
+    /// own org and its own refresh token. Corp's token is dead; the operator
+    /// requests `--account` re-login for Corp. The browser — plausibly, this
+    /// IS the feature's premise — is signed into Personal instead.
+    /// `fetch_profile` returns `{uuid: uuid-person, org: org-personal}`. A
+    /// uuid-only comparison takes the `(Some, Some)` arm and passes, because
+    /// both rows share the same person. The org-aware check must refuse, and
+    /// Corp's own refresh token must be UNCHANGED afterwards — not merely
+    /// "an error came back", which a check that still wrote to the wrong row
+    /// before erroring would also produce.
+    #[tokio::test]
+    async fn finish_login_checked_same_uuid_different_org_is_a_mismatch() {
+        let seed = r#"{ "accounts": [
+            { "name": "me@example.com (Corp)", "type": "oauth", "accessToken": "at-corp",
+              "refreshToken": "rt-corp-DEAD", "expiresAt": 1893456000000, "priority": 0,
+              "accountUuid": "uuid-person", "orgUuid": "org-corp", "orgName": "Corp" },
+            { "name": "me@example.com (Personal)", "type": "oauth", "accessToken": "at-pers",
+              "refreshToken": "rt-personal-ALIVE", "expiresAt": 1893456000000, "priority": 1,
+              "accountUuid": "uuid-person", "orgUuid": "org-personal", "orgName": "Personal" }
+        ] }"#;
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-account-same-uuid-diff-org-{}-{}.json",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(&path, seed).unwrap();
+        let mut config = load_or_default(&path).unwrap();
+        let before = std::fs::read_to_string(&path).unwrap();
+
+        // The browser authenticated as the SAME person, but the Personal org.
+        let wrong_org_profile = profile_with_identity(
+            "me@example.com",
+            Some("uuid-person"),
+            Some("org-personal"),
+            Some("Personal"),
+        );
+
+        let err = finish_login_checked(
+            &path,
+            LoginRoute::File,
+            &mut config,
+            "me@example.com",
+            &tokens("at-new", "rt-new", 1_893_456_000_000),
+            wrong_org_profile,
+            Some("me@example.com (Corp)"),
+            None,
+        )
+        .await
+        .unwrap_err();
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("me@example.com (Corp)"),
+            "names requested: {msg}"
+        );
+        assert!(
+            msg.contains("Personal") || msg.contains("me@example.com (Personal)"),
+            "names the org actually authenticated: {msg}"
+        );
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            before, after,
+            "a same-person-different-org mismatch must leave BOTH rows untouched \
+             (Corp's dead token in particular must not be silently 'fixed' onto Personal's row)"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// The mirror of the canonical failure: the SAME uuid AND the SAME org
+    /// must still succeed — the org-aware check is not merely stricter, it is
+    /// exactly as permissive as `upsert_account`'s own write-time resolution.
+    #[tokio::test]
+    async fn finish_login_checked_same_uuid_same_org_matches() {
+        let seed = r#"{ "accounts": [
+            { "name": "me@example.com (Corp)", "type": "oauth", "accessToken": "at-corp",
+              "refreshToken": "rt-corp-DEAD", "expiresAt": 1893456000000, "priority": 0,
+              "accountUuid": "uuid-person", "orgUuid": "org-corp", "orgName": "Corp" },
+            { "name": "me@example.com (Personal)", "type": "oauth", "accessToken": "at-pers",
+              "refreshToken": "rt-personal-ALIVE", "expiresAt": 1893456000000, "priority": 1,
+              "accountUuid": "uuid-person", "orgUuid": "org-personal", "orgName": "Personal" }
+        ] }"#;
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-account-same-uuid-same-org-{}-{}.json",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(&path, seed).unwrap();
+        let mut config = load_or_default(&path).unwrap();
+
+        let right_profile = profile_with_identity(
+            "me@example.com",
+            Some("uuid-person"),
+            Some("org-corp"),
+            Some("Corp"),
+        );
+
+        let name = finish_login_checked(
+            &path,
+            LoginRoute::File,
+            &mut config,
+            "me@example.com (Corp)",
+            &tokens("at-fresh-corp", "rt-fresh-corp", 1_893_456_000_000),
+            right_profile,
+            Some("me@example.com (Corp)"),
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(name, "me@example.com (Corp)");
+
+        let after: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let corp = after["accounts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|a| a["orgUuid"] == "org-corp")
+            .expect("Corp row still present");
+        assert_eq!(corp["refreshToken"], serde_json::json!("rt-fresh-corp"));
+        let personal = after["accounts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|a| a["orgUuid"] == "org-personal")
+            .expect("Personal row untouched and still present");
+        assert_eq!(
+            personal["refreshToken"],
+            serde_json::json!("rt-personal-ALIVE"),
+            "Personal's own token must be untouched by Corp's re-login"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// A requested account with no stored `account_uuid` AND a non-email
+    /// display name (e.g. an account named "work") cannot be verified by
+    /// email-equality either — there is nothing on file to compare the
+    /// browser identity against. The message must not suggest "sign out",
+    /// which cannot help here, and it must still refuse (fail closed) rather
+    /// than accept blindly.
+    #[tokio::test]
+    async fn finish_login_checked_non_email_name_with_no_uuid_refuses_honestly() {
+        let seed = r#"{ "accounts": [
+            { "name": "work", "type": "oauth", "accessToken": "at-work",
+              "refreshToken": "rt-work-DEAD", "expiresAt": 1893456000000, "priority": 0 }
+        ] }"#;
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-account-non-email-name-{}-{}.json",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(&path, seed).unwrap();
+        let mut config = load_or_default(&path).unwrap();
+        let before = std::fs::read_to_string(&path).unwrap();
+
+        let err = finish_login_checked(
+            &path,
+            LoginRoute::File,
+            &mut config,
+            "work",
+            &tokens("at-new", "rt-new", 1_893_456_000_000),
+            profile_named("someone@example.com"),
+            Some("work"),
+            None,
+        )
+        .await
+        .unwrap_err();
+
+        let msg = err.to_string();
+        assert!(
+            !msg.to_lowercase().contains("sign out"),
+            "advising a sign-out that cannot help is dishonest: {msg}"
+        );
+        assert!(
+            msg.contains("no stored account id") || msg.contains("nothing on file"),
+            "must state the real reason verification is impossible: {msg}"
+        );
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(before, after, "must still fail closed and write nothing");
 
         std::fs::remove_file(&path).ok();
     }
@@ -2592,6 +2957,7 @@ mod tests {
             "carol@example.com",
             &tokens("at-carol", "rt-carol", 1_893_456_000_000),
             profile_named("carol@example.com"),
+            None,
             None,
         )
         .await

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -296,7 +296,17 @@ struct LoginFlow {
 /// `oauth2` client. PKCE (S256), `state`, and standard params (`response_type`,
 /// `client_id`, `redirect_uri`, `scope`, `code_challenge*`) are all produced by
 /// the library; only Claude's non-standard `code=true` is added by hand.
-fn build_login_flow(redirect_uri: &str) -> anyhow::Result<LoginFlow> {
+///
+/// `login_hint`, when present, is passed through to `claude.ai/oauth/authorize`
+/// so the login page pre-selects that address — **ergonomics only**, never the
+/// source of truth. Measured 2026-08-14 (σ3, N=1, clean incognito session): the
+/// endpoint honors it and pre-fills the exact address passed. Untested (σ1):
+/// whether it overrides an *already signed-in* browser session — precisely the
+/// case `open_browser` produces by handing the URL to the default browser.
+/// Because that case is unverified, the caller must never rely on the hint for
+/// correctness; the identity assertion after `fetch_profile` returns is what
+/// actually enforces the requested account, and depends on nothing external.
+fn build_login_flow(redirect_uri: &str, login_hint: Option<&str>) -> anyhow::Result<LoginFlow> {
     let client = BasicClient::new(ClientId::new(CLIENT_ID.to_string()))
         .set_auth_uri(AuthUrl::new(AUTHORIZE_URL.to_string()).context("invalid authorize URL")?)
         .set_token_uri(TokenUrl::new(TOKEN_ENDPOINT.to_string()).context("invalid token URL")?)
@@ -307,7 +317,7 @@ fn build_login_flow(redirect_uri: &str) -> anyhow::Result<LoginFlow> {
     // oauth2 generates a random verifier and its S256 challenge together.
     let (challenge, verifier) = PkceCodeChallenge::new_random_sha256();
 
-    let (auth_url, csrf) = client
+    let mut request = client
         // 32-byte state, NOT the crate-default `new_random()` (16 bytes / 22
         // chars): Claude's authorize endpoint rejects the short state with
         // "Invalid request format" once a logged-in session validates the
@@ -317,8 +327,11 @@ fn build_login_flow(redirect_uri: &str) -> anyhow::Result<LoginFlow> {
         .add_scope(Scope::new(OAUTH_SCOPES.to_string()))
         .set_pkce_challenge(challenge)
         // Claude's authorize endpoint requires this non-standard flag.
-        .add_extra_param("code", "true")
-        .url();
+        .add_extra_param("code", "true");
+    if let Some(email) = login_hint {
+        request = request.add_extra_param("login_hint", email);
+    }
+    let (auth_url, csrf) = request.url();
 
     Ok(LoginFlow {
         verifier: verifier.secret().clone(),
@@ -1009,13 +1022,31 @@ async fn login_route(
 /// server owns the write with its own current state, so the window above
 /// does not exist on that path at all. Detection is read-only; the server is
 /// never signalled.
-pub async fn login(config_path: &Path, force: bool) -> anyhow::Result<String> {
+pub async fn login(
+    config_path: &Path,
+    force: bool,
+    account: Option<&str>,
+) -> anyhow::Result<String> {
     let port = login_target_port(config_path);
     let incumbent = singleton::live_proxy_server(port);
     let route = login_route(config_path, incumbent, port, force).await?;
     if let LoginRoute::Refuse(msg) = route {
         bail!("{}", msg);
     }
+
+    // Resolve --account early, ONLY to compute the login_hint (ergonomics —
+    // see build_login_flow's doc-comment). Fail fast here on a typo'd or
+    // ambiguous name rather than after a full browser round trip. The SAME
+    // resolution runs again below, against a freshly loaded config, where it
+    // is load-bearing rather than a convenience.
+    let hint = match account {
+        Some(query) => {
+            let probe_config = load_or_default(config_path)?;
+            let idx = crate::cli::resolve_account(&probe_config.accounts, query, None)?;
+            Some(crate::identity::email_of(&probe_config.accounts[idx].name).to_string())
+        }
+        None => None,
+    };
 
     // Bind the callback server on a random loopback port (127.0.0.1 only).
     let listener = TcpListener::bind(("127.0.0.1", 0))
@@ -1025,7 +1056,7 @@ pub async fn login(config_path: &Path, force: bool) -> anyhow::Result<String> {
     let redirect_uri = format!("http://localhost:{callback_port}/callback");
 
     // PKCE + CSRF state + authorize URL, built by the oauth2 crate.
-    let flow = build_login_flow(&redirect_uri)?;
+    let flow = build_login_flow(&redirect_uri, hint.as_deref())?;
     println!("Opening browser for authentication...");
     println!("If it doesn't open, visit:\n  {}\n", flow.auth_url);
     open_browser(&flow.auth_url);
@@ -1047,7 +1078,92 @@ pub async fn login(config_path: &Path, force: bool) -> anyhow::Result<String> {
         None => prompt_account_name(&fallback),
     };
 
-    finish_login(config_path, route, &mut config, &name, &tokens, profile).await
+    finish_login_checked(
+        config_path,
+        route,
+        &mut config,
+        &name,
+        &tokens,
+        profile,
+        account,
+    )
+    .await
+}
+
+/// [`finish_login`], but first asserting the requested `--account` identity
+/// when one was given. Split out so the assertion + write sequence `login()`
+/// runs is directly testable without a real browser or network round trip —
+/// exactly the reason [`finish_login`] itself was split from [`login`].
+async fn finish_login_checked(
+    config_path: &Path,
+    route: LoginRoute,
+    config: &mut Config,
+    name: &str,
+    tokens: &Tokens,
+    profile: Profile,
+    requested_account: Option<&str>,
+) -> anyhow::Result<String> {
+    if let Some(query) = requested_account {
+        assert_requested_identity(config, query, &profile)?;
+    }
+    finish_login(config_path, route, config, name, tokens, profile).await
+}
+
+/// The load-bearing half of `tcr login --account <query>`: resolve `query`
+/// against `config` via [`crate::cli::resolve_account`] — the exact
+/// exact-name-then-email-then-org rule `tcr enable`/`tcr disable` and TcrBar's
+/// row buttons already rely on, not a second copy of it — and refuse to
+/// proceed unless the identity that came back from `fetch_profile` is the
+/// SAME account. `account_uuid` is preferred when both sides have one (an
+/// email can be reused across orgs, a UUID cannot); otherwise email is
+/// compared. Called strictly BEFORE any write path
+/// ([`finish_login`]/[`persist_via_file`]/[`persist_via_account`]): on
+/// mismatch, or on an unresolvable requested account, or on a profile that
+/// carries neither an email nor a uuid (`fetch_profile`'s all-`None` failure
+/// return, `src/oauth.rs:589-592` above — an assertion that cannot be
+/// evaluated must fail closed, not pass by default), nothing is written.
+fn assert_requested_identity(
+    config: &Config,
+    query: &str,
+    profile: &Profile,
+) -> anyhow::Result<()> {
+    let idx = crate::cli::resolve_account(&config.accounts, query, None)?;
+    let requested = &config.accounts[idx];
+
+    if profile.email.is_none() && profile.account_uuid.is_none() {
+        bail!(
+            "could not confirm the identity that just authenticated (the profile carried no \
+             email and no account id) — refusing to touch '{}'. Nothing was changed.",
+            requested.name
+        );
+    }
+
+    let matches = match (&requested.account_uuid, &profile.account_uuid) {
+        (Some(want), Some(got)) => want == got,
+        _ => {
+            let want_email = crate::identity::email_of(&requested.name);
+            profile
+                .email
+                .as_deref()
+                .is_some_and(|got| got == want_email)
+        }
+    };
+
+    if !matches {
+        let got = profile
+            .email
+            .as_deref()
+            .unwrap_or("an account with no email in its profile");
+        bail!(
+            "requested re-login for '{}', but the browser authenticated as '{got}' instead — \
+             nothing was written. Sign out of that account in the browser first, or use a \
+             private/incognito window, then retry `tcr login --account {}`.",
+            requested.name,
+            query
+        );
+    }
+
+    Ok(())
 }
 
 /// The file half of a login: `upsert_account` + whole-file [`config::save`].
@@ -1365,7 +1481,7 @@ mod tests {
     fn login_flow_produces_verifier_and_state() {
         // The oauth2-built flow yields a non-empty verifier and CSRF state, and
         // an authorize URL rooted at Claude's endpoint.
-        let flow = build_login_flow("http://localhost:12345/callback").unwrap();
+        let flow = build_login_flow("http://localhost:12345/callback", None).unwrap();
         assert!(!flow.verifier.is_empty());
         assert!(!flow.state.is_empty());
         assert!(flow.auth_url.starts_with(AUTHORIZE_URL));
@@ -1757,7 +1873,7 @@ mod tests {
     fn authorize_url_carries_required_params() {
         // The oauth2-built authorize URL must carry every required OAuth param
         // plus Claude's non-standard `code=true`.
-        let url = build_login_flow("http://localhost:12345/callback")
+        let url = build_login_flow("http://localhost:12345/callback", None)
             .unwrap()
             .auth_url;
         assert!(url.starts_with(AUTHORIZE_URL));
@@ -1769,6 +1885,16 @@ mod tests {
         assert!(url.contains("state="));
         // redirect_uri is percent-encoded by oauth2.
         assert!(url.contains("redirect_uri=http%3A%2F%2Flocalhost%3A12345%2Fcallback"));
+        // No --account given: no login_hint at all (add-a-new-account path).
+        assert!(!url.contains("login_hint"));
+    }
+
+    #[test]
+    fn authorize_url_carries_login_hint_when_given() {
+        let url = build_login_flow("http://localhost:12345/callback", Some("alice@example.com"))
+            .unwrap()
+            .auth_url;
+        assert!(url.contains("login_hint=alice%40example.com"));
     }
 
     #[tokio::test]
@@ -2265,6 +2391,217 @@ mod tests {
             org_uuid: None,
             org_name: None,
         }
+    }
+
+    // --- `--account` identity assertion (`tcr login --account`) ------------
+
+    fn two_account_seed() -> String {
+        r#"{ "accounts": [
+            { "name": "alice@example.com", "type": "oauth", "accessToken": "at-alice",
+              "refreshToken": "rt-alice", "expiresAt": 1893456000000, "priority": 0 },
+            { "name": "bob@example.com", "type": "oauth", "accessToken": "at-bob",
+              "refreshToken": "rt-bob", "expiresAt": 1893456000000, "priority": 1 }
+        ] }"#
+            .to_string()
+    }
+
+    /// A mismatch between the requested account and the identity that came
+    /// back writes NOTHING — the config file is byte-identical afterwards —
+    /// and the error names both sides.
+    #[tokio::test]
+    async fn finish_login_checked_mismatch_writes_nothing() {
+        let seed = two_account_seed();
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-account-mismatch-{}-{}.json",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(&path, &seed).unwrap();
+        let mut config = load_or_default(&path).unwrap();
+        let before = std::fs::read_to_string(&path).unwrap();
+
+        let err = finish_login_checked(
+            &path,
+            LoginRoute::File,
+            &mut config,
+            "alice@example.com",
+            &tokens("at-new", "rt-new", 1_893_456_000_000),
+            profile_named("mallory@example.com"),
+            Some("alice@example.com"),
+        )
+        .await
+        .unwrap_err();
+
+        let msg = err.to_string();
+        assert!(msg.contains("alice@example.com"), "names requested: {msg}");
+        assert!(msg.contains("mallory@example.com"), "names returned: {msg}");
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(before, after, "a mismatch must leave the config untouched");
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// A match writes normally, through the exact same `finish_login` path as
+    /// today's no-`--account` flow.
+    #[tokio::test]
+    async fn finish_login_checked_match_writes_normally() {
+        let seed = two_account_seed();
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-account-match-{}-{}.json",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(&path, &seed).unwrap();
+        let mut config = load_or_default(&path).unwrap();
+
+        let name = finish_login_checked(
+            &path,
+            LoginRoute::File,
+            &mut config,
+            "alice@example.com",
+            &tokens("at-fresh", "rt-fresh", 1_893_456_000_000),
+            profile_named("alice@example.com"),
+            Some("alice@example.com"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(name, "alice@example.com");
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            after.contains("rt-fresh"),
+            "a matching identity must be written: {after}"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// `fetch_profile`'s all-`None` failure return (`src/oauth.rs:589-592`)
+    /// must refuse rather than pass by default — an assertion that cannot be
+    /// evaluated is not evidence of a match.
+    #[tokio::test]
+    async fn finish_login_checked_all_none_profile_refuses() {
+        let seed = two_account_seed();
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-account-allnone-{}-{}.json",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(&path, &seed).unwrap();
+        let mut config = load_or_default(&path).unwrap();
+        let before = std::fs::read_to_string(&path).unwrap();
+
+        let all_none = Profile {
+            email: None,
+            account_uuid: None,
+            org_uuid: None,
+            org_name: None,
+        };
+        let err = finish_login_checked(
+            &path,
+            LoginRoute::File,
+            &mut config,
+            "alice@example.com",
+            &tokens("at-new", "rt-new", 1_893_456_000_000),
+            all_none,
+            Some("alice@example.com"),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("alice@example.com"),
+            "{}",
+            err.to_string()
+        );
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            before, after,
+            "an unconfirmable identity must write nothing"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// An ambiguous `--account` query is an error, not a guess — same
+    /// zero/one/many rule `crate::cli::resolve_account` already enforces for
+    /// every other command.
+    #[tokio::test]
+    async fn finish_login_checked_ambiguous_query_is_an_error() {
+        let seed = r#"{ "accounts": [
+            { "name": "dup@example.com", "type": "oauth", "accessToken": "at-1",
+              "refreshToken": "rt-1", "expiresAt": 1893456000000, "priority": 0,
+              "orgUuid": "org-a", "orgName": "Corp A" },
+            { "name": "dup@example.com", "type": "oauth", "accessToken": "at-2",
+              "refreshToken": "rt-2", "expiresAt": 1893456000000, "priority": 1,
+              "orgUuid": "org-b", "orgName": "Corp B" }
+        ] }"#;
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-account-ambiguous-{}-{}.json",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(&path, seed).unwrap();
+        let mut config = load_or_default(&path).unwrap();
+        let before = std::fs::read_to_string(&path).unwrap();
+
+        let err = finish_login_checked(
+            &path,
+            LoginRoute::File,
+            &mut config,
+            "dup@example.com",
+            &tokens("at-new", "rt-new", 1_893_456_000_000),
+            profile_named("dup@example.com"),
+            Some("dup@example.com"),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            err.to_string().to_lowercase().contains("more than one")
+                || err.to_string().to_lowercase().contains("ambiguous"),
+            "{}",
+            err.to_string()
+        );
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(before, after, "an ambiguous query must not guess and write");
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// No `--account` behaves exactly as before: no identity check runs at
+    /// all, so an unrelated returned identity still writes normally (this is
+    /// the add-a-new-account path, which must not grow an assertion it
+    /// cannot satisfy).
+    #[tokio::test]
+    async fn finish_login_checked_no_account_skips_the_check() {
+        let seed = two_account_seed();
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-account-none-{}-{}.json",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(&path, &seed).unwrap();
+        let mut config = load_or_default(&path).unwrap();
+
+        let name = finish_login_checked(
+            &path,
+            LoginRoute::File,
+            &mut config,
+            "carol@example.com",
+            &tokens("at-carol", "rt-carol", 1_893_456_000_000),
+            profile_named("carol@example.com"),
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(name, "carol@example.com");
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(after.contains("carol@example.com"), "{after}");
+
+        std::fs::remove_file(&path).ok();
     }
 
     /// THE BITING TEST for the whole-file-write hazard `finish_login` exists to

--- a/tests/fixtures/status-contract.json
+++ b/tests/fixtures/status-contract.json
@@ -5,6 +5,7 @@
     "disabled": false,
     "fiveHour": 0.04,
     "freeAtMs": null,
+    "gate": "ok",
     "held": [],
     "inputTokens": 8000000,
     "lastStreamError": "overloaded_error",
@@ -32,6 +33,7 @@
     "disabled": false,
     "fiveHour": 0.95,
     "freeAtMs": null,
+    "gate": "ok",
     "held": [
       {
         "minutesUntilReset": 0,
@@ -70,6 +72,7 @@
     "disabled": false,
     "fiveHour": 1.0,
     "freeAtMs": 1767312000000,
+    "gate": "ok",
     "held": [
       {
         "minutesUntilReset": 0,
@@ -108,6 +111,7 @@
     "disabled": true,
     "fiveHour": null,
     "freeAtMs": null,
+    "gate": "ok",
     "held": [],
     "inputTokens": 0,
     "lastStreamError": null,


### PR DESCRIPTION
Five of thirteen accounts on the machine this was found on held rejected refresh tokens. They were serving zero traffic, and the panel rendered each of them as a grey `unmeasured` pill whose tooltip said "never probed" — telling the operator to wait for a sweep that can never clear a dead credential. The fleet was running on five usable accounts while the header reported thirteen.

Three separate things in the panel had stopped being true. Each was correct when written, and each outlived its premise.

## What changed

**A dead credential names its real cause and offers the real remedy.** `AccountStatus::Error` (`src/manager/mod.rs:187`, set when a refresh token is rejected at `refresh.rs:93-101`, hard-excluded from selection at `select.rs:931`) now decodes to a typed `AccountHealth` and threads through display order, the fleet tally, the capacity summary, the menu-bar glyph and the row. The row gets a red `NEEDS RE-LOGIN` pill and its own `Re-login…` button.

**"Add account…" is un-gated.** It disabled itself because `tcr login` refused while a proxy held the port. `a385f0f` (2026-08-11) added a live account-add route two days after that gate landed, so a modern proxy takes the login live. The button had been dark for the entire time the thing it protected against did not exist.

**`tcr login --account <name>`.** Sends OAuth `login_hint`, and — the load-bearing half — asserts the identity returned by `fetch_profile` resolves to the same account that was requested, refusing to write anything on a mismatch. Without it, a re-login silently refreshes whichever account the browser happens to be signed in as and reports success while the broken one stays broken. That is not hypothetical: it happened during testing, on a real account, and the assertion is the only reason nothing was overwritten.

**`tcr status --json` emits `gate`.** `account_terminal_gate` has three terminal gates; the panel could see two, so an account failing the third (`quota.status == "rejected"`, Anthropic's own verdict) still drew as rotating. `AccountSnapshot.gate` already existed and was already serializable — it simply never reached `render_accounts_json`. The panel now reads the router's verdict instead of inferring it from a status string.

## Review found two HIGH defects in the first draft

Both were confirmed against source and fixed. Recording them because the shape matters more than the fix.

**`isReady` had no health clause.** A credential that dies *after* being probed keeps its last-learned quota and `probeStatus: ok`, and `quotaState` is Rust's `#[default]` `"ok"` — so a dead account read as READY, counted as capacity, and turned the menu-bar glyph green. The header would render `1 of 1 ready · 1 need re-login` in a single frame.

The reason it survived review is the useful part: the test fixture pinned `quota: nil`, so every test could only express the *never-probed* variant, and the rendered screenshot used that same fixture. Every check was downstream of one assumption. Fixed, plus the same gap in `capacityGlyphState`'s `.near` branch, and proven by mutation — 5 of 7 new tests fail against the old code, one printing exactly `"1 of 1 ready · 1 need re-login" is not equal to "No capacity · 1 need re-login"`. A `04c-probed-then-broken-row` render scene now exists so the state is visible to a human.

**The identity assertion compared `account_uuid`, which cannot distinguish orgs.** `src/identity.rs:3-8` says the UUID is *the person*, and the same person belongs to multiple organizations each with its own token; the pre-existing `upsert_second_org_same_email_appends_distinct_account` uses one UUID for both org rows. So for a same-person-different-org browser session the check passed and the credential landed on the wrong row. The doc-comment's stated rationale was inverted. It now builds a probe and resolves through `identity::resolve` — the same path `upsert_account` writes through, so check and write cannot disagree by construction. Mutation-tested: the old logic writes the wrong account and prints success. `--org` is plumbed so the ambiguity message names a remedy that exists.

Also from review: the quota bar drew a stale reading in live green, so the bar and the pill disagreed about how alarmed to look — muted to `Tok.disabled` for that shape only; the re-login `.command` path is now unique per invocation, closing an overwrite race that only became a correctness surface once the file carried per-account content; a contract test reads `src/manager/mod.rs` and fails if the `"error"` token is renamed, since the Rust/Swift boundary had nothing defending it.

## Verification

Rust: build, `clippy --all-targets`, `fmt --check`, full suite green (63 oauth tests, up from 58). Swift: build, 191 tests, 28 render scenes. The cross-language contract fixture was regenerated for the new `gate` field and the Swift decode suite ran green against it afterwards.

Every new assertion was watched failing before being trusted. Scenes not intended to change were confirmed byte-identical by checksum rather than by inspection.

## Note for the reviewer

`5b4987e` carries a copy-pasted subject line from `45beb44`; its actual content is the org-identity fix. Not amended because the branch was already shared.

The recovery path was exercised end to end on a live fleet: four dead credentials restored through the live route with no server restart and no cold prompt-cache prefix.
