### PR TITLE
fix: restore the 0.2.5 appcast entry and unblock the preflight tag check

### DIFF
--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.5</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.5</link>
+      <sparkle:version>318</sparkle:version>
+      <sparkle:shortVersionString>0.2.5</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Thu, 13 Aug 2026 19:50:18 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.5/TcrBar-0.2.5.dmg" type="application/octet-stream" sparkle:edSignature="rzy03R6ESej3z/NZempsgF8BSYe3an4YM/1DUIxG9yNwtuQy/OHsgvoZdv1XwEIHPXigpF2SlASI6l739+1/Ag==" length="5988151" />
+    </item>
+    <item>
       <title>TcrBar 0.2.4</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.4</link>
       <sparkle:version>284</sparkle:version>

--- a/apps/macos/scripts/release-preflight.sh
+++ b/apps/macos/scripts/release-preflight.sh
@@ -133,11 +133,25 @@ fi
 # ---------------------------------------------------------------------------
 # 2 — the tag does not exist, locally OR on origin
 # ---------------------------------------------------------------------------
-check "2/5  the tag does not already exist"
+check "2/5  the tag does not name a different commit"
+# The guard is against a tag that names OTHER code, not against the tag
+# existing: the documented order pushes vX.Y.Z first, because that push is what
+# starts the release, and the local script then uploads onto the Release the
+# push created. A tag that already points at HEAD is therefore the expected
+# state here. What must still refuse is a tag pointing somewhere else — that is
+# the v0.2.4 incident, where a tag was re-pointed onto a commit that did not
+# carry the fix and the release shipped code the tag did not name.
+head_sha="$(git -C "$repo_root" rev-parse HEAD)"
 if git -C "$repo_root" rev-parse -q --verify "refs/tags/$tag" >/dev/null 2>&1; then
-  fail "$tag already exists as a LOCAL tag." \
-       "Releasing again would either be a no-op or move a published tag." \
-       "Inspect it first:  git show $tag --stat"
+  local_tag_sha="$(git -C "$repo_root" rev-parse "$tag^{commit}")"
+  if [ "$local_tag_sha" = "$head_sha" ]; then
+    ok "local tag $tag points at HEAD"
+  else
+    fail "$tag exists as a LOCAL tag naming a DIFFERENT commit than HEAD." \
+         "Releasing would publish assets for code the tag does not name." \
+         "Inspect it first:  git show $tag --stat" \
+         "tag: ${local_tag_sha:0:12}  HEAD: ${head_sha:0:12}"
+  fi
 else
   ok "no local tag $tag"
 fi
@@ -153,9 +167,16 @@ remote_rc=$?
 set -e
 case "$remote_rc" in
   0)
-    fail "$tag already exists on origin." \
-         "Pushing it again cannot start a release, and a release may already" \
-         "be in flight for it — see check 4/5 below." ;;
+    remote_sha="${remote_out%%$'\t'*}"
+    if [ "$remote_sha" = "$head_sha" ]; then
+      ok "tag $tag on origin points at HEAD — the tag push is what starts the release"
+    else
+      fail "$tag exists on origin naming a DIFFERENT commit than HEAD." \
+           "A release started now would upload assets for code the published" \
+           "tag does not name, and moving a published tag is the v0.2.4" \
+           "incident. Reconcile the tag before releasing." \
+           "origin: ${remote_sha:0:12}  HEAD: ${head_sha:0:12}"
+    fi ;;
   2)
     ok "no tag $tag on origin" ;;
   *)


### PR DESCRIPTION
Two release-pipeline repairs, both found while preparing the 0.2.6 release. Neither is user-facing today; both would have bitten the next release.

**The 0.2.5 appcast entry was never committed.** `release-tcrbar.sh` inserts each new item into this repo copy and uploads the result as a release asset. The 0.2.5 item was inserted locally and left uncommitted, so `main` advertised 0.2.4 as the newest build.

Users were never stranded — Sparkle reads `releases/latest/download/appcast.xml`, the asset attached to the latest GitHub Release, and 0.2.5's release carries a correct one. But the next release cuts from the repo copy, so 0.2.6 would have published a feed running 0.2.6 → 0.2.4, dropping a shipped release from its own history.

**Preflight checks 2/5 and 3/5 refused whenever the tag existed at all.** The documented release order pushes `vX.Y.Z` first, because that push is what starts the release, and the local script then uploads onto the Release the push created. A tag pointing at HEAD is therefore the expected state at preflight time, and the check failed the happy path.

They now refuse only a tag naming a *different* commit than HEAD — which is the case the guard was written for: the v0.2.4 incident, where a re-pointed tag shipped code the tag did not name. The failure message reports both SHAs so the reconciliation is obvious.

Verified: pre-commit gates green (secret scan clean, release-version gate satisfied under 0.2.6). The preflight change is exercised by the 0.2.6 release immediately following this merge.