### PR TITLE
fix: repair the release preflight and cut 0.2.7

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -262,13 +262,28 @@ fi
 # one. This is not hypothetical — the v0.2.3 entry was left uncommitted for
 # exactly this reason, and the published feed sat on 0.2.1 while a signed 0.2.3
 # DMG was already on the release.
+#
+# apps/macos/scripts/release-preflight.sh is exempt, BY NAME and not by
+# directory, because its own usage line makes the argument: "asserts the
+# release is safe to start; changes nothing." It reads Cargo.toml, the
+# appcast, the git index and two APIs and either exits 0 or names what is
+# wrong — it cannot make a build claim a version it isn't, because it never
+# touches an artifact. Its neighbours in the same directory are the opposite
+# case and must stay covered: build-tcrbar.sh writes Info.plist, including
+# SUPublicEDKey and SUFeedURL — a build from it has produced an app with no
+# SUPublicEDKey at all — and release-tcrbar.sh orchestrates signing,
+# notarization and stapling. Both change what ships even though neither
+# compiles it. Widen this to `apps/macos/scripts/**` and both slip through
+# under an already-released version; add new preflight-only scripts here by
+# name, the same way, never by loosening the directory.
 staged_shippable="$(git diff --cached --name-only --diff-filter=ACMR -- . \
                     ':(exclude)*.md' \
                     ':(exclude)docs/**' \
                     ':(exclude)assets/**' \
                     ':(exclude).github/**' \
                     ':(exclude).githooks/**' \
-                    ':(exclude)apps/macos/appcast.xml' || true)"
+                    ':(exclude)apps/macos/appcast.xml' \
+                    ':(exclude)apps/macos/scripts/release-preflight.sh' || true)"
 
 if [ -n "$staged_shippable" ]; then
   # Read the INDEX (`:Cargo.toml`), not the working tree: that is what this

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaude-rs"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/apps/macos/scripts/release-preflight.sh
+++ b/apps/macos/scripts/release-preflight.sh
@@ -254,7 +254,7 @@ else
   # for (`gh release edit $tag --prerelease`). Failing on that state refuses
   # the very remedy it recommends.
   set +e
-  api_out="$(gh api "repos/$repo/releases/tags/$tag" --jq '[[.assets[].name] | join(" "), (.draft|tostring), (.prerelease|tostring)] | join("\t")' 2>&1)"
+  api_out="$(gh api "repos/$repo/releases/tags/$tag" --jq '[([.assets[].name] | join(" ")), (.draft|tostring), (.prerelease|tostring)] | join("\t")' 2>&1)"
   api_rc=$?
   set -e
   if [ "$api_rc" = 0 ]; then

--- a/apps/macos/scripts/release-preflight.sh
+++ b/apps/macos/scripts/release-preflight.sh
@@ -161,21 +161,43 @@ fi
 # the release, so the remote is the only authority. --exit-code makes the three
 # outcomes distinguishable — 0 found, 2 no such ref, anything else an error we
 # must NOT read as "absent".
+#
+# Two refs are asked for, not one: for an ANNOTATED tag (`git tag -a`, what
+# this project uses), `refs/tags/$tag` names the tag OBJECT, not the commit —
+# ls-remote returns that wrapper's own sha, which never equals a commit sha and
+# so always disagreed with $head_sha even when the tag was correct. The peeled
+# form `refs/tags/$tag^{}` is what ls-remote reports as the commit the tag
+# points at; a LIGHTWEIGHT tag has no such entry because it IS the commit ref,
+# so the plain form is used only when the peeled one is absent — never compare
+# a wrapper sha to a commit sha.
 set +e
-remote_out="$(git -C "$repo_root" ls-remote --exit-code --tags origin "refs/tags/$tag" 2>&1)"
+remote_out="$(git -C "$repo_root" ls-remote --exit-code --tags origin "refs/tags/$tag" "refs/tags/$tag^{}" 2>&1)"
 remote_rc=$?
 set -e
 case "$remote_rc" in
   0)
-    remote_sha="${remote_out%%$'\t'*}"
-    if [ "$remote_sha" = "$head_sha" ]; then
-      ok "tag $tag on origin points at HEAD — the tag push is what starts the release"
+    remote_peeled_sha=""
+    remote_plain_sha=""
+    while IFS=$'\t' read -r sha ref; do
+      case "$ref" in
+        "refs/tags/$tag^{}") remote_peeled_sha="$sha" ;;
+        "refs/tags/$tag") remote_plain_sha="$sha" ;;
+      esac
+    done <<<"$remote_out"
+    remote_sha="${remote_peeled_sha:-$remote_plain_sha}"
+    if [ -z "$remote_sha" ]; then
+      fail "ls-remote reported $tag but neither the peeled commit nor the" \
+           "plain ref could be parsed out of its output." \
+           "Not treated as absent: an unread answer is not a pass." \
+           "git said: ${remote_out:-<no output>}"
+    elif [ "$remote_sha" = "$head_sha" ]; then
+      ok "tag $tag on origin points at HEAD (commit ${remote_sha:0:12}) — the tag push is what starts the release"
     else
       fail "$tag exists on origin naming a DIFFERENT commit than HEAD." \
            "A release started now would upload assets for code the published" \
            "tag does not name, and moving a published tag is the v0.2.4" \
            "incident. Reconcile the tag before releasing." \
-           "origin: ${remote_sha:0:12}  HEAD: ${head_sha:0:12}"
+           "origin (commit): ${remote_sha:0:12}  HEAD: ${head_sha:0:12}"
     fi ;;
   2)
     ok "no tag $tag on origin" ;;
@@ -224,38 +246,53 @@ else
   # have to be told apart: a 404 means no release yet (fine, the normal case)
   # while an auth or network error means we do not know (never fine). Anything
   # that is not a clean 404 and not a clean success is a failure here.
+  #
+  # `is_draft`/`is_prerelease` come out of the SAME call: `releases/latest`
+  # skips both a draft and a prerelease and falls back to the next eligible
+  # release, so an assetless release that is EITHER is not serving the feed —
+  # it is exactly the state check 4's own remedy tells an operator to reach
+  # for (`gh release edit $tag --prerelease`). Failing on that state refuses
+  # the very remedy it recommends.
   set +e
-  assets="$(gh api "repos/$repo/releases/tags/$tag" --jq '[.assets[].name] | join(" ")' 2>&1)"
+  api_out="$(gh api "repos/$repo/releases/tags/$tag" --jq '[[.assets[].name] | join(" "), (.draft|tostring), (.prerelease|tostring)] | join("\t")' 2>&1)"
   api_rc=$?
   set -e
   if [ "$api_rc" = 0 ]; then
+    IFS=$'\t' read -r assets is_draft is_prerelease <<<"$api_out"
     case " $assets " in
       *" appcast.xml "*)
         ok "release $tag exists and already carries appcast.xml" ;;
       *)
-        fail "release $tag ALREADY EXISTS and has no appcast.xml asset." \
-             "The update feed is dark RIGHT NOW: releases/latest/download/appcast.xml" \
-             "is the URL Sparkle fetches, and it resolves to this release." \
-             "Every installed copy's update check is failing with" \
-             "\"An error occurred in retrieving update information\", and GitHub's" \
-             "CDN caches that 404 against the exact URL Sparkle requests." \
-             "Measured on v0.2.4, 2026-08-10: 11m 37s of outage this way." \
-             "" \
-             "Do NOT start another release. Finish this one, or step out of the" \
-             "way of the feed:" \
-             "  gh release edit $tag --prerelease --repo $repo   # latest falls back" \
-             "  gh release upload $tag <dmg> $appcast_rel --clobber --repo $repo" \
-             "  gh release edit $tag --prerelease=false --latest --repo $repo" \
-             "" \
-             "assets currently on it: ${assets:-<none>}" ;;
+        if [ "$is_draft" = "true" ] || [ "$is_prerelease" = "true" ]; then
+          ok "release $tag exists, is assetless, but is $( [ "$is_draft" = "true" ] && printf draft || printf prerelease )." \
+             "releases/latest/download/appcast.xml falls back past it, so it is" \
+             "not serving the feed. It still needs finishing before it can go" \
+             "live: assets currently on it: ${assets:-<none>}"
+        else
+          fail "release $tag ALREADY EXISTS and has no appcast.xml asset." \
+               "The update feed is dark RIGHT NOW: releases/latest/download/appcast.xml" \
+               "is the URL Sparkle fetches, and it resolves to this release." \
+               "Every installed copy's update check is failing with" \
+               "\"An error occurred in retrieving update information\", and GitHub's" \
+               "CDN caches that 404 against the exact URL Sparkle requests." \
+               "Measured on v0.2.4, 2026-08-10: 11m 37s of outage this way." \
+               "" \
+               "Do NOT start another release. Finish this one, or step out of the" \
+               "way of the feed:" \
+               "  gh release edit $tag --prerelease --repo $repo   # latest falls back" \
+               "  gh release upload $tag <dmg> $appcast_rel --clobber --repo $repo" \
+               "  gh release edit $tag --prerelease=false --latest --repo $repo" \
+               "" \
+               "assets currently on it: ${assets:-<none>}"
+        fi ;;
     esac
-  elif printf '%s' "$assets" | grep -q '404'; then
+  elif printf '%s' "$api_out" | grep -q '404'; then
     ok "no GitHub Release for $tag yet — nothing is serving an empty feed"
   else
     fail "could not ask GitHub about release $tag." \
          "Not treated as absent: this is the check that stands between a user" \
          "and a broken update feed, and it must not pass on an unread answer." \
-         "gh said: ${assets:-<no output>}"
+         "gh said: ${api_out:-<no output>}"
   fi
 fi
 


### PR DESCRIPTION
Three defects in the release pipeline, all found by actually trying to ship 0.2.6, plus the version bump that follows from them.

## The preflight bugs

**Check 2/5 compared an annotated tag's wrapper object against a commit.** `git ls-remote refs/tags/<tag>` returns the tag OBJECT sha for an annotated tag, never the commit. The local arm of the same check already peeled correctly with `$tag^{commit}`, so the two halves disagreed about what a tag is. Measured on the live repo: wrapper `73d98ce`, peeled `ceffc41`, HEAD `ceffc41` — a correct tag reported as naming different code. The old code failed outright whenever the tag existed, so this comparison had never run before; the capability and the bug arrived together.

**Check 4/5 refused the state it recommends.** Its concern is an assetless release *serving* the update feed, and its own remedy is `gh release edit <tag> --prerelease` so `latest` falls back. Once that remedy was applied it still failed, because it keyed on the release existing rather than on it serving. It now passes for a draft or prerelease with a note that the release still needs finishing, and keeps the hard failure for an assetless release that IS latest.

**A jq precedence bug, caught during live verification.** `join(" ")` sat outside the array element's parens, and `|` binds looser than `,`, so `.draft`/`.prerelease` evaluated against the joined name-array instead of the release object. Every real call errored into the unread-answer branch. Only surfaced by running it against the real API rather than a fixture.

## The hook exemption

`release-preflight.sh` could not be committed while `Cargo.toml` sat at an already-tagged version. It is exempted **by exact path**, not by directory: `build-tcrbar.sh` and `release-tcrbar.sh` live alongside it and do materially determine the shipped artifact — `build-tcrbar.sh` writes `Info.plist` including `SUPublicEDKey`, which it silently omitted today. The comment names that counter-example so the exemption is not widened later. Verified both directions: the exempted file commits, and a staged edit to `build-tcrbar.sh` still blocks.

## Why 0.2.7

Those fixes had to land on `main` to be usable, which moved HEAD past the commit `v0.2.6` names. `build-tcrbar.sh` stamps `rev-parse --short HEAD` into the bundle and `tcr status --json` reports it, so building 0.2.6 from here ships an artifact whose sha the tag does not name — the exact thing check 2/5 refuses.

Re-pointing `v0.2.6` was the alternative and is worse: it is the v0.2.4 incident this repo already guards against, and cargo-dist has attached tarballs built from `ceffc41` to that release. `v0.2.6` remains a prerelease carrying only cargo-dist artifacts. It never served the update feed — `latest` resolved to v0.2.5 throughout, and no DMG or appcast was ever published for it.

## Verification

Live preflight against the real repo: check 4/5 now passes on the actual prerelease state. Bug 1 proven against real `ls-remote` output in three cases — peeled commit passes, wrapper sha fails, unrelated sha fails — with no tag created or moved. Bug 2's guard proven still able to deny: an assetless release with `prerelease=false` still reports the feed dark.