### PR TITLE
chore: commit the 0.2.7 appcast entry the release generated

### DIFF
--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.7</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.7</link>
+      <sparkle:version>348</sparkle:version>
+      <sparkle:shortVersionString>0.2.7</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Fri, 14 Aug 2026 15:45:36 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.7/TcrBar-0.2.7.dmg" type="application/octet-stream" sparkle:edSignature="Z5e7pk7fsBz9p6dSf/6zrQGkIGxYjdAEVcxZrwsZHRSlNAoghy6MZk1uqP5cNAUctMVil8mYSBsp2gcA0Va9Dw==" length="5896786" />
+    </item>
+    <item>
       <title>TcrBar 0.2.5</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.5</link>
       <sparkle:version>318</sparkle:version>


### PR DESCRIPTION
`release-tcrbar.sh` inserts the new `<item>` into `apps/macos/appcast.xml` and uploads the result as the release asset, so a successful release always leaves the repo copy dirty. Committing it is the last step of releasing, not optional cleanup.

Leaving it uncommitted is precisely how 0.2.5's entry went missing: the published feed was correct (Sparkle reads the asset on the latest Release) while `main` still advertised 0.2.4, and the next release would have cut a feed skipping a shipped version. Preflight check 5/5 refuses to start a release while this file is dirty, which is the backstop — this PR is the fix.

v0.2.7 is live and verified end to end: `releases/latest/download/appcast.xml` serves TcrBar 0.2.7 with a `TcrBar-0.2.7.dmg` enclosure and six signed entries; the app in that DMG carries `SUPublicEDKey` and is notarized and stapled.