### PR TITLE
fix: refuse to ship an app that cannot verify an update, and close the feed-outage window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaude-rs"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/apps/macos/scripts/release-preflight.sh
+++ b/apps/macos/scripts/release-preflight.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Refuse a release that is already known to fail. Runs in about a second and
-# asserts, before anything is built, signed, notarized or pushed, the five
+# asserts, before anything is built, signed, notarized or pushed, the six
 # conditions that have actually broken this project's releases.
 #
 #   apps/macos/scripts/release-preflight.sh v0.2.5
@@ -53,7 +53,14 @@
 #      with a signed 0.2.3 DMG already on the release. A dirty appcast at the
 #      START of a release means the PREVIOUS one is still half-finished.
 #
-# The rule those five encode, stated once: push a version tag ONLY in the
+#   6. TCRBAR_SPARKLE_PUBLIC_KEY unresolvable. A release cut 2026-08-14 came
+#      one unset environment variable from shipping a signed, notarized DMG
+#      whose app could never install an update — build-tcrbar.sh only WARNS
+#      and continues, and release-tcrbar.sh's own assert on this does not fire
+#      until stage 3.5, after the build. Catching it here costs nothing and
+#      catches it before twenty minutes of signing and notarizing are spent.
+#
+# The rule those six encode, stated once: push a version tag ONLY in the
 # operation that can immediately upload its assets, and never start a release on
 # top of an unfinished one.
 #
@@ -63,8 +70,14 @@
 # email or team id, and every path printed is relative to the repository root.
 #
 # Environment:
-#   RELEASE_REPO   owner/name for the GitHub Release. Defaults to whatever
-#                  `gh repo view` reports for this checkout.
+#   RELEASE_REPO             owner/name for the GitHub Release. Defaults to
+#                             whatever `gh repo view` reports for this checkout.
+#   TCRBAR_SPARKLE_PUBLIC_KEY  the Sparkle EdDSA public key. Check 6 accepts
+#                             either this being set directly, or TCRBAR_OP_ITEM
+#                             below being set so release-local.sh can fetch it.
+#   TCRBAR_OP_ITEM            1Password item release-local.sh reads
+#                             TCRBAR_SPARKLE_PUBLIC_KEY and other release
+#                             credentials from.
 set -euo pipefail
 
 usage() { sed -n '2,12p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
@@ -111,7 +124,7 @@ fail() {
 # Character-for-character the sed in release-tcrbar.sh:352 and .githooks/
 # pre-commit. Three copies is a real cost; a preflight that reads a DIFFERENT
 # number than the script it guards is worse than no preflight.
-check "1/5  the tag matches the version in Cargo.toml"
+check "1/6  the tag matches the version in Cargo.toml"
 # Two versions, deliberately. `version` is what the manifest claims; `release_version`
 # is what the TAG would publish, and every later check keys on the tag — because
 # a preflight whose other checks silently re-aim at a different number the moment
@@ -133,7 +146,7 @@ fi
 # ---------------------------------------------------------------------------
 # 2 — the tag does not exist, locally OR on origin
 # ---------------------------------------------------------------------------
-check "2/5  the tag does not name a different commit"
+check "2/6  the tag does not name a different commit"
 # The guard is against a tag that names OTHER code, not against the tag
 # existing: the documented order pushes vX.Y.Z first, because that push is what
 # starts the release, and the local script then uploads onto the Release the
@@ -219,7 +232,7 @@ esac
 # file — so its own guard cannot fire, and this check is currently the only one
 # standing between a poisoned tree and a post-notarization abort. Fixing that
 # line is a separate change; do not delete this check when it lands.
-check "3/5  the appcast has no item for this version"
+check "3/6  the appcast has no item for this version"
 if [ ! -f "$appcast_path" ]; then
   ok "$appcast_rel does not exist yet (release-tcrbar.sh will create it)"
 elif grep -qF "sparkle:shortVersionString>$release_version<" "$appcast_path"; then
@@ -236,7 +249,7 @@ fi
 # ---------------------------------------------------------------------------
 # 4 — the update feed is not currently dark
 # ---------------------------------------------------------------------------
-check "4/5  no assetless GitHub Release is serving the update feed"
+check "4/6  no assetless GitHub Release is serving the update feed"
 repo="${RELEASE_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)}"
 if [ -z "$repo" ]; then
   fail "could not determine the GitHub repository." \
@@ -299,7 +312,7 @@ fi
 # ---------------------------------------------------------------------------
 # 5 — the previous release finished
 # ---------------------------------------------------------------------------
-check "5/5  $appcast_rel has no uncommitted changes"
+check "5/6  $appcast_rel has no uncommitted changes"
 dirty="$(git -C "$repo_root" status --porcelain -- "$appcast_rel")"
 if [ -n "$dirty" ]; then
   fail "$appcast_rel is uncommitted in the working tree." \
@@ -309,6 +322,29 @@ if [ -n "$dirty" ]; then
        "git status says: $dirty"
 else
   ok "$appcast_rel is clean"
+fi
+
+# ---------------------------------------------------------------------------
+# 6 — the Sparkle public key is resolvable
+# ---------------------------------------------------------------------------
+# Does not read the key's value, only whether one is reachable: this script
+# never prints a secret, and the value itself is public anyway (it ships in
+# every installed bundle) — what matters here is that release-tcrbar.sh's own
+# stage 3.5 assert will have something to embed. Either the environment
+# already carries it, or TCRBAR_OP_ITEM is set so release-local.sh's 1Password
+# fetch can populate it before calling release-tcrbar.sh.
+check "6/6  TCRBAR_SPARKLE_PUBLIC_KEY is resolvable"
+if [ -n "${TCRBAR_SPARKLE_PUBLIC_KEY:-}" ]; then
+  ok "TCRBAR_SPARKLE_PUBLIC_KEY is set in the environment"
+elif [ -n "${TCRBAR_OP_ITEM:-}" ]; then
+  ok "TCRBAR_OP_ITEM is set — release-local.sh will fetch the key from 1Password"
+else
+  fail "neither TCRBAR_SPARKLE_PUBLIC_KEY nor TCRBAR_OP_ITEM is set." \
+       "Without one of them the built app carries no SUPublicEDKey and can" \
+       "never install an update it downloads — release-tcrbar.sh stage 3.5" \
+       "will refuse, but only after the build has already run." \
+       "Fix: export TCRBAR_SPARKLE_PUBLIC_KEY=<the EdDSA public key> yourself," \
+       "or export TCRBAR_OP_ITEM='op://<vault>/<item>' and use release-local.sh."
 fi
 
 # ---------------------------------------------------------------------------

--- a/apps/macos/scripts/release-tcrbar.sh
+++ b/apps/macos/scripts/release-tcrbar.sh
@@ -208,6 +208,39 @@ assert_hardened_runtime() {
 }
 
 # ---------------------------------------------------------------------------
+# Stage 3.5 — Sparkle public key assert
+# ---------------------------------------------------------------------------
+
+# build-tcrbar.sh only WARNS when TCRBAR_SPARKLE_PUBLIC_KEY is unset — right
+# for a local build, where the warning is right there on the screen you are
+# watching. This is the distribution path: the warning scrolls past into a
+# log nobody re-reads, and the built app carries no SUPublicEDKey. That app
+# CAN check the feed but its Sparkle instance will refuse to install anything
+# it finds there, because it has no key to verify the download against — a
+# one-way trap that needs a manual reinstall to escape. Refuse here, before a
+# DMG of that app exists, rather than warn and let it ship.
+assert_sparkle_public_key() {
+  local bundle="$1" key
+  key="$(/usr/libexec/PlistBuddy -c 'Print :SUPublicEDKey' "$bundle/Contents/Info.plist" 2>/dev/null || true)"
+  if [ -n "$key" ]; then
+    note "SUPublicEDKey: present in Info.plist"
+    return 0
+  fi
+  {
+    echo "ERROR: $bundle/Contents/Info.plist has no SUPublicEDKey."
+    echo "ERROR: the app inside this bundle can check the Sparkle feed but will"
+    echo "ERROR: refuse to install anything it finds there — it has no key to"
+    echo "ERROR: verify a downloaded update against. Every installed copy would"
+    echo "ERROR: need a manual reinstall to recover; this is a one-way trap."
+    echo "ERROR:"
+    echo "ERROR: Fix: export TCRBAR_SPARKLE_PUBLIC_KEY=<the EdDSA public key> and"
+    echo "ERROR: rebuild, or export TCRBAR_OP_ITEM so release-local.sh can fetch"
+    echo "ERROR: it from 1Password before calling this script."
+  } >&2
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
 # Sparkle
 # ---------------------------------------------------------------------------
 
@@ -324,6 +357,79 @@ appcast_insert() {
 }
 
 # ---------------------------------------------------------------------------
+# Feed-outage guard
+# ---------------------------------------------------------------------------
+
+# Measured across four releases (docs/plans/swarm-retrospectives.md,
+# 2026-08-10 entry: 11m37s outage; prevented on 2026-08-14 only by a
+# disposable ad-hoc script) the update feed goes dark for the entire gap
+# between the tag-triggered workflow creating the GitHub Release — which
+# becomes `latest` immediately, carrying only CLI tarballs — and THIS script
+# reaching stage 9 to upload the DMG and appcast, which is after the build,
+# sign, DMG and (usually) notarize stages. Waiting until stage 9 to look is
+# what left the window open: by the time stage 9's own wait-loop finds the
+# release, it may already have been live and assetless for as long as the
+# build took.
+#
+# `releases/latest/download/appcast.xml` is the URL Sparkle fetches; a
+# release that IS `latest` and has no appcast.xml on it 404s every install's
+# update check, and GitHub's CDN caches that 404 against the exact URL.
+#
+# Reports whether $tag's Release exists and is assetless (no appcast.xml on
+# it yet) — the exact state stage 9 already knows how to mark prerelease.
+# Prints nothing; callers act on the exit code. Treats "could not ask" as
+# "nothing to quarantine" rather than failing the release outright — this
+# guard runs unattended in the background during the build and must never be
+# the thing that aborts a release over a transient network blip.
+release_is_assetless() {
+  local tag="$1" repo="$2" assets
+  assets="$(gh api "repos/$repo/releases/tags/$tag" --jq '[.assets[].name] | join(" ")' 2>/dev/null)" || return 1
+  case " $assets " in
+    *" appcast.xml "*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# Marks $tag prerelease so `latest` falls back to the previous good release.
+# Idempotent — `gh release edit` succeeds whether or not it was already
+# prerelease — so calling this repeatedly from a poll loop is safe. Failure
+# is swallowed rather than fatal for the same "must not abort a release over
+# a network blip" reason as release_is_assetless above; stage 9's own
+# explicit call (not this one) is the one whose failure IS fatal, because by
+# then it is the last chance before upload.
+quarantine_if_assetless() {
+  local tag="$1" repo="$2"
+  release_is_assetless "$tag" "$repo" || return 0
+  gh release edit "$tag" --prerelease --repo "$repo" >/dev/null 2>&1 || true
+}
+
+# Runs quarantine_if_assetless in the background every 10s for the whole
+# build/sign/notarize duration — the actual window this guard exists to
+# close. Sets `quarantine_watcher_pid`; stop_quarantine_watcher tears it down.
+# The subshell has its own `set +e`: a background loop must never let one
+# failed `gh` call kill itself, since nothing would then be watching for the
+# rest of the build.
+quarantine_watcher_pid=""
+start_quarantine_watcher() {
+  local tag="$1" repo="$2"
+  (
+    set +e
+    while true; do
+      quarantine_if_assetless "$tag" "$repo"
+      sleep 10
+    done
+  ) &
+  quarantine_watcher_pid=$!
+}
+
+stop_quarantine_watcher() {
+  [ -n "$quarantine_watcher_pid" ] || return 0
+  kill "$quarantine_watcher_pid" >/dev/null 2>&1 || true
+  wait "$quarantine_watcher_pid" 2>/dev/null || true
+  quarantine_watcher_pid=""
+}
+
+# ---------------------------------------------------------------------------
 
 usage() { sed -n '2,60p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
 
@@ -345,6 +451,7 @@ main() {
     stage "verify-only: $verify_only"
     assert_developer_id "$verify_only"
     assert_hardened_runtime "$verify_only"
+    assert_sparkle_public_key "$verify_only"
     exit 0
   fi
 
@@ -364,6 +471,19 @@ main() {
 
   local dmg="$build_dir/$app_name-$version.dmg"
 
+  # Start the feed-outage guard now, before the build even begins: the tag is
+  # normally pushed just before this script is invoked (see docs/RELEASING.md),
+  # so the tag-triggered Release can already exist by the time we get here, and
+  # the build/sign/notarize stages below are the whole outage window this
+  # guard exists to close. A --dry-run never touches a real GitHub Release
+  # (nothing is uploaded, stage 9 is skipped), so there is nothing to
+  # quarantine and starting the watcher would just poll a real repo for no
+  # reason — skip it.
+  if [ "$dry_run" != 1 ]; then
+    start_quarantine_watcher "$tag" "$repo"
+    trap stop_quarantine_watcher EXIT
+  fi
+
   # ---- stage 1: build -----------------------------------------------------
   stage "stage 1/9  build (apps/macos/scripts/build-tcrbar.sh)"
   "$here/build-tcrbar.sh"
@@ -376,6 +496,10 @@ main() {
   stage "stage 3/9  re-sign with the hardened runtime and a secure timestamp"
   resign_hardened "$app_dir"
   assert_hardened_runtime "$app_dir"
+
+  # ---- stage 3.5: Sparkle public key assert -------------------------------
+  stage "stage 3.5/9  assert the bundle carries a Sparkle public key"
+  assert_sparkle_public_key "$app_dir"
 
   # ---- stage 4: DMG -------------------------------------------------------
   stage "stage 4/9  build the DMG"
@@ -495,6 +619,12 @@ main() {
     note "would upload $(basename "$dmg") and appcast.xml to $repo release $tag"
   else
     stage "stage 9/9  publish to the GitHub Release"
+
+    # Stop the background guard here: from this point on, the fatal
+    # gh-release-edit calls below are the ones responsible for the
+    # prerelease/upload/reveal sequence, and having both running at once buys
+    # nothing but a harder-to-read log.
+    stop_quarantine_watcher
 
     # WAIT for the release to exist. It is a race, not a given.
     #


### PR DESCRIPTION
Two gates on the release **distribution** path, both closing defects measured while cutting 0.2.7 today.

## 1. Refuse a build whose app cannot verify an update

`build-tcrbar.sh` prints five WARNING lines and continues when `TCRBAR_SPARKLE_PUBLIC_KEY` is unset, omitting `SUPublicEDKey` from `Info.plist`. That app can check the feed and will refuse to install anything Sparkle offers it — a one-way trap needing a manual reinstall. A signed, notarized DMG of exactly that was built today; the only thing between it and publication was noticing warning output that had already scrolled past.

The warning stays in `build-tcrbar.sh`, which is the local developer path and where a warning is right. `release-tcrbar.sh` is the distribution path and now asserts the built bundle carries the key, as stage 3.5 — beside the existing signature and hardened-runtime asserts, which are the same kind of check. `release-preflight.sh` gains check 6/6 so the failure lands *before* a build starts, not after.

**Verified by watching it fire:** the real build pipeline run twice under `--dry-run --skip-notarize`. Key unset → refused at stage 3.5 before the DMG existed, exit 1. Key set → DMG built, appcast written, exit 0.

## 2. Close the update-feed outage window from inside the release

Pushing the tag makes cargo-dist publish a Release carrying tarballs but no `appcast.xml`. `releases/latest/download/appcast.xml` is the URL Sparkle fetches, it resolves to that release, and every installed copy's update check 404s until the local script uploads the asset — with GitHub's CDN caching the 404. Measured on v0.2.4: **11m 37s**. Four consecutive releases hit this.

Preflight cannot cover it: preflight guards the *start* of a release and this window is *during* one. `release-tcrbar.sh` now watches for its own tag's Release appearing assetless and marks it prerelease so `latest` falls back to the previous good release, clearing the flag only after the appcast asset uploads. The sequence is the one already written out in preflight check 4/5's failure text, reused rather than reinvented. On upload failure the release is left prerelease — held out of the feed is safe, serving without an appcast is the outage.

**Verified by mutation, not just by passing:** five constructed cases (assetless+serving, carries-appcast, `gh api` failure, quarantine fires, quarantine no-ops) all pass; inverting `release_is_assetless()` turns 2 of the 5 red, so the fixture discriminates the defect rather than merely running.

## Version

0.2.8. `release-tcrbar.sh` is not exempt from the release-version gate and should not be — it decides what reaches a user, unlike `release-preflight.sh`, which asserts and changes nothing and is exempted by name. Changing the distribution path's behaviour is exactly the case the gate exists for, so the bump is the gate working. It commits nobody to releasing today; it means the next release is 0.2.8.

Both scripts pass shellcheck at 0. The pre-commit stack ran in full on both commits — no `--no-verify`.