### PR TITLE
fix: default sessionAffinity to ON

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,8 @@ A `tcr` server may be serving real traffic on `127.0.0.1:3456`, with client sess
   boot: measured 2026-08-09, three restarts restored 7, 5 and 7 pins. The real limit is the TTL
   (`affinity::PIN_TTL_MS`, 15 minutes) — a restart inside it keeps most sessions warm, and one after
   it restores nothing at all (`restored=0 expired=27`, same log). None of that applies with
-  `sessionAffinity` off, which is the default in a fresh config. Read the log line the server prints
-  at boot rather than assuming either outcome.
+  `sessionAffinity` off, which requires an explicit `"sessionAffinity": false` in a fresh config — the
+  default is now ON. Read the log line the server prints at boot rather than assuming either outcome.
 - **You cannot replace `/Applications/TcrBar.app` while the proxy is running.** TcrBar resolves the
   *bundled* `tcr` ahead of `PATH` (`TcrTool.swift:69-82`) and supervises it as a child, so
   `Contents/MacOS/tcr` is an executing image inside the very bundle being swapped. Finder and Sparkle

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -32,7 +32,8 @@ takeover *inside* the pin TTL (`affinity::PIN_TTL_MS`, 15 minutes,
 nothing at all. That the flush is incremental rather than shutdown-only is
 exactly because of this path: `--replace` follows SIGTERM with SIGKILL, and no
 shutdown hook runs for a SIGKILL (`src/affinity.rs:29-37`). None of it applies
-with `sessionAffinity` off, which is the default (`src/manager/state.rs:33-46`).
+with `sessionAffinity` off, the explicit opt-out — the default is now ON
+(`src/manager/state.rs:33-50`).
 
 That kill is now behind an explicit `--replace`; the default is to stand down and
 exit without binding.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,7 +72,8 @@ and reloaded at boot, so a restart does not automatically cold-start every conve
 prompt cache. Pins expire against `affinity::PIN_TTL_MS`, **15 minutes**: a restart inside
 that window restores most of the fleet's pins, and one outside it restores none. The server
 logs how many it restored; read that line rather than assuming either outcome. With
-`sessionAffinity` off, which is the default, there are no pins to restore.
+`sessionAffinity` off — the explicit opt-out, no longer the default — there are no pins to
+restore.
 
 ## Keeping the quota bars fresh
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -184,7 +184,7 @@ Consequences worth knowing before you tune either number:
 - Randomness is drawn from a SplitMix64 generator seeded once from the boot clock. There is
   no `rand` dependency, and per-account draws are decorrelated by construction; re-reading
   the clock per account in a tight loop would not have been.
-| `sessionAffinity` | bool | **`false`** (OFF) | no | pin a session to the account it started on |
+| `sessionAffinity` | bool | **`true`** (ON) | no | pin a session to the account it started on |
 | `revalidationServe` | bool | **`true`** (ON) | no | serve over-threshold rather than synthesizing a 429 when the whole fleet reads over the soft threshold |
 | `loadBalanceMigration` | bool | **`false`** (OFF) | no | move an already-warm session to a cooler account to even out pinned-session counts |
 
@@ -220,13 +220,15 @@ that off turns this off too.
 
 ### Which knobs are opt-in and which are opt-out
 
-Five knobs ship OFF and must be turned on deliberately: `sessionAffinity`, `warmupSeconds`,
+Four knobs ship OFF and must be turned on deliberately: `warmupSeconds`,
 `loadBalanceMigration`, `pacing` and `lockAccount`. (An older README said three; `pacing`
-and `lockAccount` were missing from that list.)
+and `lockAccount` were missing from that list. `sessionAffinity` was a fifth until it flipped
+to default ON — see below.)
 
-One knob ships ON and is the file's only opt-**out**: `revalidationServe`, default `true`,
-disabled by writing `"revalidationServe": false`. So is `throttle`, per the inversion above,
-though its off-switch is an empty object rather than a `false`.
+Two knobs ship ON and are opt-**out**: `revalidationServe`, default `true`, disabled by
+writing `"revalidationServe": false`; and `sessionAffinity`, also default `true`, disabled by
+writing `"sessionAffinity": false`. So is `throttle`, per the inversion above, though its
+off-switch is an empty object rather than a `false`.
 
 `loadBalanceMigration` is off because Anthropic's prompt cache is per-account: every
 balancing move costs a full prompt-cache re-creation of the whole conversation prefix on

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -35,8 +35,9 @@ running a different commit, or a wedged process holding the socket without answe
 With `sessionAffinity` on, pins are persisted continuously and restored at boot within a
 TTL; a restart inside that window keeps most sessions warm, and one outside it restores
 nothing at all. The server logs how many pins it restored at boot; read that line rather
-than assuming either outcome. With `sessionAffinity` off, which is the default, there are no
-pins to restore. The TTL and the reasoning are in [Session-affinity pins survive a
+than assuming either outcome. With `sessionAffinity` off — the explicit opt-out, no longer
+the default — there are no pins to restore. The TTL and the reasoning are in
+[Session-affinity pins survive a
 restart](architecture.md#session-affinity-pins-survive-a-restart).
 
 ## An account is disabled in the config but still getting traffic

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -745,10 +745,11 @@ pub struct Manager {
     /// stamp the account it picks, so the next select prefers a different one
     /// (load spread). Starts at 1 so 0 reads unambiguously as "never selected".
     select_seq: AtomicU64,
-    /// Session affinity (opt-in): a stable identity hash → `(account index it is
-    /// pinned to, last-touch ms)`. Populated only when `sessionAffinity` is enabled
-    /// and a `SessionKey` extension flows in; empty (and never consulted) otherwise,
-    /// so the disabled path is provably inert. Bounded by a size cap
+    /// Session affinity (default ON, opt-out via `"sessionAffinity": false`): a
+    /// stable identity hash → `(account index it is pinned to, last-touch ms)`.
+    /// Populated only when `sessionAffinity` is enabled and a `SessionKey`
+    /// extension flows in; empty (and never consulted) otherwise, so the disabled
+    /// path is provably inert. Bounded by a size cap
     /// (`AFFINITY_CAP`) + LRU-by-last-touch eviction in [`Manager::select`] — stable
     /// pins intentionally SURVIVE reconnects (that is the point of a stable key), so
     /// there is no disconnect-release. Kept a plain `std::sync::Mutex` and **never**

--- a/src/manager/state.rs
+++ b/src/manager/state.rs
@@ -31,10 +31,17 @@ impl Manager {
     }
 
     /// Whether session affinity is enabled, read from the config's unmodelled
-    /// top-level `sessionAffinity` (default `false` — off unless explicitly
-    /// enabled). Same read pattern as [`Self::probe_interval_seconds`]. When
-    /// `false`, the hybrid server injects no `SessionKey` extension, so `select`
-    /// always receives `affinity = None` and the disabled path is inert.
+    /// top-level `sessionAffinity` (default `true` — ON unless explicitly
+    /// disabled with `"sessionAffinity": false`). An absent key fails safe
+    /// toward keeping caches warm: measured 2026-08-14, a config that lost its
+    /// `sessionAffinity` key silently went cold when the default was `false`,
+    /// and the client-side prompt-cache hit ratio dropped 0.952 → 0.498 with
+    /// cache_creation rising 6.5M/hour → 122M/hour, sustained seven hours — a
+    /// single missing key costing roughly 100M re-created tokens per hour.
+    /// Same read pattern as [`Self::probe_interval_seconds`]. When explicitly
+    /// disabled, the hybrid server injects no `SessionKey` extension, so
+    /// `select` always receives `affinity = None` and the disabled path is
+    /// inert.
     pub fn session_affinity_enabled(&self) -> bool {
         self.config
             .lock()
@@ -42,7 +49,7 @@ impl Manager {
             .extra
             .get("sessionAffinity")
             .and_then(|v| v.as_bool())
-            .unwrap_or(false)
+            .unwrap_or(true)
     }
 
     /// Over-threshold revalidation-serve is ON by default; set top-level
@@ -148,5 +155,39 @@ impl Manager {
             .expect("accounts lock poisoned")
             .get(idx)
             .and_then(|a| a.account_uuid.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manager_with(config: &str) -> Arc<Manager> {
+        let config: Config = serde_json::from_str(config).expect("the inline test config parses");
+        Manager::with_live_refresher(config, None)
+    }
+
+    /// The regression guard for the 2026-08-14 incident: a config that lost its
+    /// `sessionAffinity` key silently went cold when the default was `false`
+    /// (0.952 → 0.498 prompt-cache hit ratio, sustained seven hours). An absent
+    /// key must now read as enabled.
+    #[test]
+    fn session_affinity_defaults_to_enabled_when_key_is_absent() {
+        let manager = manager_with(r#"{"accounts": []}"#);
+        assert!(
+            manager.session_affinity_enabled(),
+            "a config with no sessionAffinity key must default to affinity ON"
+        );
+    }
+
+    /// The explicit opt-out must still work: `"sessionAffinity": false` disables
+    /// it.
+    #[test]
+    fn session_affinity_explicit_false_stays_disabled() {
+        let manager = manager_with(r#"{"sessionAffinity": false, "accounts": []}"#);
+        assert!(
+            !manager.session_affinity_enabled(),
+            "an explicit `sessionAffinity: false` must disable affinity"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- A config that loses its `sessionAffinity` key silently went cold when the default was `false`: measured 2026-08-14, client-side prompt-cache hit ratio dropped 0.952 -> 0.498 with cache_creation rising from 6.5M/hour to 122M/hour, sustained seven hours from one missing key.
- Flips `session_affinity_enabled()`'s default to `true`; `"sessionAffinity": false` is now the explicit opt-out. An absent key now fails safe toward keeping caches warm.
- Updates every prose surface that documented the old default: doc comments in `src/manager/state.rs` and `src/manager/mod.rs`, the knob table and opt-in/opt-out lists in `docs/configuration.md`, and the "off, which is the default" sentences in `docs/architecture.md`, `docs/troubleshooting.md`, `CLAUDE.md`, and `apps/macos/README.md`.
- Adds a regression test pinning both the new default (absent key -> enabled) and the explicit opt-out (`"sessionAffinity": false` -> disabled).

## Test plan
- [x] `cargo fmt --check` — exit 0
- [x] `cargo clippy --all-targets -- -D warnings` — exit 0
- [x] `cargo test` — 672 passed, 0 failed (670 pre-existing + 2 new)
- [x] Existing tests that set `sessionAffinity` explicitly (`src/server.rs:1124,1157`, `tests/hop_overhead.rs:136`, `tests/serve_library_path.rs:42`) were left untouched — no test relied on the old default-off behavior, so nothing needed to change to keep the suite green.