### PR TITLE
feat: add http1Only config to cap connection-fault blast radius

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,6 +43,7 @@ section below.
 | `pacing` | object | both knobs unset → **OFF** | no | per-account concurrency/spacing, see below |
 | `throttle` | object | `{minSpacingMs: 350, burst: 4}` → **ON** | no | fleet-wide egress rate limiter, see below |
 | `lockAccount` | string | absent → normal routing | no | pin ALL traffic to one account by `name` |
+| `http1Only` | bool | **`false`** (OFF) | no | force the upstream client onto HTTP/1.1, see below |
 | `accounts` | array | `[]` | no | the rotatable accounts |
 
 `switchThreshold` is **0.95**, not 0.90. The default function is
@@ -220,10 +221,10 @@ that off turns this off too.
 
 ### Which knobs are opt-in and which are opt-out
 
-Four knobs ship OFF and must be turned on deliberately: `warmupSeconds`,
-`loadBalanceMigration`, `pacing` and `lockAccount`. (An older README said three; `pacing`
-and `lockAccount` were missing from that list. `sessionAffinity` was a fifth until it flipped
-to default ON — see below.)
+Five knobs ship OFF and must be turned on deliberately: `warmupSeconds`,
+`loadBalanceMigration`, `pacing`, `lockAccount` and `http1Only`. (An older README said three;
+`pacing` and `lockAccount` were missing from that list. `sessionAffinity` was a sixth until
+it flipped to default ON — see below.)
 
 Two knobs ship ON and are opt-**out**: `revalidationServe`, default `true`, disabled by
 writing `"revalidationServe": false`; and `sessionAffinity`, also default `true`, disabled by
@@ -256,6 +257,26 @@ resilience it removes the resilience entirely. Treat it as a debugging tool.
 A name matching no account is not a startup failure: the proxy logs an error naming the
 available accounts and runs **unlocked**. So a typo'd `lockAccount` looks exactly like an
 ordinary rotating proxy unless you read the log at boot.
+
+## `http1Only`: caps blast radius, costs multiplexing
+
+A connection-level fault on HTTP/2 (GOAWAY, a framing error) kills **every** multiplexed
+stream sharing that connection at once — one fault can take down several concurrent
+sessions on the same account. `http1Only` forces the upstream-forwarding client onto
+HTTP/1.1, which does not multiplex, so the same fault costs exactly one in-flight request
+instead. It is a structural cap on blast radius, not a statistical one, and it stacks with
+the per-account connection pool (each account already owns its own client, so this narrows
+the blast radius further within an account rather than duplicating that isolation).
+
+The trade is real, which is why it ships OFF: h1 gives up multiplexing entirely, opens one
+TCP+TLS connection per concurrent request instead of sharing one, and raises the open-socket
+count against Anthropic's edge. Turn it on only if you have actually observed the
+connection-fault symptom (many sessions failing at once, not a single request failing).
+
+Its state is visible from outside the process on purpose — a knob nobody can see the state
+of is how this repo once lost seven hours of prompt-cache to session-affinity being silently
+off. Check `tcr status` (`http1Only=` on the `source=` line, `http1Only` per row with
+`--json`) or the `"server started"` log line at boot.
 
 ## File permissions and secrecy
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -852,6 +852,7 @@ fn render_accounts_json(
     thresholds: &[f64],
     source: StatusSource,
     server: Option<&BuildInfo>,
+    http1_only: bool,
 ) -> String {
     let now = OffsetDateTime::now_utc();
     let rows: Vec<serde_json::Value> = snapshot
@@ -879,6 +880,10 @@ fn render_accounts_json(
                 // it is verifying.
                 "serverSha": server.map(|b| b.sha.as_str()),
                 "serverDirty": server.and_then(|b| b.dirty),
+                // Server-wide, repeated per row like `serverSha` above — whether
+                // this server's upstream clients are forced onto HTTP/1.1. See
+                // `Config::http1_only` and `Manager::http1_only`.
+                "http1Only": http1_only,
                 "name": a.name,
                 "priority": a.priority,
                 "status": a.status,
@@ -1184,11 +1189,20 @@ pub async fn status(config_path: &Path, json: bool) -> anyhow::Result<()> {
     let config = config::load(config_path)
         .with_context(|| format!("load config at {}", config_path.display()))?;
 
-    let (source, server_build, snapshot, thresholds) = match fetch_live_status(&config).await {
+    let (source, server_build, snapshot, thresholds, http1_only) = match fetch_live_status(&config)
+        .await
+    {
         Ok(payload) => {
             let build = payload.build.clone();
+            let http1_only = payload.http1_only;
             let (snapshot, thresholds) = payload.into_snapshot();
-            (StatusSource::Live, Some(build), snapshot, thresholds)
+            (
+                StatusSource::Live,
+                Some(build),
+                snapshot,
+                thresholds,
+                http1_only,
+            )
         }
         Err(reason) => {
             // Both "it answered something unusable" and "it answered nothing"
@@ -1196,11 +1210,16 @@ pub async fn status(config_path: &Path, json: bool) -> anyhow::Result<()> {
             if !matches!(reason, LiveStatusError::NoServer) {
                 let why = reason.why();
                 eprintln!(
-                    "[tcr] warning: could not read live status from the proxy on :{} ({why}) — falling back to an offline snapshot, whose serving counters are all zero.",
-                    config.proxy.port
-                );
+                        "[tcr] warning: could not read live status from the proxy on :{} ({why}) — falling back to an offline snapshot, whose serving counters are all zero.",
+                        config.proxy.port
+                    );
             }
             let thresholds = resolve_thresholds(&config);
+            // `config` is consumed by `snapshot_offline` below, so read
+            // `http1_only` off it first — this is the config FILE's value,
+            // not a running server's (there is none in this branch), which
+            // is the honest answer for an offline snapshot.
+            let http1_only = config.http1_only;
             let snapshot = snapshot_offline(
                 config,
                 Arc::new(NoRefresh),
@@ -1208,7 +1227,13 @@ pub async fn status(config_path: &Path, json: bool) -> anyhow::Result<()> {
                 true,
             )
             .await;
-            (StatusSource::Offline, None, snapshot, thresholds)
+            (
+                StatusSource::Offline,
+                None,
+                snapshot,
+                thresholds,
+                http1_only,
+            )
         }
     };
 
@@ -1222,13 +1247,23 @@ pub async fn status(config_path: &Path, json: bool) -> anyhow::Result<()> {
     if json {
         println!(
             "{}",
-            render_accounts_json(&snapshot, &thresholds, source, server_build.as_ref())
+            render_accounts_json(
+                &snapshot,
+                &thresholds,
+                source,
+                server_build.as_ref(),
+                http1_only
+            )
         );
     } else {
         // One greppable `source=` line above the account lines, in the same
         // key=value idiom, so the provenance is visible without --json.
+        // `http1Only` rides here rather than per-account: it is a server-wide
+        // fact, like `source` itself, not a per-account gating detail — see
+        // `Manager::http1_only`'s doc-comment for why this must NOT be
+        // re-derived from the config file when `source=live`.
         println!(
-            "status source={}{}{}",
+            "status source={}{}{} http1Only={}",
             source.as_str(),
             match source {
                 StatusSource::Live => String::new(),
@@ -1236,6 +1271,7 @@ pub async fn status(config_path: &Path, json: bool) -> anyhow::Result<()> {
                     " note=serving-counters-unavailable-no-server-answered".to_string(),
             },
             build_fields(server_build.as_ref()),
+            http1_only,
         );
         print!("{}", render_accounts(&snapshot, &thresholds, source));
     }
@@ -1892,7 +1928,7 @@ mod tests {
         )
         .await;
 
-        let json = render_accounts_json(&snapshot, &thresholds, StatusSource::Offline, None);
+        let json = render_accounts_json(&snapshot, &thresholds, StatusSource::Offline, None, false);
         let rows: Vec<serde_json::Value> = serde_json::from_str(&json).expect("valid json");
         assert_eq!(rows.len(), 2, "one row per account");
         for row in &rows {
@@ -1920,7 +1956,7 @@ mod tests {
         let mut counted = snapshot.clone();
         counted.accounts[0].input_tokens = 1_000;
         counted.accounts[0].cache_read_tokens = 750;
-        let live = render_accounts_json(&counted, &thresholds, StatusSource::Live, None);
+        let live = render_accounts_json(&counted, &thresholds, StatusSource::Live, None, false);
         let rows: Vec<serde_json::Value> = serde_json::from_str(&live).expect("valid json");
         assert_eq!(rows[0]["cacheHitRatio"], serde_json::json!(0.75));
         assert_eq!(rows[0]["source"], "live");
@@ -1962,7 +1998,8 @@ mod tests {
         )
         .await;
 
-        let offline = render_accounts_json(&snapshot, &thresholds, StatusSource::Offline, None);
+        let offline =
+            render_accounts_json(&snapshot, &thresholds, StatusSource::Offline, None, false);
         let rows: Vec<serde_json::Value> = serde_json::from_str(&offline).expect("valid json");
         for row in &rows {
             // `get`, not `row[...]`: indexing a MISSING key also yields Null, so
@@ -1981,7 +2018,7 @@ mod tests {
         }
 
         // Measured and genuinely clean is a DIFFERENT state, and renders as 0.
-        let live = render_accounts_json(&snapshot, &thresholds, StatusSource::Live, None);
+        let live = render_accounts_json(&snapshot, &thresholds, StatusSource::Live, None, false);
         let rows: Vec<serde_json::Value> = serde_json::from_str(&live).expect("valid json");
         assert_eq!(rows[0]["streamErrorCount"], serde_json::json!(0));
 
@@ -1989,7 +2026,7 @@ mod tests {
         let mut errored = snapshot.clone();
         errored.accounts[0].stream_error_count = 3;
         errored.accounts[0].last_stream_error = Some("overloaded_error".to_string());
-        let live = render_accounts_json(&errored, &thresholds, StatusSource::Live, None);
+        let live = render_accounts_json(&errored, &thresholds, StatusSource::Live, None, false);
         let rows: Vec<serde_json::Value> = serde_json::from_str(&live).expect("valid json");
         assert_eq!(rows[0]["streamErrorCount"], serde_json::json!(3));
         assert_eq!(
@@ -2053,7 +2090,13 @@ mod tests {
         let build = payload.build.clone();
         let (snapshot, thresholds) = payload.into_snapshot();
 
-        let json = render_accounts_json(&snapshot, &thresholds, StatusSource::Live, Some(&build));
+        let json = render_accounts_json(
+            &snapshot,
+            &thresholds,
+            StatusSource::Live,
+            Some(&build),
+            false,
+        );
         let rows: Vec<serde_json::Value> = serde_json::from_str(&json).expect("valid json");
         assert_eq!(
             rows[0]["cacheHitRatio"],
@@ -2096,7 +2139,7 @@ mod tests {
         )
         .await;
 
-        let json = render_accounts_json(&snapshot, &thresholds, StatusSource::Offline, None);
+        let json = render_accounts_json(&snapshot, &thresholds, StatusSource::Offline, None, false);
         let rows: Vec<serde_json::Value> = serde_json::from_str(&json).expect("valid json");
         for row in &rows {
             assert!(
@@ -2426,7 +2469,7 @@ mod tests {
             assert!(secs > 0, "a promised instant is in the future: {line}");
         }
         // JSON mirrors it for machine consumers, in ms like every other instant.
-        let json = render_accounts_json(&gated, &thresholds, StatusSource::Live, None);
+        let json = render_accounts_json(&gated, &thresholds, StatusSource::Live, None, false);
         assert!(
             json.contains("\"freeAtMs\""),
             "json carries freeAtMs: {json}"
@@ -2535,7 +2578,7 @@ mod tests {
         );
 
         // JSON mirrors the held fields for machine consumers.
-        let json = render_accounts_json(&snapshot, &thresholds, StatusSource::Offline, None);
+        let json = render_accounts_json(&snapshot, &thresholds, StatusSource::Offline, None, false);
         assert!(json.contains("\"held\""), "json carries held array: {json}");
         assert!(
             json.contains("\"window\": \"5h\""),
@@ -2776,7 +2819,13 @@ mod tests {
         // itself emits none.
         format!(
             "{}\n",
-            render_accounts_json(&snapshot, &thresholds, StatusSource::Live, Some(&build))
+            render_accounts_json(
+                &snapshot,
+                &thresholds,
+                StatusSource::Live,
+                Some(&build),
+                false
+            )
         )
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -239,6 +239,20 @@ pub struct Config {
     /// fail rather than rotating. Set to the exact `accounts[].name`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lock_account: Option<String>,
+    /// Force the upstream-forwarding client onto HTTP/1.1 instead of the
+    /// h2-and-fall-back-to-h1 negotiation reqwest does by default. Absent →
+    /// `false` (h2). OFF by default deliberately: an intermittent
+    /// connection-level fault (GOAWAY / framing error) on HTTP/2 kills EVERY
+    /// multiplexed stream sharing that connection at once, so one fault takes
+    /// down every concurrent session an account happens to be serving. h1
+    /// does not multiplex, so a fault there costs exactly one in-flight
+    /// request — a structural cap on blast radius, not a statistical one.
+    /// The trade: h1 gives up multiplexing, opens one TCP+TLS connection per
+    /// concurrent request instead of sharing one, and raises the open-socket
+    /// count against Anthropic's edge — real costs, which is why this stays
+    /// opt-in. Set `"http1Only": true` to enable.
+    #[serde(default)]
+    pub http1_only: bool,
     #[serde(default)]
     pub accounts: Vec<Account>,
     /// Any top-level keys we do not model, preserved verbatim on save.
@@ -1386,6 +1400,15 @@ mod tests {
         assert_eq!(config.pacing.max_in_flight_per_account, None);
         assert_eq!(config.pacing.min_spacing_ms, None);
         assert!(!config.pacing.is_active());
+        // Absent `http1Only` key → OFF: the serving client stays on h2.
+        assert!(!config.http1_only);
+    }
+
+    #[test]
+    fn http1_only_true_deserializes() {
+        let config: Config =
+            serde_json::from_str(r#"{ "accounts": [], "http1Only": true }"#).unwrap();
+        assert!(config.http1_only);
     }
 
     #[test]

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -80,7 +80,7 @@ fn base(name: &str, priority: i64) -> AccountRuntime {
         stream_error_times_ms: std::collections::VecDeque::new(),
         last_stream_error: None,
         refresh_lock: Arc::new(AsyncMutex::new(())),
-        http: crate::manager::build_serving_client(),
+        http: crate::manager::build_serving_client(false),
     }
 }
 

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -390,7 +390,14 @@ pub(crate) fn fail_next_client_build() {
 /// [`AccountRuntime::http`]) so every account's client is configured
 /// identically and differs from every other account's only in the connection
 /// pool it privately owns.
-pub(crate) fn build_serving_client() -> Arc<reqwest::Client> {
+///
+/// `http1_only` mirrors [`config::Config::http1_only`] — see its doc-comment
+/// for why this exists and why it defaults to `false`. When `true`, every
+/// stream this client opens is capped at HTTP/1.1, so the
+/// `http2_keep_alive_*` settings below become inert (h1 has no PING frame to
+/// send); they are left in place because they are still correct for the
+/// default h2 path.
+pub(crate) fn build_serving_client(http1_only: bool) -> Arc<reqwest::Client> {
     #[cfg(test)]
     if FAIL_NEXT_CLIENT_BUILD.with(|f| f.replace(false)) {
         panic!("build reqwest client (test-injected failure)");
@@ -399,33 +406,36 @@ pub(crate) fn build_serving_client() -> Arc<reqwest::Client> {
     // proxy — routing our upstream through an ambient proxy (e.g. the JS
     // teamclaude on :3456) loops us through the thing we replace and every
     // request dies as "upstream unreachable". Always reach Anthropic directly.
-    Arc::new(
-        reqwest::Client::builder()
-            .no_proxy()
-            // Cap only the CONNECT phase. A blackholed route (no RST, no reply)
-            // otherwise stalls the attempt until the OS TCP timeout, and with a
-            // retry budget of `account_count * 2 + 4` that is many minutes of a
-            // hung request. `oauth.rs` and `probe.rs` both already set one.
-            //
-            // DELIBERATELY NOT a total `.timeout(...)`, and do not add one: these
-            // responses are long-lived SSE streams that legitimately run longer
-            // than any bound worth setting, and a total timeout would truncate
-            // them mid-stream. `connect_timeout` cannot — it applies only before
-            // the response headers arrive, so once a stream is flowing it is out
-            // of the picture.
-            .connect_timeout(std::time::Duration::from_secs(10))
-            // Keep the single HTTP/2 connection to Anthropic warm across
-            // interactive think-time pauses. reqwest reaps idle connections
-            // after 90s by default, but a coding session routinely pauses
-            // longer — so the next request would pay a fresh TCP+TLS handshake
-            // (~100-300ms). h2 keep-alive PINGs + a 5-min idle timeout hold the
-            // connection open so a post-pause request skips the reconnect.
-            .http2_keep_alive_interval(std::time::Duration::from_secs(30))
-            .http2_keep_alive_while_idle(true)
-            .pool_idle_timeout(std::time::Duration::from_secs(300))
-            .build()
-            .expect("build reqwest client"),
-    )
+    let mut builder = reqwest::Client::builder()
+        .no_proxy()
+        // Cap only the CONNECT phase. A blackholed route (no RST, no reply)
+        // otherwise stalls the attempt until the OS TCP timeout, and with a
+        // retry budget of `account_count * 2 + 4` that is many minutes of a
+        // hung request. `oauth.rs` and `probe.rs` both already set one.
+        //
+        // DELIBERATELY NOT a total `.timeout(...)`, and do not add one: these
+        // responses are long-lived SSE streams that legitimately run longer
+        // than any bound worth setting, and a total timeout would truncate
+        // them mid-stream. `connect_timeout` cannot — it applies only before
+        // the response headers arrive, so once a stream is flowing it is out
+        // of the picture.
+        .connect_timeout(std::time::Duration::from_secs(10))
+        // Keep the single HTTP/2 connection to Anthropic warm across
+        // interactive think-time pauses. reqwest reaps idle connections
+        // after 90s by default, but a coding session routinely pauses
+        // longer — so the next request would pay a fresh TCP+TLS handshake
+        // (~100-300ms). h2 keep-alive PINGs + a 5-min idle timeout hold the
+        // connection open so a post-pause request skips the reconnect.
+        .http2_keep_alive_interval(std::time::Duration::from_secs(30))
+        .http2_keep_alive_while_idle(true)
+        .pool_idle_timeout(std::time::Duration::from_secs(300));
+    if http1_only {
+        // Structural blast-radius cap: h1 does not multiplex, so a
+        // connection-level fault (GOAWAY / framing error) kills at most the
+        // one request on that connection instead of every stream sharing it.
+        builder = builder.http1_only();
+    }
+    Arc::new(builder.build().expect("build reqwest client"))
 }
 
 /// A rotation slot answers a user's account query by the same three fields a
@@ -511,7 +521,7 @@ pub enum AddAccountOutcome {
 }
 
 impl AccountRuntime {
-    fn from_config(account: &config::Account) -> Self {
+    fn from_config(account: &config::Account, http1_only: bool) -> Self {
         Self {
             name: account.name.clone(),
             account_type: account.account_type.clone(),
@@ -552,7 +562,7 @@ impl AccountRuntime {
             stream_error_times_ms: VecDeque::new(),
             last_stream_error: None,
             refresh_lock: Arc::new(AsyncMutex::new(())),
-            http: build_serving_client(),
+            http: build_serving_client(http1_only),
         }
     }
 }
@@ -865,7 +875,7 @@ impl Manager {
         let accounts: Vec<AccountRuntime> = config
             .accounts
             .iter()
-            .map(AccountRuntime::from_config)
+            .map(|a| AccountRuntime::from_config(a, config.http1_only))
             .collect();
         Self::assemble(config, refresher, prober, warmer, config_path, accounts)
     }
@@ -1390,7 +1400,8 @@ impl Manager {
     /// an appended account gets its own `refresh_lock` for free — there is no
     /// longer a parallel structure to keep in sync.
     pub fn add_account(&self, account: config::Account) -> usize {
-        let runtime = AccountRuntime::from_config(&account);
+        let http1_only = self.config.lock().expect("config lock poisoned").http1_only;
+        let runtime = AccountRuntime::from_config(&account, http1_only);
         let idx = {
             let mut accounts = self.accounts.write().expect("accounts lock poisoned");
             accounts.push(runtime);
@@ -1713,7 +1724,8 @@ impl Manager {
                     // attempt is guaranteed to have a runtime ready, so it
                     // cannot hit this arm again.
                     drop(_writing);
-                    speculative_runtime = Some(AccountRuntime::from_config(&account));
+                    let http1_only = self.config.lock().expect("config lock poisoned").http1_only;
+                    speculative_runtime = Some(AccountRuntime::from_config(&account, http1_only));
                     continue;
                 }
                 Resolution::Added { idx } => {
@@ -1926,6 +1938,23 @@ mod tests {
     /// silently turn a re-key test into a divert test.
     const LONG_HOLD_SECS: i64 = CACHE_WARM_HOLD_SECS + 60;
 
+    /// `build_serving_client` must not panic on either branch of `http1_only` —
+    /// h1 support is part of the reqwest/rustls TLS backend this crate already
+    /// pulls in, but a builder method rejecting a combination it doesn't support
+    /// is exactly the kind of thing that only shows up at `.build()`.
+    ///
+    /// This cannot assert the built client actually NEGOTIATES h1 on the wire:
+    /// reqwest exposes no introspection on a built `Client` for its ALPN/HTTP
+    /// version policy, and asserting anything less than that would only prove
+    /// the bool reached this function's own argument — not that it reaches
+    /// reqwest's TLS layer. See the PR report for the explicit statement of
+    /// that gap.
+    #[test]
+    fn build_serving_client_builds_under_both_http1_only_settings() {
+        let _off = build_serving_client(false);
+        let _on = build_serving_client(true);
+    }
+
     #[test]
     fn throttle_slot_burst1_is_strict_spacing() {
         // B=1 (tau=0): threading the TAT across 3 calls at a fixed `now` yields
@@ -1986,6 +2015,7 @@ mod tests {
             pacing: PacingConfig::default(),
             throttle: ThrottleConfig::default(),
             lock_account: None,
+            http1_only: false,
             accounts,
             extra: serde_json::Map::new(),
         }
@@ -5052,7 +5082,7 @@ mod tests {
 
     /// A fresh active runtime with empty quota, for the [`Manager::account_gate`] tests.
     fn gate_runtime() -> AccountRuntime {
-        AccountRuntime::from_config(&account("gate", 0))
+        AccountRuntime::from_config(&account("gate", 0), false)
     }
 
     #[test]
@@ -5165,7 +5195,7 @@ mod tests {
         let now = OffsetDateTime::now_utc();
         let now_ms = odt_to_ms(now);
         let reset = now + Duration::seconds(600);
-        let mut a = AccountRuntime::from_config(&account("std-hold", 0));
+        let mut a = AccountRuntime::from_config(&account("std-hold", 0), false);
         a.switch_threshold = Some(0.90);
         a.rate_limited_until_ms = Some(now_ms + 8_000); // short Hold, +8s
         a.quota.requests_limit = Some(200);
@@ -5452,21 +5482,21 @@ mod tests {
 
         // Account A — weekly-gated: its 5h resets SOON (200s) but its 7d stays over
         // threshold until 5000s, so A does NOT actually return until 5000s.
-        let mut a = AccountRuntime::from_config(&account("a", 0));
+        let mut a = AccountRuntime::from_config(&account("a", 0), false);
         a.switch_threshold = Some(0.90);
         a.quota.five_hour = Some(window(0.99, Some(at(200))));
         a.quota.seven_day = Some(window(0.99, Some(at(5_000))));
 
         // Account B — a dead credential (Error) that holds the SOONEST raw reset
         // (100s). It never self-frees, so it must contribute nothing to the hint.
-        let mut b = AccountRuntime::from_config(&account("b", 0));
+        let mut b = AccountRuntime::from_config(&account("b", 0), false);
         b.switch_threshold = Some(0.90);
         b.status = AccountStatus::Error;
         b.quota.five_hour = Some(window(0.99, Some(at(100))));
 
         // Account C — the TRUE first recovery: 5h-gated with a later reset (900s)
         // and a healthy 7d, so it genuinely returns at 900s.
-        let mut c = AccountRuntime::from_config(&account("c", 0));
+        let mut c = AccountRuntime::from_config(&account("c", 0), false);
         c.switch_threshold = Some(0.90);
         c.quota.five_hour = Some(window(0.99, Some(at(900))));
 

--- a/src/manager/pins.rs
+++ b/src/manager/pins.rs
@@ -151,7 +151,12 @@ mod tests {
     /// A manager holding exactly `accounts`, in that order. `from_runtimes` never
     /// invokes its refresher/prober/warmer, and nothing here reaches the network.
     fn manager_over(accounts: &[Account]) -> Arc<Manager> {
-        Manager::from_runtimes(accounts.iter().map(AccountRuntime::from_config).collect())
+        Manager::from_runtimes(
+            accounts
+                .iter()
+                .map(|a| AccountRuntime::from_config(a, false))
+                .collect(),
+        )
     }
 
     /// A unique path per test: the suite runs tests in parallel threads of ONE

--- a/src/manager/snapshot.rs
+++ b/src/manager/snapshot.rs
@@ -86,6 +86,16 @@ impl Manager {
             .collect()
     }
 
+    /// Whether this server's accounts are forced onto HTTP/1.1 — see
+    /// [`config::Config::http1_only`]. Server-wide, not per-account, and
+    /// exposed for the same reason `thresholds` is: a client must not
+    /// re-derive this from `~/.config/teamclaude.json`, which may have been
+    /// edited (or the process not yet restarted to pick it up) since the
+    /// server actually booted its clients.
+    pub fn http1_only(&self) -> bool {
+        self.config.lock().expect("config lock poisoned").http1_only
+    }
+
     /// Compute the live snapshot the TUI renders. Every quota figure is evaluated
     /// at `now` so the display can never show a past-reset window as still full.
     pub fn snapshot(&self, now: OffsetDateTime) -> StatsSnapshot {

--- a/src/mitm.rs
+++ b/src/mitm.rs
@@ -826,6 +826,7 @@ mod tests {
             pacing: crate::config::PacingConfig::default(),
             throttle: crate::config::ThrottleConfig::default(),
             lock_account: None,
+            http1_only: false,
             accounts: vec![crate::config::Account {
                 name: "dummy".to_string(),
                 account_type: "oauth".to_string(),

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1095,8 +1095,11 @@ async fn status_handler(
     }
 
     let now = OffsetDateTime::now_utc();
-    let payload =
-        crate::status::StatusPayload::from_snapshot(&manager.snapshot(now), &manager.thresholds());
+    let payload = crate::status::StatusPayload::from_snapshot(
+        &manager.snapshot(now),
+        &manager.thresholds(),
+        manager.http1_only(),
+    );
     let Ok(body) = serde_json::to_string(&payload) else {
         // Serializing plain numbers and strings cannot realistically fail, but a
         // proxy never panics on a client request — surface it as a 500 instead.
@@ -3350,6 +3353,7 @@ mod tests {
             pacing: crate::config::PacingConfig::default(),
             throttle: crate::config::ThrottleConfig::default(),
             lock_account: None,
+            http1_only: false,
             accounts: vec![Account {
                 name: "dummy".to_string(),
                 account_type: "oauth".to_string(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -797,6 +797,13 @@ pub async fn serve(options: ServeOptions) -> anyhow::Result<ServeOutcome> {
     // The build stamp beside it is the field that actually identifies the code
     // this pid is executing — the thing that used to need an `lsof -p <pid>`
     // inode comparison to establish. See `build_info`.
+    // `http1_only` rides on the SAME boot line rather than a separate one,
+    // deliberately: this repo lost seven hours of prompt-cache once to a
+    // default-off knob whose state was invisible from outside the process,
+    // and the fix is making the state show up at the one place every boot is
+    // already guaranteed to log — not adding a second line an operator has to
+    // know to look for. See `Config::http1_only`.
+    let http1_only = manager.http1_only();
     tracing::info!(
         version = env!("CARGO_PKG_VERSION"),
         sha = build_info::SHA,
@@ -804,6 +811,7 @@ pub async fn serve(options: ServeOptions) -> anyhow::Result<ServeOutcome> {
         built_at = build_info::BUILT_AT,
         pid = std::process::id(),
         port = bound.port(),
+        http1_only,
         "server started"
     );
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -107,6 +107,20 @@ pub struct StatusPayload {
     /// it made a newer client unable to parse an older running server at all.
     #[serde(default)]
     pub build: BuildInfo,
+    /// Whether the SERVING process is forcing HTTP/1.1 on its upstream
+    /// clients — see [`crate::config::Config::http1_only`]. Server-wide, like
+    /// `build`, and for the same reason: re-deriving it from
+    /// `~/.config/teamclaude.json` on the client would report the file's
+    /// state, not the already-booted process's, and the two can differ (the
+    /// config was edited after boot; the flag is only read at client
+    /// construction).
+    ///
+    /// `#[serde(default)]` for the same back-compat reason as `build`: an
+    /// OLD server's payload has no such key, and absent must read as `false`
+    /// (the actual default) rather than fail the parse and drop to the
+    /// offline snapshot.
+    #[serde(default)]
+    pub http1_only: bool,
 }
 
 /// One account's live row. Field-for-field the serializable half of
@@ -193,7 +207,7 @@ impl StatusPayload {
     /// per-account list (see [`crate::manager::Manager::thresholds`]); a short
     /// list falls back to `1.0` per account, which can only fail CLOSED — at 1.0
     /// nothing but a fully-exhausted window reads as held, never a false hold.
-    pub fn from_snapshot(snapshot: &StatsSnapshot, thresholds: &[f64]) -> Self {
+    pub fn from_snapshot(snapshot: &StatsSnapshot, thresholds: &[f64], http1_only: bool) -> Self {
         let accounts = snapshot
             .accounts
             .iter()
@@ -232,6 +246,7 @@ impl StatusPayload {
             // Compile-time constants of the SERVING binary — not passed in,
             // because the only honest answer is the one baked into this process.
             build: BuildInfo::current(),
+            http1_only,
         }
     }
 
@@ -334,7 +349,7 @@ mod tests {
     #[test]
     fn payload_round_trips_every_rendered_field() {
         let snapshot = snapshot_with_counters();
-        let wire = serde_json::to_string(&StatusPayload::from_snapshot(&snapshot, &[0.85]))
+        let wire = serde_json::to_string(&StatusPayload::from_snapshot(&snapshot, &[0.85], false))
             .expect("serialize");
         let back: StatusPayload = serde_json::from_str(&wire).expect("deserialize");
         assert_eq!(back.kind, STATUS_KIND);
@@ -365,6 +380,7 @@ mod tests {
         let wire = serde_json::to_string(&StatusPayload::from_snapshot(
             &snapshot_with_counters(),
             &[0.85],
+            false,
         ))
         .expect("serialize");
         let back: StatusPayload = serde_json::from_str(&wire).expect("deserialize");
@@ -457,6 +473,7 @@ mod tests {
         let wire = serde_json::to_string(&StatusPayload::from_snapshot(
             &snapshot_with_counters(),
             &[0.9],
+            false,
         ))
         .expect("serialize");
         assert!(

--- a/tests/fixtures/status-contract.json
+++ b/tests/fixtures/status-contract.json
@@ -7,6 +7,7 @@
     "freeAtMs": null,
     "gate": "ok",
     "held": [],
+    "http1Only": false,
     "inputTokens": 8000000,
     "lastStreamError": "overloaded_error",
     "name": "alice@example.com",
@@ -46,6 +47,7 @@
         "window": "7d"
       }
     ],
+    "http1Only": false,
     "inputTokens": 8000000,
     "lastStreamError": "overloaded_error",
     "name": "bob@example.com",
@@ -85,6 +87,7 @@
         "window": "7d"
       }
     ],
+    "http1Only": false,
     "inputTokens": 8000000,
     "lastStreamError": "overloaded_error",
     "name": "carol@example.com",
@@ -113,6 +116,7 @@
     "freeAtMs": null,
     "gate": "ok",
     "held": [],
+    "http1Only": false,
     "inputTokens": 0,
     "lastStreamError": null,
     "name": "dave@example.com",

--- a/tests/workload_scenarios.rs
+++ b/tests/workload_scenarios.rs
@@ -215,6 +215,7 @@ impl Fleet {
             // path and has no bearing on selection.
             throttle: ThrottleConfig::default(),
             lock_account: None,
+            http1_only: false,
             accounts: accounts.iter().map(|(n, p)| account(n, *p)).collect(),
             extra: serde_json::Map::new(),
         };


### PR DESCRIPTION
## Summary
- Adds an opt-in `http1Only` config field that forces the upstream-forwarding client onto HTTP/1.1. Ships **OFF** by default.
- Why: an HTTP/2 connection-level fault (GOAWAY / framing error) kills every multiplexed stream sharing that connection at once, so one fault can take down several concurrent sessions on an account. h1 does not multiplex, so the same fault costs exactly one in-flight request — a structural cap on blast radius rather than a statistical one (the per-account connection pool already narrows blast radius across accounts, not within one).
- Trade-off, and why it stays opt-in: h1 gives up multiplexing, opens one TCP+TLS connection per concurrent request instead of sharing one, and raises the open-socket count against Anthropic's edge.
- Observability (required, not optional — a prior default-off knob whose state was invisible cost this repo seven hours of prompt-cache): the flag now appears on the `"server started"` boot log line, and in `tcr status` (both the `source=` line and `--json`, live and offline paths, per the existing per-account-repeats-server-wide-facts pattern `serverSha` already uses).

## Changes
- `src/config.rs`: `Config.http1_only: bool`, `#[serde(default)]` (camelCase → `http1Only`).
- `src/manager/mod.rs`: `build_serving_client(http1_only: bool)` calls `.http1_only()` on the reqwest builder when set; `AccountRuntime::from_config` threads the flag through to every call site (boot, `add_account`, `add_or_update_account`'s speculative-build path).
- `src/manager/snapshot.rs`: `Manager::http1_only()` accessor, mirroring `Manager::thresholds()`.
- `src/status.rs`: `StatusPayload.http1_only`, server-wide wire field with `#[serde(default)]` for the same back-compat reason `build` has it.
- `src/cli.rs`: `tcr status` renders `http1Only=` on the plain line and `"http1Only"` per JSON row.
- `src/server.rs`: boot log carries `http1_only`.
- `docs/configuration.md`: added to the top-level table, the opt-in count (four → five), and a new `## http1Only` section.
- `tests/fixtures/status-contract.json`: regenerated (`TCR_UPDATE_FIXTURES=1`); the Swift decode suite (`apps/macos: swift test --filter RealWorldDecodeTests`) still passes — Codable ignores the new key gracefully, no Swift source changes needed.

## Test plan
- [x] `cargo test`: 674 lib tests + integration suites, all green, including new tests: `http1_only` defaults to `false` on a minimal config, `"http1Only": true` deserializes, `build_serving_client(true)`/`build_serving_client(false)` both build without panicking.
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`: both clean.
- [x] `apps/macos: swift test --filter RealWorldDecodeTests`: 10/10 pass against the regenerated fixture.
- Explicit gap: this cannot assert the flag actually reaches reqwest's TLS/ALPN layer — reqwest exposes no introspection on a built `Client` for that. The test only proves the builder does not panic under either setting and that the bool reaches the wrapper function. Verifying real h1-vs-h2 negotiation would need a live-network or mock-TLS-server test, which is out of scope here.