### PR TITLE
chore: commit the 0.2.8 appcast entry the release just generated

### DIFF
--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.8</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.8</link>
+      <sparkle:version>360</sparkle:version>
+      <sparkle:shortVersionString>0.2.8</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Fri, 14 Aug 2026 20:05:28 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.8/TcrBar-0.2.8.dmg" type="application/octet-stream" sparkle:edSignature="jQVGiTz11UEEeTwSVJFVJrX3A8uFIuPsXlfkmxn0OYG7/v24vmnK0//l1gsA+P6H7T7MxWhyD76M7WaV/ZXlCw==" length="5902767" />
+    </item>
+    <item>
       <title>TcrBar 0.2.7</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.7</link>
       <sparkle:version>348</sparkle:version>


### PR DESCRIPTION
`release-tcrbar.sh` stage 8 writes the `<item>` into the working tree — it is the release's own output, not a stray edit.

Leaving it uncommitted fails the **next** release at preflight check 5 (`apps/macos/appcast.xml has uncommitted changes`), which is exactly what that check exists to catch. Same shape as `8011e97` for 0.2.7.

## Verified against what is actually published

- `enclosure length=5902767` equals the byte count of the live DMG (`curl -L .../TcrBar-0.2.8.dmg` → HTTP 200, 5902767 bytes).
- The feed Sparkle actually fetches — `releases/latest/download/appcast.xml` — returns **HTTP 200** with `0.2.8` as its newest item.
- Release `v0.2.8` is `draft=false`, `prerelease=false`, with `appcast.xml` among its assets.

That last check is the one that matters: an assetless `latest` Release looks fine in the GitHub UI while every installed copy's update check 404s. It cost 11m37s on v0.2.4 and ~2 minutes on v0.2.2.