### PR TITLE
feat: cap TcrBar popover account list at 4 visible rows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaude-rs"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -42,7 +42,8 @@ struct FleetView: View {
     /// nothing is worse than one that says why.
     @State private var loginError: String?
 
-    /// Measured height of the account rows.
+    /// Measured height of each account row, keyed by account id (`Account.id`
+    /// is the account name).
     ///
     /// A `ScrollView` has a flexible ideal height, and the window this panel
     /// lives in sizes itself to its content's *ideal* height — so a scroll view
@@ -54,7 +55,11 @@ struct FleetView: View {
     /// is equally true of the `NSPopover` it lives in now, whose hosting
     /// controller is set to `sizingOptions = [.preferredContentSize]`
     /// (`MenuBarShell.swift`) for exactly this reason.
-    @State private var rowsHeight: CGFloat = 0
+    ///
+    /// Per-row rather than one summed total because rows are not uniform
+    /// height — see `Tok.visibleAccountRows`. `visibleRowsHeight(for:)` sums
+    /// the first `Tok.visibleAccountRows` of these, in display order.
+    @State private var rowHeights: [String: CGFloat] = [:]
 
     var body: some View {
         VStack(alignment: .leading, spacing: Tok.rowSpacing) {
@@ -179,15 +184,9 @@ struct FleetView: View {
             } else {
                 ScrollView {
                     rowStack(fleet)
-                        .background(
-                            GeometryReader { proxy in
-                                Color.clear.preference(
-                                    key: RowsHeightKey.self, value: proxy.size.height)
-                            }
-                        )
                 }
-                .frame(height: min(max(rowsHeight, Tok.rowSpacing), Tok.panelMaxHeight))
-                .onPreferenceChange(RowsHeightKey.self) { rowsHeight = $0 }
+                .frame(height: visibleRowsHeight(for: fleet))
+                .onPreferenceChange(RowHeightsKey.self) { rowHeights = $0 }
             }
         }
     }
@@ -202,8 +201,39 @@ struct FleetView: View {
                     onChanged: { await poller.pollOnce() },
                     onRelogin: { reloginAccount(account.name) }
                 )
+                .background(
+                    GeometryReader { proxy in
+                        Color.clear.preference(
+                            key: RowHeightsKey.self, value: [account.id: proxy.size.height])
+                    }
+                )
             }
         }
+    }
+
+    /// Height of the scroll viewport: room for the first `Tok.visibleAccountRows`
+    /// rows (any accounts past that scroll into view), clamped so it never
+    /// collapses to nothing and never exceeds the historical panel-wide cap.
+    ///
+    /// Sums per-row *measured* heights rather than `Tok.visibleAccountRows *`
+    /// some constant, because rows are not uniform height — see the doc on
+    /// `Tok.visibleAccountRows`.
+    ///
+    /// Fallback: before SwiftUI has laid out and reported any row height (the
+    /// first frame, prior to the first `onPreferenceChange`), `rowHeights` is
+    /// empty and this returns `Tok.panelMaxHeight` — the original
+    /// always-room-for-roughly-8-rows behaviour — so the panel never renders
+    /// at zero or one-row height while waiting for a real measurement.
+    private func visibleRowsHeight(for fleet: Fleet) -> CGFloat {
+        let orderedHeights = fleet.rowsInDisplayOrder.compactMap { rowHeights[$0.id] }
+        guard !orderedHeights.isEmpty else {
+            return Tok.panelMaxHeight
+        }
+        let visibleCount = min(orderedHeights.count, Tok.visibleAccountRows)
+        let summed =
+            orderedHeights.prefix(visibleCount).reduce(0, +)
+            + Tok.rowSpacing * CGFloat(max(visibleCount - 1, 0))
+        return min(max(summed, Tok.rowSpacing), Tok.panelMaxHeight)
     }
 
     private func offlineNotice(_ source: StatusSource) -> some View {
@@ -560,11 +590,14 @@ struct FleetView: View {
     }
 }
 
-/// Carries the measured height of the account rows out of the scroll view.
-private struct RowsHeightKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
+/// Carries the measured height of each account row out of the scroll view,
+/// keyed by `Account.id`. A dictionary rather than one summed scalar because
+/// rows are not uniform height — `visibleRowsHeight(for:)` needs the first N
+/// individually, in display order, not just their total.
+private struct RowHeightsKey: PreferenceKey {
+    static let defaultValue: [String: CGFloat] = [:]
+    static func reduce(value: inout [String: CGFloat], nextValue: () -> [String: CGFloat]) {
+        value.merge(nextValue()) { _, new in new }
     }
 }
 

--- a/apps/macos/Sources/TcrBar/Tokens.swift
+++ b/apps/macos/Sources/TcrBar/Tokens.swift
@@ -249,6 +249,15 @@ public enum Tok {
 
     public static let panelWidth: CGFloat = 380
     public static let panelMaxHeight: CGFloat = 520
+    /// Number of account rows visible before the list scrolls. Fixed, not a
+    /// user setting (Gil, 2026-08-14) — a 13-account fleet otherwise renders
+    /// ~8 rows and pushes the footer off the bottom of the screen. This is a
+    /// ROW COUNT, not a per-row height multiplier: rows are not uniform
+    /// height (`AccountRow` grows for the needs-relogin state and several
+    /// conditional detail lines), so the panel sums actual measured heights
+    /// for the first N rows rather than multiplying this by a constant — see
+    /// `FleetView.visibleRowsHeight(for:)`.
+    public static let visibleAccountRows = 4
     public static let gutter = space4
     public static let rowSpacing = space3
     public static let tightSpacing = space2


### PR DESCRIPTION
## Summary
- Caps the account list in the TcrBar popover at 4 visible rows (scrollable) instead of ~8, so the footer no longer runs off the bottom of the screen with a large fleet.
- Fixed count (`Tok.visibleAccountRows = 4`), not a user setting — decided.
- The scroll view already existed (`FleetView.swift`); this changes what height it targets, summing *measured* per-row heights for the first N rows rather than a constant multiplier, because rows are not uniform height (needs-relogin state, conditional detail lines).
- Bumps `Cargo.toml`/`Cargo.lock` to 0.2.10 (0.2.9 is already tagged; required by the release-version pre-commit gate for any commit touching shipped files).

## Test plan
- [x] `swift build -c release --product TcrBar` — exit 0
- [x] `swift test` (apps/macos) — 191/191 passed
- [x] `cargo fmt --check` — exit 0
- [x] `TcrBar --shell-probe` against the built release binary, 13-account fixture — 9/9 assertions pass, `contentSize=380x629` (assertion 5's `>300pt` threshold held; no revision needed)
- [ ] No automated coverage of the SwiftUI view layer exists (`TcrBarTests` depends on `TcrBarCore` only — `FleetView`/`AccountRow`/`Tok` are unreachable from unit tests); verified by build + shell-probe only
- [ ] `--render-states` PNGs will NOT reflect this change — `snapshotMode` renders rows unscrolled by design (ImageRenderer can't rasterize `ScrollView` content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)