### PR TITLE
fix: align the footer's two button rows and drop personal detail from a comment

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -269,6 +269,11 @@ struct FleetView: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             fleetActions
+            // Draws the fleet/app scope boundary the two rows used to imply
+            // through opposite alignment. Same divider the panel uses between
+            // its other sections, so the footer is grouped the way the rest of
+            // the panel is rather than by a rule of its own.
+            Hairline()
             appActions
 
             if let loginError {
@@ -310,7 +315,7 @@ struct FleetView: View {
     /// `launchAtLogin` is documented as living beside Quit precisely because it
     /// "is about TcrBar, not about the fleet".
     private var fleetActions: some View {
-        HStack {
+        HStack(spacing: Tok.tightSpacing) {
             if server.state.isOurChild {
                 Button("Stop server") { server.stop() }
             } else {
@@ -340,16 +345,23 @@ struct FleetView: View {
                         + "an older one refuses before any browser opens and "
                         + "prints how to recover."
                 )
-            Spacer()
+            Spacer(minLength: 0)
         }
         .buttonStyle(.bordered)
     }
 
-    /// Actions that act on the APP, trailing-aligned so they read as a separate
-    /// group from the fleet row above without needing a rule between them.
+    /// Actions that act on the APP rather than on the fleet.
+    ///
+    /// These used to be trailing-aligned, on the reasoning that opposite
+    /// alignment would read as a separate group "without needing a rule between
+    /// them". In practice it read as misalignment: two button rows with
+    /// different left edges look broken before they look grouped, and the
+    /// second row's buttons floated away from everything above them. The scope
+    /// split is real, so it is now drawn — a `Hairline`, the same divider this
+    /// panel already uses to separate its sections — and both rows share one
+    /// left edge so the footer has a single vertical rhythm.
     private var appActions: some View {
-        HStack {
-            Spacer()
+        HStack(spacing: Tok.tightSpacing) {
             // Disabled rather than silently no-op while Sparkle already has
             // a check in flight — the same rule "Take over port…" follows.
             Button("Check for Updates…") { updater.checkForUpdates() }
@@ -359,6 +371,7 @@ struct FleetView: View {
                         + "Also reachable as `tcrbar://check-for-updates`."
                 )
             Button("Quit") { NSApplication.shared.terminate(nil) }
+            Spacer(minLength: 0)
         }
         .buttonStyle(.bordered)
     }

--- a/apps/macos/Sources/TcrBar/Tokens.swift
+++ b/apps/macos/Sources/TcrBar/Tokens.swift
@@ -249,14 +249,14 @@ public enum Tok {
 
     public static let panelWidth: CGFloat = 380
     public static let panelMaxHeight: CGFloat = 520
-    /// Number of account rows visible before the list scrolls. Fixed, not a
-    /// user setting (Gil, 2026-08-14) — a 13-account fleet otherwise renders
-    /// ~8 rows and pushes the footer off the bottom of the screen. This is a
-    /// ROW COUNT, not a per-row height multiplier: rows are not uniform
-    /// height (`AccountRow` grows for the needs-relogin state and several
-    /// conditional detail lines), so the panel sums actual measured heights
-    /// for the first N rows rather than multiplying this by a constant — see
-    /// `FleetView.visibleRowsHeight(for:)`.
+    /// Number of account rows visible before the list scrolls. Fixed rather
+    /// than a preference: a long fleet otherwise renders far enough to push the
+    /// footer past the bottom of the screen, taking Quit and the checkboxes with
+    /// it. This is a ROW COUNT, not a per-row height multiplier — rows are not
+    /// uniform height (`AccountRow` grows for the needs-relogin state and
+    /// several conditional detail lines), so the panel sums actual measured
+    /// heights for the first N rows rather than multiplying this by a constant.
+    /// See `FleetView.visibleRowsHeight(for:)`.
     public static let visibleAccountRows = 4
     public static let gutter = space4
     public static let rowSpacing = space3


### PR DESCRIPTION
Two cleanups in the same surface.

## The footer read as misaligned

The app-scope row (`Check for Updates…`, `Quit`) was **trailing**-aligned while the fleet-scope row above it (`Stop server`, `Refresh`, `Add account…`) was **leading**-aligned. The existing comment justified this as reading "as a separate group … without needing a rule between them".

It didn't. Two button rows with different left edges read as broken before they read as grouped, and the second row's buttons floated away from everything above them.

Both rows now share one left edge, and the scope boundary is **drawn** — with the `Hairline` this panel already uses between its other sections (`FleetView.swift:67`, `:69`, `:538`), so the footer is grouped the same way the rest of the panel is rather than by a rule of its own.

Also: `Tok.tightSpacing` on both rows instead of the container default, and `Spacer(minLength: 0)` on both so neither row reserves width it doesn't need.

## A doc-comment carried personal detail

The `visibleAccountRows` comment named a person, a date, and a specific fleet size. **This repository is public.** None of that is load-bearing for what the constant means. Rewritten to say what it does and why it is fixed, rather than who asked for it.

## Verification

- `swift build -c release --product TcrBar` — exit 0
- `TcrBar --shell-probe` — **9/9 passed**, `contentSize=380x634`. The added divider costs 5pt; assertion 5's `>300pt` floor is unaffected.

**No automated coverage exists for this view.** `TcrBarTests` depends on `TcrBarCore` only, so `FleetView` and `Tok` are unreachable from unit tests, and `--render-states` bypasses the panel's `ScrollView` by design. Verified by build plus the shell probe, nothing more.