### PR TITLE
fix: group the footer's button rows with space, not a third rule

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -269,12 +269,17 @@ struct FleetView: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             fleetActions
-            // Draws the fleet/app scope boundary the two rows used to imply
-            // through opposite alignment. Same divider the panel uses between
-            // its other sections, so the footer is grouped the way the rest of
-            // the panel is rather than by a rule of its own.
-            Hairline()
+            // Scope boundary by PROXIMITY, not by a rule. A `Hairline` shipped
+            // here first and was then rendered with `--render-states`: it put a
+            // THIRD full-width rule into the bottom third of the panel — one
+            // above this block, one here, one above the danger zone — and the
+            // new one sat between two rows that are both just buttons, while
+            // the checkboxes directly below it got no separator at all. The
+            // original trailing-alignment was reaching for the right thing
+            // ("without needing a rule between them"); only its method was
+            // wrong. Space groups these two without adding weight.
             appActions
+                .padding(.top, Tok.tightSpacing)
 
             if let loginError {
                 Text(loginError)


### PR DESCRIPTION
Follow-up to #96, from actually **rendering** it rather than trusting a passing probe.

#96 aligned both footer button rows to one left edge (right) and drew the fleet/app scope boundary with a `Hairline` (wrong).

## What rendering showed

The `Hairline` put a **third** full-width rule into the bottom third of the panel — one above the footer block, one between the button rows, one above the danger zone. The new one sat between two rows that are both just buttons, while the checkboxes directly beneath it got no separator at all. It read as over-division, not as grouping.

## The fix

The original author's instinct was right; only the method was wrong. The comment #96 replaced justified trailing-alignment as reading *"as a separate group without needing a rule between them"* — that failed because mismatched left edges read as broken, **not** because avoiding a rule was wrong.

Extra top padding on the app row groups the two by proximity, adds no weight, and keeps the single left edge #96 bought. Uses `Tok.tightSpacing` via `.padding(.top,)`, the same idiom this file already applies at two other group boundaries (`:126`, `:544`).

## Verification

- `swift build -c release --product TcrBar` — exit 0
- `TcrBar --shell-probe` — 9/9, `contentSize=380x633`
- `--render-states` PNGs compared before/after in the two-account and thirteen-account states

Worth noting: **the probe passed on the version this PR fixes.** Geometry in range is not the same as looking right — the rule problem was only visible by looking at the rendered panel.