### PR TITLE
feat: border account rows and add right-click context menus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaude-rs"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -846,6 +846,33 @@ struct AccountRow: View {
     }
 
     var body: some View {
+        rowContent
+            // The card inset. Concentric with the border below it: the corner
+            // radius is `Tok.radiusMedium` and this is the padding that keeps
+            // that curve from clipping the account name or the toggle button —
+            // an outer radius with no matching inset draws a border that bites
+            // into its own content at the corners.
+            .padding(.horizontal, Tok.space3)
+            .padding(.vertical, Tok.space2)
+            .background(
+                RoundedRectangle(cornerRadius: Tok.radiusMedium)
+                    .fill(Tok.raised)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Tok.radiusMedium)
+                    .strokeBorder(Tok.hairlineStrong, lineWidth: Tok.hairlineWidth)
+            )
+            .contextMenu { contextMenuItems }
+    }
+
+    /// The row's own layout, unchanged from before the border was added except
+    /// for its name: this used to be `body` directly. Split out so the border
+    /// and the context menu are the ONE place that wraps every row shape,
+    /// rather than three copies of the same background/overlay/contextMenu
+    /// pair — the broken-row branch and the normal branch would otherwise have
+    /// to repeat it identically.
+    @ViewBuilder
+    private var rowContent: some View {
         // A broken row draws its two buttons on their OWN line, below the name
         // and pills, rather than beside `information` the way `toggleButton`
         // alone sits for every other row. Measured, not assumed: beside
@@ -875,6 +902,58 @@ struct AccountRow: View {
             }
             .padding(.vertical, Tok.rowPaddingV)
         }
+    }
+
+    /// Actions beyond the single toggle button, reached by right-click (or
+    /// Control-click / two-finger click, whatever the platform maps to a
+    /// context menu). Built from what ``AccountController`` and the row's own
+    /// `onRelogin` closure already expose — nothing here calls anything new.
+    ///
+    /// Deliberately does NOT add routing or pin controls: that is a separate
+    /// feature, not this row's to invent.
+    @ViewBuilder
+    private var contextMenuItems: some View {
+        let enabling = account.disabled
+        Button(enabling ? "Enable" : "Disable") {
+            Task { await performToggle(enabling: enabling) }
+        }
+        .disabled(accounts.isPending(account.name))
+        if account.health == .needsRelogin {
+            Button("Re-login…") { onRelogin() }
+        }
+        Divider()
+        Button("Copy Account Name") {
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString(account.name, forType: .string)
+        }
+    }
+
+    /// The one place `tcr enable`/`tcr disable` is actually run. Shared by
+    /// ``toggleButton`` and the context menu's own entry so the two can never
+    /// drift into two different notions of what a toggle does — see the
+    /// doc-comment on `toggleButton`'s old inline `Task` for why the
+    /// read-back-and-record dance below is not optional.
+    private func performToggle(enabling: Bool) async {
+        // Exit 0 is not the outcome — it is permission to go and find out
+        // what the outcome was. The refresh's own result is compared
+        // against what was asked, and the row says which thing happened.
+        //
+        // `notice` is threaded through rather than dropped: `tcr` reports
+        // half-done work (a park the config cannot persist, a proxy too old
+        // for the route) on stderr while exiting 0, and the read-back
+        // cannot see it — `disabled` flipped, so the comparison confirms.
+        // Losing it here is what let the row stamp `parked ✓` on a change
+        // that would not survive a restart.
+        let attempt = await accounts.setEnabled(enabling, account: account.name)
+        guard case .accepted(let notice) = attempt else { return }
+        let readback = await onChanged()
+        accounts.record(
+            readback: readback,
+            requestedEnabled: enabling,
+            account: account.name,
+            notice: notice
+        )
     }
 
     private var information: some View {
@@ -1089,27 +1168,7 @@ struct AccountRow: View {
         let verb = enabling ? "Enable" : "Disable"
         let title = pending ? (enabling ? "Enabling…" : "Disabling…") : verb
         return Button(title) {
-            Task {
-                // Exit 0 is not the outcome — it is permission to go and find out
-                // what the outcome was. The refresh's own result is compared
-                // against what was asked, and the row says which thing happened.
-                //
-                // `notice` is threaded through rather than dropped: `tcr` reports
-                // half-done work (a park the config cannot persist, a proxy too old
-                // for the route) on stderr while exiting 0, and the read-back
-                // cannot see it — `disabled` flipped, so the comparison confirms.
-                // Losing it here is what let the row stamp `parked ✓` on a change
-                // that would not survive a restart.
-                let attempt = await accounts.setEnabled(enabling, account: account.name)
-                guard case .accepted(let notice) = attempt else { return }
-                let readback = await onChanged()
-                accounts.record(
-                    readback: readback,
-                    requestedEnabled: enabling,
-                    account: account.name,
-                    notice: notice
-                )
-            }
+            Task { await performToggle(enabling: enabling) }
         }
         // `.bordered`, not `.borderless`. Borderless draws the label as bare
         // text, so the ONE actionable control in the row looked exactly like

--- a/apps/macos/Sources/TcrBar/MenuBarShell.swift
+++ b/apps/macos/Sources/TcrBar/MenuBarShell.swift
@@ -117,6 +117,11 @@ final class MenuBarShell {
         if let button = statusItem.button {
             button.target = self
             button.action = #selector(togglePanel(_:))
+            // Left click still opens the popover, unchanged. Right click (and
+            // Control-click, which AppKit reports as the same `.rightMouseUp`)
+            // is the only thing added here — the button otherwise only ever
+            // sends on `.leftMouseUp`.
+            button.sendAction(on: [.leftMouseUp, .rightMouseUp])
         }
 
         // Both publishers, combined, so the image is recomposed whenever either
@@ -183,8 +188,78 @@ final class MenuBarShell {
     // MARK: - The panel
 
     @objc private func togglePanel(_ sender: Any?) {
+        // `NSApp.currentEvent` is how a single action selector, wired to both
+        // mouse buttons above, tells them apart — AppKit does not pass the
+        // triggering event to the action itself. A right-click (or a
+        // Control-click, which arrives as the same `.rightMouseUp`) opens the
+        // quick-actions menu instead of the popover; anything else falls
+        // through to the original left-click behaviour, unchanged.
+        if NSApp.currentEvent?.type == .rightMouseUp {
+            showQuickActionsMenu()
+            return
+        }
         if popover.isShown { closePanel() } else { openPanel() }
     }
+
+    // MARK: - Quick actions
+
+    /// Deliberately never assigned to `statusItem.menu`: doing that makes
+    /// AppKit show the menu on *every* click, left included, which is exactly
+    /// the popover-breaking regression this feature must not cause.
+    /// `NSMenu.popUp(positioning:at:in:)` shows a menu once, transiently, with
+    /// the status item's own click handling untouched.
+    private func showQuickActionsMenu() {
+        guard let button = statusItem.button else { return }
+        let menu = NSMenu()
+
+        let serverItem: NSMenuItem
+        if server.state.isOurChild {
+            serverItem = NSMenuItem(
+                title: "Stop server", action: #selector(quickStopServer), keyEquivalent: "")
+        } else {
+            serverItem = NSMenuItem(
+                title: "Start server", action: #selector(quickStartServer), keyEquivalent: "")
+        }
+        serverItem.target = self
+        menu.addItem(serverItem)
+
+        let refreshItem = NSMenuItem(
+            title: "Refresh", action: #selector(quickRefresh), keyEquivalent: "")
+        refreshItem.target = self
+        menu.addItem(refreshItem)
+
+        menu.addItem(.separator())
+
+        let awakeItem = NSMenuItem(
+            title: "Keep this Mac awake", action: #selector(quickToggleAwake), keyEquivalent: "")
+        awakeItem.target = self
+        awakeItem.state = awake.isOn ? .on : .off
+        menu.addItem(awakeItem)
+
+        menu.addItem(.separator())
+
+        let updateItem = NSMenuItem(
+            title: "Check for Updates…", action: #selector(quickCheckForUpdates),
+            keyEquivalent: "")
+        updateItem.target = self
+        updateItem.isEnabled = updater.canCheckForUpdates
+        menu.addItem(updateItem)
+
+        let quitItem = NSMenuItem(
+            title: "Quit", action: #selector(quickQuit), keyEquivalent: "")
+        quitItem.target = self
+        menu.addItem(quitItem)
+
+        menu.popUp(
+            positioning: nil, at: NSPoint(x: 0, y: button.bounds.height + 4), in: button)
+    }
+
+    @objc private func quickStartServer() { server.start() }
+    @objc private func quickStopServer() { server.stop() }
+    @objc private func quickRefresh() { Task { await poller.pollOnce() } }
+    @objc private func quickToggleAwake() { awake.toggle() }
+    @objc private func quickCheckForUpdates() { updater.checkForUpdates() }
+    @objc private func quickQuit() { NSApplication.shared.terminate(nil) }
 
     func openPanel() {
         guard let button = statusItem.button else { return }


### PR DESCRIPTION
## Summary
- Account rows now render as bounded cards: `Tok.raised` fill, `Tok.hairlineStrong` border, `Tok.radiusMedium` concentric radius (padding matches the border radius so it does not clip the name or the toggle button at the corners).
- Account rows gain a right-click context menu: enable/disable (shares the exact `performToggle` codepath the visible button already used — no second notion of what a toggle does), Re-login… when the row needs it, Copy Account Name. No routing/pin actions, per scope.
- The menu-bar status item gains a right-click quick-actions menu: start/stop server, refresh, keep-awake toggle (checkable), check for updates, quit — built via `NSMenu.popUp(positioning:at:in:)`, never assigned to `statusItem.menu`, so the existing left-click-opens-popover behaviour is untouched.
- Bumps `Cargo.toml`/`Cargo.lock` to 0.2.11 — v0.2.10 is already tagged and the release-version pre-commit gate blocks a commit to shipped files otherwise.

## Test plan
- [x] `swift build -c release --product TcrBar` — exit 0
- [x] `swift test` (apps/macos) — 191 tests, 0 failures
- [x] `TcrBar --shell-probe` — 9/9 passed, `contentSize=380x665` (no threshold revision needed)
- [x] `TcrBar --render-states` — visually reviewed light/dark, 2-account and 13-account states; rows read as bounded cards, not a cage
- [ ] Context menus (row right-click, status-item right-click) — no automated coverage; `ImageRenderer` cannot render `.contextMenu`/`NSMenu` and the shell-probe does not drive right-click. Manually verify by running the built app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)