### PR TITLE
feat: gap the quota bar from its pills, add a gear menu to the account row

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -898,16 +898,20 @@ struct AccountRow: View {
                 information
                     .accessibilityElement(children: .combine)
                     .accessibilityLabel(rowAccessibilityLabel)
-                toggleButton
+                accountActionsMenu
             }
             .padding(.vertical, Tok.rowPaddingV)
         }
     }
 
-    /// Actions beyond the single toggle button, reached by right-click (or
-    /// Control-click / two-finger click, whatever the platform maps to a
-    /// context menu). Built from what ``AccountController`` and the row's own
-    /// `onRelogin` closure already expose — nothing here calls anything new.
+    /// Actions beyond the single toggle, reached three ways: the gear menu
+    /// beside the row, right-click (or Control-click / two-finger click) for
+    /// a context menu, and — on a broken row only — the standalone
+    /// ``reloginButton``. Built from what ``AccountController`` and the
+    /// row's own `onRelogin` closure already expose — nothing here calls
+    /// anything new. All three routes share this one `@ViewBuilder` so the
+    /// gear and the context menu cannot drift into two different notions of
+    /// what the row can do.
     ///
     /// Deliberately does NOT add routing or pin controls: that is a separate
     /// feature, not this row's to invent.
@@ -927,6 +931,40 @@ struct AccountRow: View {
             pasteboard.clearContents()
             pasteboard.setString(account.name, forType: .string)
         }
+    }
+
+    /// The visible affordance for `contextMenuItems`. Right-click was the
+    /// only way to reach Enable/Disable, Re-login… and Copy Account Name
+    /// before this — undiscoverable, since nothing on the row hinted a menu
+    /// existed. Replaces the row's old trailing `toggleButton` text button
+    /// (still used, unchanged, on the `.needsRelogin` layout — see the
+    /// doc-comment there) so the account name also gets back the width that
+    /// button's text ("Disable"/"Enabling…") used to take, which matters
+    /// because the name already truncates.
+    ///
+    /// `.menuStyle(.borderlessButton)` rather than the `.bordered` style
+    /// every other control in this panel uses: those are all text buttons,
+    /// and a bordered icon-only control reads as heavier chrome than a
+    /// 13pt row wants. This is the one icon-only control in the panel, so
+    /// there is no existing icon-menu style to match instead.
+    private var accountActionsMenu: some View {
+        Menu {
+            contextMenuItems
+        } label: {
+            Image(systemName: "gearshape")
+                .font(Tok.bodyFont)
+                .foregroundStyle(.secondary)
+                // The Menu's own `.accessibilityLabel` below names the
+                // control; without hiding the glyph too, VoiceOver reads
+                // both the image ("gearshape, image") and the label,
+                // announcing the same control twice.
+                .accessibilityHidden(true)
+        }
+        .menuStyle(.borderlessButton)
+        .controlSize(.small)
+        .fixedSize()
+        .accessibilityLabel("Account actions for \(account.name)")
+        .help("Enable/disable, re-login, or copy the account name.")
     }
 
     /// The one place `tcr enable`/`tcr disable` is actually run. Shared by
@@ -1015,6 +1053,16 @@ struct AccountRow: View {
                 }
             }
             QuotaBar(fraction: account.quota, tint: quotaTint)
+                // `Tok.rowLineSpacing` (2pt, shared by every line in this
+                // column) put the bar visually inside the pills above it —
+                // the pills carry their own 2pt vertical padding on top of
+                // that gap, so the two collided. The fix is asymmetric, not
+                // a blanket increase to `rowLineSpacing`: the bar belongs
+                // WITH the percent/req-cache numbers beneath it (same fact,
+                // two notations, and already tight to them), not with the
+                // pills above. So only the bar gets extra top padding,
+                // leaving the numbers below it untouched.
+                .padding(.top, Tok.tightSpacing)
                 // Sighted-hover half of the same fix `quotaTint` makes for the
                 // fill colour: a muted bar alone can still read as "just a
                 // dim healthy bar" rather than "not live" without a word


### PR DESCRIPTION
## Summary
- The quota bar sat only `Tok.rowLineSpacing` (2pt) below the name/pills line, and the pills' own vertical padding closed the gap further, so the bar visually collided with the ROTATING/OK pills. `QuotaBar` now gets its own top padding (`Tok.tightSpacing`) instead of loosening `rowLineSpacing` for the whole column — the bar stays tight to the percent/req·cache numbers it belongs with.
- Replaces the row's trailing Disable/Enable text button with a gear `Menu` carrying the same actions as the existing right-click context menu (Enable/Disable, Re-login… when applicable, Copy Account Name). Both routes share one `@ViewBuilder` and `performToggle(enabling:)` so they cannot diverge. The context menu stays as a power-user path. The gear also frees up width for the account name, which already truncates.
- The `.needsRelogin` row keeps its current Re-login…/Disable button pair unchanged — Re-login is the recovery action for a broken account and needs to stay a visible button, not something buried in a menu, and the row is already tight at 356pt.

## Test plan
- [x] `swift build -c release --product TcrBar` — exit 0
- [x] `swift test` (191 tests) — exit 0
- [x] `TcrBar --shell-probe` — 9/9 passed, no threshold changes needed
- [x] `TcrBar --render-states` — inspected light/dark 2-account, 13-account and needs-relogin PNGs: the pill/bar collision is visibly gone in every state. The gear itself renders as the same generic AppKit-control placeholder `--render-states` already shows for the `.checkbox` toggles at the bottom of the panel (`ImageRenderer` cannot rasterise `Menu`/`Toggle`, only `Button`) — so the gear's own glyph is **not** verified by this gate; it needs a live-app screenshot, which is outside this PR's scope.

## No automated coverage
- The gear's SF Symbol appearance and menu contents are not exercised by `--render-states` (see above) or by `swift test` — no test opens a `Menu`.
- VoiceOver behaviour (does `.accessibilityHidden` on the glyph plus `.accessibilityLabel` on the `Menu` avoid a double announcement) is asserted by neither gate; it needs a live VoiceOver pass.