### PR TITLE
feat: add a control-account affordance to the account row

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -13,6 +13,8 @@ struct FleetView: View {
     @ObservedObject var server: ServerController
     @ObservedObject var loginItem: LoginItem
     @ObservedObject var accounts: AccountController
+    /// The identity-bound control account. See ``ControlAccountController``.
+    @ObservedObject var control: ControlAccountController
     /// Owned by the app, for the same reason the poller is: the panel is a view
     /// and the mode is not, and an assertion released when the view went away
     /// would be a keep-awake control that keeps nothing awake. Under
@@ -198,6 +200,7 @@ struct FleetView: View {
                     account: account,
                     countersAreStructural: fleet.source.countersAreStructural,
                     accounts: accounts,
+                    control: control,
                     onChanged: { await poller.pollOnce() },
                     onRelogin: { reloginAccount(account.name) }
                 )
@@ -644,6 +647,8 @@ struct AccountRow: View {
     let account: Account
     let countersAreStructural: Bool
     @ObservedObject var accounts: AccountController
+    /// The identity-bound control account. See ``ControlAccountController``.
+    @ObservedObject var control: ControlAccountController
     /// Called after a successful toggle so the row re-reads reality. It returns
     /// the state of the read it just performed, which is what the verdict is
     /// computed against — reading the poller's published `state` afterwards could
@@ -756,6 +761,32 @@ struct AccountRow: View {
     /// could not serve — here the red NEEDS RE-LOGIN pill already says
     /// exactly that, unambiguously, so a second pill would only have two ways
     /// left to be wrong.
+    /// Row-level marker for the identity-bound control account, drawn beside
+    /// the name so it survives without opening the gear menu — the gear's own
+    /// checkmark state is one click away, and `ImageRenderer` cannot rasterise
+    /// a `Menu` at all (see the harness note on `--render-states`), so this is
+    /// also the only place this fact is ever visually verifiable outside a live
+    /// run.
+    ///
+    /// `Tok.accent` — the system control-accent colour, not one of the
+    /// quota/rotation status hues (`ok`/`near`/`spent`/`unmeasured`/`disabled`/
+    /// `unknown`) and not `Tok.awake` (already spoken for by keep-awake mode,
+    /// a genuinely different fact). "Control account" is a designation, not a
+    /// measured state, and `accent` is the one token in this palette already
+    /// reserved for exactly that distinction elsewhere in the app.
+    ///
+    /// Silent — not merely dim — when `control.unavailable` or nothing is set:
+    /// a phantom checkmark on an older `tcr` build (which cannot even confirm
+    /// the concept exists) would be worse than the feature simply not
+    /// appearing yet.
+    @ViewBuilder
+    private var controlIndicator: some View {
+        if control.isControl(account.name) {
+            StatusPill("control", tint: Tok.accent)
+                .help("This account is held out of rotation as the control account.")
+        }
+    }
+
     @ViewBuilder
     private var rotationPill: some View {
         if account.disabled {
@@ -783,6 +814,13 @@ struct AccountRow: View {
     /// actionable.
     private var rowAccessibilityLabel: String {
         var parts = [account.name]
+        // Spoken beside the name for the same reason `controlIndicator` is
+        // drawn beside it: this is an identity fact, not a rotation/quota one,
+        // and a VoiceOver user reaching the row should not have to open the
+        // gear menu to learn it.
+        if control.isControl(account.name) {
+            parts.append("control account")
+        }
         // Spoken in both directions, for the same reason the pill is drawn in
         // both: silence is not a state, and a VoiceOver user has even less to
         // infer it from than a sighted one. A broken row says neither
@@ -926,11 +964,41 @@ struct AccountRow: View {
             Button("Re-login…") { onRelogin() }
         }
         Divider()
+        // Hidden entirely while `control` cannot answer the question at all
+        // (``ControlAccountController/unavailable``) — an older `tcr` has no
+        // `control` subcommand, and an action this build cannot even read back
+        // is worse than no action: a click would exit non-zero with a message
+        // about a route that does not exist, on every single row, forever.
+        if !control.unavailable {
+            if control.isControl(account.name) {
+                Button("Clear Control Account") {
+                    Task { await performSetControl(name: nil, key: account.name) }
+                }
+                .disabled(control.isPending(account.name))
+            } else {
+                Button("Use as Control Account") {
+                    Task { await performSetControl(name: account.name, key: account.name) }
+                }
+                .disabled(control.isPending(account.name))
+            }
+        }
+        Divider()
         Button("Copy Account Name") {
             let pasteboard = NSPasteboard.general
             pasteboard.clearContents()
             pasteboard.setString(account.name, forType: .string)
         }
+    }
+
+    /// The one place `tcr control` is actually run for this row — set when
+    /// picked from another row's menu, or cleared when picked from the row that
+    /// currently holds it. Mirrors ``performToggle(enabling:)``: exit 0 is
+    /// permission to re-read, never the outcome itself, so `control.refresh()`
+    /// runs afterward and the row draws whatever it actually says.
+    private func performSetControl(name: String?, key: String) async {
+        let attempt = await control.setControl(name: name, key: key)
+        guard case .accepted = attempt else { return }
+        await control.refresh()
     }
 
     /// The visible affordance for `contextMenuItems`. Right-click was the
@@ -1008,6 +1076,7 @@ struct AccountRow: View {
                     .truncationMode(.middle)
                     .help(account.name)
                     .textSelection(.enabled)
+                controlIndicator
                 Spacer(minLength: Tok.tightSpacing)
                 rotationPill
                 // A never-probed account's `quotaState` is Rust's default, not a

--- a/apps/macos/Sources/TcrBar/MenuBarShell.swift
+++ b/apps/macos/Sources/TcrBar/MenuBarShell.swift
@@ -26,6 +26,11 @@ final class MenuBarShell {
     let server: ServerController
     let loginItem: LoginItem
     let accounts: AccountController
+    /// The identity-bound control account, read via `tcr control --show` and
+    /// set/cleared via `tcr control`. Owned here, alongside `accounts`, for the
+    /// same reason: it outlives the panel view, and `openPanel()` refreshes it
+    /// the same way it refreshes `loginItem`.
+    let control: ControlAccountController
     /// Owned here, not by the panel: the panel is a view that can be torn down,
     /// and an assertion that ended when the panel closed would be a keep-awake
     /// control that keeps nothing awake.
@@ -52,6 +57,7 @@ final class MenuBarShell {
         server: ServerController? = nil,
         loginItem: LoginItem? = nil,
         accounts: AccountController? = nil,
+        control: ControlAccountController? = nil,
         awake: AwakeController? = nil,
         preference: LaunchPreference? = nil,
         updater: Updater? = nil
@@ -60,6 +66,7 @@ final class MenuBarShell {
         self.server = server ?? ServerController()
         self.loginItem = loginItem ?? LoginItem()
         self.accounts = accounts ?? AccountController()
+        self.control = control ?? ControlAccountController()
         self.awake = awake ?? AwakeController()
         self.preference = preference ?? LaunchPreference()
         self.updater = updater ?? Updater()
@@ -97,8 +104,8 @@ final class MenuBarShell {
         let hosting = NSHostingController(
             rootView: FleetPanel(
                 poller: self.poller, server: self.server, loginItem: self.loginItem,
-                accounts: self.accounts, awake: self.awake, preference: self.preference,
-                updater: self.updater))
+                accounts: self.accounts, control: self.control, awake: self.awake,
+                preference: self.preference, updater: self.updater))
         // Without this the popover takes a default size and the panel is clipped.
         //
         // This is the specific thing `MenuBarExtra` did for free. `FleetView`
@@ -271,6 +278,13 @@ final class MenuBarShell {
         // `onAppear` now fires once and never again — losing this line is a
         // silent regression, not a visible one.
         loginItem.refresh()
+        // Same reasoning as `loginItem.refresh()` above: another `tcr control`
+        // call — from this app's own menu on a previous open, from the CLI
+        // directly, or from a second TcrBar instance — can have changed it
+        // since this panel last drew, and there is no push channel that would
+        // tell this view. `control` is `@Published`, so a stale in-flight open
+        // still redraws once this completes.
+        Task { await control.refresh() }
         // Without activation the panel opens without key focus, and
         // `.textSelection(.enabled)` on the account name (`FleetView.swift:537`)
         // stops working.
@@ -299,6 +313,7 @@ struct FleetPanel: View {
     @ObservedObject var server: ServerController
     @ObservedObject var loginItem: LoginItem
     @ObservedObject var accounts: AccountController
+    @ObservedObject var control: ControlAccountController
     @ObservedObject var awake: AwakeController
     @ObservedObject var preference: LaunchPreference
     @ObservedObject var updater: Updater
@@ -309,6 +324,7 @@ struct FleetPanel: View {
             server: server,
             loginItem: loginItem,
             accounts: accounts,
+            control: control,
             awake: awake,
             updater: updater,
             startServerAtLaunch: $preference.startServerAtLaunch

--- a/apps/macos/Sources/TcrBar/RenderStates.swift
+++ b/apps/macos/Sources/TcrBar/RenderStates.swift
@@ -60,22 +60,28 @@ enum RenderStates {
     ///
     /// Those figures move whenever the footer's wording or spacing does; if they
     /// look stale, re-measure rather than trusting them.
-    private static var scenes: [(name: String, state: PollState, awake: Bool)] {
+    private static var scenes: [(name: String, state: PollState, awake: Bool, control: String?)] {
         [
-            ("01-healthy", .loaded(fleet(healthyJSON)), false),
-            ("02-mixed-thirteen", .loaded(fleet(mixedJSON)), false),
-            ("03-zero-capacity", .loaded(fleet(exhaustedJSON)), false),
-            ("04-unmeasured-row", .loaded(fleet(unmeasuredJSON)), false),
-            ("04b-needs-relogin-row", .loaded(fleet(needsReloginJSON)), false),
-            ("04c-probed-then-broken-row", .loaded(fleet(probedThenBrokenJSON)), false),
-            ("05-unreadable-row", .loaded(partiallyUnreadableFleet()), false),
-            ("06-offline-source", .loaded(fleet(offlineJSON)), false),
-            ("07-empty-fleet", .loaded(fleet("[]")), false),
-            ("08-tool-missing", .toolMissing(searched: ["/usr/local/bin/tcr", "/opt/homebrew/bin/tcr"]), false),
-            ("09-command-failed", .commandFailed(exitCode: 1, message: "connection refused"), false),
-            ("10-undecodable", .undecodable(message: "DecodingError.valueNotFound: quota"), false),
-            ("11-pending", .pending, false),
-            ("12-keeping-awake", .loaded(fleet(healthyJSON)), true),
+            ("01-healthy", .loaded(fleet(healthyJSON)), false, nil),
+            ("02-mixed-thirteen", .loaded(fleet(mixedJSON)), false, nil),
+            ("03-zero-capacity", .loaded(fleet(exhaustedJSON)), false, nil),
+            ("04-unmeasured-row", .loaded(fleet(unmeasuredJSON)), false, nil),
+            ("04b-needs-relogin-row", .loaded(fleet(needsReloginJSON)), false, nil),
+            ("04c-probed-then-broken-row", .loaded(fleet(probedThenBrokenJSON)), false, nil),
+            ("05-unreadable-row", .loaded(partiallyUnreadableFleet()), false, nil),
+            ("06-offline-source", .loaded(fleet(offlineJSON)), false, nil),
+            ("07-empty-fleet", .loaded(fleet("[]")), false, nil),
+            ("08-tool-missing", .toolMissing(searched: ["/usr/local/bin/tcr", "/opt/homebrew/bin/tcr"]), false, nil),
+            ("09-command-failed", .commandFailed(exitCode: 1, message: "connection refused"), false, nil),
+            ("10-undecodable", .undecodable(message: "DecodingError.valueNotFound: quota"), false, nil),
+            ("11-pending", .pending, false, nil),
+            ("12-keeping-awake", .loaded(fleet(healthyJSON)), true, nil),
+            // The control-account row indicator (`FleetView.controlIndicator`) —
+            // the ONE piece of this feature `ImageRenderer` can actually draw.
+            // `Menu` contents (the gear's "Use as control account" item, its
+            // checkmark) never rasterise regardless of state; see this file's
+            // own header and `AccountRow.accountActionsMenu`'s doc-comment.
+            ("13-control-account", .loaded(fleet(healthyJSON)), false, "alice@example.com"),
         ]
     }
 
@@ -116,7 +122,7 @@ enum RenderStates {
 
     @MainActor
     private static func render(
-        _ scene: (name: String, state: PollState, awake: Bool),
+        _ scene: (name: String, state: PollState, awake: Bool, control: String?),
         appearance: Appearance,
         into directory: URL
     ) -> Bool {
@@ -140,6 +146,7 @@ enum RenderStates {
                 server: ServerController(),
                 loginItem: LoginItem(),
                 accounts: AccountController(),
+                control: ControlAccountController(pinned: scene.control),
                 awake: awake,
                 // `startingUpdater: false`: this process was asked for PNGs. A
                 // started updater schedules background checks and can put a

--- a/apps/macos/Sources/TcrBarCore/ControlAccountController.swift
+++ b/apps/macos/Sources/TcrBarCore/ControlAccountController.swift
@@ -1,0 +1,232 @@
+import Combine
+import Foundation
+
+/// Setting, clearing, and reading the identity-bound **control account** — the
+/// one account `tcr control` holds out of the inference rotation while still
+/// tracking its usage (`src/main.rs`'s `Control` subcommand; see its own
+/// doc-comment for the exact CLI contract this mirrors).
+///
+/// Same two rules as ``AccountController``/``AccountCommand``, and for the same
+/// reasons:
+///
+///  1. **This app never writes the tcr config.** Every change is a subprocess —
+///     `tcr control <query>` / `tcr control --clear` — never a direct edit of
+///     `~/.config/teamclaude.json`.
+///  2. **This app never depends on `tcr status --json` for this fact.** The
+///     brief for this feature is explicit that whether that payload carries a
+///     `control` field is a separate, undecided question; reading it here would
+///     couple this UI to that decision. `tcr control --show` is its own
+///     read path and stays that way regardless of what `status` does later.
+///
+/// A third rule is new to this controller, because `--show` is a command that
+/// can fail in a way `tcr status` cannot: an **older `tcr`** — the common case
+/// while this feature is unmerged on the Rust side — has no `control`
+/// subcommand at all and exits non-zero with "unrecognized subcommand". That is
+/// not "no control account is set"; it is "this build cannot answer the
+/// question", and the two must never collapse into the same `nil`. See
+/// ``current`` and ``unavailable``.
+public enum ControlAccountCommand {
+    /// `tcr control --show`.
+    public static let showArguments = ["control", "--show"]
+
+    /// `tcr control <name>` to set it, or `tcr control --clear` to clear it.
+    /// `name` is passed positionally and verbatim, exactly like
+    /// ``AccountCommand/arguments(enabled:name:)`` — no `--org`, nothing that
+    /// could be mistaken for a flag.
+    public static func setArguments(name: String?) -> [String] {
+        guard let name else { return ["control", "--clear"] }
+        return ["control", name]
+    }
+
+    /// What `--show` established. Three arms, not two — mirrors
+    /// ``PollState`` in keeping "no reading" and "a reading of none" apart.
+    public enum Reading: Equatable, Sendable {
+        /// A control account is set, by name.
+        case set(String)
+        /// `tcr control --show` ran and printed `(none)`: this build asked and
+        /// the answer is that nothing is set.
+        case none
+        /// The question could not be asked — `tcr` is missing, the subcommand
+        /// does not exist on this build, or the call otherwise failed. Distinct
+        /// from ``none`` on purpose: rendering this as "no control account" would
+        /// be the same false-negative `PollState.toolMissing` was split out to
+        /// avoid for the fleet list.
+        case unavailable(reason: String)
+    }
+
+    /// Pure classification of a finished `--show` invocation.
+    public static func classifyShow(exitCode: Int32, stdout: Data, stderr: String) -> Reading {
+        guard exitCode == 0 else {
+            let text = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            return .unavailable(reason: text.isEmpty ? "exit \(exitCode)" : text)
+        }
+        let text =
+            String(data: stdout, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if text.isEmpty || text == "(none)" { return .none }
+        return .set(text)
+    }
+
+    /// Why a set/clear did not happen. `tcr`'s own words, unparaphrased — same
+    /// posture as ``AccountCommand/Failure``.
+    public struct Failure: Error, Equatable, Sendable {
+        public let exitCode: Int32
+        public let message: String
+
+        public init(exitCode: Int32, message: String) {
+            self.exitCode = exitCode
+            self.message = message
+        }
+
+        public var summary: String {
+            let detail = message.isEmpty ? "no output" : message
+            return "control failed (exit \(exitCode)): \(detail)"
+        }
+    }
+
+    /// Exit 0 has two meanings here too — `tcr` can apply the change to the
+    /// file only and warn on stderr that the running proxy was too old for the
+    /// route (`src/cli.rs`'s `set_control`, the `NoRoute` arm) — so this stays a
+    /// three-arm outcome exactly like ``AccountCommand/Outcome``.
+    public enum Outcome: Equatable, Sendable {
+        case clean
+        case spoke(notice: String)
+        case failed(Failure)
+    }
+
+    public static func classifySet(exitCode: Int32, stderr: String) -> Outcome {
+        let text = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard exitCode == 0 else {
+            return .failed(Failure(exitCode: exitCode, message: text))
+        }
+        return text.isEmpty ? .clean : .spoke(notice: text)
+    }
+
+    /// Blocking `--show` — always called off the main actor.
+    nonisolated static func performShow() -> Reading {
+        switch TcrTool.resolve() {
+        case .failure(let notFound):
+            return .unavailable(
+                reason: "tcr not found (searched \(notFound.searched.count) locations)")
+        case .success(let executable):
+            do {
+                let output = try TcrTool.run(executable: executable, arguments: showArguments)
+                return classifyShow(exitCode: output.exitCode, stdout: output.stdout, stderr: output.stderr)
+            } catch {
+                return .unavailable(reason: error.localizedDescription)
+            }
+        }
+    }
+
+    /// Blocking set/clear — always called off the main actor.
+    nonisolated static func performSet(name: String?) -> Outcome {
+        switch TcrTool.resolve() {
+        case .failure(let notFound):
+            return .failed(
+                Failure(
+                    exitCode: -1,
+                    message: "tcr not found (searched \(notFound.searched.count) locations)"))
+        case .success(let executable):
+            do {
+                let output = try TcrTool.run(
+                    executable: executable, arguments: setArguments(name: name))
+                return classifySet(exitCode: output.exitCode, stderr: output.stderr)
+            } catch {
+                return .failed(Failure(exitCode: -1, message: error.localizedDescription))
+            }
+        }
+    }
+}
+
+/// Panel-facing state for the control account: which one is set (if this build
+/// can tell), and per-account in-flight/failure tracking for the gear menu's
+/// "Use as control account" / "Clear control account" actions.
+@MainActor
+public final class ControlAccountController: ObservableObject {
+    /// The account name currently held as control, or `nil` when either none is
+    /// set or this build cannot ask (see ``unavailable``). Never written
+    /// optimistically by a set/clear call — only ``refresh()`` ever assigns it,
+    /// so the row always shows what `tcr control --show` actually said, the
+    /// same discipline ``AccountController`` uses for `disabled`.
+    @Published public private(set) var current: String?
+    /// True when the last `--show` could not answer the question at all — an
+    /// older `tcr`, no binary found, or the call erroring. The row must degrade
+    /// silently on this (no phantom checkmark, no error banner), per this
+    /// feature's own brief.
+    @Published public private(set) var unavailable: Bool = false
+    @Published public private(set) var pending: Set<String> = []
+    @Published public private(set) var failures: [String: ControlAccountCommand.Failure] = [:]
+
+    public init() {}
+
+    /// A controller pinned to one reading, for deterministic rendering — the
+    /// same seam ``StatusPoller/init(pinnedState:lastPollAt:)`` provides for the
+    /// fleet. It never calls `refresh()`, so no subprocess ever runs.
+    public init(pinned: String?, unavailable: Bool = false) {
+        self.current = pinned
+        self.unavailable = unavailable
+    }
+
+    public func isPending(_ name: String) -> Bool { pending.contains(name) }
+    public func failure(for name: String) -> ControlAccountCommand.Failure? { failures[name] }
+    public func isControl(_ name: String) -> Bool { !unavailable && current == name }
+
+    /// Re-read `tcr control --show`. Safe to call any time — on panel open,
+    /// after a set/clear, or on a timer — and idempotent with itself; nothing
+    /// here assumes it is the only caller.
+    public func refresh() async {
+        let reading = await Task.detached(priority: .utility) {
+            ControlAccountCommand.performShow()
+        }.value
+        switch reading {
+        case .set(let name):
+            unavailable = false
+            current = name
+        case .none:
+            unavailable = false
+            current = nil
+        case .unavailable:
+            unavailable = true
+            current = nil
+        }
+    }
+
+    /// What a set/clear did, as far as the subprocess can say — mirrors
+    /// ``AccountController/Attempt``.
+    public enum Attempt: Equatable, Sendable {
+        case skipped
+        case refused
+        case accepted(notice: String?)
+    }
+
+    /// Set `name` as the control account, or clear it when `name` is `nil`.
+    /// `key` is the account name used to key ``pending``/``failures`` — for a
+    /// clear it is the name of the row that currently holds the control, so
+    /// that row (and only that row) shows the in-flight/failure state.
+    ///
+    /// `.accepted` only means `tcr` exited 0; the caller must follow it with
+    /// ``refresh()`` to learn what actually took, exactly like
+    /// ``AccountController/setEnabled(_:account:)`` never updates `disabled`
+    /// itself.
+    @discardableResult
+    public func setControl(name: String?, key: String) async -> Attempt {
+        guard !pending.contains(key) else { return .skipped }
+        pending.insert(key)
+        failures[key] = nil
+        defer { pending.remove(key) }
+
+        let outcome = await Task.detached(priority: .userInitiated) {
+            ControlAccountCommand.performSet(name: name)
+        }.value
+
+        switch outcome {
+        case .clean:
+            return .accepted(notice: nil)
+        case .spoke(let notice):
+            return .accepted(notice: notice)
+        case .failed(let failure):
+            failures[key] = failure
+            return .refused
+        }
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/ControlAccountCommandTests.swift
+++ b/apps/macos/Tests/TcrBarTests/ControlAccountCommandTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import XCTest
+
+@testable import TcrBarCore
+
+/// Pure classification for `tcr control`. Same posture as
+/// `ToggleVerdictTests`: `ImageRenderer` cannot draw `Menu` contents at all, so
+/// the gear's "Use as control account" / "Clear control account" items are
+/// never covered by a snapshot — this is the only place the logic behind them
+/// is actually exercised.
+///
+/// Account names are obviously fake — this repository is public.
+final class ControlAccountCommandTests: XCTestCase {
+
+    private let alice = "alice@example.com"
+
+    // MARK: - argument shape
+
+    func testSetArgumentsPassTheNamePositionally() {
+        XCTAssertEqual(ControlAccountCommand.setArguments(name: alice), ["control", alice])
+    }
+
+    func testSetArgumentsWithNilNameClear() {
+        XCTAssertEqual(ControlAccountCommand.setArguments(name: nil), ["control", "--clear"])
+    }
+
+    // MARK: - `--show` classification
+
+    /// The name printed on stdout, trimmed, is a `.set` reading.
+    func testShowReportsTheNameWhenOneIsSet() {
+        let reading = ControlAccountCommand.classifyShow(
+            exitCode: 0, stdout: Data("\(alice)\n".utf8), stderr: "")
+        XCTAssertEqual(reading, .set(alice))
+    }
+
+    /// `tcr`'s literal `(none)` sentinel is a real answer — "asked, and the
+    /// answer is nothing" — not the same as not being able to ask at all.
+    func testShowReportsNoneForTheSentinel() {
+        let reading = ControlAccountCommand.classifyShow(
+            exitCode: 0, stdout: Data("(none)\n".utf8), stderr: "")
+        XCTAssertEqual(reading, .none)
+    }
+
+    /// A non-zero exit — the shape an older `tcr` with no `control` subcommand
+    /// takes — must NOT collapse into `.none`. That is the exact defect this
+    /// type exists to keep apart: "no control account is set" and "this build
+    /// cannot answer the question" are different facts, and only one of them
+    /// justifies a row drawing nothing.
+    func testShowIsUnavailableOnANonZeroExit() {
+        let reading = ControlAccountCommand.classifyShow(
+            exitCode: 2, stdout: Data(), stderr: "error: unrecognized subcommand 'control'")
+        guard case .unavailable(let reason) = reading else {
+            return XCTFail("expected .unavailable, got \(reading)")
+        }
+        XCTAssertEqual(reason, "error: unrecognized subcommand 'control'")
+    }
+
+    @MainActor
+    func testControllerNeverReportsControlWhenUnavailable() {
+        let controller = ControlAccountController(pinned: alice, unavailable: true)
+        // Pinned with a name AND marked unavailable — the pathological
+        // combination a stale read could leave behind — must still read as "no
+        // phantom checkmark", which is what `isControl` exists to guarantee.
+        XCTAssertFalse(controller.isControl(alice))
+    }
+
+    @MainActor
+    func testControllerReportsControlWhenAvailableAndMatching() {
+        let controller = ControlAccountController(pinned: alice)
+        XCTAssertTrue(controller.isControl(alice))
+        XCTAssertFalse(controller.isControl("bob@example.com"))
+    }
+
+    // MARK: - set/clear classification
+
+    func testSetIsCleanOnExitZeroWithNoStderr() {
+        XCTAssertEqual(ControlAccountCommand.classifySet(exitCode: 0, stderr: ""), .clean)
+    }
+
+    /// Exit 0 with output on stderr is `tcr` reporting half-done work — same
+    /// rule as `AccountCommand.classify`, mirrored here rather than assumed to
+    /// still hold for a different subcommand.
+    func testSetSpeaksUpOnExitZeroWithStderr() {
+        let outcome = ControlAccountCommand.classifySet(
+            exitCode: 0,
+            stderr: "[tcr] WARNING: the proxy running on :3456 is too old to accept live "
+                + "account control, so only the config file was changed.")
+        guard case .spoke(let notice) = outcome else {
+            return XCTFail("expected .spoke, got \(outcome)")
+        }
+        XCTAssertTrue(notice.contains("too old"))
+    }
+
+    func testSetFailsOnANonZeroExit() {
+        let outcome = ControlAccountCommand.classifySet(
+            exitCode: 1, stderr: "the proxy running on :3456 refused this: no match")
+        guard case .failed(let failure) = outcome else {
+            return XCTFail("expected .failed, got \(outcome)")
+        }
+        XCTAssertEqual(failure.exitCode, 1)
+        XCTAssertTrue(failure.summary.contains("refused this"))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ControlAccountController` (TcrBarCore), which shells out to `tcr control <query>` / `tcr control --clear` and reads it back via `tcr control --show` — deliberately decoupled from `tcr status --json`, which does not carry a `control` field on every build.
- Gear menu: "Use as Control Account" / "Clear Control Account" per row.
- A `CONTROL` pill (system accent colour, text-paired) beside the account name so the designation is visible without opening the menu.
- Degrades silently on an older `tcr` with no `control` subcommand (no phantom checkmark, no error banner) — see `ControlAccountCommand.Reading.unavailable`.

## Test plan
- [x] `swift build -c release --product TcrBar` — exit 0
- [x] `swift test` — 201/201 passing, including new `ControlAccountCommandTests`
- [x] `TcrBar --shell-probe` — 9/9 assertions pass
- [x] `TcrBar --render-states` — 30/30 PNGs, new `13-control-account-{dark,light}` scene shows the row pill

🤖 Generated with [Claude Code](https://claude.com/claude-code)