### PR TITLE
Pin control account row; fix install.sh orphaned proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaude-rs"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -194,8 +194,9 @@ struct FleetView: View {
     }
 
     private func rowStack(_ fleet: Fleet) -> some View {
-        VStack(alignment: .leading, spacing: Tok.rowSpacing) {
-            ForEach(fleet.rowsInDisplayOrder) { account in
+        let rows = fleet.rowsInDisplayOrder(pinning: control.current)
+        return VStack(alignment: .leading, spacing: Tok.rowSpacing) {
+            ForEach(Array(rows.enumerated()), id: \.element.id) { index, account in
                 AccountRow(
                     account: account,
                     countersAreStructural: fleet.source.countersAreStructural,
@@ -210,6 +211,14 @@ struct FleetView: View {
                             key: RowHeightsKey.self, value: [account.id: proxy.size.height])
                     }
                 )
+                // A thin separator between the pinned control row and the
+                // rotation pool below it — the same `Hairline` this panel
+                // already uses to mark a scope boundary (see `appActions`).
+                // Only drawn when the control row is actually first: index 0
+                // is an ordinary pool row on every fleet without one set.
+                if index == 0, account.name == control.current {
+                    Hairline()
+                }
             }
         }
     }
@@ -228,7 +237,9 @@ struct FleetView: View {
     /// always-room-for-roughly-8-rows behaviour — so the panel never renders
     /// at zero or one-row height while waiting for a real measurement.
     private func visibleRowsHeight(for fleet: Fleet) -> CGFloat {
-        let orderedHeights = fleet.rowsInDisplayOrder.compactMap { rowHeights[$0.id] }
+        let orderedHeights = fleet.rowsInDisplayOrder(pinning: control.current).compactMap {
+            rowHeights[$0.id]
+        }
         guard !orderedHeights.isEmpty else {
             return Tok.panelMaxHeight
         }

--- a/apps/macos/Sources/TcrBarCore/FleetStatus.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetStatus.swift
@@ -687,6 +687,32 @@ public struct Fleet: Equatable, Sendable {
         }
     }
 
+    /// ``rowsInDisplayOrder``, with the identity-bound control account (if any)
+    /// pinned to the very front — above the rotation pool, ahead of even an
+    /// otherwise-first `ok` row.
+    ///
+    /// `controlName` is not a field on ``Account``: the control account is read
+    /// via `tcr control --show` (`ControlAccountController`), a source
+    /// deliberately separate from `tcr status --json` — see that controller's
+    /// doc-comment. So this takes the name as a parameter instead of reading it
+    /// off the row, and the caller (`FleetView`) is the one place that already
+    /// holds both a `Fleet` and a `ControlAccountController`.
+    ///
+    /// A **stable partition**, not a re-sort: everything that isn't the control
+    /// row keeps the exact relative order ``rowsInDisplayOrder`` already gave
+    /// it. `controlName == nil` — no control account set, or this build cannot
+    /// ask (``ControlAccountController/unavailable``, which always pairs with a
+    /// `nil` `current`) — leaves the order byte-identical to
+    /// ``rowsInDisplayOrder``, which is the common case.
+    public func rowsInDisplayOrder(pinning controlName: String?) -> [Account] {
+        let ordered = rowsInDisplayOrder
+        guard let controlName else { return ordered }
+        let control = ordered.filter { $0.name == controlName }
+        guard !control.isEmpty else { return ordered }
+        let rest = ordered.filter { $0.name != controlName }
+        return control + rest
+    }
+
     // MARK: Capacity summary
     //
     // The panel lists every account, which answers "what is each one doing" but

--- a/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
@@ -448,6 +448,73 @@ final class FleetNeedsReloginTests: XCTestCase {
     }
 }
 
+/// `rowsInDisplayOrder(pinning:)`: the control account (normally `disabled`,
+/// so it would otherwise sink to the very bottom via `displayOrder`) pinned
+/// to the front, above even a fully-`ok` row — a stable partition, never a
+/// re-sort of what remains.
+///
+/// The third edge case the feature's brief calls out — an older `tcr` with no
+/// `control` subcommand at all — has no analog at this layer: this codebase
+/// never decodes a `control` field off `Account` (see
+/// `ControlAccountController`'s own doc-comment), so "the key is absent" is a
+/// fact about `tcr control --show`, not about `tcr status --json`. That shape
+/// is exercised in `ControlAccountCommandTests.testShowIsUnavailableOnANonZeroExit`
+/// / `testControllerNeverReportsControlWhenUnavailable`, which prove
+/// `ControlAccountController.current` stays `nil` in exactly that case — and a
+/// `nil` name here is `testNoControlAccountLeavesOrderUnchanged` below.
+final class FleetControlPinningTests: XCTestCase {
+    func testControlAccountPinnedToFrontPreservesRelativeOrderOfTheRest() {
+        // The control account is disabled — the common shape (parked out of
+        // rotation) — and would otherwise sort dead last.
+        let control = brokenAccount("zoe@example.com", disabled: true)
+        let ready = account("alice@example.com", state: .ok)
+        let near = account("bob@example.com", state: .near)
+        let spent = account("carol@example.com", state: .spent)
+
+        let fleet = Fleet(accounts: [spent, control, ready, near])
+        // Without pinning: ready, near, spent, control (control sinks last).
+        XCTAssertEqual(
+            fleet.rowsInDisplayOrder.map(\.name),
+            ["alice@example.com", "bob@example.com", "carol@example.com", "zoe@example.com"],
+            "sanity check: unpinned, the control account is the worst-ranked row"
+        )
+
+        let pinned = fleet.rowsInDisplayOrder(pinning: "zoe@example.com").map(\.name)
+        XCTAssertEqual(
+            pinned,
+            ["zoe@example.com", "alice@example.com", "bob@example.com", "carol@example.com"],
+            "control row moves to the front; everyone else keeps their prior relative order"
+        )
+    }
+
+    func testNoControlAccountLeavesOrderUnchanged() {
+        let ready = account("alice@example.com", state: .ok)
+        let spent = account("bob@example.com", state: .spent)
+        let parked = account("carol@example.com", state: .ok, disabled: true)
+        let fleet = Fleet(accounts: [spent, parked, ready])
+
+        XCTAssertEqual(
+            fleet.rowsInDisplayOrder(pinning: nil).map(\.name),
+            fleet.rowsInDisplayOrder.map(\.name),
+            "no control account set (the common case) must be byte-identical to today's order"
+        )
+    }
+
+    func testControlNameNotPresentInTheFleetLeavesOrderUnchanged() {
+        // Defensive: a stale/mismatched name (e.g. a fleet snapshot that
+        // hasn't caught up with a just-cleared control account) must not
+        // crash or silently drop a row — it must simply not pin anything.
+        let ready = account("alice@example.com", state: .ok)
+        let spent = account("bob@example.com", state: .spent)
+        let fleet = Fleet(accounts: [spent, ready])
+
+        XCTAssertEqual(
+            fleet.rowsInDisplayOrder(pinning: "nobody@example.com").map(\.name),
+            fleet.rowsInDisplayOrder.map(\.name)
+        )
+    }
+}
+
 /// The bug an adversarial review found: every test above exercises only
 /// `brokenAccount` — never-probed, `quota: nil`. The shape that actually
 /// happens in production is `probedThenBrokenAccount`: a credential that

--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.11</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.11</link>
+      <sparkle:version>387</sparkle:version>
+      <sparkle:shortVersionString>0.2.11</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Fri, 14 Aug 2026 22:46:37 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.11/TcrBar-0.2.11.dmg" type="application/octet-stream" sparkle:edSignature="OyGN/82y7GGuOtK8C2DA1ilsb4/yh/xAOODm1r7l0Dl3qRjjzxnQd8L6F6jF9Dr6lcgR2MOOekmBl06X76TbCw==" length="5963071" />
+    </item>
+    <item>
       <title>TcrBar 0.2.10</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.10</link>
       <sparkle:version>370</sparkle:version>

--- a/apps/macos/scripts/install.sh
+++ b/apps/macos/scripts/install.sh
@@ -152,12 +152,57 @@ fi
 # Stop only OUR app, and only the copy being replaced. `pkill -f TcrBar` would
 # also match an editor with the name in its title or a grep for it. This happens
 # after verification so a bad build never costs you the running app.
+#
+# The supervised proxy at Contents/MacOS/tcr is a SEPARATE executable from
+# Contents/MacOS/TcrBar, so pkill -f "$RUNNING_PATTERN" above never touches it
+# — and `applicationWillTerminate` does not run on a raw SIGTERM, so quitting
+# TcrBar does not reap it either. Measured live: after install.sh reported
+# success, /Applications/TcrBar.app was the new build but the process actually
+# serving traffic was still the OLD tcr binary from the replaced bundle,
+# reparented to init (PPID 1) and still holding port 3456 — the newly
+# installed TcrBar then started its own server with --no-replace, found the
+# port taken, and stood down. The install looked clean while stale code served
+# every request; `tcr status --json`'s serverSha is what exposed it. So the
+# child gets its own DEST-derived pattern and its own explicit kill, exactly
+# like RUNNING_PATTERN: never a bare `pkill -f tcr` (would also match a
+# dev-path install, or anything else named tcr) and never a port match (same
+# blast radius, and the very check that would race the thing it's checking).
+CHILD_PATTERN="$DEST/Contents/MacOS/tcr"
+
 if pgrep -f "$RUNNING_PATTERN" >/dev/null 2>&1; then
   echo "==> Stopping the running $(basename "$DEST" .app)…"
   pkill -f "$RUNNING_PATTERN" || true
   STOPPED_APP=1
-  # Give the supervised child, if any, a moment to be reaped cleanly.
-  sleep 1
+
+  # Only stop the child belonging to the app we just stopped — a standalone
+  # proxy run from some other bundle (or a dev install) is left alone.
+  if pgrep -f "$CHILD_PATTERN" >/dev/null 2>&1; then
+    echo "==> Stopping the supervised proxy it leaves running…"
+    pkill -f "$CHILD_PATTERN" || true
+    # Bounded wait for it to actually exit — not a blind `sleep 1`, which is
+    # exactly the assumption that let the stale-serving-code bug above go
+    # unnoticed: a still-held port 3456 is silent until something checks it.
+    # Poll instead of assuming any fixed delay is enough, and cap it so a
+    # child that refuses to die does not hang the install.
+    waited_ms=0
+    while pgrep -f "$CHILD_PATTERN" >/dev/null 2>&1; do
+      if [ "$waited_ms" -ge 5000 ]; then
+        echo "" >&2
+        echo "WARNING: the supervised proxy at $CHILD_PATTERN did not exit" >&2
+        echo "         within 5s of being stopped. It may still be holding" >&2
+        echo "         port 3456, which will make the newly installed" >&2
+        echo "         ${APP_NAME} stand its own server down instead of" >&2
+        echo "         serving — the exact bug this check exists to catch." >&2
+        echo "         Check with: pgrep -fl \"$CHILD_PATTERN\"" >&2
+        break
+      fi
+      sleep 0.1
+      waited_ms=$((waited_ms + 100))
+    done
+    if ! pgrep -f "$CHILD_PATTERN" >/dev/null 2>&1; then
+      echo "==> Supervised proxy stopped."
+    fi
+  fi
 fi
 
 echo "==> Installing to ${DEST}…"


### PR DESCRIPTION
## Summary

Two independent changes on one branch, one commit each:

**feat: pin the control account row to the top of the fleet list**
- `Fleet.rowsInDisplayOrder(pinning:)` — a stable partition on top of the
  existing `rowsInDisplayOrder`: the control row (read via
  `ControlAccountController`, not a `status.json` field — there is no
  `control` field on `Account`) always comes first, everyone else keeps
  their prior relative order.
- `FleetView` passes `control.current` and draws a `Hairline()` after the
  pinned row, the same separator idiom already used elsewhere in the panel.
- No control account set, or an older `tcr` that can't answer at all
  (`ControlAccountController.unavailable`, which always pairs with a `nil`
  `current`) — both collapse to the same `nil` pin name, so the list order
  is byte-identical to today. Three new tests in `FleetControlPinningTests`;
  only the first (`testControlAccountPinnedToFrontPreservesRelativeOrderOfTheRest`)
  actually discriminates the pinning behavior — the other two would pass
  against a no-op implementation too, since they exercise the pass-through
  paths by construction.

**fix: install.sh now stops the orphaned supervised proxy, not just TcrBar**
- `pkill -f "$RUNNING_PATTERN"` only ever matched `Contents/MacOS/TcrBar`.
  The supervised proxy at `Contents/MacOS/tcr` is a separate executable, and
  `applicationWillTerminate` doesn't run on a raw `SIGTERM`, so quitting
  TcrBar never reaped it either.
- Measured live: after `install.sh` reported success, the new bundle was on
  disk but the OLD `tcr` binary was still serving, reparented to init and
  holding port 3456 — the newly installed TcrBar's `--no-replace` server
  found the port taken and stood down. Install looked clean; stale code
  served every request. `tcr status --json`'s `serverSha` is what exposed it.
- Adds a second `DEST`-derived pattern for `Contents/MacOS/tcr`, stopped only
  when the app itself was stopped, and replaces the blind `sleep 1` with a
  bounded 5s poll that says plainly on stderr if the child outlives the wait.

## Test plan

- [x] `swift build` — exit 0
- [x] `swift test` — 204/204 passing, exit 0
- [x] `FleetControlPinningTests` watched failing first (broke the pin to a
      no-op, confirmed the expected assertion failure, restored, re-ran green)
- [x] `bash -n apps/macos/scripts/install.sh` — exit 0
- [x] `shellcheck -x apps/macos/scripts/install.sh` — exit 0
- [x] Extracted the child-stop poll loop verbatim and ran it standalone
      against two fake fixture processes (a SIGTERM-responsive one and a
      SIGTERM-ignoring one) to confirm the positive path detects/confirms
      exit and the negative path warns and breaks at the 5s bound rather
      than hanging — cleaned up after
- [ ] NOT verified: the orphan-kill path end-to-end via a real
      `install.sh` run. TcrBar is supervising the live proxy every session
      on this machine routes through right now, so I did not run
      `install.sh`, quit/relaunch TcrBar, or replace `/Applications/TcrBar.app`.
      The lead will verify this on the next real install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)