### PR TITLE
chore: commit the 0.2.13 appcast entry the release generated

### DIFF
--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.13</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.13</link>
+      <sparkle:version>393</sparkle:version>
+      <sparkle:shortVersionString>0.2.13</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Sat, 15 Aug 2026 07:43:30 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.13/TcrBar-0.2.13.dmg" type="application/octet-stream" sparkle:edSignature="ajKN14f4KKy/d7eYZYZ8czG4CpweYPGmRYTUO6kVP35R9aVN7XVLwRbNNV/JzCg2jjngFf7P4XNFjQ2ody4kBw==" length="5964327" />
+    </item>
+    <item>
       <title>TcrBar 0.2.11</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.11</link>
       <sparkle:version>387</sparkle:version>


### PR DESCRIPTION
The v0.2.13 release generated this Sparkle feed entry and left the working tree dirty. Committing it is the last step of a release, not cleanup — the ledger records the same gap for 0.2.5 and 0.2.7, and #102 did this for 0.2.10.

Feed already verified live: `releases/latest/download/appcast.xml` returns 200 with `TcrBar 0.2.13` as its newest entry.