### PR TITLE
fix: fire the release-version gate at merge time, not just commit time

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -276,50 +276,29 @@ fi
 # compiles it. Widen this to `apps/macos/scripts/**` and both slip through
 # under an already-released version; add new preflight-only scripts here by
 # name, the same way, never by loosening the directory.
-staged_shippable="$(git diff --cached --name-only --diff-filter=ACMR -- . \
-                    ':(exclude)*.md' \
-                    ':(exclude)docs/**' \
-                    ':(exclude)assets/**' \
-                    ':(exclude).github/**' \
-                    ':(exclude).githooks/**' \
-                    ':(exclude)apps/macos/appcast.xml' \
-                    ':(exclude)apps/macos/scripts/release-preflight.sh' || true)"
+# The pathspec exclusion and version-already-tagged check are both delegated
+# to scripts/check-release-version.sh, which is also called from
+# .github/workflows/ci.yml on pull_request — the commit-time hook only ever
+# sees the tags that exist AT COMMIT TIME, so it cannot catch two branches
+# that each legitimately bump to the same next version and merge with no
+# conflict. The CI job re-runs this same check at merge time, against a fully
+# fetched tag list, which is when the second branch's tag collision actually
+# exists to be seen. See that script's header for the full story.
+mapfile -t staged_files < <(git diff --cached --name-only --diff-filter=ACMR -- . || true)
 
-if [ -n "$staged_shippable" ]; then
-  # Read the INDEX (`:Cargo.toml`), not the working tree: that is what this
-  # commit will actually contain, and it falls back to HEAD's copy when
-  # Cargo.toml is not staged — which is precisely the case this gate catches.
-  #
-  # The sed is character-for-character the one in `build-tcrbar.sh:98`. Two
-  # copies of one expression is a real cost, but the alternative is this hook
-  # and the build script disagreeing about what the version IS, and a gate that
-  # reads a different number than the thing it guards is worse than no gate.
-  staged_version="$(git show :Cargo.toml 2>/dev/null \
-                    | sed -n 's/^version[[:space:]]*=[[:space:]]*"\([0-9][^"]*\)".*/\1/p' \
-                    | head -1 || true)"
-
-  if [ -z "$staged_version" ]; then
-    # Say so rather than pass silently. A gate that cannot read its input has
-    # not checked anything, and must not look like it did.
-    echo "pre-commit: could not read a version from the staged Cargo.toml — release-version gate SKIPPED." >&2
-  elif git rev-parse -q --verify "refs/tags/v$staged_version" >/dev/null 2>&1; then
+if [ "${#staged_files[@]}" -gt 0 ]; then
+  # git runs hooks from the repo root (see the gitleaks block above), so
+  # scripts/check-release-version.sh resolves without needing $0's dirname.
+  if ! scripts/check-release-version.sh --source=index "${staged_files[@]}"; then
     echo "" >&2
-    echo "pre-commit: BLOCKED — v$staged_version is already a released tag." >&2
-    echo "" >&2
-    echo "  This commit changes shipped files but leaves Cargo.toml at $staged_version," >&2
-    echo "  a version that has already been tagged and published. Everything built" >&2
-    echo "  from here would claim to be $staged_version while not being it." >&2
-    echo "" >&2
+    echo "  Staged files that triggered this are listed above." >&2
     echo "  Bump the version in Cargo.toml, stage it, and commit again:" >&2
     echo "" >&2
-    echo "      \$EDITOR Cargo.toml    # version = \"$staged_version\"  ->  the next one" >&2
+    echo "      \$EDITOR Cargo.toml    # bump the version field" >&2
     echo "      git add Cargo.toml" >&2
     echo "" >&2
-    echo "  Staged files that triggered this:" >&2
-    printf '%s\n' "$staged_shippable" | sed 's/^/      /' >&2
-    echo "" >&2
     echo "  Commits that install nothing (*.md, docs/, assets/, .github/, .githooks/) are exempt." >&2
-    echo "  If this genuinely should ship under $staged_version:  git commit --no-verify" >&2
+    echo "  If this genuinely should ship under the already-released version:  git commit --no-verify" >&2
     exit 1
   fi
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,43 @@ jobs:
       - name: Audit dependencies
         run: cargo audit
 
+  # ── release-version (merge-time) ──────────────────────────────────────────
+  # .githooks/pre-commit runs the same check, but it can only ever see the
+  # tags that exist AT COMMIT TIME: the tag that actually invalidates a
+  # branch is created later, at release. Two branches can each legitimately
+  # bump to the same next version, both pass the commit-time hook, and merge
+  # with no conflict at all (same line, same value) — nothing for a human to
+  # notice. This job re-runs scripts/check-release-version.sh here, at PR
+  # time, against a fully fetched tag list, which is when that collision
+  # actually exists to be seen.
+  #
+  # NOT wired into branch protection by this change — see the PR body. A
+  # non-required check is advisory only; it must be added to the required
+  # checks list (alongside ci, audit, macos) to actually block a merge.
+  release-version:
+    name: release-version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # A shallow clone has no tags, and the check would silently pass —
+          # full history plus explicit tag fetch is load-bearing here, not
+          # a nicety.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Check release version
+        run: |
+          mapfile -t changed_files < <(git diff --name-only --diff-filter=ACMR \
+            "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" -- .)
+          if [ "${#changed_files[@]}" -eq 0 ]; then
+            echo "release-version: no changed files in this PR — nothing to check."
+            exit 0
+          fi
+          scripts/check-release-version.sh --source=worktree "${changed_files[@]}"
+
   tsan:
     name: tsan
     runs-on: ubuntu-latest

--- a/scripts/check-release-version.sh
+++ b/scripts/check-release-version.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# check-release-version.sh — refuse a diff that ships code under a version
+# that has ALREADY been released.
+#
+# Extracted from .githooks/pre-commit's release-version gate (see that file
+# for the full incident writeup, 2026-08-09). That hook can only ever see the
+# tags that exist AT COMMIT TIME — the tag that actually invalidates a branch
+# is created later, at release. Two branches can each bump to the same next
+# version, both pass the commit-time gate legitimately, and merge with no
+# conflict at all (same line, same value) — nothing for a human to notice.
+# This script is the second caller: run again at PR/merge time, against a
+# fully-fetched tag list, it catches the case the commit-time hook structurally
+# cannot.
+#
+# Usage:
+#   check-release-version.sh <diff-filter-args...>
+#
+# The caller supplies how to enumerate the shippable file list — `git diff
+# --cached --name-only --diff-filter=ACMR -- .` for the pre-commit hook,
+# `git diff --name-only --diff-filter=ACMR <base>...<head> -- .` for CI —
+# because "which files changed" differs by context but "which files are
+# shippable" and "what counts as already released" do not. Everything after
+# the caller's own diff invocation is the same pathspec exclusion list, so
+# this script takes the fully-formed list of changed files on stdin (one per
+# line) and applies the shippable-file exclusion + version-already-tagged
+# check uniformly.
+#
+# Reads the version to check from `git show :Cargo.toml` in pre-commit
+# context (the INDEX) or from the working tree in CI context — see
+# --source below.
+#
+# Exit 0: no shippable changes, or version not yet released, or version
+#         could not be read (SKIPPED, matching the pre-commit hook's existing
+#         graceful-degradation behaviour).
+# Exit 1: the version being shipped is already a released tag.
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: check-release-version.sh --source=<index|worktree> [changed-file...]
+
+  --source=index      Read Cargo.toml from the git index (`git show :Cargo.toml`).
+                       Use this from a pre-commit hook.
+  --source=worktree    Read Cargo.toml from the working tree. Use this from CI,
+                       where there is no index to speak of — just a checkout.
+
+Changed files are passed as positional arguments (already diff-filtered by
+the caller); this script applies the shippable-file exclusion list and the
+already-released-tag check.
+EOF
+}
+
+source_mode=""
+args=()
+for arg in "$@"; do
+  case "$arg" in
+    --source=*)
+      source_mode="${arg#--source=}"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      args+=("$arg")
+      ;;
+  esac
+done
+
+if [ "$source_mode" != "index" ] && [ "$source_mode" != "worktree" ]; then
+  echo "check-release-version.sh: --source must be 'index' or 'worktree'" >&2
+  usage
+  exit 2
+fi
+
+# Shippable-file exclusion list — authoritative copy from
+# .githooks/pre-commit:279-286. Do not re-derive or "tidy" this; every entry
+# has a documented reason in that file.
+shippable=()
+for f in "${args[@]}"; do
+  case "$f" in
+    *.md) continue ;;
+    docs/*) continue ;;
+    assets/*) continue ;;
+    .github/*) continue ;;
+    .githooks/*) continue ;;
+    apps/macos/appcast.xml) continue ;;
+    apps/macos/scripts/release-preflight.sh) continue ;;
+    *) shippable+=("$f") ;;
+  esac
+done
+
+if [ "${#shippable[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+# The sed is character-for-character the one in .githooks/pre-commit:297-299
+# and build-tcrbar.sh:98. A gate that reads a different number than the thing
+# it guards is worse than no gate.
+if [ "$source_mode" = "index" ]; then
+  version="$(git show :Cargo.toml 2>/dev/null \
+            | sed -n 's/^version[[:space:]]*=[[:space:]]*"\([0-9][^"]*\)".*/\1/p' \
+            | head -1 || true)"
+else
+  version="$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([0-9][^"]*\)".*/\1/p' Cargo.toml \
+            | head -1 || true)"
+fi
+
+if [ -z "$version" ]; then
+  echo "check-release-version.sh: could not read a version from Cargo.toml — release-version gate SKIPPED." >&2
+  exit 0
+fi
+
+if git rev-parse -q --verify "refs/tags/v$version" >/dev/null 2>&1; then
+  echo "" >&2
+  echo "check-release-version.sh: BLOCKED — v$version is already a released tag." >&2
+  echo "" >&2
+  echo "  This change ships shippable files but leaves Cargo.toml at $version," >&2
+  echo "  a version that has already been tagged and published. Everything built" >&2
+  echo "  from here would claim to be $version while not being it." >&2
+  echo "" >&2
+  echo "  Bump the version in Cargo.toml to the next one." >&2
+  echo "" >&2
+  echo "  Shippable files that triggered this:" >&2
+  printf '      %s\n' "${shippable[@]}" >&2
+  echo "" >&2
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## The defect

`.githooks/pre-commit` refuses a commit that ships code under an **already-released** version. The rule is right; **its evaluation time is wrong.**

A pre-commit hook can only ever see tags that exist *at commit time*. The tag that invalidates a branch is created later, at release. Observed today on this repo:

- `main` was `0.2.13`, latest tag `v0.2.13`.
- Two branches independently bumped to `0.2.14`. At commit time `v0.2.14` did not exist, so **both passed the gate legitimately**.
- Both set the **same line to the same value**, so git auto-merges them with **no conflict at all** — there is nothing for a human to notice.
- If a release tags `v0.2.14` between the two merges, the second branch's code lands claiming to be `0.2.14` while not being in the published `0.2.14`.

A pre-commit hook cannot catch this: at commit time the information does not exist. Separately, a hook never runs on a merge at all.

## The fix

**One script, two callers** — not a third copy of the version-reading expression, which the hook's own comment already flags as a real cost ("a gate that reads a different number than the thing it guards is worse than no gate").

- `scripts/check-release-version.sh` (new) — owns the rule. Same shippable-file exclusion list and the identical `sed` as before.
- `.githooks/pre-commit` — now calls it. Behaviour unchanged, including the SKIPPED-on-unreadable-version path.
- `.github/workflows/ci.yml` — new `release-version` job on `pull_request`, which **re-evaluates against fresh tags at merge time**.

`fetch-depth: 0` + `fetch-tags: true` are load-bearing, not a nicety: a shallow clone has no tags and the check would *silently pass*.

## Fixture-run — four directions, all watched

A gate never watched firing is theater; an audit here previously found three shipped gates structurally unable to fire.

| direction | result |
|---|---|
| Fires on a shippable change under a released tag | exit 1 ✅ |
| Passes when the version has no matching tag | exit 0 ✅ |
| Existing pre-commit sequential case still blocks | exit 1 ✅ |
| **Docs-only change under a released tag does NOT fire** | exit 0 ✅ |

The first was proved against **real repo state**, not a synthetic fixture: this branch was based on a commit where `Cargo.toml` said `0.2.13` and `v0.2.13` was genuinely published, so the gate blocked its own author's commit for exactly the reason it exists. Any synthetic tags created for the other directions were deleted and never pushed.

The fourth direction is the false-positive check — a gate that reddens every README PR gets disabled. It was added after review because the first three all tested "does it fire" and none tested "does it correctly stay quiet."

## Note for the merger

This job is **not** currently in branch protection's required checks (`ci`, `audit`, `macos`). Until it is added there it is **advisory only** and will not block a merge. Adding it is a deliberate decision, not something this PR assumes.