### PR TITLE
fix: correct throttle-exempt findings from the PR #106 review

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -188,6 +188,7 @@ Consequences worth knowing before you tune either number:
 | `sessionAffinity` | bool | **`true`** (ON) | no | pin a session to the account it started on |
 | `revalidationServe` | bool | **`true`** (ON) | no | serve over-threshold rather than synthesizing a 429 when the whole fleet reads over the soft threshold |
 | `loadBalanceMigration` | bool | **`false`** (OFF) | no | move an already-warm session to a cooler account to even out pinned-session counts |
+| `throttleExemptNoise` | bool | **`false`** (OFF) | no | skip the fleet-wide GCRA entirely for `Noise`-classified traffic (`/api/event_logging*`, `/mcp-registry*`) instead of making it queue behind inference |
 
 ### `sessionAffinity` also pins identity-less loopback requests
 
@@ -221,10 +222,10 @@ that off turns this off too.
 
 ### Which knobs are opt-in and which are opt-out
 
-Five knobs ship OFF and must be turned on deliberately: `warmupSeconds`,
-`loadBalanceMigration`, `pacing`, `lockAccount` and `http1Only`. (An older README said three;
-`pacing` and `lockAccount` were missing from that list. `sessionAffinity` was a sixth until
-it flipped to default ON — see below.)
+Six knobs ship OFF and must be turned on deliberately: `warmupSeconds`,
+`loadBalanceMigration`, `pacing`, `lockAccount`, `http1Only` and `throttleExemptNoise`. (An
+older README said three; `pacing` and `lockAccount` were missing from that list.
+`sessionAffinity` was on this list too until it flipped to default ON — see below.)
 
 Two knobs ship ON and are opt-**out**: `revalidationServe`, default `true`, disabled by
 writing `"revalidationServe": false`; and `sessionAffinity`, also default `true`, disabled by

--- a/src/manager/throttle.rs
+++ b/src/manager/throttle.rs
@@ -3,6 +3,29 @@
 use super::select::{classify_request, RequestClass};
 use super::*;
 
+/// Whether a [`RequestClass`] is exempt from the fleet-wide GCRA when
+/// [`Manager::throttle_exempt_noise_enabled`] is on. Today this is a single
+/// `== RequestClass::Noise` comparison, but it is named rather than inlined at
+/// the call site because of a load-bearing fact [`classify_request`]'s own
+/// doc-comment states for the SELECTION side and this file depends on too:
+/// `classify_request` **fails safe toward `ControlPreferred`** for any unknown
+/// path. For throttling specifically, `ControlPreferred` is one of the two
+/// classes that stays throttled (along with `Inference`) — so the
+/// selection-side fail-safe direction happens to also be the throttle-side
+/// fail-safe direction: an unrecognised path degrades to "still throttled",
+/// never to "silently exempt". That agreement is a happy accident nobody had
+/// written down before this comment.
+///
+/// The other reason this is named: `classify_request` now drives TWO
+/// independent policies — account selection (`src/manager/select.rs`) and
+/// throttling (here). Changing its `Noise` arm for a selection reason (e.g.
+/// widening or narrowing the `/api/event_logging*` / `/mcp-registry*` prefix
+/// match) silently changes which traffic this predicate exempts too. There is
+/// no compiler check tying the two together — only this comment.
+fn throttle_exempt(class: RequestClass) -> bool {
+    class == RequestClass::Noise
+}
+
 impl Manager {
     /// Whether `Noise`-classified traffic (`/api/event_logging*`,
     /// `/mcp-registry*` — see [`classify_request`]) skips the fleet-wide GCRA
@@ -40,7 +63,7 @@ impl Manager {
     /// immediately without consuming a GCRA slot — telemetry stops queueing
     /// behind inference, but only once explicitly opted in.
     pub async fn throttle_send(&self, path: &str) {
-        if self.throttle_exempt_noise_enabled() && classify_request(path) == RequestClass::Noise {
+        if self.throttle_exempt_noise_enabled() && throttle_exempt(classify_request(path)) {
             return;
         }
         let Some(spacing_ms) = self.throttle.effective_min_spacing() else {

--- a/tests/throttle_exempt.rs
+++ b/tests/throttle_exempt.rs
@@ -1,25 +1,32 @@
 //! Behavioural coverage for the `throttleExemptNoise` knob
 //! (`Manager::throttle_exempt_noise_enabled`, `src/manager/throttle.rs`).
 //!
-//! Structure mirrors `tests/hop_overhead.rs::throttle_burst_cost`: a real
-//! `mitm::serve` listener in front of a real `Manager`, a fake upstream that
-//! counts hits, and a concurrent burst measured end-to-end. Unlike that file
-//! these are ASSERTIONS, not timing measurements — every test uses a
+//! A real `mitm::serve` listener in front of a real `Manager`, a fake
+//! upstream that counts hits, and a concurrent burst measured end-to-end.
+//! These are ASSERTIONS, not timing measurements — every test uses a
 //! deliberately wide margin (the throttle's own spacing is 350ms and this
-//! never asserts anything finer than 250ms either side of it), so these are
+//! never asserts anything finer than 100ms either side of it), so these are
 //! NOT `#[ignore]`d.
 //!
-//! Three behaviours, one per test:
+//! Four behaviours, one per test:
 //!
 //! 1. Knob OFF (default) — a burst of `Noise`-classified requests
 //!    (`/api/event_logging/v2/batch`) still pays the fleet-wide GCRA, exactly
 //!    as before this change. Current behaviour preserved.
 //! 2. Knob ON — the SAME burst of `Noise` requests skips the GCRA entirely:
 //!    all admit near-instantly instead of queueing behind `burst=4`.
-//! 3. Knob ON, query-string trap — `/v1/messages?beta=true` (the shape live
-//!    traffic actually sends) must still classify as `Inference`, not
-//!    `Noise`: a burst against it is throttled exactly like case 1, proving
-//!    `classify_request` is being fed `uri.path()` and not the raw target.
+//! 3. Knob ON, exempt-prefix boundary — `classify_request` (`src/manager/select.rs`)
+//!    matches `Noise` by PREFIX, so `/api/event_logging/v2/batch` (already
+//!    covered by case 2) and the shorter `/api/event_logging` root both
+//!    classify as `Noise` and skip the GCRA the same way.
+//! 4. Knob ON, exempt-prefix miss — `/api/event_loggingXYZ` still
+//!    `starts_with("/api/event_logging")`, so `classify_request` returns
+//!    `Noise` for it too and it is exempt exactly like case 3, even though
+//!    it is not a real event-logging path. This asserts what the code
+//!    ACTUALLY does today (prefix match, no trailing `/` or path-boundary
+//!    check), not the tighter behaviour a reader might assume from the name
+//!    "prefix". If this ever starts failing, `classify_request`'s matching
+//!    got stricter and this comment (and case 3's) should be revisited.
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -36,7 +43,7 @@ use teamclaude_rs::probe::{ProbeError, ProbeFuture, UsageProber};
 use teamclaude_rs::warmer::{AccountWarmer, WarmError, WarmFuture};
 
 // ---------------------------------------------------------------------------
-// Stubs — nothing here ever reaches the network. Verbatim from hop_overhead.rs.
+// Stubs — nothing here ever reaches the network.
 // ---------------------------------------------------------------------------
 
 struct NeverRefreshes;
@@ -101,7 +108,7 @@ fn account(i: usize) -> Account {
     }
 }
 
-/// Mirrors `hop_overhead.rs::config`, plus the knob under test in `extra`.
+/// Plus the knob under test in `extra`.
 fn config(upstream: &str, throttle: ThrottleConfig, throttle_exempt_noise: bool) -> Config {
     let mut extra = serde_json::Map::new();
     extra.insert("sessionAffinity".to_string(), serde_json::Value::Bool(true));
@@ -234,7 +241,7 @@ async fn post(cli: &reqwest::Client, base: &str, path: &str, payload: &[u8]) -> 
 /// for the LAST one to complete, relative to a shared start instant. Warms the
 /// route with one request first (route/pool build), then sleeps long enough
 /// for the GCRA bucket to fully refill (`burst * spacing` = 1.4s) before the
-/// timed burst, exactly as `hop_overhead.rs::throttle_burst_cost` does.
+/// timed burst.
 async fn burst_last_elapsed(proxy: &str, path: &str, n: usize) -> Duration {
     let cli = client();
     let (s, _) = post(&cli, proxy, path, &body("user_warmup")).await;
@@ -270,9 +277,14 @@ const BURST: usize = 8;
 /// Asserted with a wide margin below the closed form so scheduler jitter on a
 /// loaded CI box cannot flake it.
 const THROTTLED_FLOOR: Duration = Duration::from_millis(900);
-/// Upper bound for a burst that skips the GCRA entirely — no request should
-/// ever wait anywhere near one throttle tick.
-const EXEMPT_CEILING: Duration = Duration::from_millis(300);
+/// Upper bound for a burst that skips the GCRA entirely. `THROTTLED_FLOOR`
+/// (900ms) vs. an actually-exempt burst (~0ms) is a ~900ms discriminating
+/// gap, so 800ms buys 2.7x headroom against CI flake (`cargo test --all
+/// --locked`, debug build, 2-vCPU runners, three 4-worker tokio runtimes
+/// contending) while still catching a real regression: it costs zero
+/// discriminating power relative to 300ms because nothing exempt should ever
+/// approach even a fraction of one 350ms throttle tick.
+const EXEMPT_CEILING: Duration = Duration::from_millis(800);
 
 /// Case 1: knob OFF (default) — `Noise` traffic still pays the throttle.
 /// Current behaviour preserved.
@@ -305,22 +317,51 @@ async fn noise_burst_exempt_when_knob_on() {
     );
 }
 
-/// Case 3: knob ON, query-string trap. `/v1/messages?beta=true` — the shape
-/// live traffic sends — must classify as `Inference`, never `Noise`, so a
-/// burst against it is throttled exactly like case 1 even with the knob on.
-/// This is the test that catches passing the raw target instead of
-/// `uri.path()` into `classify_request`.
+/// Case 3: knob ON, bare-prefix boundary. `/api/event_logging` (no trailing
+/// segment at all, unlike case 2's `/api/event_logging/v2/batch`) still
+/// `starts_with("/api/event_logging")`, so `classify_request` returns `Noise`
+/// for it too and the burst is exempt just like case 2.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn inference_query_string_not_exempt_when_knob_on() {
+async fn exempt_prefix_root_when_knob_on() {
     let (upstream, _hits) = spawn_json_upstream().await;
     let mgr = manager(&upstream, throttle_live(), true);
     let proxy = spawn_proxy(mgr).await;
 
-    let last = burst_last_elapsed(&proxy, "/v1/messages?beta=true", BURST).await;
+    let last = burst_last_elapsed(&proxy, "/api/event_logging", BURST).await;
     assert!(
-        last >= THROTTLED_FLOOR,
-        "knob ON: `/v1/messages?beta=true` must still classify as Inference \
-         and pay the GCRA — last request completed in {last:?}, expected >= {THROTTLED_FLOOR:?} \
-         (a failure here means the raw target, not uri.path(), reached classify_request)"
+        last <= EXEMPT_CEILING,
+        "knob ON: `/api/event_logging` (bare prefix root) classifies as Noise \
+         and must skip the GCRA — last request completed in {last:?}, expected <= {EXEMPT_CEILING:?}"
+    );
+}
+
+/// Case 4: knob ON, prefix overreach. `classify_request` matches `Noise` with
+/// a plain `str::starts_with` — no trailing `/` or path-segment boundary
+/// check — so `/api/event_loggingXYZ` and `/mcp-registry-anything` (neither a
+/// real event-logging or mcp-registry route) ALSO `starts_with` their
+/// respective prefixes and classify as `Noise`. This asserts what the code
+/// actually does today: both are exempt from the GCRA, same as a genuine
+/// `/api/event_logging/...` path. If this starts failing, `classify_request`
+/// grew a path-boundary check and this comment is stale.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn exempt_prefix_overreach_when_knob_on() {
+    let (upstream, _hits) = spawn_json_upstream().await;
+    let mgr = manager(&upstream, throttle_live(), true);
+    let proxy = spawn_proxy(mgr).await;
+
+    let last_logging = burst_last_elapsed(&proxy, "/api/event_loggingXYZ", BURST).await;
+    assert!(
+        last_logging <= EXEMPT_CEILING,
+        "knob ON: `/api/event_loggingXYZ` prefix-matches `/api/event_logging` \
+         and classifies as Noise (no path-boundary check) — last request completed \
+         in {last_logging:?}, expected <= {EXEMPT_CEILING:?}"
+    );
+
+    let last_mcp = burst_last_elapsed(&proxy, "/mcp-registry-anything", BURST).await;
+    assert!(
+        last_mcp <= EXEMPT_CEILING,
+        "knob ON: `/mcp-registry-anything` prefix-matches `/mcp-registry` \
+         and classifies as Noise (no path-boundary check) — last request completed \
+         in {last_mcp:?}, expected <= {EXEMPT_CEILING:?}"
     );
 }


### PR DESCRIPTION
Follow-up to #106, which merged with **zero human reviews** on a change to the single outbound send site of a fleet-wide proxy. An adversarial review afterwards returned REVISE. These are the clear-cut findings; the behaviour of the feature is unchanged and the knob still ships OFF.

## 1. Deleted a test that was green under the bug it named

`tests/throttle_exempt.rs` case 3 claimed: *"This is the test that catches passing the raw target instead of `uri.path()` into `classify_request`."* **It cannot.**

`classify_request` matches `Noise` by **prefix**, and a query string is a **suffix** — a query can never flip a `Noise` verdict. The only thing a query changes is `Inference` ↔ `ControlPreferred`, and **both of those are throttled**. So substituting `path_and_query` at the call site — the exact defect — leaves every assertion passing.

A test that is green under the bug it advertises is worse than no test: it sells coverage that does not exist. The PR body of #106 overstated its test coverage by exactly one third, and this is that third.

The underlying claim still holds — the path genuinely is query-stripped at `proxy.rs:1794`, bound outside the retry loop, so both the 401 and transient-429 retries re-pass the stripped value. It just was never a risk *at this call site*.

## 2. Replaced it with boundary tests for a risk that IS real

`classify_request` uses raw `str::starts_with`, not `path_is_under`. So `/api/event_loggingXYZ` and `/mcp-registry-anything` classify as `Noise` and — with the knob ON — skip the fleet-wide GCRA entirely.

The new tests assert **what the code actually does today**, documented as such, rather than the tighter behaviour one might wish for. They are honest about the missing path-boundary check instead of hiding it.

## 3. Named the fail-safe that was previously an accident

Extracted `fn throttle_exempt(class: RequestClass) -> bool` and documented the load-bearing fact nobody had written down: `classify_request` fails safe toward `ControlPreferred` for unknown paths, and for *throttling* `ControlPreferred` means **throttled** — so the selection-side fail-safe direction happens to also be the throttle-side one.

That is currently a happy accident. It is now named, because `classify_request` drives **two independent policies** with nothing in the compiler tying them together: adding a path to the `Noise` arm for account-selection reasons would silently unthrottle it fleet-wide.

The reciprocal note on `RequestClass::Noise` in `select.rs` is **deferred** — a concurrent branch holds that file.

## 4. Flake headroom

`EXEMPT_CEILING` 300ms → 800ms. CI runs `cargo test --all --locked` (debug) on 2-vCPU runners with three 4-worker tokio runtimes contending. The discriminating gap is ~1400ms vs ~0, so this costs zero discriminating power and buys 2.7× headroom.

## 5. Dangling references in a public repo

Removed three doc-comments pointing at `tests/hop_overhead.rs`, which **does not exist in this repository** (`git cat-file -e origin/main:tests/hop_overhead.rs` fails). It is an untracked local file. This repo is public and those comments pointed readers at nothing.

## 6. Documentation

`docs/configuration.md` — added `throttleExemptNoise` to the unmodelled-bool-knob table, and corrected *"Five knobs ship OFF"* → **six**. That sentence already carried a parenthetical about having gone stale once before; #106 repeated the failure the document narrates in place.

## Verification

The kept and new tests were **mutation-tested**: forcing `throttle_exempt` to always return `false` turned the exempt-path tests red as expected, while the knob-OFF test correctly stayed green. Sensitivity is not correctness, but a test never watched failing proves neither.

Gates: `cargo build --release`, `cargo test --test throttle_exempt`, `cargo fmt --check`, `cargo clippy` — all exit 0.

---

*Note: this is the first PR to run through the `release-version` CI job added in #107.*