### PR TITLE
chore: bump version to 0.2.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaude-rs"
-version = "0.2.14"
+version = "0.2.15"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms


### PR DESCRIPTION
chore: bump version to 0.2.15

v0.2.14 cannot be released. Its GitHub Release was created while immutable
releases were enabled, and GitHub burns a tag name permanently once an
immutable release has used it: deleting that release does not free the tag,
and creating another one on it fails with "tag_name was used by an immutable
release". The tag remains in history and names merged, tested code; there is
simply no way to attach the TcrBar dmg and appcast to it.

Nothing shipped in 0.2.14 is lost. Sticky divert destinations, the honest
status surface, the per-request usage line, the boot-line knob inventory and
background-task death reporting are all on main and will ship as 0.2.15.

Also unblocks ordinary commits: main read 0.2.14 while v0.2.14 was tagged, so
the release-version gate would refuse any commit touching shipped files until
the version moved off the released one.

The appcast is deliberately NOT touched here. The failed release run left a
0.2.14 item in it whose enclosure URL points at a release that no longer
exists; committing that would have Sparkle offer an update it cannot download,
which is worse than offering none. The 0.2.15 release regenerates the entry.

---

**Two files, four lines.** `Cargo.toml` and `Cargo.lock` only.

Once merged: tag `v0.2.15` → cargo-dist publishes the binaries → `apps/macos/scripts/release-local.sh v0.2.15` adds the signed dmg and appcast. Immutable releases are now off, so the second phase works.

**Follow-up worth filing:** `release-preflight.sh` should check that the tag has not already been consumed by an immutable release. That failure is invisible until the moment it is unrecoverable — the release object must exist for anyone to notice, and by then the tag is already burned.