### PR TITLE
test: replay a sticky-divert trace through select() end to end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaude-rs"
-version = "0.2.15"
+version = "0.2.16"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/src/manager/select.rs
+++ b/src/manager/select.rs
@@ -2057,3 +2057,167 @@ mod revalidation_sticky_tests {
         );
     }
 }
+
+/// Replay of a divert trace observed in a live deployment: four consecutive
+/// diverts for one session pinned to a rate-limited account, landing on three
+/// distinct destinations. Session key and account names are fabricated here —
+/// the shape is what carries over, and this repository is public. Drives the
+/// REAL `select()` across repeated calls rather than `divert_verdict` in
+/// isolation (that predicate is already covered by `divert_tests` above).
+///
+/// The bounce this replay exists to catch was observable because the build
+/// carrying `select()`'s sticky overlay (`:688-716`) had not yet booted when
+/// those diverts fired; no `divert-sticky` line had been emitted at all at
+/// the time this test was written.
+///
+/// Self-authored oracle — σ2, same cap as `revalidation_sticky_tests` above
+/// and for the same reason (the same change added both the overlay's test
+/// coverage and this replay). Neutralizing the overlay turns this test red
+/// with the destination-bounce it asserts against, which shows sensitivity to
+/// the change but not independence from it. A genuinely independent oracle
+/// would be unit F's replay harness reading retained log lines directly
+/// (§6), which this test does not have access to.
+#[cfg(test)]
+mod sticky_divert_replay_tests {
+    use super::*;
+    use crate::config::{Account, ProxyConfig};
+    use crate::oauth::NoRefresh;
+    use crate::probe::LiveUsageProber;
+    use crate::warmer::LiveWarmer;
+    use std::collections::HashSet;
+
+    fn account(name: &str) -> Account {
+        Account {
+            name: name.to_string(),
+            account_type: "oauth".to_string(),
+            account_uuid: None,
+            org_uuid: None,
+            org_name: None,
+            access_token: format!("at-{name}"),
+            refresh_token: Some(format!("rt-{name}")),
+            expires_at: Some(crate::now_ms() + 3_600_000),
+            priority: Some(0),
+            switch_threshold: None,
+            disabled: None,
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    fn config_with(accounts: Vec<Account>) -> Config {
+        Config {
+            proxy: ProxyConfig::default(),
+            upstream: "https://api.anthropic.com".to_string(),
+            switch_threshold: 0.90,
+            pacing: PacingConfig::default(),
+            throttle: ThrottleConfig::default(),
+            lock_account: None,
+            control_account: None,
+            control_reserve: 0.05,
+            http1_only: false,
+            accounts,
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    fn build_manager(config: Config) -> Arc<Manager> {
+        Manager::new(
+            config,
+            Arc::new(NoRefresh),
+            Arc::new(LiveUsageProber::new()),
+            Arc::new(LiveWarmer::new()),
+            None,
+        )
+    }
+
+    /// Four `select()` calls in a row for one pinned, rate-limited session —
+    /// the exact shape of the retained trace (four diverts, `pin-tried`
+    /// every time because the pin is already in the request's own `tried`
+    /// set after the first attempt upstream, matching the real log's
+    /// `reason=pin-tried` on all four lines). Every call after the first
+    /// must return the SAME alternate: that reuse is the entire point of
+    /// PR #110, and its absence (a fresh least-utilised pick every time) is
+    /// the bounce the production trace shows.
+    #[test]
+    fn four_diverts_in_one_episode_reuse_the_same_alternate() {
+        let manager = build_manager(config_with(vec![
+            account("alice"),
+            account("bob"),
+            account("carol"),
+        ]));
+        let now = OffsetDateTime::now_utc();
+        let key = 42_u64;
+
+        // Initial pin, mirroring the trace: the session pins to `alice`,
+        // which then gets rate-limited.
+        let pin = manager
+            .select(&HashSet::new(), now, None, Some(key), "/v1/messages", None)
+            .expect("an account is eligible for the initial pin");
+        manager.mark_rate_limited(pin, 120);
+
+        // Every one of the four replayed diverts hits the SAME upstream
+        // gate the log's `reason=pin-tried` names: the pin already failed
+        // this request (it is in `tried`), so `select()` diverts and keeps
+        // the pin rather than re-keying the session.
+        let mut tried = HashSet::new();
+        tried.insert(pin);
+
+        let first = manager
+            .select(&tried, now, None, Some(key), "/v1/messages", None)
+            .expect("an alternate is eligible for the first divert");
+        assert_ne!(
+            first, pin,
+            "the first divert must land on an alternate, not the held pin"
+        );
+
+        for n in 2..=4 {
+            let dest = manager
+                .select(&tried, now, None, Some(key), "/v1/messages", None)
+                .unwrap_or_else(|| panic!("an alternate is eligible for divert #{n}"));
+            assert_eq!(
+                dest, first,
+                "divert #{n} must reuse the episode's sticky destination {first}, \
+                 not bounce to a different alternate — this is the exact shape \
+                 of the production trace this test replays"
+            );
+        }
+
+        // The episode ledger backs the reuse: one recorded episode, keyed
+        // on this session, with exactly one distinct destination touched
+        // across all four diverts.
+        let episode = manager
+            .divert_ledger
+            .lock()
+            .expect("divert ledger lock poisoned")
+            .get(&key)
+            .copied()
+            .expect("episode recorded");
+        assert_eq!(episode.pin, pin);
+        assert_eq!(episode.sticky, first);
+        assert_eq!(
+            episode.destinations.count_ones(),
+            1,
+            "four diverts reusing the same destination is one distinct \
+             destination, not four"
+        );
+
+        // Episode reset is structural, not timed (§4.1): a NEW rate-limit
+        // deadline on the same pin changes the episode's identity
+        // `(pin, until_ms)`, so the next divert is `Fresh` again and is free
+        // to land on any eligible alternate — including a different one.
+        // With `first` now the most-recently-selected account (its
+        // `last_selected_seq` is ahead of the untouched third account), the
+        // LRU-ordered normal pick this fixture exercises actually lands on
+        // the OTHER alternate, making the "allowed to change" claim
+        // concrete rather than vacuous.
+        manager.mark_rate_limited(pin, 200);
+        let after_reset = manager
+            .select(&tried, now, None, Some(key), "/v1/messages", None)
+            .expect("an alternate is eligible after the episode resets");
+        assert_ne!(
+            after_reset, first,
+            "a new rate-limit deadline is a new episode (§4.1) — the sticky \
+             destination must be free to change, and with an untouched \
+             third account in the fleet the LRU pick actually does change it"
+        );
+    }
+}


### PR DESCRIPTION
## Why

Sticky divert shipped in #110, and as of writing it had **never actually executed**. No `divert-sticky` line had ever been emitted: every divert in the retained log window fired before the build carrying the fix was running. The feature was live in the sense that the code was in the binary, and untested in the sense that reality had never handed it the situation it exists for.

Existing coverage only exercised the `divert_verdict` predicate in isolation. The sticky overlay inside `select()` itself — the part that actually decides which alternate a diverted request lands on — had no end-to-end test.

## What

One test, `four_diverts_in_one_episode_reuse_the_same_alternate`, replaying the shape of an observed trace: a session pinned to an account that gets rate-limited, then four consecutive diverts. Without the fix those four landed on three distinct destinations, and every fresh destination re-writes the whole conversation prefix cold — the exact cost #110 was written to avoid.

It drives the real `select()` across repeated calls rather than the predicate alone, and asserts:

- the first divert lands on an alternate rather than the held pin;
- diverts 2 through 4 reuse **that same** alternate;
- the ledger records exactly one distinct destination across all four;
- a new rate-limit deadline on the same pin structurally starts a new episode, freeing the sticky destination to change again.

The last one matters because episode reset here is structural rather than timed — a new hold necessarily carries a different deadline, so a mismatch *is* a new episode. The test pins that property rather than leaving it implied.

## Confidence

**σ2, and it does not go higher on the strength of this PR.** The test is a self-authored oracle: the same change that added the overlay's coverage added this replay. Neutralizing the sticky overlay does turn it red with precisely the destination-bounce it asserts against, which demonstrates sensitivity to the change — but sensitivity is not independence, and a test written to match a fix will pass for that fix.

What would genuinely promote it is a real rate-limit arriving at a pinned session in a live deployment, producing a `divert-sticky` line with a reused destination. That is a waiting game, not something this PR can manufacture.

## Notes for review

- Session key and account names are fabricated (`alice`/`bob`/`carol`). This repository is public; the shape is the part that carries over, not the identifiers.
- The added code is entirely inside a `#[cfg(test)]` module, so **the release binary is unchanged by this PR**. The version bump to 0.2.16 is present only because the release-version pre-commit gate matches on pathspec and cannot distinguish a test-only addition inside a shipped source file from one that alters it. Worth a follow-up; not fixed here to keep this PR to one thing.
