### PR TITLE
Stop tcr run from being wrapped around itself

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -107,6 +107,16 @@ A value **you** exported is inherited untouched: an explicit choice wins, and it
 escape hatch for a `claude` with no claude.ai login of its own, which does need some
 credential to start. The process exits with `claude`'s own exit code.
 
+Every child also gets `TCR_RUN_ACTIVE=1`, on all three paths including the proxy-down
+passthrough. It means one thing: **a `tcr run` is already above you in this chain.**
+`tcr run` finds `claude` on `PATH`, so on a machine where something else also wraps
+`claude` that lookup can land on a launcher which wraps in `tcr run` again — the routing
+environment applied twice is identical and nothing breaks, but every startup line prints
+twice and a second `tcr` sits in the process tree for the session. A launcher that checks
+this variable hands off to the real `claude` instead. The name avoids the `CMUX_` prefix
+on purpose: cmux's own claude wrapper clears every `CMUX_*` variable before exec, so a
+marker named after it would be erased in transit.
+
 ---
 
 ## `tcr login`

--- a/src/main.rs
+++ b/src/main.rs
@@ -378,6 +378,7 @@ fn run_claude(args: RunArgs) -> anyhow::Result<()> {
 
     let mut cmd = std::process::Command::new("claude");
     cmd.args(&args.args);
+    mark_run_active(&mut cmd);
 
     if cli::proxy_is_up(port) {
         if let Some(notice) = withheld_api_key_notice(
@@ -402,6 +403,37 @@ fn run_claude(args: RunArgs) -> anyhow::Result<()> {
         .status()
         .context("failed to launch `claude` — is it on PATH?")?;
     std::process::exit(status.code().unwrap_or(1));
+}
+
+/// The marker `tcr run` leaves on its child: **a `tcr run` is already above you
+/// in this process chain, so do not start another one.**
+///
+/// `tcr run` resolves `claude` from `PATH`, and on a machine where something else
+/// also wraps `claude` that lookup can land back on a launcher that wraps in
+/// `tcr run` — which then resolves `claude` from `PATH` again. The chain still
+/// terminates and the routing environment applied twice is identical, so nothing
+/// breaks; what you see is every startup line printed twice and a second `tcr`
+/// process parked in the tree for the life of the session. Measured 2026-08-17
+/// inside a cmux pane: a hand-typed `tcr run` produced two see-through banners,
+/// and dropping cmux's shim directory from `PATH` produced one.
+///
+/// A launcher cannot infer this from the routing variables — those are also what
+/// a `tcr`-launched shell exports to everything it runs — so we state it, and a
+/// wrapper that understands the marker hands off instead of wrapping again.
+///
+/// The name is deliberately **not** `CMUX_`-prefixed. cmux's own claude wrapper
+/// clears every variable matching that prefix before exec'ing the real binary, so
+/// a marker named for the wrapper it has to survive would be erased in transit by
+/// exactly the process it exists to inform. [`marker_survives_the_cmux_prefix_sweep`]
+/// pins that.
+const RUN_ACTIVE_ENV: &str = "TCR_RUN_ACTIVE";
+
+/// Set on **every** `tcr run` child, including the proxy-down passthrough: the
+/// claim is about this chain already containing a `tcr run`, which is true there
+/// too, and a launcher re-wrapping that case just prints the passthrough notice
+/// twice instead of the routing banner.
+fn mark_run_active(cmd: &mut std::process::Command) {
+    cmd.env(RUN_ACTIVE_ENV, "1");
 }
 
 /// The CA to advertise for see-through mode, or `None` when we must fall back to
@@ -1075,6 +1107,30 @@ mod tests {
                  login and disables every claude.ai connector"
             );
         }
+    }
+
+    /// The re-entry marker must reach the child, and must not be named such that
+    /// the wrapper it informs deletes it on the way.
+    ///
+    /// cmux's claude wrapper runs `for k in ${!CMUX_@}; do unset "$k"; done` before
+    /// exec'ing the real binary. A marker under that prefix would be swept exactly
+    /// where it is needed, and the double-wrap would come back looking like a bug
+    /// in the launcher rather than in the name.
+    #[test]
+    fn marker_survives_the_cmux_prefix_sweep() {
+        assert!(
+            !RUN_ACTIVE_ENV.starts_with("CMUX_"),
+            "{RUN_ACTIVE_ENV} would be erased by cmux's own CMUX_* sweep before the \
+             launcher that reads it ever runs"
+        );
+
+        let mut cmd = std::process::Command::new("claude");
+        mark_run_active(&mut cmd);
+        assert!(
+            cmd.get_envs()
+                .any(|(k, v)| k == RUN_ACTIVE_ENV && v == Some("1".as_ref())),
+            "every `tcr run` child must carry {RUN_ACTIVE_ENV}"
+        );
     }
 
     /// A WEDGED INCUMBENT MUST NOT BE OFFERED A RECOVERY THAT CANNOT WORK.


### PR DESCRIPTION
## What you see

Inside a cmux pane, a hand-typed `tcr run` prints its startup lines twice:

```
[tcr] see-through mode: claude keeps https://api.anthropic.com, tunnelling via http://127.0.0.1:3456
[tcr] trusting our MITM leaf via NODE_EXTRA_CA_CERTS=/…/tcr-ca.pem
[tcr] see-through mode: claude keeps https://api.anthropic.com, tunnelling via http://127.0.0.1:3456
[tcr] trusting our MITM leaf via NODE_EXTRA_CA_CERTS=/…/tcr-ca.pem
```

## Why

`tcr run` resolves `claude` from `PATH`. In a cmux pane that lookup lands on cmux's own
`claude` shim, whose wrapper then execs its configured claude binary — a launcher that
wraps in `tcr run`. So one launch passes through tcr twice:

```
tcr run  →  PATH claude (cmux shim)  →  cmux wrapper  →  launcher  →  tcr run  →  real claude
   ①                                                                     ②
```

The launcher does have a re-entry guard, but it is armed only for chains it starts itself
(cmux → launcher → tcr → …). A chain that *starts* at `tcr run` arrives with the guard
unset, so the launcher reads a fresh launch and wraps tcr around the tcr already running.

Nothing breaks: the routing environment applied on both passes is identical, so
see-through mode, rotation and the capability defaults are unaffected. The cost is the
doubled banner and a second `tcr` parked in the process tree for the life of the session.

## The change

Every `tcr run` child now carries `TCR_RUN_ACTIVE=1` — "a `tcr run` is already above you in
this chain" — on all three paths, including the proxy-down passthrough. A launcher that
reads it hands off to the real `claude` instead of wrapping again. A launcher cannot infer
this from the routing variables, since a tcr-launched shell exports those to everything it
runs; hence an explicit marker.

The name deliberately avoids the `CMUX_` prefix: cmux's wrapper runs
`for k in ${!CMUX_@}; do unset "$k"; done` before exec, so a marker named after the wrapper
it must survive would be erased in transit by the very process it exists to inform. The
test pins that property, not the string.

## Verified

- Reproduced: `tcr run -- --version` in a cmux pane → banner ×2; the same command with
  cmux's shim directory dropped from `PATH` → banner ×1. That is the control that
  identifies the re-entry, not the theory.
- Traced: a logging stand-in at the wrapper's configured claude path recorded exactly one
  visit, with the launcher's guard variable **unset** — the hop where the second `tcr run`
  is born.
- `cargo test --bin tcr` → 16 passed. New test watched fail both ways before passing: under
  a `CMUX_`-prefixed name, and with the marker not set on the child.
- `cargo fmt --check`, `cargo clippy --all-targets` clean. gitleaks and the disclosure scan
  re-run over `origin/main..HEAD` (the commit was authored by ref, so `.githooks/pre-commit`
  did not fire); both clean, disclosure scan with a positive control.

σ4 on the mechanism: reproduced, isolated by removing the shim from `PATH`, and traced to
the single hop. One alternative I did not exclude — that some *other* PATH element also
wraps `claude` — is ruled out only by the trace showing one launcher visit, not by
enumerating every entry.

Landing this only removes the doubling once the launcher side also checks `TCR_RUN_ACTIVE`
(done locally in `~/.local/bin/cmux-claude-tcr`) and a `tcr` built from this commit is on
`PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFA8Tw5YGhR6cu9i9WDQYK
