### PR TITLE
chore: bump version to 0.2.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaude-rs"
-version = "0.2.15"
+version = "0.2.16"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms


### PR DESCRIPTION
`v0.2.15` is a released tag, so `check-release-version.sh` blocks every commit that ships a non-doc file while `Cargo.toml` still reads `0.2.15`. The gate is right — anything built from here would claim to be 0.2.15 without being it — but the consequence is that the block is **repo-wide**, not specific to any one branch. No Rust change can be committed off `main` until this lands.

Two branches had each already bumped to `0.2.16` independently in their own trees (`fix/tcr-run-reentry-marker`, `test/sticky-divert-replay`). That is the same-line / same-value collision `check-release-version.sh`'s own header describes as invisible at merge time:

> Two branches can each bump to the same next version, both pass the commit-time gate legitimately, and merge with no conflict at all (same line, same value) — nothing for a human to notice.

Landing the bump on `main` once gives both a single source to inherit instead of adding a third copy.

## Scope

`Cargo.toml` and `Cargo.lock` only, one line each. The `0.2.16` appcast entry is deliberately **not** included — that belongs to whoever cuts the release.

## Verified

- `git show --stat e1f048c` → 2 files changed, 2 insertions(+), 2 deletions(-)
- Both files confirmed to be a pure `1/1` version-line change before committing; nothing else from the working tree was staged or swept in.