### PR TITLE
chore: commit the stranded appcast entry and bump to 0.2.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaude-rs"
-version = "0.2.16"
+version = "0.2.17"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.15</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.15</link>
+      <sparkle:version>401</sparkle:version>
+      <sparkle:shortVersionString>0.2.15</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Sat, 15 Aug 2026 11:23:20 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.15/TcrBar-0.2.15.dmg" type="application/octet-stream" sparkle:edSignature="0ESfe7UBoo3llTsvLOUJg17Se6N+dzTlcjRxPNBGKJtyojdNrqxC+45EgKz0i4zKzd2HosJJLecoq+ZC0S5tDw==" length="5986763" />
+    </item>
+    <item>
       <title>TcrBar 0.2.13</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.13</link>
       <sparkle:version>393</sparkle:version>


### PR DESCRIPTION
Unblocks the TcrBar app release. `release-preflight.sh` refuses to run today, and both reasons are in here.

## What happened

v0.2.16 shipped the **CLI only**. The tag was pushed before the local app release ran, so cargo-dist published a Release with no `appcast.xml` asset — and `releases/latest/download/appcast.xml` is exactly the URL Sparkle fetches. Every installed copy's update check returned 404 until v0.2.16 was marked prerelease so `latest` falls back to v0.2.15. The feed is lit again and serves 11 items, newest 0.2.15.

`release-preflight.sh` catches this as check 4/6, and cites the precedent itself: *"it is how v0.2.3 shipped a signed DMG while the published feed sat on 0.2.1 for a day"*, with a measured 11m 37s outage on v0.2.4.

## The two commits

**`chore: commit the stranded 0.2.15 appcast entry`** — `release-tcrbar.sh` writes a new `<item>` as stage 8 of a release, and the 0.2.15 run's item was never committed. Preflight check 5/6 blocks on it. Pure addition, nine lines, identical to the item already published as an asset on the v0.2.15 release.

**`chore: bump version to 0.2.17`** — attaching the app to v0.2.16 after the fact would mean moving a published tag that already carries CLI artifacts. Cutting 0.2.17 in the documented order instead (dry-run → tag → `release-local.sh`) rewrites nothing and costs only a version number.

## After this lands

Per `docs/RELEASING.md`: `release-tcrbar.sh --dry-run`, then tag, then `release-local.sh v0.2.17`. That produces the signed, notarized, stapled DMG plus an appcast item, both attached to the release — which is what makes "Check for Updates" find anything.

v0.2.16 should stay marked prerelease until v0.2.17 carries an appcast asset; it is the only thing keeping the feed lit.

## Verified

- `git diff --stat origin/main...HEAD` → 3 files, 11 insertions(+), 2 deletions(-)
- Each file confirmed to be a pure version-line or pure-addition change before committing; nothing else swept in.