### PR TITLE
feat: draw two per-window quota bars per account row

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,7 +639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -867,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1829,7 +1829,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2152,7 +2152,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2538,7 +2538,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaude-rs"
-version = "0.2.17"
+version = "0.2.18"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -718,16 +718,18 @@ struct AccountRow: View {
     /// `hasStaleQuotaReading` demotes BOTH bars together, same as `quotaTint`.
     private var fiveHourTint: Color {
         if hasStaleQuotaReading { return Tok.disabled }
-        guard let state = account.fiveHourState else { return quotaTint }
-        return Tok.color(for: state)
+        return Tok.color(for: account.effectiveQuotaState(for: .fiveHour))
     }
 
     /// The 7-day bar's own tint — the 5h counterpart to ``fiveHourTint``, same
-    /// fallback and same stale-demotion rule.
+    /// fallback and same stale-demotion rule. Both route through
+    /// `Account.effectiveQuotaState(for:)` (`TcrBarCore/FleetStatus.swift`) —
+    /// the per-window-field-else-composite selection lives there, pure and
+    /// unit-tested, precisely so a swapped `fiveHour`/`sevenDay` binding here
+    /// would be a test failure, not just a hoped-for eyeball catch.
     private var sevenDayTint: Color {
         if hasStaleQuotaReading { return Tok.disabled }
-        guard let state = account.sevenDayState else { return quotaTint }
-        return Tok.color(for: state)
+        return Tok.color(for: account.effectiveQuotaState(for: .sevenDay))
     }
 
     /// True for exactly the shape this whole round exists to demote: a
@@ -1164,36 +1166,37 @@ struct AccountRow: View {
             // display stops using them, since with both windows drawn and
             // numbered here, a third "most-spent-of-both" percentage would be
             // the same fact restated rather than new information.
+            //
+            // The label sits ABOVE its own bar, not below — a first attempt put
+            // "5h X%" underneath the 5h bar and "7d Y%" underneath the 7d bar,
+            // which reads as a column of bar / label / bar / label with no
+            // visual rule saying which label belongs to which neighbour. Above
+            // reads unambiguously: "5h X%" immediately precedes the bar it
+            // describes, with the PRIOR bar a full row away.
+            // `Tok.rowLineSpacing` (2pt, shared by every line in this column)
+            // put this label line visually inside the pills above it — the
+            // pills carry their own 2pt vertical padding on top of that gap,
+            // so the two collided. The fix is asymmetric, not a blanket
+            // increase to `rowLineSpacing`: only this label line, right below
+            // the pills, gets extra top padding, leaving the rest of the
+            // column untouched.
+            HStack(spacing: Tok.tightSpacing) {
+                Text("5h \(QuotaFormat.percent(account.fiveHour))")
+                    .font(Tok.secondaryDigitFont)
+                    // Demoted alongside the bar, not left `.secondary`: the eye
+                    // should group these digits as historical rather than live,
+                    // the same distinction `fiveHourTint` draws for the fill.
+                    // The number itself is unchanged — it is still true, just
+                    // no longer reachable.
+                    .foregroundStyle(hasStaleQuotaReading ? Tok.disabled : .secondary)
+                Spacer()
+            }
+            .padding(.top, Tok.tightSpacing)
             QuotaBar(fraction: account.fiveHour, tint: fiveHourTint, label: "5-hour quota")
-                // `Tok.rowLineSpacing` (2pt, shared by every line in this
-                // column) put the bar visually inside the pills above it —
-                // the pills carry their own 2pt vertical padding on top of
-                // that gap, so the two collided. The fix is asymmetric, not
-                // a blanket increase to `rowLineSpacing`: the bar belongs
-                // WITH the percent number beneath it (same fact, two
-                // notations, and already tight to them), not with the pills
-                // above. So only the first bar gets extra top padding,
-                // leaving the numbers below it untouched.
-                .padding(.top, Tok.tightSpacing)
                 // Sighted-hover half of the same fix `quotaTint`/`fiveHourTint`
                 // make for the fill colour: a muted bar alone can still read
                 // as "just a dim healthy bar" rather than "not live" without a
                 // word saying so on hover.
-                .help(
-                    hasStaleQuotaReading
-                        ? "The last reading taken before the credential was rejected. "
-                            + "This headroom is unreachable until you re-login."
-                        : ""
-                )
-            Text("5h \(QuotaFormat.percent(account.fiveHour))")
-                .font(Tok.secondaryDigitFont)
-                // Demoted alongside the bar, not left `.secondary`: the eye
-                // should group these digits as historical rather than live,
-                // the same distinction `fiveHourTint` draws for the fill. The
-                // number itself is unchanged — it is still true, just no
-                // longer reachable.
-                .foregroundStyle(hasStaleQuotaReading ? Tok.disabled : .secondary)
-            QuotaBar(fraction: account.sevenDay, tint: sevenDayTint, label: "7-day quota")
                 .help(
                     hasStaleQuotaReading
                         ? "The last reading taken before the credential was rejected. "
@@ -1225,6 +1228,13 @@ struct AccountRow: View {
                         .lineLimit(1)
                 }
             }
+            QuotaBar(fraction: account.sevenDay, tint: sevenDayTint, label: "7-day quota")
+                .help(
+                    hasStaleQuotaReading
+                        ? "The last reading taken before the credential was rejected. "
+                            + "This headroom is unreachable until you re-login."
+                        : ""
+                )
             if let hold = account.soonestHold {
                 Label(hold.countdownLabel, systemImage: "hourglass")
                     .font(Tok.secondaryFont)

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -708,6 +708,28 @@ struct AccountRow: View {
         return account.hasQuotaEvidence ? Tok.color(for: account.quotaState) : Tok.unmeasured
     }
 
+    /// The 5-hour bar's OWN tint — Gil's explicit call: a 7d-red account with an
+    /// empty 5h window must not paint its 5h bar red. `account.fiveHourState`
+    /// is `nil` both when the field is absent on the wire (an older `tcr`) and
+    /// when this window has no reading yet, and either way the honest fallback
+    /// is the shared `quotaTint` this row already computed, not a bespoke
+    /// "unknown" branch — so an old server or a never-probed window degrades to
+    /// today's single-bar behaviour rather than a new, undocumented look.
+    /// `hasStaleQuotaReading` demotes BOTH bars together, same as `quotaTint`.
+    private var fiveHourTint: Color {
+        if hasStaleQuotaReading { return Tok.disabled }
+        guard let state = account.fiveHourState else { return quotaTint }
+        return Tok.color(for: state)
+    }
+
+    /// The 7-day bar's own tint — the 5h counterpart to ``fiveHourTint``, same
+    /// fallback and same stale-demotion rule.
+    private var sevenDayTint: Color {
+        if hasStaleQuotaReading { return Tok.disabled }
+        guard let state = account.sevenDayState else { return quotaTint }
+        return Tok.color(for: state)
+    }
+
     /// True for exactly the shape this whole round exists to demote: a
     /// broken account that has a REAL last-learned quota reading, not an
     /// absent one. Gated on `hasQuotaEvidence` as well as `health`, not
@@ -1124,29 +1146,54 @@ struct AccountRow: View {
                         .help(
                             account.probeError.map { "Quota probe failed: \($0)" }
                                 ?? "The quota probe ran and failed "
-                                    + "(\(account.probeStatus.token)) — this account's "
-                                    + "quota is unknown."
+                                + "(\(account.probeStatus.token)) — this account's "
+                                + "quota is unknown."
                         )
                 } else {
                     StatusPill("unmeasured", tint: quotaTint)
                         .help("Never probed — this account's quota is unknown, not zero.")
                 }
             }
-            QuotaBar(fraction: account.quota, tint: quotaTint)
+            // Two stacked bars, 5-hour on top and 7-day directly under it —
+            // Gil's explicit call (bridge, 2026-08-18) — each tinted by its OWN
+            // window's state (`fiveHourTint`/`sevenDayTint`) rather than the
+            // shared gating tint the single bar used to wear: a 7d-red account
+            // with an empty 5h window must not paint its 5h bar red. The
+            // composite `quota`/`quotaState` fields are UNCHANGED on the wire
+            // and still drive the status pill above — only this bar+percentage
+            // display stops using them, since with both windows drawn and
+            // numbered here, a third "most-spent-of-both" percentage would be
+            // the same fact restated rather than new information.
+            QuotaBar(fraction: account.fiveHour, tint: fiveHourTint, label: "5-hour quota")
                 // `Tok.rowLineSpacing` (2pt, shared by every line in this
                 // column) put the bar visually inside the pills above it —
                 // the pills carry their own 2pt vertical padding on top of
                 // that gap, so the two collided. The fix is asymmetric, not
                 // a blanket increase to `rowLineSpacing`: the bar belongs
-                // WITH the percent/req-cache numbers beneath it (same fact,
-                // two notations, and already tight to them), not with the
-                // pills above. So only the bar gets extra top padding,
+                // WITH the percent number beneath it (same fact, two
+                // notations, and already tight to them), not with the pills
+                // above. So only the first bar gets extra top padding,
                 // leaving the numbers below it untouched.
                 .padding(.top, Tok.tightSpacing)
-                // Sighted-hover half of the same fix `quotaTint` makes for the
-                // fill colour: a muted bar alone can still read as "just a
-                // dim healthy bar" rather than "not live" without a word
-                // saying so on hover.
+                // Sighted-hover half of the same fix `quotaTint`/`fiveHourTint`
+                // make for the fill colour: a muted bar alone can still read
+                // as "just a dim healthy bar" rather than "not live" without a
+                // word saying so on hover.
+                .help(
+                    hasStaleQuotaReading
+                        ? "The last reading taken before the credential was rejected. "
+                            + "This headroom is unreachable until you re-login."
+                        : ""
+                )
+            Text("5h \(QuotaFormat.percent(account.fiveHour))")
+                .font(Tok.secondaryDigitFont)
+                // Demoted alongside the bar, not left `.secondary`: the eye
+                // should group these digits as historical rather than live,
+                // the same distinction `fiveHourTint` draws for the fill. The
+                // number itself is unchanged — it is still true, just no
+                // longer reachable.
+                .foregroundStyle(hasStaleQuotaReading ? Tok.disabled : .secondary)
+            QuotaBar(fraction: account.sevenDay, tint: sevenDayTint, label: "7-day quota")
                 .help(
                     hasStaleQuotaReading
                         ? "The last reading taken before the credential was rejected. "
@@ -1154,23 +1201,12 @@ struct AccountRow: View {
                         : ""
                 )
             HStack(spacing: Tok.tightSpacing) {
-                Text(QuotaFormat.percent(account.quota))
+                Text("7d \(QuotaFormat.percent(account.sevenDay))")
                     .font(Tok.secondaryDigitFont)
-                    // Demoted alongside the bar, not left `.secondary`: the
-                    // eye should group these digits as historical rather than
-                    // live, the same distinction `quotaTint` draws for the
-                    // fill. The number itself is unchanged — it is still
-                    // true, just no longer reachable.
+                    // Same demotion as the 5h percentage — one bar reading
+                    // live and the other historical would be its own new
+                    // contradiction inside a single row.
                     .foregroundStyle(hasStaleQuotaReading ? Tok.disabled : .secondary)
-                Text(
-                    "· 5h \(QuotaFormat.percent(account.fiveHour)) "
-                        + "· 7d \(QuotaFormat.percent(account.sevenDay))"
-                )
-                .font(Tok.secondaryDigitFont)
-                // Same demotion as the leading percentage — one run reading
-                // live and the other historical would be its own new
-                // contradiction inside a single line.
-                .foregroundStyle(hasStaleQuotaReading ? Tok.disabled : .secondary)
                 Spacer()
                 // `status` is the account's own field and it keeps saying
                 // "active" while `disabled` is true — verified against live
@@ -1359,6 +1395,11 @@ struct AccountRow: View {
 struct QuotaBar: View {
     let fraction: Double?
     let tint: Color
+    /// Which window this bar speaks for — "Quota" (the pre-existing composite
+    /// bar) or "5-hour quota" / "7-day quota" for the two per-window bars this
+    /// row now draws. Named so VoiceOver reading two bars in a row hears two
+    /// distinct labels rather than "Quota" twice.
+    var label: String = "Quota"
 
     /// Honour the system Reduce Motion setting. SwiftUI does not suppress an
     /// explicit `.animation` for you.
@@ -1394,7 +1435,7 @@ struct QuotaBar: View {
         .frame(height: Tok.barHeight)
         .animation(reduceMotion ? nil : Tok.standardAnimation, value: fraction)
         .accessibilityElement()
-        .accessibilityLabel("Quota")
+        .accessibilityLabel(label)
         .accessibilityValue(spokenValue)
     }
 }

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -709,27 +709,42 @@ struct AccountRow: View {
     }
 
     /// The 5-hour bar's OWN tint — Gil's explicit call: a 7d-red account with an
-    /// empty 5h window must not paint its 5h bar red. `account.fiveHourState`
-    /// is `nil` both when the field is absent on the wire (an older `tcr`) and
-    /// when this window has no reading yet, and either way the honest fallback
-    /// is the shared `quotaTint` this row already computed, not a bespoke
-    /// "unknown" branch — so an old server or a never-probed window degrades to
-    /// today's single-bar behaviour rather than a new, undocumented look.
+    /// empty 5h window must not paint its 5h bar red.
+    ///
+    /// Routes through `Account.quotaBarTintSource(for:)`
+    /// (`TcrBarCore/FleetStatus.swift`) rather than reading
+    /// `effectiveQuotaState(for:)` directly — that was the bug this comment
+    /// used to describe incorrectly: `effectiveQuotaState` alone cannot tell
+    /// "this window has no reading" from "old server, borrow the composite
+    /// state", so a naive call fell through to the COMPOSITE (7d-driven)
+    /// state and painted an empty 5h bar red whenever the 7d window was
+    /// spent — the exact overclaim two-window tinting exists to prevent, and
+    /// an ordinary state, not an exotic one (`src/quota.rs` populates the two
+    /// windows independently from separate response headers, so one sitting
+    /// at `None` while its sibling accumulates happens routinely). Proven
+    /// with the `01d-unmeasured-window-proof` golden scene before the fix
+    /// landed: the 5h outline rendered red. `quotaBarTintSource` makes the
+    /// no-reading-vs-old-server distinction correctly (gates on the
+    /// FRACTION, not the state word — see its own doc-comment) and is pinned
+    /// by `QuotaWindowStateTests`.
+    ///
     /// `hasStaleQuotaReading` demotes BOTH bars together, same as `quotaTint`.
     private var fiveHourTint: Color {
         if hasStaleQuotaReading { return Tok.disabled }
-        return Tok.color(for: account.effectiveQuotaState(for: .fiveHour))
+        switch account.quotaBarTintSource(for: .fiveHour) {
+        case .unmeasured: return Tok.unmeasured
+        case .state(let state): return Tok.color(for: state)
+        }
     }
 
     /// The 7-day bar's own tint — the 5h counterpart to ``fiveHourTint``, same
-    /// fallback and same stale-demotion rule. Both route through
-    /// `Account.effectiveQuotaState(for:)` (`TcrBarCore/FleetStatus.swift`) —
-    /// the per-window-field-else-composite selection lives there, pure and
-    /// unit-tested, precisely so a swapped `fiveHour`/`sevenDay` binding here
-    /// would be a test failure, not just a hoped-for eyeball catch.
+    /// `quotaBarTintSource` routing and same stale-demotion rule.
     private var sevenDayTint: Color {
         if hasStaleQuotaReading { return Tok.disabled }
-        return Tok.color(for: account.effectiveQuotaState(for: .sevenDay))
+        switch account.quotaBarTintSource(for: .sevenDay) {
+        case .unmeasured: return Tok.unmeasured
+        case .state(let state): return Tok.color(for: state)
+        }
     }
 
     /// True for exactly the shape this whole round exists to demote: a

--- a/apps/macos/Sources/TcrBar/RenderStates.swift
+++ b/apps/macos/Sources/TcrBar/RenderStates.swift
@@ -281,18 +281,27 @@ enum RenderStates {
     /// other scene — this is the one scene that can actually distinguish
     /// them. Two rows, each diverging the OTHER way:
     ///
-    ///  - `divergent-low-high`: 5h ~8% (green, `ok`) under 7d ~96% (red,
-    ///    `spent`) — the top bar must stay green while the bottom is red.
-    ///  - `divergent-high-low`: 5h ~99% (red, `spent`) under 7d ~15% (green,
-    ///    `ok`) — the top bar must be red while the bottom stays green.
+    ///  - `divergent-low-high`: 5h ~8% (green, `ok`) under 7d ~96% (amber,
+    ///    `near`) — the top bar must stay green while the bottom is amber.
+    ///  - `divergent-high-low`: 5h ~99% (amber, `near`) over 7d ~15% (green,
+    ///    `ok`) — the top bar must be amber while the bottom stays green.
+    ///
+    /// `near`, not `spent`: the server's own rule (`src/manager/snapshot.rs`)
+    /// is `>= 1.0 => Exhausted`, `>= threshold => NearLimit`, else `Normal` —
+    /// 0.96 and 0.99 are both under 1.0, so the server can never emit
+    /// `"spent"` for them. An earlier version of this fixture painted them
+    /// `"spent"` anyway, which is a state the real server cannot produce and
+    /// would have taught a future reader a threshold that doesn't exist. The
+    /// swap this scene exists to catch shows just as clearly at `near`
+    /// (amber) against `ok` (green) as it would at `spent` (red).
     private static var divergentWindowsJSON: String {
         let lowHigh = account(
-            "divergent-low-high@example.com", quota: "0.96", state: "spent",
+            "divergent-low-high@example.com", quota: "0.96", state: "near",
             fiveHour: "0.08", fiveHourState: "ok",
-            sevenDay: "0.96", sevenDayState: "spent")
+            sevenDay: "0.96", sevenDayState: "near")
         let highLow = account(
-            "divergent-high-low@example.com", quota: "0.99", state: "spent",
-            fiveHour: "0.99", fiveHourState: "spent",
+            "divergent-high-low@example.com", quota: "0.99", state: "near",
+            fiveHour: "0.99", fiveHourState: "near",
             sevenDay: "0.15", sevenDayState: "ok")
         return "[\(lowHigh),\(highLow)]"
     }

--- a/apps/macos/Sources/TcrBar/RenderStates.swift
+++ b/apps/macos/Sources/TcrBar/RenderStates.swift
@@ -64,6 +64,7 @@ enum RenderStates {
         [
             ("01-healthy", .loaded(fleet(healthyJSON)), false, nil),
             ("01c-divergent-windows", .loaded(fleet(divergentWindowsJSON)), false, nil),
+            ("01d-unmeasured-window-proof", .loaded(fleet(unmeasuredWindowJSON)), false, nil),
             ("02-mixed-thirteen", .loaded(fleet(mixedJSON)), false, nil),
             ("03-zero-capacity", .loaded(fleet(exhaustedJSON)), false, nil),
             ("04-unmeasured-row", .loaded(fleet(unmeasuredJSON)), false, nil),
@@ -252,10 +253,21 @@ enum RenderStates {
         let fhState = fiveHourState ?? state
         let sd = sevenDay ?? quota
         let sdState = sevenDayState ?? state
+        // `fiveHourState`/`sevenDayState` are JSON string fields on the wire
+        // ("ok"/"near"/"spent") but the proof fixture for the unmeasured-
+        // window overclaim needs to write a genuine JSON `null`, not the
+        // string `"null"` — `QuotaState?` decodes the STRING "null" as
+        // `.unknown("null")`, a real (if odd) value, which would silently
+        // defeat the one scene built to prove a window has NO reading.
+        // `quote(_:)` keeps every other call site (a real state word)
+        // wrapped in quotes and only passes `null` through bare.
+        func quote(_ raw: String) -> String {
+            raw == "null" ? "null" : "\"\(raw)\""
+        }
         return """
             {"name":"\(name)","priority":0,"status":"\(status)","disabled":\(disabled),
              "quota":\(quota),"quotaState":"\(state)","fiveHour":\(fh),
-             "fiveHourState":"\(fhState)","sevenDay":\(sd),"sevenDayState":"\(sdState)",
+             "fiveHourState":\(quote(fhState)),"sevenDay":\(sd),"sevenDayState":\(quote(sdState)),
              "sevenDayOi":0.0,"held":\(held),
              "requests":102,"inputTokens":8781926,"outputTokens":31860,
              "cacheReadTokens":7407414,"cacheHitRatio":0.84,"probeStatus":"\(probe)",
@@ -304,6 +316,22 @@ enum RenderStates {
             fiveHour: "0.99", fiveHourState: "near",
             sevenDay: "0.15", sevenDayState: "ok")
         return "[\(lowHigh),\(highLow)]"
+    }
+
+    /// PROOF fixture for the unmeasured-window overclaim: `sevenDay` is
+    /// genuinely spent (1.0/"spent") while `fiveHour`/`fiveHourState` are
+    /// BOTH absent — the shape `src/quota.rs` produces whenever the 5h
+    /// window has not reported yet but the 7d window already has (the two
+    /// populate independently from separate response headers). The 5h bar
+    /// must render as a NEUTRAL dashed outline (no reading), never inheriting
+    /// the 7d window's red — that is the exact overclaim this whole feature
+    /// exists to prevent.
+    private static var unmeasuredWindowJSON: String {
+        let row = account(
+            "unmeasured-5h@example.com", quota: "1.0", state: "spent",
+            fiveHour: "null", fiveHourState: "null",
+            sevenDay: "1.0", sevenDayState: "spent")
+        return "[\(row)]"
     }
 
     /// The shape that broke: thirteen rows, mixed states, one never-probed.

--- a/apps/macos/Sources/TcrBar/RenderStates.swift
+++ b/apps/macos/Sources/TcrBar/RenderStates.swift
@@ -63,6 +63,7 @@ enum RenderStates {
     private static var scenes: [(name: String, state: PollState, awake: Bool, control: String?)] {
         [
             ("01-healthy", .loaded(fleet(healthyJSON)), false, nil),
+            ("01c-divergent-windows", .loaded(fleet(divergentWindowsJSON)), false, nil),
             ("02-mixed-thirteen", .loaded(fleet(mixedJSON)), false, nil),
             ("03-zero-capacity", .loaded(fleet(exhaustedJSON)), false, nil),
             ("04-unmeasured-row", .loaded(fleet(unmeasuredJSON)), false, nil),
@@ -71,7 +72,10 @@ enum RenderStates {
             ("05-unreadable-row", .loaded(partiallyUnreadableFleet()), false, nil),
             ("06-offline-source", .loaded(fleet(offlineJSON)), false, nil),
             ("07-empty-fleet", .loaded(fleet("[]")), false, nil),
-            ("08-tool-missing", .toolMissing(searched: ["/usr/local/bin/tcr", "/opt/homebrew/bin/tcr"]), false, nil),
+            (
+                "08-tool-missing", .toolMissing(searched: ["/usr/local/bin/tcr", "/opt/homebrew/bin/tcr"]),
+                false, nil
+            ),
             ("09-command-failed", .commandFailed(exitCode: 1, message: "connection refused"), false, nil),
             ("10-undecodable", .undecodable(message: "DecodingError.valueNotFound: quota"), false, nil),
             ("11-pending", .pending, false, nil),
@@ -231,17 +235,33 @@ enum RenderStates {
         probe: String = "ok",
         held: String = "[]",
         source: String = "live",
-        status: String = "active"
+        status: String = "active",
+        // Per-window overrides, all defaulting to the composite `quota`/`state`
+        // — every EXISTING call site keeps rendering exactly the "5h == 7d"
+        // fixture it always has. Only `divergentWindowsJSON` below passes
+        // these explicitly, to build the ONE scene where the two windows
+        // genuinely disagree — the shape every other fixture here cannot
+        // exercise and a swapped 5h/7d binding would render identically to
+        // the correct one against.
+        fiveHour: String? = nil,
+        fiveHourState: String? = nil,
+        sevenDay: String? = nil,
+        sevenDayState: String? = nil
     ) -> String {
-        """
-        {"name":"\(name)","priority":0,"status":"\(status)","disabled":\(disabled),
-         "quota":\(quota),"quotaState":"\(state)","fiveHour":\(quota),
-         "sevenDay":\(quota),"sevenDayOi":0.0,"held":\(held),
-         "requests":102,"inputTokens":8781926,"outputTokens":31860,
-         "cacheReadTokens":7407414,"cacheHitRatio":0.84,"probeStatus":"\(probe)",
-         "probeError":null,"lastStreamError":null,"streamErrorCount":0,
-         "source":"\(source)","serverSha":"abc1234","serverDirty":false}
-        """
+        let fh = fiveHour ?? quota
+        let fhState = fiveHourState ?? state
+        let sd = sevenDay ?? quota
+        let sdState = sevenDayState ?? state
+        return """
+            {"name":"\(name)","priority":0,"status":"\(status)","disabled":\(disabled),
+             "quota":\(quota),"quotaState":"\(state)","fiveHour":\(fh),
+             "fiveHourState":"\(fhState)","sevenDay":\(sd),"sevenDayState":"\(sdState)",
+             "sevenDayOi":0.0,"held":\(held),
+             "requests":102,"inputTokens":8781926,"outputTokens":31860,
+             "cacheReadTokens":7407414,"cacheHitRatio":0.84,"probeStatus":"\(probe)",
+             "probeError":null,"lastStreamError":null,"streamErrorCount":0,
+             "source":"\(source)","serverSha":"abc1234","serverDirty":false}
+            """
     }
 
     private static let hold =
@@ -250,6 +270,31 @@ enum RenderStates {
     private static var healthyJSON: String {
         "[\(account("alice@example.com", quota: "0.12", state: "ok")),"
             + "\(account("bob@example.com", quota: "0.31", state: "ok"))]"
+    }
+
+    /// The bug this scene exists to catch: a 7d-red account must not paint
+    /// its 5h bar red, and the inverse — a 5h-red account must not paint its
+    /// 7d bar red. Every OTHER fixture in this file sets `fiveHour` and
+    /// `sevenDay` to the same value as the composite `quota`, so a binding
+    /// bug (5h fraction wired to the 7d bar, or both bars reading the same
+    /// state) would render byte-identical to the correct code against every
+    /// other scene — this is the one scene that can actually distinguish
+    /// them. Two rows, each diverging the OTHER way:
+    ///
+    ///  - `divergent-low-high`: 5h ~8% (green, `ok`) under 7d ~96% (red,
+    ///    `spent`) — the top bar must stay green while the bottom is red.
+    ///  - `divergent-high-low`: 5h ~99% (red, `spent`) under 7d ~15% (green,
+    ///    `ok`) — the top bar must be red while the bottom stays green.
+    private static var divergentWindowsJSON: String {
+        let lowHigh = account(
+            "divergent-low-high@example.com", quota: "0.96", state: "spent",
+            fiveHour: "0.08", fiveHourState: "ok",
+            sevenDay: "0.96", sevenDayState: "spent")
+        let highLow = account(
+            "divergent-high-low@example.com", quota: "0.99", state: "spent",
+            fiveHour: "0.99", fiveHourState: "spent",
+            sevenDay: "0.15", sevenDayState: "ok")
+        return "[\(lowHigh),\(highLow)]"
     }
 
     /// The shape that broke: thirteen rows, mixed states, one never-probed.
@@ -262,8 +307,9 @@ enum RenderStates {
             account("spent-\($0)@example.com", quota: "1.0", state: "spent", held: hold)
         }
         rows.append(
-            account("never@example.com", quota: "null", state: "ok",
-                    disabled: true, probe: "never"))
+            account(
+                "never@example.com", quota: "null", state: "ok",
+                disabled: true, probe: "never"))
         rows.append(account("parked@example.com", quota: "0.2", state: "ok", disabled: true))
         return "[\(rows.joined(separator: ","))]"
     }

--- a/apps/macos/Sources/TcrBarCore/FleetStatus.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetStatus.swift
@@ -449,6 +449,16 @@ public struct Account: Decodable, Equatable, Identifiable, Sendable {
     public let fiveHour: Double?
     public let sevenDay: Double?
     public let sevenDayOi: Double?
+    /// Per-window quota state, additive alongside `quotaState` (which stays the
+    /// combined most-spent-of-both gating verdict). `nil` both when the wire
+    /// field is absent — an older `tcr` this newer TcrBar talks to, same
+    /// forward-compat contract every other field in this struct follows, see
+    /// decision \#3 above — and when the window itself has no reading yet.
+    /// Synthesized `Decodable` already calls `decodeIfPresent` for an
+    /// `Optional` property, so no field is ever missing from a decode; a
+    /// `nil` here falls back to the shared `quotaState` tint for that bar.
+    public let fiveHourState: QuotaState?
+    public let sevenDayState: QuotaState?
     public let held: [HeldWindow]
 
     /// Pure serving counters. `null` on the wire — and `nil` here, NEVER `0` —
@@ -486,6 +496,65 @@ public struct Account: Decodable, Equatable, Identifiable, Sendable {
     public let source: StatusSource
     public let serverSha: String?
     public let serverDirty: Bool?
+
+    /// Explicit memberwise init, needed only because adding `fiveHourState`/
+    /// `sevenDayState` after the struct already had test fixtures constructing
+    /// it directly would otherwise force every one of them to grow two new
+    /// arguments. Both default to `nil` — the same "no per-window reading"
+    /// value the wire's absent-field case decodes to — so every pre-existing
+    /// call site keeps compiling unchanged. `Decodable` synthesis is untouched
+    /// by this: it is generated independently of this initializer.
+    public init(
+        name: String,
+        priority: Int,
+        status: String,
+        disabled: Bool,
+        quota: Double?,
+        quotaState: QuotaState,
+        fiveHour: Double?,
+        sevenDay: Double?,
+        sevenDayOi: Double?,
+        fiveHourState: QuotaState? = nil,
+        sevenDayState: QuotaState? = nil,
+        held: [HeldWindow],
+        requests: Int?,
+        inputTokens: Int?,
+        outputTokens: Int?,
+        cacheReadTokens: Int?,
+        cacheHitRatio: Double?,
+        probeStatus: ProbeState,
+        probeError: String?,
+        lastStreamError: String?,
+        streamErrorCount: Int?,
+        source: StatusSource,
+        serverSha: String?,
+        serverDirty: Bool?
+    ) {
+        self.name = name
+        self.priority = priority
+        self.status = status
+        self.disabled = disabled
+        self.quota = quota
+        self.quotaState = quotaState
+        self.fiveHour = fiveHour
+        self.sevenDay = sevenDay
+        self.sevenDayOi = sevenDayOi
+        self.fiveHourState = fiveHourState
+        self.sevenDayState = sevenDayState
+        self.held = held
+        self.requests = requests
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+        self.cacheReadTokens = cacheReadTokens
+        self.cacheHitRatio = cacheHitRatio
+        self.probeStatus = probeStatus
+        self.probeError = probeError
+        self.lastStreamError = lastStreamError
+        self.streamErrorCount = streamErrorCount
+        self.source = source
+        self.serverSha = serverSha
+        self.serverDirty = serverDirty
+    }
 
     public var id: String { name }
 

--- a/apps/macos/Sources/TcrBarCore/FleetStatus.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetStatus.swift
@@ -650,6 +650,30 @@ public struct Account: Decodable, Equatable, Identifiable, Sendable {
     public var isReady: Bool {
         !disabled && health != .needsRelogin && quotaState == .ok && hasQuotaEvidence
     }
+
+    /// Which window a per-window quota state or bar belongs to.
+    public enum QuotaWindow: Equatable, Sendable {
+        case fiveHour
+        case sevenDay
+    }
+
+    /// The state that SHOULD tint the given window's bar — the per-window
+    /// field when present, else the shared composite `quotaState` (an older
+    /// `tcr` this build talks to, or a window with no reading yet). This is
+    /// the exact selection `FleetView`'s `fiveHourTint`/`sevenDayTint` key
+    /// off, factored out here — pure, no SwiftUI — so a swapped `fiveHour` /
+    /// `sevenDay` binding (5h wired to `sevenDayState`, or both windows
+    /// reading the same field) is catchable by a plain unit test instead of
+    /// only by eyeballing a rendered scene, where the two bars can look
+    /// identical to the correct code whenever a fixture happens to set both
+    /// windows to the same value — as every scene except
+    /// `01c-divergent-windows` does.
+    public func effectiveQuotaState(for window: QuotaWindow) -> QuotaState {
+        switch window {
+        case .fiveHour: return fiveHourState ?? quotaState
+        case .sevenDay: return sevenDayState ?? quotaState
+        }
+    }
 }
 
 /// One bucket of the fleet breakdown line.

--- a/apps/macos/Sources/TcrBarCore/FleetStatus.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetStatus.swift
@@ -657,23 +657,61 @@ public struct Account: Decodable, Equatable, Identifiable, Sendable {
         case sevenDay
     }
 
-    /// The state that SHOULD tint the given window's bar — the per-window
-    /// field when present, else the shared composite `quotaState` (an older
-    /// `tcr` this build talks to, or a window with no reading yet). This is
-    /// the exact selection `FleetView`'s `fiveHourTint`/`sevenDayTint` key
-    /// off, factored out here — pure, no SwiftUI — so a swapped `fiveHour` /
-    /// `sevenDay` binding (5h wired to `sevenDayState`, or both windows
-    /// reading the same field) is catchable by a plain unit test instead of
-    /// only by eyeballing a rendered scene, where the two bars can look
-    /// identical to the correct code whenever a fixture happens to set both
-    /// windows to the same value — as every scene except
-    /// `01c-divergent-windows` does.
+    /// The per-window state word when present, else the shared composite
+    /// `quotaState`. NOT by itself the answer to "what should this window's
+    /// bar look like" — `fiveHourState`/`sevenDayState` are `nil` both when
+    /// this window genuinely has no reading AND when an older `tcr` never
+    /// sent the field at all (`decodeIfPresent` collapses both), so on its
+    /// own this function cannot tell "no reading, paint neutral" from "old
+    /// server, borrow the composite state" and must not be called before
+    /// that distinction is made — see ``quotaBarTintSource(for:)``, which
+    /// makes it and is what callers outside this file should actually use.
+    /// Kept internal-facing (not deprecated/removed) because
+    /// `quotaBarTintSource(for:)` still needs exactly this fallback for the
+    /// genuine old-server case: a fraction present, its state word absent.
     public func effectiveQuotaState(for window: QuotaWindow) -> QuotaState {
         switch window {
         case .fiveHour: return fiveHourState ?? quotaState
         case .sevenDay: return sevenDayState ?? quotaState
         }
     }
+
+    /// What a window's bar should be tinted with — the answer
+    /// `effectiveQuotaState(for:)` alone cannot give. `.unmeasured` when this
+    /// window has NO reading (`fiveHour`/`sevenDay` fraction is `nil` — the
+    /// same per-window fraction ``hasQuotaEvidence`` reads for the composite
+    /// bar, populated on old and new wire alike), `.state` otherwise.
+    ///
+    /// This is the fix for a real bug: `FleetView`'s `fiveHourTint`/
+    /// `sevenDayTint` used to call `effectiveQuotaState(for:)` directly, so
+    /// an account whose 7-day window was genuinely spent and whose 5-hour
+    /// window had never reported fell through `fiveHourState ?? quotaState`
+    /// to the COMPOSITE (7d-driven) state and painted the empty 5h bar red —
+    /// exactly the overclaim two-window tinting exists to prevent, and not
+    /// exotic: `src/quota.rs` populates the two windows independently from
+    /// separate response headers, so one sitting at `None` while its sibling
+    /// accumulates is ordinary. Proven with the `01d-unmeasured-window-proof`
+    /// golden scene before the fix landed (the 5h outline rendered red) and
+    /// pinned here by ``QuotaWindowStateTests``.
+    public func quotaBarTintSource(for window: QuotaWindow) -> QuotaBarTintSource {
+        let fraction: Double? = {
+            switch window {
+            case .fiveHour: return fiveHour
+            case .sevenDay: return sevenDay
+            }
+        }()
+        guard fraction != nil else { return .unmeasured }
+        return .state(effectiveQuotaState(for: window))
+    }
+}
+
+/// The two things a quota bar's fill/outline can honestly show: no reading
+/// at all, or a real per-window state. Kept distinct from a bare
+/// `QuotaState?` so a caller cannot accidentally collapse "unmeasured" into
+/// some default `QuotaState` case — the type itself forces handling both.
+public enum QuotaBarTintSource: Equatable, Sendable {
+    case unmeasured
+    case state(QuotaState)
 }
 
 /// One bucket of the fleet breakdown line.

--- a/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
@@ -285,6 +285,103 @@ final class FleetStatusTests: XCTestCase {
     }
 }
 
+/// ``Account/effectiveQuotaState(for:)`` is the pure selection
+/// `FleetView`'s `fiveHourTint`/`sevenDayTint` key off — the per-window
+/// field when present, else the shared composite `quotaState`. A fixture
+/// where BOTH windows carry the same state (every other fixture in this
+/// file, and every golden scene but `01c-divergent-windows`) cannot catch
+/// a swapped `fiveHour`/`sevenDay` binding: reading the wrong field back
+/// would still equal the right answer. These fixtures deliberately set
+/// `fiveHourState` and `sevenDayState` to DIFFERENT values so a swap fails
+/// loudly instead of rendering byte-identical to the correct code.
+final class QuotaWindowStateTests: XCTestCase {
+    private func account(fiveHourState: QuotaState, sevenDayState: QuotaState) -> Account {
+        Account(
+            name: "diverge@example.com",
+            priority: 0,
+            status: "active",
+            disabled: false,
+            quota: 0.5,
+            quotaState: .near,
+            fiveHour: 0.08,
+            sevenDay: 0.96,
+            sevenDayOi: 0.0,
+            fiveHourState: fiveHourState,
+            sevenDayState: sevenDayState,
+            held: [],
+            requests: 0,
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            cacheHitRatio: nil,
+            probeStatus: .ok,
+            probeError: nil,
+            lastStreamError: nil,
+            streamErrorCount: 0,
+            source: .live,
+            serverSha: "abc1234",
+            serverDirty: false
+        )
+    }
+
+    func testFiveHourWindowReadsItsOwnFieldNotSevenDays() {
+        let a = account(fiveHourState: .ok, sevenDayState: .spent)
+        XCTAssertEqual(a.effectiveQuotaState(for: .fiveHour), .ok)
+        // The failure mode this guards: a binding that reads `sevenDayState`
+        // for the 5h bar would return `.spent` here instead.
+        XCTAssertNotEqual(a.effectiveQuotaState(for: .fiveHour), a.sevenDayState)
+    }
+
+    func testSevenDayWindowReadsItsOwnFieldNotFiveHours() {
+        let a = account(fiveHourState: .ok, sevenDayState: .spent)
+        XCTAssertEqual(a.effectiveQuotaState(for: .sevenDay), .spent)
+        // The failure mode this guards: a binding that reads `fiveHourState`
+        // for the 7d bar would return `.ok` here instead.
+        XCTAssertNotEqual(a.effectiveQuotaState(for: .sevenDay), a.fiveHourState)
+    }
+
+    func testBothWindowsDivergeFromEachOtherInTheFixture() {
+        // Belt-and-suspenders on the fixture itself: if a future edit ever
+        // let these two collapse to the same value, the two tests above
+        // would stop being able to catch a swap at all, silently.
+        let a = account(fiveHourState: .ok, sevenDayState: .spent)
+        XCTAssertNotEqual(a.fiveHourState, a.sevenDayState)
+    }
+
+    func testAbsentPerWindowFieldFallsBackToTheCompositeState() {
+        // Older `tcr`: the per-window fields are absent (`nil`), not merely
+        // unset in this fixture. Both windows must fall back to the shared
+        // `quotaState` — the pre-existing single-bar behaviour — rather than
+        // some other default.
+        let a = Account(
+            name: "legacy@example.com",
+            priority: 0,
+            status: "active",
+            disabled: false,
+            quota: 0.5,
+            quotaState: .near,
+            fiveHour: 0.5,
+            sevenDay: 0.5,
+            sevenDayOi: 0.0,
+            held: [],
+            requests: 0,
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            cacheHitRatio: nil,
+            probeStatus: .ok,
+            probeError: nil,
+            lastStreamError: nil,
+            streamErrorCount: 0,
+            source: .live,
+            serverSha: "abc1234",
+            serverDirty: false
+        )
+        XCTAssertEqual(a.effectiveQuotaState(for: .fiveHour), .near)
+        XCTAssertEqual(a.effectiveQuotaState(for: .sevenDay), .near)
+    }
+}
+
 /// ``QuotaFormat`` carries the one honesty rule this whole task is about — a
 /// nil measurement must never print or draw as a real zero — and until now
 /// nothing exercised it directly; every existing test only asserted on the

--- a/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
@@ -382,6 +382,94 @@ final class QuotaWindowStateTests: XCTestCase {
     }
 }
 
+/// ``Account/quotaBarTintSource(for:)`` — the fix for a real bug found on
+/// pre-merge review: an account whose 7-day window is genuinely spent and
+/// whose 5-hour window has never reported must show a NEUTRAL 5h bar, not
+/// one inheriting the 7d window's red. `effectiveQuotaState(for:)` alone
+/// cannot make this call — `fiveHourState == nil` cannot distinguish "no
+/// reading" from "old server, field absent" — so `quotaBarTintSource` gates
+/// on the FRACTION (`fiveHour`/`sevenDay`, populated on old and new wire
+/// alike) instead. Golden-scene proof: `01d-unmeasured-window-proof`.
+final class QuotaBarTintSourceTests: XCTestCase {
+    private func account(
+        quotaState: QuotaState,
+        fiveHour: Double?,
+        fiveHourState: QuotaState?,
+        sevenDay: Double?,
+        sevenDayState: QuotaState?
+    ) -> Account {
+        Account(
+            name: "tint-source@example.com",
+            priority: 0,
+            status: "active",
+            disabled: false,
+            quota: sevenDay ?? fiveHour,
+            quotaState: quotaState,
+            fiveHour: fiveHour,
+            sevenDay: sevenDay,
+            sevenDayOi: 0.0,
+            fiveHourState: fiveHourState,
+            sevenDayState: sevenDayState,
+            held: [],
+            requests: 0,
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            cacheHitRatio: nil,
+            probeStatus: .ok,
+            probeError: nil,
+            lastStreamError: nil,
+            streamErrorCount: 0,
+            source: .live,
+            serverSha: "abc1234",
+            serverDirty: false
+        )
+    }
+
+    /// The exact bug: 7d genuinely spent, 5h has never reported a fraction
+    /// at all. The 5h bar must be `.unmeasured`, never `.state(.spent)`
+    /// borrowed from the composite/7d state.
+    func testAWindowWithNoFractionIsUnmeasuredNotBorrowedFromItsSibling() {
+        let a = account(
+            quotaState: .spent,
+            fiveHour: nil, fiveHourState: nil,
+            sevenDay: 1.0, sevenDayState: .spent)
+        XCTAssertEqual(a.quotaBarTintSource(for: .fiveHour), .unmeasured)
+        // The failure mode this guards: reading `effectiveQuotaState`
+        // directly (the pre-fix code path) would return `.state(.spent)`
+        // here instead, since `fiveHourState ?? quotaState` falls through to
+        // the composite `.spent`.
+        XCTAssertNotEqual(a.quotaBarTintSource(for: .fiveHour), .state(.spent))
+        // The sibling with a real reading still reports its own state.
+        XCTAssertEqual(a.quotaBarTintSource(for: .sevenDay), .state(.spent))
+    }
+
+    /// The inverse shape, for symmetry: 5h has a real spent reading, 7d has
+    /// never reported.
+    func testTheOtherWindowWithNoFractionIsAlsoUnmeasured() {
+        let a = account(
+            quotaState: .spent,
+            fiveHour: 1.0, fiveHourState: .spent,
+            sevenDay: nil, sevenDayState: nil)
+        XCTAssertEqual(a.quotaBarTintSource(for: .fiveHour), .state(.spent))
+        XCTAssertEqual(a.quotaBarTintSource(for: .sevenDay), .unmeasured)
+        XCTAssertNotEqual(a.quotaBarTintSource(for: .sevenDay), .state(.spent))
+    }
+
+    /// The genuine old-server shape this fallback still needs to serve: a
+    /// fraction IS present (not nil), only the state WORD is missing —
+    /// `quotaBarTintSource` must still borrow the composite state here,
+    /// exactly as `effectiveQuotaState` always has.
+    func testAPresentFractionWithNoStateWordStillBorrowsTheComposite() {
+        let a = account(
+            quotaState: .near,
+            fiveHour: 0.5, fiveHourState: nil,
+            sevenDay: 0.5, sevenDayState: nil)
+        XCTAssertEqual(a.quotaBarTintSource(for: .fiveHour), .state(.near))
+        XCTAssertEqual(a.quotaBarTintSource(for: .sevenDay), .state(.near))
+    }
+}
+
 /// ``QuotaFormat`` carries the one honesty rule this whole task is about — a
 /// nil measurement must never print or draw as a real zero — and until now
 /// nothing exercised it directly; every existing test only asserted on the

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1176,6 +1176,22 @@ fn render_accounts_json(
                 "fiveHour": a.five_hour,
                 "sevenDay": a.seven_day,
                 "sevenDayOi": a.seven_day_oi,
+                // Per-window state, additive alongside the existing combined
+                // `quotaState` above (which stays the most-spent-of-both gating
+                // verdict and is UNCHANGED by this field's addition — nothing
+                // that reads `quota`/`quotaState` today observes a different
+                // value). `null` when that window has no reading yet — same
+                // "not measured" idiom as `serverSha`/`cacheHitRatio` elsewhere
+                // in this row, never a fabricated "ok". Lets TcrBar tint each of
+                // the two per-window quota bars independently instead of both
+                // by the shared gating state, so a 7d-red account with an empty
+                // 5h window doesn't paint its 5h bar red.
+                "fiveHourState": a.five_hour.map(|u| {
+                    quota_state_token(crate::stats::QuotaState::from_utilization(Some(u), threshold))
+                }),
+                "sevenDayState": a.seven_day.map(|u| {
+                    quota_state_token(crate::stats::QuotaState::from_utilization(Some(u), threshold))
+                }),
                 // `null` — NEVER `0` — on the OFFLINE path, same idiom as
                 // `streamErrorCount`/`cacheHitRatio` below and for the same
                 // reason: these four are pure serving counters that live in

--- a/src/manager/snapshot.rs
+++ b/src/manager/snapshot.rs
@@ -130,11 +130,7 @@ impl Manager {
                     .into_iter()
                     .flatten()
                     .reduce(f64::max);
-                let quota_state = match gating {
-                    Some(u) if u >= 1.0 => crate::stats::QuotaState::Exhausted,
-                    Some(u) if u >= threshold => crate::stats::QuotaState::NearLimit,
-                    _ => crate::stats::QuotaState::Normal,
-                };
+                let quota_state = crate::stats::QuotaState::from_utilization(gating, threshold);
                 // Why this account is out and when it clears — the GENERAL
                 // (non-Fable) view: `is_fable = false`, so the model-scoped weekly
                 // never gates a general fleet row (an account spent only on its

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -39,6 +39,25 @@ pub enum QuotaState {
     Exhausted,
 }
 
+impl QuotaState {
+    /// The one place the `>=1.0 => Exhausted`, `>=threshold => NearLimit`, else
+    /// `Normal` rule lives. Takes an already-`Option`-flattened utilization —
+    /// `None` (window has no reading yet) maps to `Normal`, matching the
+    /// pre-existing gating computation in
+    /// [`crate::manager::Manager::snapshot`], which folds a `None` window out of
+    /// the `reduce(f64::max)` before ever reaching this match. Shared by the
+    /// combined gating state (`snapshot.rs`) and the per-window state now
+    /// surfaced in the accounts JSON (`cli.rs`), so the threshold logic exists
+    /// exactly once.
+    pub fn from_utilization(util: Option<f64>, threshold: f64) -> Self {
+        match util {
+            Some(u) if u >= 1.0 => QuotaState::Exhausted,
+            Some(u) if u >= threshold => QuotaState::NearLimit,
+            _ => QuotaState::Normal,
+        }
+    }
+}
+
 /// Why an account is currently out of rotation, mirroring the hard gates
 /// [`crate::manager::Manager::eligible`] applies — the single source of truth is
 /// [`crate::manager::Manager::account_gate`], which computes this alongside a

--- a/tests/fixtures/status-contract.json
+++ b/tests/fixtures/status-contract.json
@@ -5,6 +5,7 @@
     "control": false,
     "disabled": false,
     "fiveHour": 0.04,
+    "fiveHourState": "ok",
     "freeAtMs": null,
     "gate": "ok",
     "held": [],
@@ -26,6 +27,7 @@
     "serverSha": "abc1234",
     "sevenDay": 0.01,
     "sevenDayOi": 0.0,
+    "sevenDayState": "ok",
     "source": "live",
     "status": "active",
     "streamErrorCount": 2
@@ -36,6 +38,7 @@
     "control": false,
     "disabled": false,
     "fiveHour": 0.95,
+    "fiveHourState": "near",
     "freeAtMs": null,
     "gate": "ok",
     "held": [
@@ -68,6 +71,7 @@
     "serverSha": "abc1234",
     "sevenDay": 0.91,
     "sevenDayOi": 0.1,
+    "sevenDayState": "near",
     "source": "live",
     "status": "active",
     "streamErrorCount": 2
@@ -78,6 +82,7 @@
     "control": false,
     "disabled": false,
     "fiveHour": 1.0,
+    "fiveHourState": "spent",
     "freeAtMs": 1767312000000,
     "gate": "ok",
     "held": [
@@ -110,6 +115,7 @@
     "serverSha": "abc1234",
     "sevenDay": 1.0,
     "sevenDayOi": 0.5,
+    "sevenDayState": "spent",
     "source": "live",
     "status": "throttled",
     "streamErrorCount": 2
@@ -120,6 +126,7 @@
     "control": false,
     "disabled": true,
     "fiveHour": null,
+    "fiveHourState": null,
     "freeAtMs": null,
     "gate": "ok",
     "held": [],
@@ -141,6 +148,7 @@
     "serverSha": "abc1234",
     "sevenDay": null,
     "sevenDayOi": null,
+    "sevenDayState": null,
     "source": "live",
     "status": "active",
     "streamErrorCount": 0


### PR DESCRIPTION
## Summary
- Each account row now draws a 5-hour quota bar on top and a 7-day bar directly under it, each tinted by its OWN window's state — a 7d-red account with an empty 5h window no longer paints its 5h bar red.
- Rust: new `QuotaState::from_utilization` factors the threshold rule into one place, shared by the combined gating computation and the new `fiveHourState`/`sevenDayState` fields added to the `tcr status --json` row (additive; `quota`/`quotaState` unchanged).
- Swift: the two new fields decode absent-safe (`nil` on an older `tcr`) and fall back to the shared `quotaState` tint. The redundant "· 5h X% · 7d Y%" text run is gone; each per-window percentage now sits under its own bar. The composite `quota` percentage was also dropped from the row's display since both windows are now drawn and numbered individually.

## Test plan
- [x] `cargo test` — green (pre-existing untracked `tests/hop_overhead.rs`, not part of this change, excluded)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `swift test --package-path apps/macos` — 214/214 passing
- [x] `xcrun swift-format lint --strict` on touched files — clean
- [x] Regenerated `tests/fixtures/status-contract.json` (`TCR_UPDATE_FIXTURES=1`) and re-ran the Swift decode suite per the fixture test's own instructions
- [x] Re-rendered golden scenes (`--render-states`) and eyeballed `01-healthy` (two colored bars), `04b-needs-relogin-row` (never-probed row: both bars dashed) and `04c-probed-then-broken-row` (stale reading: both bars muted grey together)
- [x] Watched a new failure: forced `fiveHourState` to always report `Normal` and confirmed `cli::tests::status_contract_fixture_matches_committed` failed on the mismatched fixture, then restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)