### PR TITLE
Route a session to labelled accounts: tcr run --group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaude-rs"
-version = "0.2.19"
+version = "0.2.20"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2006,6 +2006,7 @@ mod tests {
             priority: None,
             switch_threshold: None,
             disabled: None,
+            groups: None,
             extra: serde_json::Map::new(),
         }
     }
@@ -2095,6 +2096,7 @@ mod tests {
             priority: None,
             switch_threshold: None,
             disabled: None,
+            groups: None,
             extra: serde_json::Map::new(),
         };
         let applied = post_add_account(&config, &account)
@@ -2145,6 +2147,7 @@ mod tests {
             priority: None,
             switch_threshold: None,
             disabled: None,
+            groups: None,
             extra: serde_json::Map::new(),
         };
         let err = post_add_account(&config, &account)

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,9 +119,26 @@ pub struct Account {
     pub switch_threshold: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub disabled: Option<bool>,
+    /// Labels used to prefer-route a session (`tcr run --group <name>`) to this
+    /// account. Absent or empty means the account belongs to no group. Backward
+    /// compatible in both directions: `Account` has no `deny_unknown_fields` and
+    /// a flattened `extra` map, so a config already carrying `groups` round-trips
+    /// today even before this field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub groups: Option<Vec<String>>,
     /// Any per-account keys we do not model (e.g. `models`, `upstream`, `sx`).
     #[serde(flatten)]
     pub extra: Map<String, Value>,
+}
+
+impl Account {
+    /// Whether this account belongs to `group`. An account with no `groups` key
+    /// belongs to none — it is reachable only by ungrouped routing.
+    pub fn in_group(&self, group: &str) -> bool {
+        self.groups
+            .as_deref()
+            .is_some_and(|groups| groups.iter().any(|g| g == group))
+    }
 }
 
 /// Per-account request pacing (opt-in; default OFF).
@@ -1455,6 +1472,47 @@ mod tests {
             serde_json::json!(["claude-fable-5"])
         );
 
+        fs::remove_file(&tmp).ok();
+    }
+
+    /// An account config carrying `groups` survives a load→save round-trip
+    /// unchanged, and — via [`SAMPLE`], whose one account has no `groups` key —
+    /// an account without the key still loads (defaulting to `None`/no groups).
+    #[test]
+    fn groups_round_trip_and_are_optional() {
+        // No `groups` key at all: loads fine, defaults to no groups.
+        let config: Config = serde_json::from_str(SAMPLE).unwrap();
+        assert_eq!(config.accounts[0].groups, None);
+        assert!(!config.accounts[0].in_group("codereview"));
+
+        // A `groups` key present: round-trips byte-for-byte through save→reload.
+        let with_groups = r#"{
+          "accounts": [
+            {
+              "name": "acct-grouped",
+              "type": "oauth",
+              "accessToken": "at-grouped",
+              "priority": 0,
+              "groups": ["codereview", "burst"]
+            }
+          ]
+        }"#;
+        let config: Config = serde_json::from_str(with_groups).unwrap();
+        assert_eq!(
+            config.accounts[0].groups,
+            Some(vec!["codereview".to_string(), "burst".to_string()])
+        );
+        assert!(config.accounts[0].in_group("codereview"));
+        assert!(
+            !config.accounts[0].in_group("CodeReview"),
+            "matching is case-sensitive"
+        );
+        assert!(!config.accounts[0].in_group("nope"));
+
+        let tmp = std::env::temp_dir().join(format!("tcr-cfg-groups-{}.json", std::process::id()));
+        save(&tmp, &config).unwrap();
+        let reloaded: Config = serde_json::from_str(&fs::read_to_string(&tmp).unwrap()).unwrap();
+        assert_eq!(reloaded.accounts[0].groups, config.accounts[0].groups);
         fs::remove_file(&tmp).ok();
     }
 
@@ -2808,6 +2866,7 @@ mod tests {
             priority: Some(2),
             switch_threshold: None,
             disabled: None,
+            groups: None,
             extra: serde_json::Map::new(),
         }
     }

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -48,6 +48,7 @@ fn base(name: &str, priority: i64) -> AccountRuntime {
         org_name: Some("Demo Org".to_string()),
         priority,
         disabled: false,
+        groups: Vec::new(),
         switch_threshold: None,
         access_token: "demo-access-token".to_string(),
         refresh_token: Some("demo-refresh-token".to_string()),

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -247,6 +247,7 @@ pub fn probe(
         priority: None,
         switch_threshold: None,
         disabled: None,
+        groups: None,
         extra: serde_json::Map::new(),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use clap::{Parser, Subcommand};
 
 use teamclaude_rs::cli::{self, PriorityArg};
 use teamclaude_rs::config::{self, Config, ConfigError};
+use teamclaude_rs::proxy::GROUP_HEADER_NAME;
 use teamclaude_rs::{affinity, build_info, demo, mitm, oauth, server, singleton, tui, update};
 
 #[derive(Parser)]
@@ -206,6 +207,12 @@ struct RunArgs {
     /// Path to the config file (default: ~/.config/teamclaude.json).
     #[arg(long)]
     config: Option<PathBuf>,
+    /// Route this session to accounts labelled with this group. PREFER
+    /// semantics only (Phase 1): serves from the group when it has capacity,
+    /// falls back to the whole pool otherwise. The restricting form
+    /// (routing ONLY within the group, never falling back) is Phase 2.
+    #[arg(long)]
+    group: Option<String>,
     /// Args passed verbatim to `claude` (e.g. `tcr run -- -p "hi"`).
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     args: Vec<String>,
@@ -376,9 +383,51 @@ fn run_claude(args: RunArgs) -> anyhow::Result<()> {
     let (config, _) = load_config(&config_path);
     let port = config.proxy.port;
 
+    // `--group`: validate the name and the claude version BEFORE spawning
+    // anything, in this order — a. name, b. version — so a typo or too-old
+    // `claude` never launches a session silently ungrouped.
+    if let Some(group) = args.group.as_deref() {
+        validate_group(&config, group)?;
+        match check_claude_version() {
+            ClaudeVersionCheck::TooOld(found) => {
+                anyhow::bail!(
+                    "claude {found} is older than {MIN_CLAUDE_VERSION_FOR_GROUP_STR}, the minimum \
+                     that forwards ANTHROPIC_CUSTOM_HEADERS as a real request header — `--group` \
+                     cannot work on this install. Upgrade claude and retry."
+                );
+            }
+            // Phase 1 is PREFER-only, so degrading to ordinary (ungrouped) routing on an
+            // unreadable/missing `claude` is safe — warn and continue rather than refuse.
+            // Phase 2's `--only` must refuse here instead: there the operator believes
+            // they are CONTAINED to the group, and silently routing everywhere is the
+            // wrong kind of wrong for that contract.
+            ClaudeVersionCheck::Unknown => {
+                eprintln!(
+                    "[tcr] --group {group}: could not determine the installed claude version \
+                     (need >= {MIN_CLAUDE_VERSION_FOR_GROUP_STR} for ANTHROPIC_CUSTOM_HEADERS) — \
+                     proceeding, but if it is too old this session will silently route to the \
+                     whole pool instead of the group"
+                );
+            }
+            ClaudeVersionCheck::Ok => {}
+        }
+    }
+
     let mut cmd = std::process::Command::new("claude");
     cmd.args(&args.args);
     mark_run_active(&mut cmd);
+
+    // c/d. Compose and set the group header — merging with, never clobbering,
+    // whatever `ANTHROPIC_CUSTOM_HEADERS` this process already inherited (a
+    // user's own headers, or an outer `tcr run`'s — see [`RUN_ACTIVE_ENV`]).
+    // Set unconditionally of see-through vs base-URL mode below: both apply
+    // env to the same `cmd`, and this line runs before either.
+    if let Some(group) = args.group.as_deref() {
+        let inherited = std::env::var("ANTHROPIC_CUSTOM_HEADERS").ok();
+        let composed = compose_group_header(inherited.as_deref(), group);
+        cmd.env("ANTHROPIC_CUSTOM_HEADERS", &composed);
+        eprintln!("[tcr] --group {group}: routing this session via {GROUP_HEADER_NAME}");
+    }
 
     if cli::proxy_is_up(port) {
         if let Some(notice) = withheld_api_key_notice(
@@ -403,6 +452,127 @@ fn run_claude(args: RunArgs) -> anyhow::Result<()> {
         .status()
         .context("failed to launch `claude` — is it on PATH?")?;
     std::process::exit(status.code().unwrap_or(1));
+}
+
+/// The oldest Claude Code that forwards `ANTHROPIC_CUSTOM_HEADERS` as a real
+/// outbound header on every `/v1/messages` request — verified against
+/// Anthropic's gateway-protocol documentation. Older than this, `--group`
+/// would set an env var claude silently never sends.
+const MIN_CLAUDE_VERSION_FOR_GROUP: (u64, u64, u64) = (2, 1, 227);
+const MIN_CLAUDE_VERSION_FOR_GROUP_STR: &str = "2.1.227";
+
+/// `--group`'s validation half (step a): the requested name must be a label
+/// SOME configured account actually carries. A typo must never resolve to an
+/// empty set — with Phase 1's prefer-only semantics that would silently route
+/// every session across the whole pool with no error at all, which is the
+/// quiet-wrong-answer this refusal exists to prevent.
+fn validate_group(config: &Config, group: &str) -> anyhow::Result<()> {
+    let mut configured: Vec<&str> = config
+        .accounts
+        .iter()
+        .filter_map(|a| a.groups.as_ref())
+        .flatten()
+        .map(String::as_str)
+        .collect();
+    configured.sort_unstable();
+    configured.dedup();
+
+    if configured.contains(&group) {
+        return Ok(());
+    }
+    if configured.is_empty() {
+        anyhow::bail!(
+            "--group {group}: no account in the config carries a `groups` label — nothing to route to"
+        );
+    }
+    anyhow::bail!(
+        "--group {group}: not a configured group. Configured groups: {}",
+        configured.join(", ")
+    );
+}
+
+/// Three-state result of checking the installed `claude` against
+/// [`MIN_CLAUDE_VERSION_FOR_GROUP`] — kept distinct from a plain bool even
+/// though Phase 1 collapses `TooOld` and `Unknown` to different outcomes,
+/// because Phase 2's `--only` must refuse on BOTH: there, degrading silently
+/// on an unreadable version would tell the operator they were contained to
+/// the group while the session actually ran across the whole fleet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ClaudeVersionCheck {
+    Ok,
+    /// The parsed version, for the error message.
+    TooOld(String),
+    /// `claude --version` failed to run, exited non-zero, or its output did
+    /// not parse as `MAJOR.MINOR.PATCH …`.
+    Unknown,
+}
+
+fn check_claude_version() -> ClaudeVersionCheck {
+    let output = match std::process::Command::new("claude")
+        .arg("--version")
+        .output()
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return ClaudeVersionCheck::Unknown,
+    };
+    classify_claude_version_output(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// [`check_claude_version`]'s classification half, split out so it is testable
+/// without spawning a `claude` process: feed it `claude --version`'s stdout
+/// directly.
+fn classify_claude_version_output(stdout: &str) -> ClaudeVersionCheck {
+    match parse_claude_version(stdout) {
+        Some(found) if found >= MIN_CLAUDE_VERSION_FOR_GROUP => ClaudeVersionCheck::Ok,
+        Some((maj, min, patch)) => ClaudeVersionCheck::TooOld(format!("{maj}.{min}.{patch}")),
+        None => ClaudeVersionCheck::Unknown,
+    }
+}
+
+/// Parse the leading `MAJOR.MINOR.PATCH` off `claude --version`'s output
+/// (observed shape: `"2.1.237 (Claude Code)"`, first token before whitespace).
+/// `None` on anything else — garbage, a `v`-prefixed or two-component
+/// version, empty output — which is exactly what routes [`check_claude_version`]
+/// to `Unknown` rather than a wrong guess.
+fn parse_claude_version(output: &str) -> Option<(u64, u64, u64)> {
+    let first_token = output.split_whitespace().next()?;
+    let mut parts = first_token.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    Some((major, minor, patch))
+}
+
+/// `--group`'s header-composition half (steps c/d): the new value for
+/// `ANTHROPIC_CUSTOM_HEADERS`, merging with whatever this process already
+/// inherited rather than clobbering it — a user may have set their own
+/// headers, and silently dropping them is a bug.
+///
+///  - No inherited value (or an empty one) → just `x-tcr-group: <name>`.
+///  - Inherited value present → append ours on a new line.
+///  - Inherited value already carries an `x-tcr-group` line (matched
+///    case-insensitively on the header NAME) → that line is replaced, not
+///    duplicated. Not hypothetical: `tcr run` nests (see `mark_run_active` /
+///    [`RUN_ACTIVE_ENV`]), and two conflicting group headers on one request
+///    is a worse failure than either value alone.
+///  - Every OTHER inherited line's text and order is preserved exactly.
+///
+/// Pure — takes the inherited value and the group name, returns the new
+/// value — so all of the above is testable without spawning a process.
+fn compose_group_header(inherited: Option<&str>, group: &str) -> String {
+    let ours = format!("{GROUP_HEADER_NAME}: {group}");
+    let Some(inherited) = inherited.filter(|s| !s.is_empty()) else {
+        return ours;
+    };
+    let mut lines: Vec<&str> = inherited
+        .lines()
+        .filter(|line| {
+            let name = line.split(':').next().unwrap_or(line).trim();
+            !name.eq_ignore_ascii_case(GROUP_HEADER_NAME)
+        })
+        .collect();
+    lines.push(&ours);
+    lines.join("\n")
 }
 
 /// The marker `tcr run` leaves on its child: **a `tcr run` is already above you
@@ -1679,5 +1849,168 @@ mod tests {
                 "pre-existing file {date} must survive pruning: {remaining:?}"
             );
         }
+    }
+
+    // ---- `--group` header composition (`compose_group_header`) ----------------
+
+    #[test]
+    fn group_header_with_no_inherited_value_is_just_ours() {
+        assert_eq!(
+            compose_group_header(None, "codereview"),
+            "x-tcr-group: codereview"
+        );
+        // Empty is treated the same as absent.
+        assert_eq!(
+            compose_group_header(Some(""), "codereview"),
+            "x-tcr-group: codereview"
+        );
+    }
+
+    #[test]
+    fn group_header_appends_to_unrelated_inherited_headers() {
+        let composed = compose_group_header(Some("X-Custom: yes"), "codereview");
+        assert_eq!(composed, "X-Custom: yes\nx-tcr-group: codereview");
+    }
+
+    #[test]
+    fn group_header_replaces_rather_than_duplicates_an_existing_group_line() {
+        let composed = compose_group_header(
+            Some("X-Custom: yes\nx-tcr-group: stale\nX-Other: also-kept"),
+            "codereview",
+        );
+        assert_eq!(
+            composed, "X-Custom: yes\nX-Other: also-kept\nx-tcr-group: codereview",
+            "the stale line is replaced in place at the END, never duplicated, \
+             and every unrelated line's text and order survive"
+        );
+        assert_eq!(
+            composed.matches("x-tcr-group").count(),
+            1,
+            "must never carry two group headers"
+        );
+    }
+
+    #[test]
+    fn group_header_replacement_matches_the_name_case_insensitively() {
+        let composed = compose_group_header(Some("X-TCR-Group: stale"), "codereview");
+        assert_eq!(composed, "x-tcr-group: codereview");
+    }
+
+    // ---- `--group` claude version gate (`classify_claude_version_output`) -----
+
+    #[test]
+    fn claude_version_parses_the_real_output_shape() {
+        assert_eq!(
+            parse_claude_version("2.1.237 (Claude Code)"),
+            Some((2, 1, 237))
+        );
+        assert_eq!(parse_claude_version("2.1.237"), Some((2, 1, 237)));
+    }
+
+    #[test]
+    fn claude_version_parse_fails_closed_on_garbage() {
+        for garbage in ["", "not a version", "v2.1.237", "2.1", "2.1.abc"] {
+            assert_eq!(
+                parse_claude_version(garbage),
+                None,
+                "{garbage:?} must not parse as a version"
+            );
+        }
+    }
+
+    #[test]
+    fn claude_version_too_old_refuses() {
+        assert_eq!(
+            classify_claude_version_output("2.1.226 (Claude Code)"),
+            ClaudeVersionCheck::TooOld("2.1.226".to_string())
+        );
+        assert_eq!(
+            classify_claude_version_output("1.9.999 (Claude Code)"),
+            ClaudeVersionCheck::TooOld("1.9.999".to_string())
+        );
+    }
+
+    #[test]
+    fn claude_version_at_or_above_minimum_is_ok() {
+        assert_eq!(
+            classify_claude_version_output("2.1.227 (Claude Code)"),
+            ClaudeVersionCheck::Ok
+        );
+        assert_eq!(
+            classify_claude_version_output("2.1.237 (Claude Code)"),
+            ClaudeVersionCheck::Ok
+        );
+        assert_eq!(
+            classify_claude_version_output("3.0.0 (Claude Code)"),
+            ClaudeVersionCheck::Ok
+        );
+    }
+
+    #[test]
+    fn claude_version_unparseable_output_warns_and_proceeds() {
+        assert_eq!(
+            classify_claude_version_output("garbage"),
+            ClaudeVersionCheck::Unknown
+        );
+        assert_eq!(
+            classify_claude_version_output(""),
+            ClaudeVersionCheck::Unknown
+        );
+    }
+
+    // ---- `--group` name validation (`validate_group`) --------------------------
+
+    fn account_with_groups(name: &str, groups: Option<&[&str]>) -> config::Account {
+        config::Account {
+            name: name.to_string(),
+            account_type: "oauth".to_string(),
+            account_uuid: None,
+            org_uuid: None,
+            org_name: None,
+            access_token: format!("at-{name}"),
+            refresh_token: None,
+            expires_at: None,
+            priority: None,
+            switch_threshold: None,
+            disabled: None,
+            groups: groups.map(|gs| gs.iter().map(|g| g.to_string()).collect()),
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    #[test]
+    fn validate_group_accepts_a_configured_group() {
+        let mut config = default_config();
+        config.accounts = vec![
+            account_with_groups("alice", Some(&["codereview"])),
+            account_with_groups("bob", None),
+        ];
+        assert!(validate_group(&config, "codereview").is_ok());
+    }
+
+    #[test]
+    fn validate_group_rejects_an_unknown_name_and_lists_the_configured_groups() {
+        let mut config = default_config();
+        config.accounts = vec![
+            account_with_groups("alice", Some(&["codereview", "burst"])),
+            account_with_groups("bob", Some(&["burst"])),
+        ];
+        let err = validate_group(&config, "typo-group")
+            .expect_err("an unconfigured group name must be refused");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("burst") && msg.contains("codereview"),
+            "the error must name every configured group so the operator can fix the typo: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_group_rejects_when_no_account_has_any_group() {
+        let mut config = default_config();
+        config.accounts = vec![account_with_groups("alice", None)];
+        assert!(
+            validate_group(&config, "codereview").is_err(),
+            "a typo must never silently resolve to the empty set — that routes everywhere"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,10 +207,12 @@ struct RunArgs {
     /// Path to the config file (default: ~/.config/teamclaude.json).
     #[arg(long)]
     config: Option<PathBuf>,
-    /// Route this session to accounts labelled with this group. PREFER
-    /// semantics only (Phase 1): serves from the group when it has capacity,
-    /// falls back to the whole pool otherwise. The restricting form
-    /// (routing ONLY within the group, never falling back) is Phase 2.
+    /// Prefer accounts labelled with this group when picking an account for a
+    /// NEW request — falls back to the whole pool when the group has no
+    /// capacity, and once a session settles onto an account (a "pin"), that
+    /// pin is honoured group-blind for the rest of the session (correct for
+    /// this PREFER semantics; the restricting form that also constrains an
+    /// existing pin is Phase 2).
     #[arg(long)]
     group: Option<String>,
     /// Args passed verbatim to `claude` (e.g. `tcr run -- -p "hi"`).
@@ -461,12 +463,53 @@ fn run_claude(args: RunArgs) -> anyhow::Result<()> {
 const MIN_CLAUDE_VERSION_FOR_GROUP: (u64, u64, u64) = (2, 1, 227);
 const MIN_CLAUDE_VERSION_FOR_GROUP_STR: &str = "2.1.227";
 
+/// Reject a group label whose CONTENT could corrupt `compose_group_header`'s
+/// output — a literal newline (legal in JSON via `\n`), any other control
+/// character, or a codepoint above U+00FF — and reject empty/whitespace-only.
+///
+/// Defense in depth, NOT a fix for a live vulnerability: Claude Code's own
+/// header-value parser already hard-errors (naming the offending pair by
+/// position) on a header value containing a line break, NUL, or a codepoint
+/// above U+00FF, so a bad label fails closed downstream today regardless of
+/// this check. This exists so our OWN header composition never depends on a
+/// downstream process's validation to protect its own output — `format!` has
+/// no opinion about what goes into a header value, and `compose_group_header`
+/// must not be the thing that first notices.
+///
+/// Returns the failing character class in `Err` (never the raw character —
+/// most of what this rejects is unprintable) so both call sites in
+/// [`validate_group`] can say exactly what was wrong.
+fn validate_group_label_chars(label: &str) -> Result<(), &'static str> {
+    if label.trim().is_empty() {
+        return Err("empty or whitespace-only");
+    }
+    for c in label.chars() {
+        if c == '\n' || c == '\r' {
+            return Err("contains a newline");
+        }
+        if c.is_control() {
+            return Err("contains a control character");
+        }
+        if (c as u32) > 0xFF {
+            return Err("contains a codepoint above U+00FF");
+        }
+    }
+    Ok(())
+}
+
 /// `--group`'s validation half (step a): the requested name must be a label
-/// SOME configured account actually carries. A typo must never resolve to an
-/// empty set — with Phase 1's prefer-only semantics that would silently route
-/// every session across the whole pool with no error at all, which is the
-/// quiet-wrong-answer this refusal exists to prevent.
+/// SOME configured account actually carries, and every label involved —
+/// the requested one AND every configured one, since either could end up in
+/// `compose_group_header`'s output — must pass [`validate_group_label_chars`].
+/// A typo must never resolve to an empty set — with Phase 1's prefer-only
+/// semantics that would silently route every session across the whole pool
+/// with no error at all, which is the quiet-wrong-answer this refusal exists
+/// to prevent.
 fn validate_group(config: &Config, group: &str) -> anyhow::Result<()> {
+    if let Err(reason) = validate_group_label_chars(group) {
+        anyhow::bail!("--group {group:?}: invalid group label — {reason}");
+    }
+
     let mut configured: Vec<&str> = config
         .accounts
         .iter()
@@ -474,6 +517,11 @@ fn validate_group(config: &Config, group: &str) -> anyhow::Result<()> {
         .flatten()
         .map(String::as_str)
         .collect();
+    for label in &configured {
+        if let Err(reason) = validate_group_label_chars(label) {
+            anyhow::bail!("config carries an invalid group label {label:?}: {reason}");
+        }
+    }
     configured.sort_unstable();
     configured.dedup();
 
@@ -1930,6 +1978,23 @@ mod tests {
         );
     }
 
+    /// The comparison must be NUMERIC per-component, not lexicographic on the
+    /// version string. `"2.1.9"` sorts AFTER `"2.1.227"` as a plain string
+    /// (`'9' > '2'`), which would wrongly classify it `Ok` against the
+    /// 2.1.227 minimum; numerically `9 < 227`, so it must be `TooOld`. Every
+    /// other version-gate test here (`2.1.226`/`1.9.999` vs `2.1.227`) would
+    /// pass under EITHER comparison and so does not guard this property —
+    /// this is the one case where the two implementations disagree.
+    #[test]
+    fn claude_version_compares_patch_numerically_not_lexicographically() {
+        assert_eq!(
+            classify_claude_version_output("2.1.9 (Claude Code)"),
+            ClaudeVersionCheck::TooOld("2.1.9".to_string()),
+            "2.1.9 must be TooOld against a 2.1.227 minimum — a lexicographic \
+             compare would wrongly say Ok because '9' > '2' as characters"
+        );
+    }
+
     #[test]
     fn claude_version_at_or_above_minimum_is_ok() {
         assert_eq!(
@@ -2011,6 +2076,82 @@ mod tests {
         assert!(
             validate_group(&config, "codereview").is_err(),
             "a typo must never silently resolve to the empty set — that routes everywhere"
+        );
+    }
+
+    // ---- `--group` label character validation (`validate_group_label_chars`) --
+
+    #[test]
+    fn group_label_chars_accepts_an_ordinary_ascii_label() {
+        assert_eq!(validate_group_label_chars("codereview"), Ok(()));
+        assert_eq!(validate_group_label_chars("code-review_2"), Ok(()));
+    }
+
+    #[test]
+    fn group_label_chars_rejects_empty_and_whitespace_only() {
+        assert_eq!(
+            validate_group_label_chars(""),
+            Err("empty or whitespace-only")
+        );
+        assert_eq!(
+            validate_group_label_chars("   "),
+            Err("empty or whitespace-only")
+        );
+    }
+
+    #[test]
+    fn group_label_chars_rejects_a_newline() {
+        assert_eq!(
+            validate_group_label_chars("code\nreview"),
+            Err("contains a newline")
+        );
+        assert_eq!(
+            validate_group_label_chars("code\rreview"),
+            Err("contains a newline")
+        );
+    }
+
+    #[test]
+    fn group_label_chars_rejects_other_control_characters() {
+        assert_eq!(
+            validate_group_label_chars("code\0review"),
+            Err("contains a control character")
+        );
+        assert_eq!(
+            validate_group_label_chars("code\treview"),
+            Err("contains a control character")
+        );
+    }
+
+    #[test]
+    fn group_label_chars_rejects_codepoints_above_u00ff() {
+        assert_eq!(
+            validate_group_label_chars("codereview\u{1F600}"), // an emoji
+            Err("contains a codepoint above U+00FF")
+        );
+    }
+
+    #[test]
+    fn validate_group_rejects_a_group_argument_with_an_embedded_newline() {
+        let mut config = default_config();
+        config.accounts = vec![account_with_groups("alice", Some(&["codereview"]))];
+        let err = validate_group(&config, "code\nreview")
+            .expect_err("a newline in the --group argument must be refused");
+        assert!(
+            err.to_string().contains("newline"),
+            "the error must name the character class at fault: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_group_rejects_a_config_declared_label_with_a_control_character() {
+        let mut config = default_config();
+        config.accounts = vec![account_with_groups("alice", Some(&["code\0review"]))];
+        let err = validate_group(&config, "codereview")
+            .expect_err("a control character in a CONFIG-declared label must also be refused");
+        assert!(
+            err.to_string().contains("control character"),
+            "the error must name the character class at fault: {err}"
         );
     }
 }

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -220,6 +220,10 @@ pub struct AccountRuntime {
     pub org_name: Option<String>,
     pub priority: i64,
     pub disabled: bool,
+    /// Mirrors [`config::Account::groups`], normalized to an owned `Vec` (empty
+    /// when the config carried no `groups` key) so [`Manager::eligible`] can test
+    /// membership without an `Option` at every call site.
+    pub groups: Vec<String>,
     pub switch_threshold: Option<f64>,
     pub access_token: String,
     pub refresh_token: Option<String>,
@@ -535,6 +539,7 @@ impl AccountRuntime {
             org_name: account.org_name.clone(),
             priority: account.priority.unwrap_or(0),
             disabled: account.disabled.unwrap_or(false),
+            groups: account.groups.clone().unwrap_or_default(),
             switch_threshold: account.switch_threshold,
             access_token: account.access_token.clone(),
             refresh_token: account.refresh_token.clone(),
@@ -2006,6 +2011,11 @@ impl Manager {
                             priority: Some(row.priority),
                             switch_threshold: row.switch_threshold,
                             disabled: row.disabled.then_some(true),
+                            // Same "carry the row's REAL routing state" rule as
+                            // priority/switch_threshold/disabled above: group labels
+                            // are configured routing state, not identity, so a
+                            // credential re-add/refresh must not silently clear them.
+                            groups: (!row.groups.is_empty()).then(|| row.groups.clone()),
                             extra: serde_json::Map::new(),
                         };
                         Resolution::Updated {
@@ -2349,7 +2359,17 @@ mod tests {
             priority: Some(priority),
             switch_threshold: None,
             disabled: None,
+            groups: None,
             extra: serde_json::Map::new(),
+        }
+    }
+
+    /// Like [`account`], carrying group labels — for the `--group` prefer-routing
+    /// tests.
+    fn account_in_groups(name: &str, priority: i64, groups: &[&str]) -> Account {
+        Account {
+            groups: Some(groups.iter().map(|g| g.to_string()).collect()),
+            ..account(name, priority)
         }
     }
 
@@ -2808,6 +2828,71 @@ mod tests {
             account.probe_status = ProbeStatus::Ok;
             account.quota_known = true;
         }
+    }
+
+    // ---- `--group` prefer-routing (Phase 1: PREFER, never `--only`) -----------
+
+    /// The whole feature: with exactly one account carrying the requested group,
+    /// an unpinned select with that group MUST land on it — even though the
+    /// OTHER account would win the ordinary (no-preference) LRU/priority pick.
+    /// Then, group-out the grouped account (via `disabled`, the simplest hard
+    /// gate) and confirm the SAME select call FALLS BACK to the ungrouped
+    /// account rather than returning `None` — the prefer-semantics that make
+    /// Phase 1 different from the restricting `--only` of Phase 2.
+    #[test]
+    fn group_preference_prefers_then_falls_back_to_the_pool() {
+        let grouped = account_in_groups("grouped", 5, &["codereview"]);
+        let plain = account("plain", 0); // lower priority number sorts FIRST ordinarily
+        let manager = build_manager(config_with(vec![grouped, plain]), lock_refresher());
+        let now = OffsetDateTime::now_utc();
+
+        // Sanity control: with NO group requested, priority ordering picks the
+        // UNGROUPED account (index 1) — proves the group assertion below is
+        // actually exercising the preference, not just priority order.
+        assert_eq!(
+            manager.select_with_group(&HashSet::new(), now, None, None, "/v1/messages", None, None),
+            Some(1),
+            "no group requested: ordinary priority order picks the ungrouped account"
+        );
+
+        // The whole feature: `--group codereview` prefers index 0 despite its
+        // worse priority.
+        assert_eq!(
+            manager.select_with_group(
+                &HashSet::new(),
+                now,
+                None,
+                None,
+                "/v1/messages",
+                None,
+                Some("codereview"),
+            ),
+            Some(0),
+            "a group with capacity must be preferred over a better-priority ungrouped account"
+        );
+
+        // Gate the grouped account out entirely (disabled = hard-ineligible).
+        {
+            let mut accounts = manager.accounts.write().expect("accounts lock poisoned");
+            accounts[0].disabled = true;
+        }
+
+        // The prefer-semantics that distinguish Phase 1 from Phase 2's `--only`:
+        // the group has no capacity, so the SAME request falls back to the whole
+        // pool rather than failing.
+        assert_eq!(
+            manager.select_with_group(
+                &HashSet::new(),
+                now,
+                None,
+                None,
+                "/v1/messages",
+                None,
+                Some("codereview"),
+            ),
+            Some(1),
+            "group exhausted: must fall back to the whole pool, not return None"
+        );
     }
 
     // ---- hard account lock (`lockAccount`; no failover) -----------------------
@@ -3596,7 +3681,8 @@ mod tests {
                 true,
                 now,
                 now_ms,
-                false
+                false,
+                None,
             ),
             "served 0ms ago (< 1000ms) → skipped"
         );
@@ -3610,7 +3696,8 @@ mod tests {
                 true,
                 later,
                 later_ms,
-                false
+                false,
+                None,
             ),
             "after the spacing window → eligible again"
         );
@@ -3745,7 +3832,8 @@ mod tests {
                 true,
                 now,
                 now_ms,
-                false
+                false,
+                None,
             ),
             "cap=0 → account stays eligible regardless of in_flight (no dark pool)"
         );

--- a/src/manager/pins.rs
+++ b/src/manager/pins.rs
@@ -144,6 +144,7 @@ mod tests {
             priority: Some(0),
             switch_threshold: None,
             disabled: None,
+            groups: None,
             extra: serde_json::Map::new(),
         }
     }

--- a/src/manager/select.rs
+++ b/src/manager/select.rs
@@ -803,11 +803,26 @@ impl Manager {
                     self.pick_least_loaded(&accounts, pool_tried, now, now_ms, is_fable, None)
                 {
                     if let Some(account) = accounts.get(idx) {
-                        tracing::info!(
-                            account = %account.name,
-                            in_flight = account.in_flight,
-                            "pacing: all accounts paced, serving least-loaded"
-                        );
+                        // This fallback fires whenever the first (group- and
+                        // pacing-respecting) pass came up empty — which can be pacing
+                        // alone, the group alone, or both together. Name whichever
+                        // constraints were actually IN PLAY on the first pass rather
+                        // than always blaming pacing: an operator debugging why
+                        // `--group` did not land where expected must not read a log
+                        // line about pacing when pacing was never the reason.
+                        match group {
+                            Some(g) => tracing::info!(
+                                account = %account.name,
+                                in_flight = account.in_flight,
+                                group = g,
+                                "group: requested group had no eligible account under pacing — falling back to the whole pool (group and pacing both ignored), serving least-loaded"
+                            ),
+                            None => tracing::info!(
+                                account = %account.name,
+                                in_flight = account.in_flight,
+                                "pacing: all accounts paced, serving least-loaded"
+                            ),
+                        }
                     }
                     best = Some(idx);
                 }

--- a/src/manager/select.rs
+++ b/src/manager/select.rs
@@ -226,6 +226,12 @@ impl Manager {
     /// ([`Self::conn_affinity`]); everything else prefers the control account
     /// via [`Self::control_eligible`] (which deliberately bypasses `disabled`).
     /// Inert whenever [`Self::control`] is `None`.
+    ///
+    /// Thin wrapper over [`Self::select_with_group`] with no group preference —
+    /// kept as the stable signature the test suite (and every caller that has no
+    /// `--group` to express) already calls by the hundred, so a per-request
+    /// preference this narrow does not force every one of them to grow a new
+    /// trailing `None`.
     pub fn select(
         &self,
         tried: &HashSet<usize>,
@@ -234,6 +240,29 @@ impl Manager {
         affinity: Option<u64>,
         path: &str,
         conn_key: Option<u64>,
+    ) -> Option<usize> {
+        self.select_with_group(tried, now, model, affinity, path, conn_key, None)
+    }
+
+    /// [`Self::select`], with an optional PREFER-semantics group (`tcr run
+    /// --group <name>`, Phase 1 — see `docs/plans/account-groups-bridge-phase1.md`).
+    /// `group` narrows only the pacing-respecting first pass of the normal pick
+    /// (mirroring how that pass already narrows on `respect_pacing`); the soft
+    /// fallback pass always passes `None`, so a group with no current capacity
+    /// degrades to the whole pool rather than a 429. Every OTHER eligibility check
+    /// in this function — honouring an existing pin, a connection's noise
+    /// affinity, a sticky divert destination — passes `None` unconditionally: an
+    /// already-warm session is never re-keyed by a per-request preference.
+    #[allow(clippy::too_many_arguments)]
+    pub fn select_with_group(
+        &self,
+        tried: &HashSet<usize>,
+        now: OffsetDateTime,
+        model: Option<&str>,
+        affinity: Option<u64>,
+        path: &str,
+        conn_key: Option<u64>,
+        group: Option<&str>,
     ) -> Option<usize> {
         // Hard account lock: pin ALL traffic to the configured account, bypassing
         // rotation/affinity/migration. `tried` still ends the rotation loop — once the
@@ -349,6 +378,7 @@ impl Manager {
                                 now,
                                 now_ms,
                                 is_fable,
+                                None, // no group preference — honouring an existing pin/connection/sticky destination
                             )
                         });
                         if !x_usable {
@@ -489,6 +519,7 @@ impl Manager {
                                         now,
                                         now_ms,
                                         is_fable,
+                                        None, // no group preference — honouring an existing pin/connection/sticky destination
                                     ) {
                                         continue;
                                     }
@@ -612,6 +643,7 @@ impl Manager {
                                             now,
                                             now_ms,
                                             is_fable,
+                                            None, // no group preference — honouring an existing pin/connection/sticky destination
                                         )
                                     })
                                 };
@@ -705,6 +737,7 @@ impl Manager {
                             now,
                             now_ms,
                             is_fable,
+                            None, // no group preference — honouring an existing pin/connection/sticky destination
                         )
                     });
                     usable.then_some(sticky)
@@ -752,19 +785,22 @@ impl Manager {
             let pool_tried: &HashSet<usize> = &pool_tried;
 
             // First pass: honour pacing (skip accounts at the concurrency cap or
-            // inside the min-spacing window). With pacing OFF this is byte-identical
+            // inside the min-spacing window) AND, when `--group` was requested,
+            // prefer that group. With pacing OFF and no group this is byte-identical
             // to the pre-pacing pick.
-            let mut best = self.pick_eligible(&accounts, pool_tried, now, now_ms, is_fable, true);
+            let mut best =
+                self.pick_eligible(&accounts, pool_tried, now, now_ms, is_fable, true, group);
 
-            // Soft fallback (CRITICAL — pacing must never DROP a servable request):
-            // if pacing gated EVERY account out but at least one is servable ignoring
-            // pacing, serve the least-loaded (lowest in_flight, then the normal LRU
-            // key). With pacing OFF the first pass and this pass use identical
-            // eligibility, so a None first pass ⟹ None here too — default-OFF stays
-            // byte-identical (no spurious fallback, no log).
+            // Soft fallback (CRITICAL — pacing must never DROP a servable request,
+            // and a group with no current capacity must never either): if the first
+            // pass found nothing, retry ignoring BOTH pacing and the group, serving
+            // the least-loaded (lowest in_flight, then the normal LRU key) account in
+            // the WHOLE pool. With pacing OFF and no group, the first pass and this
+            // pass use identical eligibility, so a None first pass ⟹ None here too —
+            // default-OFF stays byte-identical (no spurious fallback, no log).
             if best.is_none() {
                 if let Some(idx) =
-                    self.pick_least_loaded(&accounts, pool_tried, now, now_ms, is_fable)
+                    self.pick_least_loaded(&accounts, pool_tried, now, now_ms, is_fable, None)
                 {
                     if let Some(account) = accounts.get(idx) {
                         tracing::info!(
@@ -1398,6 +1434,7 @@ impl Manager {
         true
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn eligible(
         account: &AccountRuntime,
         global_threshold: f64,
@@ -1406,6 +1443,7 @@ impl Manager {
         now: OffsetDateTime,
         now_ms: i64,
         is_fable: bool,
+        group: Option<&str>,
     ) -> bool {
         if account.disabled || account.status == AccountStatus::Error {
             return false;
@@ -1429,6 +1467,19 @@ impl Manager {
         // decision reads [`Self::account_hard_ok`], which excludes this gate.
         if Self::model_blocked(account, global_threshold, now, is_fable) {
             return false;
+        }
+        // `--group` PREFER routing (Phase 1: no `--only`, so this never hard-blocks
+        // an account on its own — it only narrows the CALLER's chosen pass, since
+        // the fallback pass always calls this with `group: None`). A HARD-looking
+        // early return by design, positioned after the model-block gate and before
+        // the SOFT pacing gate below, matching this account's true selectivity: it
+        // filters exactly like a hard gate WITHIN one pass. `account_gate` /
+        // `account_hard_ok` are untouched — Phase 1 never reports a group as the
+        // reason an account is hard-blocked.
+        if let Some(g) = group {
+            if !account.groups.iter().any(|acct_group| acct_group == g) {
+                return false;
+            }
         }
         // SOFT pacing gate, evaluated LAST so it only ever narrows an already-healthy
         // account. When `respect_pacing` is false (the fallback pass) or pacing is
@@ -1594,6 +1645,7 @@ impl Manager {
         !account.quota.is_near(reserved, now)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn pick_eligible(
         &self,
         accounts: &[AccountRuntime],
@@ -1602,6 +1654,7 @@ impl Manager {
         now_ms: i64,
         is_fable: bool,
         respect_pacing: bool,
+        group: Option<&str>,
     ) -> Option<usize> {
         let mut best: Option<usize> = None;
         let mut best_key: Option<(i64, u64, i128)> = None;
@@ -1617,6 +1670,7 @@ impl Manager {
                 now,
                 now_ms,
                 is_fable,
+                group,
             ) {
                 // Distinguish a pacing skip (healthy but capped/spaced) from a real
                 // ineligibility (disabled/error/quota) so the log names only the former.
@@ -1630,6 +1684,7 @@ impl Manager {
                         now,
                         now_ms,
                         is_fable,
+                        group,
                     )
                 {
                     tracing::info!(
@@ -1670,6 +1725,7 @@ impl Manager {
         now: OffsetDateTime,
         now_ms: i64,
         is_fable: bool,
+        group: Option<&str>,
     ) -> Option<usize> {
         let mut best: Option<usize> = None;
         let mut best_key: Option<(u32, i64, u64, i128)> = None;
@@ -1685,6 +1741,7 @@ impl Manager {
                 now,
                 now_ms,
                 is_fable,
+                group,
             ) {
                 continue;
             }
@@ -1961,6 +2018,7 @@ mod revalidation_sticky_tests {
             priority: Some(0),
             switch_threshold: None,
             disabled: None,
+            groups: None,
             extra: serde_json::Map::new(),
         }
     }
@@ -2099,6 +2157,7 @@ mod sticky_divert_replay_tests {
             priority: Some(0),
             switch_threshold: None,
             disabled: None,
+            groups: None,
             extra: serde_json::Map::new(),
         }
     }

--- a/src/mitm.rs
+++ b/src/mitm.rs
@@ -1375,6 +1375,7 @@ mod tests {
                 priority: Some(0),
                 switch_threshold: None,
                 disabled: None,
+                groups: None,
                 extra: serde_json::Map::new(),
             }],
             extra: serde_json::Map::new(),

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -746,6 +746,7 @@ pub fn upsert_account(
                 priority: Some(next_priority),
                 switch_threshold: None,
                 disabled: None,
+                groups: None,
                 extra: serde_json::Map::new(),
             });
             Ok(())
@@ -924,6 +925,7 @@ async fn probe_add_capability(config: &Config) -> AddCapability {
         priority: None,
         switch_threshold: None,
         disabled: None,
+        groups: None,
         extra: serde_json::Map::new(),
     };
     match crate::cli::post_add_account(config, &probe).await {
@@ -1299,6 +1301,7 @@ fn persist_via_file(
         priority: None,
         switch_threshold: None,
         disabled: None,
+        groups: None,
         extra: serde_json::Map::new(),
     };
     match config::save_account(config_path, &account) {
@@ -1444,6 +1447,7 @@ async fn finish_login(
                 priority: None,
                 switch_threshold: None,
                 disabled: None,
+                groups: None,
                 extra: serde_json::Map::new(),
             };
             match crate::cli::post_add_account(config, &account).await {
@@ -3070,6 +3074,7 @@ mod tests {
             priority: None,
             switch_threshold: None,
             disabled: None,
+            groups: None,
             extra: serde_json::Map::new(),
         };
         let rotate_config = load_or_default(&path).unwrap();
@@ -3271,6 +3276,7 @@ mod tests {
             priority: None,
             switch_threshold: None,
             disabled: None,
+            groups: None,
             extra: serde_json::Map::new(),
         };
         config::save_account(&path, &rotated_alice).expect("the rotation must land on disk");
@@ -3368,6 +3374,7 @@ mod tests {
             priority: None,
             switch_threshold: None,
             disabled: None,
+            groups: None,
             extra: serde_json::Map::new(),
         };
         config::save_account(&path, &rotated_alice).expect("the rotation must land on disk");
@@ -3550,6 +3557,7 @@ mod tests {
             priority: None,
             switch_threshold: None,
             disabled: None,
+            groups: None,
             extra: serde_json::Map::new(),
         };
         config::save_account(&path, &rotated_alice).expect("the rotation must land on disk");

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -49,6 +49,13 @@ use crate::stats::{RequestLogEntry, SessionKind};
 /// no legitimate payload near this, but an unbounded read is a DoS surface. The
 /// non-stream *response* body is bounded by the same cap (see [`read_capped_body`]).
 const MAX_BODY_BYTES: usize = 256 * 1024 * 1024;
+/// Header `tcr run --group <name>` sets via `ANTHROPIC_CUSTOM_HEADERS` (see
+/// `src/main.rs`'s `compose_group_header`), which Claude Code forwards
+/// verbatim as a real outbound header on every `/v1/messages` request. `pub`
+/// so `main.rs` — a separate (binary) crate — shares this one definition
+/// rather than duplicating the header name as a second literal that could
+/// drift out of sync with what this file reads.
+pub const GROUP_HEADER_NAME: &str = "x-tcr-group";
 /// Depth of the SSE tee side-channel. A fast upstream feeding a slow parser task
 /// can retain at most this many chunks; beyond it, `try_send` drops chunks for
 /// the parser (usage counting becomes best-effort) rather than letting the buffer
@@ -1724,6 +1731,7 @@ async fn add_account_handler(State(manager): State<Arc<Manager>>, req: Request) 
         priority: parsed.priority,
         switch_threshold: parsed.switch_threshold,
         disabled: None,
+        groups: None,
         extra: serde_json::Map::new(),
     };
     // Captured before the move below: on an ambiguous match this is the ONLY
@@ -1931,6 +1939,16 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
         .as_deref()
         .is_some_and(crate::model::is_fable_model);
 
+    // `tcr run --group <name>` (Phase 1, PREFER semantics only). Read once,
+    // constant across the rotation loop — same shape as `request_model` above.
+    // An empty header value is treated as absent rather than an empty-string
+    // group, matching `compose_group_header`'s own "no inherited value" case.
+    let request_group = req_headers
+        .get(GROUP_HEADER_NAME)
+        .and_then(|v| v.to_str().ok())
+        .filter(|g| !g.is_empty())
+        .map(str::to_string);
+
     // The session key pins this connection to one account (opt-in). The extension
     // is present iff session affinity is enabled, so `session_key` is `None` (LRU
     // rotation) by default. When on, key on the most STABLE client identity —
@@ -2068,13 +2086,14 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
         let now = OffsetDateTime::now_utc();
         let idx = match next_idx.take() {
             Some(i) => i,
-            None => match manager.select(
+            None => match manager.select_with_group(
                 &tried,
                 now,
                 request_model.as_deref(),
                 session_key,
                 &path,
                 conn_key,
+                request_group.as_deref(),
             ) {
                 Some(idx) => idx,
                 None => {
@@ -2543,13 +2562,14 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
                 let mut with_this_one = tried.clone();
                 with_this_one.insert(idx);
                 let failover_now = OffsetDateTime::now_utc();
-                if let Some(other) = manager.select(
+                if let Some(other) = manager.select_with_group(
                     &with_this_one,
                     failover_now,
                     request_model.as_deref(),
                     session_key,
                     &path,
                     conn_key,
+                    request_group.as_deref(),
                 ) {
                     debug_assert_ne!(
                         other, idx,
@@ -3599,6 +3619,7 @@ mod tests {
                 priority: Some(0),
                 switch_threshold: None,
                 disabled: None,
+                groups: None,
                 extra: serde_json::Map::new(),
             }],
             extra: serde_json::Map::new(),
@@ -4837,6 +4858,7 @@ mod tests {
             priority: Some(priority),
             switch_threshold: None,
             disabled: None,
+            groups: None,
             extra: serde_json::Map::new(),
         };
         Config {
@@ -6621,6 +6643,7 @@ mod tests {
             priority: None,
             switch_threshold: None,
             disabled: None,
+            groups: None,
             extra: serde_json::Map::new(),
         };
         let resp = client

--- a/tests/throttle_exempt.rs
+++ b/tests/throttle_exempt.rs
@@ -104,6 +104,7 @@ fn account(i: usize) -> Account {
         priority: Some(i as i64),
         switch_threshold: None,
         disabled: None,
+        groups: None,
         extra: serde_json::Map::new(),
     }
 }

--- a/tests/workload_scenarios.rs
+++ b/tests/workload_scenarios.rs
@@ -113,6 +113,7 @@ fn account(name: &str, priority: i64) -> Account {
         priority: Some(priority),
         switch_threshold: None,
         disabled: None,
+        groups: None,
         extra: serde_json::Map::new(),
     }
 }


### PR DESCRIPTION
Label accounts, then route a session to them: `tcr run --group codereview`.

Phase 1 of the plan in `docs/plans/account-groups-plan.md`. **PREFER semantics only** — the restricting `--only` form is Phase 2 and is deliberately absent here.

## Why

Measured on a live fleet: 16 concurrent `tcr run` sessions against 14 accounts, several pinned at `5h=100%` and `7d=100%`. A batch swarm burns the shared pool while an interactive session queues behind it, and there is no way to say "these accounts are for that workload."

Two degenerate cases of this already ship, which is the argument that the abstraction belongs here rather than being imported: `lock_account` pins *all* routing to one named account — this feature with one account, globally; and `control_reserve` holds back a fraction of the control account — the reservation shape in miniature.

## How the label travels

`tcr run` sets environment variables and execs `claude`; it is never in the request path, so it cannot attach anything to a request directly. It instead sets Claude Code's `ANTHROPIC_CUSTOM_HEADERS`, which Claude Code forwards as a real header on every `/v1/messages` request, and the proxy reads `x-tcr-group` from there.

Merging is a correctness detail, not a nicety: an inherited `ANTHROPIC_CUSTOM_HEADERS` is preserved rather than clobbered, and an existing `x-tcr-group` line is *replaced* rather than duplicated — `tcr run` nests (see `TCR_RUN_ACTIVE`), and two conflicting group headers on one request is worse than either alone.

## Semantics

Prefer, never restrict. The first pick pass is narrowed to the group; the existing fallback pass runs the whole pool. A request is never dropped because a group is busy.

The group is consulted when choosing an account for a new request. An existing affinity pin, connection reuse, or sticky divert destination is honoured group-blind, matching the pre-existing invariant that a warm pin is never re-keyed by a per-request preference. The CLI help says so explicitly, because it would otherwise be a surprise.

## Guards

- Unknown group name is rejected at launch, listing the configured groups — a typo must not resolve to an empty set.
- Group labels are validated for character safety (no control characters, newlines, or codepoints above U+00FF) so a label can never produce a malformed header value. Defense-in-depth: Claude Code's own header parser already fails closed on these.
- `tcr run --group` refuses on Claude Code older than 2.1.227, which predates `ANTHROPIC_CUSTOM_HEADERS`. Without the header the server sees no group and routes normally — for Phase 2's `--only` that would mean running unrestricted while believing otherwise, so the three-state version classifier is in place now.

## Notes

- `select()` keeps its signature; `select_with_group()` is new and wired at the proxy's two real call sites. Changing `select()` would have touched ~140 in-crate test call sites for no benefit.
- `account_gate` / `account_hard_ok` are untouched. A group never hard-blocks in this phase, so there is no gate reason to report. Phase 2 adds `--only` and `GateReason::Group` and updates all three in lockstep.
- The group is deliberately **not** an input to `stable_session_key` — folding it in would cold-start every affected session's prompt cache whenever a group changed.
- A group-exhausted request falls through `pick_least_loaded` (in-flight-ordered) rather than `pick_eligible` (priority-ordered), so it is not identical to an ungrouped request in tie-break order. Intentional reuse of the existing fallback; documented rather than "fixed".
- Version bumped for the release-version gate.

## Verification

`cargo fmt --all --check`, `cargo clippy --all-targets --locked -- -D warnings`, `cargo test --all --locked`, `cargo build --release` — all exit 0; 738 lib tests plus five suites, zero failures.

Every new test was watched fail against deliberately broken production code and confirmed green on restore, including both directions of the prefer/fallback test (revert the group filter → the prefer assertion fails; make the fallback group-aware → the fallback assertion fails), and a version test that fails under a lexicographic comparison where the previous tests would not have.

Independent review raised the pin/sticky bypass and the tie-break difference above; both are intentional for PREFER and are recorded in the plan as requiring redesign — not extension — for Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114YEdZJWWvEgsTP4FvoNDL
