### PR TITLE
Show account groups on the status wire and in the TcrBar panel

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -124,6 +124,22 @@ struct FleetView: View {
             }
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(fleet.breakdownLabel)
+            if !fleet.groupBreakdown.isEmpty {
+                HStack(spacing: Tok.tightSpacing) {
+                    ForEach(Array(fleet.groupBreakdown.enumerated()), id: \.offset) { index, tally in
+                        if index > 0 {
+                            Text("·").font(Tok.secondaryFont).foregroundStyle(.tertiary)
+                        }
+                        Text(tally.label)
+                            .font(Tok.secondaryDigitFont)
+                            .foregroundStyle(
+                                Tok.color(for: tally.free == 0 ? FleetTally.Kind.spent : .ok)
+                            )
+                    }
+                }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(fleet.groupBreakdownLabel)
+            }
         }
         .padding(.top, Tok.tightSpacing)
     }
@@ -1169,6 +1185,19 @@ struct AccountRow: View {
                 } else {
                     StatusPill("unmeasured", tint: quotaTint)
                         .help("Never probed — this account's quota is unknown, not zero.")
+                }
+                // Group chips. At most two, with the rest collapsed to a `+N`
+                // chip — the panel is `Tok.panelWidth` (380pt) wide and an
+                // account can be in many groups. The existing `StatusPill`
+                // component, not a new one: these are the same shape of fact
+                // (a small labelled tag on the row) as the status pill beside
+                // them.
+                ForEach(Array((account.groups ?? []).prefix(2)), id: \.self) { group in
+                    StatusPill(group, tint: Tok.inkFaint)
+                }
+                if (account.groups ?? []).count > 2 {
+                    StatusPill("+\((account.groups ?? []).count - 2)", tint: Tok.inkFaint)
+                        .help((account.groups ?? []).joined(separator: ", "))
                 }
             }
             // Two stacked bars, 5-hour on top and 7-day directly under it —

--- a/apps/macos/Sources/TcrBarCore/FleetStatus.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetStatus.swift
@@ -528,6 +528,17 @@ public struct Account: Decodable, Equatable, Identifiable, Sendable {
     public let serverSha: String?
     public let serverDirty: Bool?
 
+    /// Group labels (`src/stats.rs`'s `AccountSnapshot::groups`, carried onto
+    /// the wire as `"groups"`, always an array — `[]` for an unlabelled
+    /// account, never `null`). Optional here, deliberately, unlike the wire's
+    /// own `[]`-never-`null` rule: synthesized `Decodable` would *throw* on
+    /// this whole row against an older `tcr` that predates the field and
+    /// omits the key outright, the same failure mode decision \#3 above
+    /// exists to prevent. `nil` means "this server did not report groups";
+    /// `[]` means "reported, and there are none" — both render as ungrouped,
+    /// but the type keeps the distinction rather than collapsing it.
+    public let groups: [String]?
+
     /// Explicit memberwise init, needed only because adding `fiveHourState`/
     /// `sevenDayState` after the struct already had test fixtures constructing
     /// it directly would otherwise force every one of them to grow two new
@@ -561,7 +572,8 @@ public struct Account: Decodable, Equatable, Identifiable, Sendable {
         streamErrorCount: Int?,
         source: StatusSource,
         serverSha: String?,
-        serverDirty: Bool?
+        serverDirty: Bool?,
+        groups: [String]? = nil
     ) {
         self.name = name
         self.priority = priority
@@ -589,6 +601,7 @@ public struct Account: Decodable, Equatable, Identifiable, Sendable {
         self.source = source
         self.serverSha = serverSha
         self.serverDirty = serverDirty
+        self.groups = groups
     }
 
     public var id: String { name }
@@ -1125,4 +1138,75 @@ public struct Fleet: Equatable, Sendable {
     public var breakdownLabel: String {
         breakdown.map(\.label).joined(separator: " · ")
     }
+
+    /// Per-group capacity: `[("codereview", free: 0, total: 3), ("dev", 4, 5),
+    /// ("ungrouped", 5, 6)]`. Membership is a SET, not a partition — an account
+    /// in several groups counts in each — mirroring ``breakdown``'s bucket
+    /// idiom rather than inventing a second one.
+    public var groupBreakdown: [GroupTally] {
+        // No account anywhere carries a label: a fleet that does not use
+        // groups renders nothing at all, not an all-`ungrouped` line.
+        guard accounts.contains(where: { !($0.groups ?? []).isEmpty }) else { return [] }
+
+        var totals: [String: Int] = [:]
+        var frees: [String: Int] = [:]
+        var ungroupedTotal = 0
+        var ungroupedFree = 0
+        for account in accounts {
+            let groups = account.groups ?? []
+            // `free` classifies with the same `FleetTally.Kind(account:)` this
+            // struct already uses for the top-line breakdown — a `.near`
+            // account still serves, so it counts as free exactly as it does
+            // there; only `.disabled` accounts are excluded from `free`
+            // (`total` counts them).
+            let isFree =
+                !account.disabled
+                && [.ok, .near].contains(FleetTally.Kind(account: account))
+            if groups.isEmpty {
+                ungroupedTotal += 1
+                if isFree { ungroupedFree += 1 }
+                continue
+            }
+            for group in groups {
+                totals[group, default: 0] += 1
+                if isFree { frees[group, default: 0] += 1 }
+            }
+        }
+
+        var result = totals.keys.sorted().map { name in
+            GroupTally(name: name, free: frees[name, default: 0], total: totals[name]!)
+        }
+        if ungroupedTotal > 0 {
+            result.append(GroupTally(name: "ungrouped", free: ungroupedFree, total: ungroupedTotal))
+        }
+        return result
+    }
+
+    /// `"codereview 0/3 · dev 4/5 · ungrouped 5/6"` — the same content as
+    /// ``groupBreakdown``, flattened for tests and for accessibility, matching
+    /// ``breakdownLabel``'s idiom.
+    public var groupBreakdownLabel: String {
+        groupBreakdown.map(\.label).joined(separator: " · ")
+    }
+}
+
+/// One bucket of the per-group capacity line. Unlike ``FleetTally``, whose
+/// buckets partition every account exactly once, a `GroupTally`'s accounts can
+/// (and do) overlap across buckets — group membership is a set.
+public struct GroupTally: Equatable, Sendable {
+    public let name: String
+    /// Accounts in this group that are enabled and not spent (`.ok` or
+    /// `.near` per `FleetTally.Kind`).
+    public let free: Int
+    /// Accounts carrying this label, INCLUDING disabled ones.
+    public let total: Int
+
+    public init(name: String, free: Int, total: Int) {
+        self.name = name
+        self.free = free
+        self.total = total
+    }
+
+    /// `"dev 4/5"`.
+    public var label: String { "\(name) \(free)/\(total)" }
 }

--- a/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
@@ -559,7 +559,8 @@ private func account(
     _ name: String,
     state: QuotaState,
     disabled: Bool = false,
-    held: [HeldWindow] = []
+    held: [HeldWindow] = [],
+    groups: [String]? = nil
 ) -> Account {
     Account(
         name: name,
@@ -583,7 +584,8 @@ private func account(
         streamErrorCount: 0,
         source: .live,
         serverSha: "abc1234",
-        serverDirty: false
+        serverDirty: false,
+        groups: groups
     )
 }
 
@@ -1035,6 +1037,82 @@ final class FleetCapacitySummaryTests: XCTestCase {
         XCTAssertEqual(fleet.breakdownLabel, "4 ok · 1 near · 7 spent · 1 disabled")
         XCTAssertEqual(fleet.breakdown.map(\.count).reduce(0, +), fleet.accounts.count)
         XCTAssertEqual(fleet.soonestRecovery?.minutesUntilReset, 168)
+    }
+
+    /// An account in TWO groups counts in both — membership is a set, not a
+    /// partition, unlike `breakdown`'s buckets.
+    func testAccountInTwoGroupsCountsInBoth() {
+        let fleet = Fleet(accounts: [
+            account("a@example.com", state: .ok, groups: ["codereview", "dev"])
+        ])
+        XCTAssertEqual(
+            fleet.groupBreakdown,
+            [GroupTally(name: "codereview", free: 1, total: 1), GroupTally(name: "dev", free: 1, total: 1)]
+        )
+    }
+
+    /// A group with zero free accounts still appears, so a starved group is
+    /// visible rather than silently omitted.
+    func testGroupWithZeroFreeStillAppears() {
+        let fleet = Fleet(accounts: [
+            account("a@example.com", state: .spent, groups: ["codereview"])
+        ])
+        XCTAssertEqual(fleet.groupBreakdown, [GroupTally(name: "codereview", free: 0, total: 1)])
+    }
+
+    /// The `ungrouped` bucket is synthetic, appears LAST, and only when at
+    /// least one account carries no label.
+    func testUngroupedBucketPresentAndLast() {
+        let fleet = Fleet(accounts: [
+            account("a@example.com", state: .ok, groups: ["dev"]),
+            account("b@example.com", state: .ok, groups: nil),
+        ])
+        XCTAssertEqual(
+            fleet.groupBreakdown,
+            [GroupTally(name: "dev", free: 1, total: 1), GroupTally(name: "ungrouped", free: 1, total: 1)]
+        )
+        XCTAssertEqual(fleet.groupBreakdownLabel, "dev 1/1 · ungrouped 1/1")
+    }
+
+    /// Groups sort alphabetically before `ungrouped`, so the rendering is
+    /// deterministic.
+    func testGroupsSortAlphabeticallyBeforeUngrouped() {
+        let fleet = Fleet(accounts: [
+            account("a@example.com", state: .ok, groups: ["zebra"]),
+            account("b@example.com", state: .ok, groups: ["alpha"]),
+            account("c@example.com", state: .ok, groups: nil),
+        ])
+        XCTAssertEqual(fleet.groupBreakdown.map(\.name), ["alpha", "zebra", "ungrouped"])
+    }
+
+    /// `total` counts DISABLED accounts too — group membership is config, not
+    /// a serving fact — but `free` excludes them.
+    func testTotalCountsDisabledFreeDoesNot() {
+        let fleet = Fleet(accounts: [
+            account("a@example.com", state: .ok, groups: ["dev"]),
+            account("b@example.com", state: .ok, disabled: true, groups: ["dev"]),
+        ])
+        XCTAssertEqual(fleet.groupBreakdown, [GroupTally(name: "dev", free: 1, total: 2)])
+    }
+
+    /// A `.near` account still serves, so it counts as free exactly as it does
+    /// in the top-line breakdown.
+    func testNearAccountCountsAsFree() {
+        let fleet = Fleet(accounts: [
+            account("a@example.com", state: .near, groups: ["dev"])
+        ])
+        XCTAssertEqual(fleet.groupBreakdown, [GroupTally(name: "dev", free: 1, total: 1)])
+    }
+
+    /// A fleet where no account anywhere carries a label renders NOTHING at
+    /// all — not an all-`ungrouped` line.
+    func testEmptyWhenNoAccountAnywhereCarriesALabel() {
+        let fleet = Fleet(accounts: [
+            account("a@example.com", state: .ok, groups: nil),
+            account("b@example.com", state: .ok, groups: []),
+        ])
+        XCTAssertEqual(fleet.groupBreakdown, [])
+        XCTAssertEqual(fleet.groupBreakdownLabel, "")
     }
 
     func testDisabledAccountsAreNeverCapacity() {

--- a/apps/macos/Tests/TcrBarTests/RealWorldDecodeTests.swift
+++ b/apps/macos/Tests/TcrBarTests/RealWorldDecodeTests.swift
@@ -134,6 +134,20 @@ final class RealWorldDecodeTests: XCTestCase {
         }
     }
 
+    /// `realWorldFixture` predates `groups` — it has neither key, the shape an
+    /// older `tcr` this newer TcrBar talks to would still emit. Decoding a row
+    /// without `groups` must yield `nil`, not throw and blank the row.
+    func testMissingGroupsFieldDecodesToNilNotAThrow() throws {
+        let fleet = try fleet()
+        XCTAssertTrue(
+            fleet.unreadable.isEmpty,
+            "an older tcr without the groups field must still decode every row"
+        )
+        for account in fleet.accounts {
+            XCTAssertNil(account.groups)
+        }
+    }
+
     /// One null field must not cost the other rows. Before per-row decoding, the
     /// array decoded atomically and a single null erased all thirteen accounts.
     func testTheNeverProbedRowKeepsItsNullsAndCostsNoOtherRow() throws {
@@ -316,6 +330,7 @@ final class RealWorldDecodeTests: XCTestCase {
         // A row WITH the new per-window reset fields populates them.
         XCTAssertEqual(ok.fiveHourResetAtMs, 1_767_225_600_000)
         XCTAssertEqual(ok.sevenDayResetAtMs, 1_767_312_000_000)
+        XCTAssertEqual(ok.groups, ["codereview", "dev"])
 
         // `near`: the only shape carrying the nested `held` objects.
         let near = try XCTUnwrap(byName["bob@example.com"])
@@ -349,6 +364,7 @@ final class RealWorldDecodeTests: XCTestCase {
         XCTAssertNil(never.probeError)
         XCTAssertEqual(never.quotaState, .ok, "the raw field says ok — it is a Rust default")
         XCTAssertFalse(never.hasQuotaEvidence, "but nothing has ever probed it")
+        XCTAssertEqual(never.groups, [], "reported and empty, not nil — the server did answer")
 
         // The fleet aggregates the panel headline reads.
         XCTAssertEqual(fleet.readyCount, 1)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1051,8 +1051,16 @@ pub fn render_accounts(snapshot: &StatsSnapshot, source: StatusSource) -> String
             Some(f) if f > now => format!(" free_in={}s", (f - now).whole_seconds().max(1)),
             _ => String::new(),
         };
+        // Group labels, greppable via `groups=codereview,dev`. Omitted entirely
+        // when the account carries none, matching the `fable=`/`last_stream_error=`
+        // idiom for "nothing to say" rather than printing `groups=`.
+        let groups = if a.groups.is_empty() {
+            String::new()
+        } else {
+            format!(" groups={}", a.groups.join(","))
+        };
         out.push_str(&format!(
-            "account {} priority={} {} {}{}{} state={} status={}{} probe={}{}{}{}\n",
+            "account {} priority={} {} {}{}{} state={} status={}{} probe={}{}{}{}{}\n",
             a.name,
             a.priority,
             five_hour,
@@ -1066,6 +1074,7 @@ pub fn render_accounts(snapshot: &StatsSnapshot, source: StatusSource) -> String
             stream_errors,
             last_stream_error,
             if a.disabled { " disabled" } else { "" },
+            groups,
         ));
     }
     out
@@ -1325,6 +1334,11 @@ fn render_accounts_json(
                 "rateLimitedUntilMs": a
                     .rate_limited_until
                     .map(|t| (t.unix_timestamp_nanos() / 1_000_000) as i64),
+                // Group labels (config fact, not a serving counter) — always an
+                // array, `[]` when unlabelled, real on BOTH paths like `control`
+                // above. Never `null`: "this account has no groups" is known,
+                // not unmeasured.
+                "groups": a.groups,
             })
         })
         .collect();
@@ -3403,6 +3417,7 @@ mod tests {
         probe_status: crate::probe::ProbeStatus,
         probe_error: Option<&str>,
         quota_state: QuotaState,
+        groups: &[&str],
     ) -> AccountSnapshot {
         AccountSnapshot {
             name: name.to_string(),
@@ -3433,6 +3448,7 @@ mod tests {
             } else {
                 None
             },
+            groups: groups.iter().map(|g| g.to_string()).collect(),
         }
     }
 
@@ -3473,6 +3489,10 @@ mod tests {
                 crate::probe::ProbeStatus::Ok,
                 None,
                 QuotaState::Normal,
+                // Non-empty and multi-membership — the only row the Swift decode
+                // test has real group data to read, and the one the greppable
+                // `groups=codereview,dev` text-line assertion targets.
+                &["codereview", "dev"],
             ),
             // `near`: at threshold, so `held` carries a window — the only row
             // that exercises the nested object.
@@ -3489,6 +3509,7 @@ mod tests {
                 crate::probe::ProbeStatus::RateLimited,
                 None,
                 QuotaState::NearLimit,
+                &[],
             ),
             // `spent`: fully consumed, and carrying a probe error string.
             contract_account(
@@ -3504,10 +3525,12 @@ mod tests {
                 crate::probe::ProbeStatus::Error,
                 Some("probe failed: connection reset"),
                 QuotaState::Exhausted,
+                &[],
             ),
             // Never probed AND disabled: the four quota fractions and
             // `cacheHitRatio` are all null. This row is the one that shipped a
-            // decode crash — `valueNotFound … Path: [2].quota`.
+            // decode crash — `valueNotFound … Path: [2].quota`. Also the
+            // unlabelled row: `groups` must render `[]`, never `null`.
             contract_account(
                 "dave@example.com",
                 3,
@@ -3521,6 +3544,7 @@ mod tests {
                 crate::probe::ProbeStatus::Never,
                 None,
                 QuotaState::Normal,
+                &[],
             ),
         ];
         let mut accounts = accounts;
@@ -3688,6 +3712,20 @@ mod tests {
             rows.iter().any(|r| r["rateLimitedUntilMs"].is_i64()),
             "some row pins rateLimitedUntilMs as a number: {committed}"
         );
+        assert!(
+            rows.iter().any(|r| !r["groups"]
+                .as_array()
+                .expect("groups is an array")
+                .is_empty()),
+            "some row carries non-empty groups: {committed}"
+        );
+        assert!(
+            rows.iter().any(|r| r["groups"]
+                .as_array()
+                .expect("groups is an array")
+                .is_empty()),
+            "some row carries no groups, rendered as [] not null: {committed}"
+        );
 
         // Public repo: the fixture carries no real account data. A positive
         // control on the same probe — the fake domain really is present — so an
@@ -3703,5 +3741,67 @@ mod tests {
                 "every fixture account is obviously fake: {name}"
             );
         }
+    }
+
+    /// `groups` on the JSON path: an array for a labelled account (including
+    /// multi-membership), and `[]` — never `null` — for an unlabelled one. This
+    /// is config, not a serving counter, so it does not get the
+    /// null-on-offline treatment other fields get.
+    #[test]
+    fn groups_render_as_array_never_null() {
+        let (snapshot, thresholds) = status_contract_snapshot();
+        let json = render_accounts_json(
+            &snapshot,
+            &thresholds,
+            StatusSource::Live,
+            None,
+            false,
+            None,
+        );
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&json).expect("valid json");
+        let alice = rows
+            .iter()
+            .find(|r| r["name"] == "alice@example.com")
+            .expect("alice row");
+        assert_eq!(
+            alice["groups"],
+            serde_json::json!(["codereview", "dev"]),
+            "labelled account carries its groups: {alice}"
+        );
+        let dave = rows
+            .iter()
+            .find(|r| r["name"] == "dave@example.com")
+            .expect("dave row");
+        assert_eq!(
+            dave["groups"],
+            serde_json::json!([]),
+            "unlabelled account renders [], never null: {dave}"
+        );
+    }
+
+    /// `groups=` on the text path: a greppable `groups=codereview,dev` token for
+    /// a labelled account, and the token omitted entirely (not `groups=`) for an
+    /// unlabelled one — the same "nothing to say" idiom as `fable=` and
+    /// `last_stream_error=`.
+    #[test]
+    fn groups_text_line_greppable_and_omitted_when_empty() {
+        let (snapshot, _thresholds) = status_contract_snapshot();
+        let text = render_accounts(&snapshot, StatusSource::Live);
+        let alice_line = text
+            .lines()
+            .find(|l| l.contains("alice@example.com"))
+            .expect("alice line");
+        assert!(
+            alice_line.contains("groups=codereview,dev"),
+            "labelled account's groups are greppable: {alice_line}"
+        );
+        let dave_line = text
+            .lines()
+            .find(|l| l.contains("dave@example.com"))
+            .expect("dave line");
+        assert!(
+            !dave_line.contains("groups="),
+            "unlabelled account omits the token entirely: {dave_line}"
+        );
     }
 }

--- a/src/manager/snapshot.rs
+++ b/src/manager/snapshot.rs
@@ -184,6 +184,7 @@ impl Manager {
                         now_ms,
                     ),
                     last_stream_error: a.last_stream_error.clone(),
+                    groups: a.groups.clone(),
                 }
             })
             .collect();

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -172,6 +172,9 @@ pub struct AccountSnapshot {
     /// as `stream_error_count`, and surfaced by the same two renderers
     /// (`lastStreamError` in JSON, the `last_stream_error=` token in text).
     pub last_stream_error: Option<String>,
+    /// Group labels for this account, mirroring `AccountRuntime::groups` —
+    /// empty (never `None`) when the config carried no `groups` key.
+    pub groups: Vec<String>,
 }
 
 /// Whether a live session was keyed on a stable client identity (x-api-key /

--- a/src/status.rs
+++ b/src/status.rs
@@ -202,6 +202,13 @@ pub struct AccountStatus {
     /// The most recent stream error's type, alongside the count above. Same
     /// on-the-wire decision as `stream_error_count`; rendered as `lastStreamError`.
     pub last_stream_error: Option<String>,
+    /// Group labels for this account, mirroring [`AccountSnapshot::groups`].
+    /// `#[serde(default)]` for the same forward-compat reason as
+    /// `stream_error_count`: an older server that predates groups omits the
+    /// field, and a newer client must still deserialize its payload rather than
+    /// falling back to a fabricated offline snapshot.
+    #[serde(default)]
+    pub groups: Vec<String>,
 }
 
 /// Unix milliseconds for an instant, matching [`crate::now_ms`]'s unit.
@@ -256,6 +263,7 @@ impl StatusPayload {
                 threshold: thresholds.get(i).copied().unwrap_or(1.0),
                 stream_error_count: a.stream_error_count,
                 last_stream_error: a.last_stream_error.clone(),
+                groups: a.groups.clone(),
             })
             .collect();
         Self {
@@ -308,6 +316,7 @@ impl StatusPayload {
                     free_at: a.free_at_ms.and_then(from_ms),
                     stream_error_count: a.stream_error_count,
                     last_stream_error: a.last_stream_error,
+                    groups: a.groups,
                 }
             })
             .collect();
@@ -354,6 +363,7 @@ mod tests {
                 free_at: None,
                 stream_error_count: 0,
                 last_stream_error: None,
+                groups: vec!["codereview".to_string()],
             }],
             current: Some(0),
             recent: Vec::new(),
@@ -396,6 +406,39 @@ mod tests {
         assert_eq!(after.probe_status, before.probe_status);
         assert_eq!(after.quota_state, before.quota_state);
         assert_eq!(after.gate, before.gate);
+        assert_eq!(after.groups, before.groups, "groups rides the wire intact");
+    }
+
+    /// A payload from an older server that predates `groups` still deserializes,
+    /// with the field defaulting to empty — the same forward-compat contract
+    /// `stream_error_count` already relies on.
+    #[test]
+    fn payload_without_groups_field_still_deserializes() {
+        let wire = serde_json::to_string(&StatusPayload::from_snapshot(
+            &snapshot_with_counters(),
+            &[0.85],
+            false,
+            None,
+        ))
+        .expect("serialize");
+        // Simulate an older server: strip every `"groups":[...]` occurrence from
+        // the account object rather than hand-writing a whole payload, so this
+        // test tracks the real field name if it ever changes.
+        let mut value: serde_json::Value = serde_json::from_str(&wire).expect("parse");
+        for account in value["accounts"].as_array_mut().expect("accounts array") {
+            account
+                .as_object_mut()
+                .expect("account object")
+                .remove("groups");
+        }
+        let stripped = serde_json::to_string(&value).expect("re-serialize");
+        let back: StatusPayload =
+            serde_json::from_str(&stripped).expect("deserialize without groups field");
+        assert_eq!(
+            back.accounts[0].groups,
+            Vec::<String>::new(),
+            "missing groups field on the wire defaults to empty, not a decode error"
+        );
     }
 
     /// The server's build stamp rides along and survives the wire.

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1451,6 +1451,7 @@ mod tests {
             free_at,
             stream_error_count: 0,
             last_stream_error: None,
+            groups: Vec::new(),
         }
     }
 

--- a/tests/fixtures/status-contract.json
+++ b/tests/fixtures/status-contract.json
@@ -9,6 +9,10 @@
     "fiveHourState": "ok",
     "freeAtMs": null,
     "gate": "ok",
+    "groups": [
+      "codereview",
+      "dev"
+    ],
     "held": [],
     "http1Only": false,
     "inputTokens": 8000000,
@@ -44,6 +48,7 @@
     "fiveHourState": "near",
     "freeAtMs": null,
     "gate": "ok",
+    "groups": [],
     "held": [
       {
         "minutesUntilReset": 0,
@@ -90,6 +95,7 @@
     "fiveHourState": "spent",
     "freeAtMs": 1767312000000,
     "gate": "ok",
+    "groups": [],
     "held": [
       {
         "minutesUntilReset": 0,
@@ -136,6 +142,7 @@
     "fiveHourState": null,
     "freeAtMs": null,
     "gate": "ok",
+    "groups": [],
     "held": [],
     "http1Only": false,
     "inputTokens": 0,


### PR DESCRIPTION
Carry account group labels out to `tcr status` / `--json`, and show them in TcrBar.

Phases 2a + 3 of `docs/plans/account-groups-plan.md`. The previous change added labels and `tcr run --group` routing but kept them CLI-only: `AccountRuntime.groups` existed and nothing downstream could see it.

## Why the panel needed this, not just wanted it

`FleetView`'s header documents the panel's purpose as answering *"is there capacity right now, and if not, when does it come back"*, and answers it with `4 ok · 1 near · 7 spent · 1 disabled`. Once routing is partitioned by group, that question no longer has a single answer — a fleet reading `4 ok` is worthless to a `codereview` session if all four are in `dev`. Without a per-group line the header does not merely omit information, it misleads.

```
Capacity now · next in 47m
4 ok · 1 near · 7 spent · 1 disabled
codereview 0/3 · dev 4/5 · ungrouped 5/6      <- new
```

A `0/N` group is coloured through the existing `Tok.color(for:)` and reads red exactly like `7 spent`, so a starved group is an alarm at a glance. The line renders nothing at all when no account carries a label. Rows additionally show their groups as chips beside the status pills, capped at two with a `+N` overflow.

## Decisions worth knowing

- **`groups` serializes as `[]`, never `null`.** The null-never-zero idiom used by `cacheHitRatio` / `serverSha` / `fiveHourState` exists to separate *measured zero* from *not measured*. Group membership is config, so "no groups" is a known fact — an empty array is the honest encoding.
- **Swift decodes it as `[String]?`** because synthesized `Decodable` would throw against an older server that omits the field. `nil` means "server did not report"; `[]` means "reported, none".
- **A `near` account counts as free** in the tally. It still serves; counting only `ok` would make the panel cry starvation while requests flowed fine.
- **An account in several groups counts in each** — membership is a set, not a partition. For the same reason the account list is *not* sectioned by group: that would duplicate rows or invent a false primary group. Chips are the honest rendering.
- `ungrouped` is a synthetic bucket, always last, omitted when every account is labelled. Real groups sort alphabetically so the rendering is deterministic and testable.
- The text status line gains a greppable `groups=codereview,dev` token, omitted entirely when empty, matching the existing `fable=` idiom.

## Explicitly not in this PR

No `--only`, no `GateReason::Group`, no `tcr group` CLI, and **no change to routing** — `select.rs` and `manager/mod.rs` are untouched. That half carries real routing risk and stays out of a UI change.

## Verification

All seven gates exit 0: `cargo fmt --all --check`, `cargo clippy --all-targets --locked -- -D warnings`, `cargo test --all --locked`, `cargo build --release`, CI's own `swift-format lint --strict -r apps/macos/Sources/TcrBarCore apps/macos/Tests`, `swift build`, `swift test`. 741 Rust tests and 235 Swift tests, zero failures.

Every new test was watched fail against deliberately broken production code and confirmed green on restore — including emitting `[]` unconditionally (caught by the array test), dropping the `groups=` token, zeroing `groups` in `from_snapshot`, removing `#[serde(default)]` (caught by the older-server decode test), letting disabled accounts count as free, and removing the empty-fleet guard (which fabricated an `ungrouped 2/2` for a fleet with no labels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114YEdZJWWvEgsTP4FvoNDL
