### PR TITLE
A Groups view in TcrBar: stats, members, and membership controls

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -23,6 +23,11 @@ struct FleetView: View {
     /// would.
     @ObservedObject var awake: AwakeController
     @ObservedObject var updater: Updater
+    /// Mutating group membership from the Groups view. See ``GroupController``.
+    @ObservedObject var groupController: GroupController
+    /// Which of Accounts/Groups is showing, persisted. See
+    /// ``FleetViewModePreference``.
+    @ObservedObject var viewMode: FleetViewModePreference
     /// Owned by the app so it survives the panel closing; bound here so the
     /// checkbox and the launch path can never disagree about its value.
     @Binding var startServerAtLaunch: Bool
@@ -197,7 +202,23 @@ struct FleetView: View {
             if fleet.source.countersAreStructural {
                 offlineNotice(fleet.source)
             }
-            if snapshotMode {
+            // Hidden entirely, not merely disabled, when no account anywhere
+            // carries a label — nothing changes for an operator not using
+            // groups. `effectiveMode(for:)` enforces the same rule on the
+            // content below even if a stale preference says otherwise.
+            if !fleet.groupDetails.isEmpty {
+                FleetViewModeToggle(mode: $viewMode.mode)
+            }
+            if effectiveMode(for: fleet) == .groups {
+                if snapshotMode {
+                    GroupsListView(fleet: fleet, groupController: groupController)
+                } else {
+                    ScrollView {
+                        GroupsListView(fleet: fleet, groupController: groupController)
+                    }
+                    .frame(height: Tok.panelMaxHeight)
+                }
+            } else if snapshotMode {
                 rowStack(fleet)
             } else {
                 ScrollView {
@@ -207,6 +228,14 @@ struct FleetView: View {
                 .onPreferenceChange(RowHeightsKey.self) { rowHeights = $0 }
             }
         }
+    }
+
+    /// `viewMode.mode`, forced to `.accounts` when the fleet has no group to
+    /// show — the toggle itself is hidden in that case (see
+    /// ``fleetRows(_:)``), but a stale `Groups` preference from a fleet that
+    /// used to have labels must not draw an empty grouped list.
+    private func effectiveMode(for fleet: Fleet) -> FleetViewModePreference.Mode {
+        fleet.groupDetails.isEmpty ? .accounts : viewMode.mode
     }
 
     private func rowStack(_ fleet: Fleet) -> some View {

--- a/apps/macos/Sources/TcrBar/GroupsView.swift
+++ b/apps/macos/Sources/TcrBar/GroupsView.swift
@@ -1,0 +1,327 @@
+import SwiftUI
+import TcrBarCore
+
+/// The `Accounts` / `Groups` toggle. Only ever drawn when at least one
+/// account carries a label — see `FleetView.fleetRows(_:)`, which gates its
+/// presence and forces `Accounts` when there is nothing to switch to.
+struct FleetViewModeToggle: View {
+    @Binding var mode: FleetViewModePreference.Mode
+
+    var body: some View {
+        Picker("View", selection: $mode) {
+            Text("Accounts").tag(FleetViewModePreference.Mode.accounts)
+            Text("Groups").tag(FleetViewModePreference.Mode.groups)
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .accessibilityLabel("Fleet view")
+    }
+}
+
+/// The grouped list: one disclosure row per group (alphabetical, `ungrouped`
+/// last, per `Fleet.groupDetails`), plus the "+ New group…" control at the
+/// bottom.
+struct GroupsListView: View {
+    let fleet: Fleet
+    @ObservedObject var groupController: GroupController
+
+    /// Explicit user choices override the free-== 0 default. Not reset when
+    /// the fleet re-polls, so a group an operator opened stays open across a
+    /// refresh.
+    @State private var expandedOverrides: [String: Bool] = [:]
+    @State private var confirmRemoveGroup: String?
+    @State private var newGroupFormOpen = false
+    @State private var newGroupName = ""
+    @State private var newGroupAccountName: String?
+    @State private var newGroupValidationError: GroupNameValidation.Failure?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Tok.rowSpacing) {
+            ForEach(fleet.groupDetails) { detail in
+                GroupSectionView(
+                    detail: detail,
+                    allAccounts: fleet.accounts,
+                    groupController: groupController,
+                    expandedOverrides: $expandedOverrides,
+                    confirmRemoveGroup: $confirmRemoveGroup
+                )
+            }
+            newGroupSection
+        }
+        // A group is implicit — it exists only once an account carries the
+        // label — so removing every member IS removing the group; there is
+        // no separate "delete an empty group" concept to confirm. This
+        // dialog exists for the destructive, hard-to-undo shape: clearing
+        // every member's label in one call.
+        .confirmationDialog(
+            "Remove the “\(confirmRemoveGroup ?? "")” group?",
+            isPresented: Binding(
+                get: { confirmRemoveGroup != nil },
+                set: { if !$0 { confirmRemoveGroup = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Remove Group", role: .destructive) {
+                guard let name = confirmRemoveGroup else { return }
+                confirmRemoveGroup = nil
+                Task { await groupController.removeAll(group: name) }
+            }
+            Button("Cancel", role: .cancel) { confirmRemoveGroup = nil }
+        } message: {
+            Text(
+                "This removes the label from every member account. The proxy keeps "
+                    + "routing the old way until it restarts.")
+        }
+    }
+
+    @ViewBuilder
+    private var newGroupSection: some View {
+        if newGroupFormOpen {
+            VStack(alignment: .leading, spacing: Tok.tightSpacing) {
+                TextField("Group name", text: $newGroupName)
+                    .textFieldStyle(.roundedBorder)
+                    .font(Tok.secondaryFont)
+                if let error = newGroupValidationError {
+                    Text(GroupNameValidation.message(for: error))
+                        .font(Tok.detailFont)
+                        .foregroundStyle(Tok.spent)
+                }
+                // A group is implicit — it exists only once an account
+                // carries it — so creating one requires choosing a first
+                // member; there is no "create an empty group" here.
+                Menu {
+                    ForEach(fleet.accounts.sorted(by: { $0.name < $1.name }), id: \.id) { account in
+                        Button(account.name) { newGroupAccountName = account.name }
+                    }
+                } label: {
+                    Text(newGroupAccountName ?? "Choose an account…")
+                        .font(Tok.secondaryFont)
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+                if let name = newGroupAccountName,
+                    let failure = groupController.failure(for: "\(newGroupName)/\(name)")
+                {
+                    Text(failure.summary)
+                        .font(Tok.detailFont)
+                        .foregroundStyle(Tok.spent)
+                }
+                HStack(spacing: Tok.tightSpacing) {
+                    Button("Add") { submitNewGroup() }
+                        .disabled(newGroupAccountName == nil)
+                    Button("Cancel") { closeNewGroupForm() }
+                }
+                .buttonStyle(.bordered)
+            }
+        } else {
+            Button("+ New group…") { newGroupFormOpen = true }
+                .buttonStyle(.plain)
+                .font(Tok.secondaryFont)
+                .foregroundStyle(Tok.accent)
+        }
+    }
+
+    private func closeNewGroupForm() {
+        newGroupFormOpen = false
+        newGroupName = ""
+        newGroupAccountName = nil
+        newGroupValidationError = nil
+    }
+
+    private func submitNewGroup() {
+        let trimmed = newGroupName.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let failure = GroupNameValidation.validate(trimmed) {
+            newGroupValidationError = failure
+            return
+        }
+        guard let account = newGroupAccountName else { return }
+        newGroupValidationError = nil
+        Task {
+            let attempt = await groupController.add(account: account, to: trimmed)
+            if case .accepted = attempt {
+                closeNewGroupForm()
+            }
+        }
+    }
+}
+
+/// One group's disclosure row, expanded or collapsed.
+struct GroupSectionView: View {
+    let detail: GroupDetail
+    /// The whole fleet, so "+ add account…" can offer everyone not already a
+    /// member — including an account from another group, since membership is
+    /// a set, not a partition.
+    let allAccounts: [Account]
+    @ObservedObject var groupController: GroupController
+    @Binding var expandedOverrides: [String: Bool]
+    @Binding var confirmRemoveGroup: String?
+
+    private var isExpanded: Bool {
+        // Collapsed by default, except a starved group (`free == 0`) starts
+        // expanded — that is the one an operator opened the panel for.
+        expandedOverrides[detail.name] ?? (detail.free == 0)
+    }
+
+    /// `ungrouped` is synthetic — nobody "removes" it, and there is nothing
+    /// to add an account TO, since adding one here would just mean clearing
+    /// every label it has, which is not this control's job.
+    private var isUngrouped: Bool { detail.name == "ungrouped" }
+
+    private var candidatesToAdd: [Account] {
+        let memberNames = Set(detail.members.map(\.name))
+        return allAccounts.filter { !memberNames.contains($0.name) }
+            .sorted { $0.name < $1.name }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Tok.tightSpacing) {
+            header
+            if isExpanded {
+                VStack(alignment: .leading, spacing: Tok.rowLineSpacing) {
+                    ForEach(detail.members.sorted(by: { $0.name < $1.name }), id: \.id) { member in
+                        GroupMemberRow(
+                            account: member, group: detail.name, groupController: groupController)
+                    }
+                    if !isUngrouped {
+                        addAccountControl
+                    }
+                }
+                .padding(.leading, Tok.space4)
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: Tok.tightSpacing) {
+            HStack(spacing: Tok.tightSpacing) {
+                Button {
+                    expandedOverrides[detail.name] = !isExpanded
+                } label: {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(isExpanded ? "Collapse \(detail.name)" : "Expand \(detail.name)")
+
+                Text(detail.name)
+                    .font(Tok.secondaryFont.weight(.semibold))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text("\(detail.free)/\(detail.total)")
+                    .font(Tok.secondaryDigitFont)
+                    .foregroundStyle(Tok.color(for: detail.free == 0 ? FleetTally.Kind.spent : .ok))
+                Spacer(minLength: 0)
+                if !isUngrouped {
+                    Menu {
+                        Button("Remove Group…", role: .destructive) {
+                            confirmRemoveGroup = detail.name
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis.circle")
+                            .foregroundStyle(.secondary)
+                    }
+                    .menuStyle(.borderlessButton)
+                    .fixedSize()
+                }
+            }
+            if let statLine = detail.statLine {
+                Text(statLine)
+                    .font(Tok.secondaryFont)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            // No live config reload — a successful mutation changes nothing
+            // until the proxy restarts, and this view never offers to
+            // restart it (that is the guarded, separate control elsewhere).
+            if groupController.needsRestart(detail.name) {
+                Text("restart the proxy to apply")
+                    .font(Tok.detailFont)
+                    .foregroundStyle(Tok.near)
+            }
+            if let failure = groupController.failure(for: detail.name) {
+                Text(failure.summary)
+                    .font(Tok.detailFont)
+                    .foregroundStyle(Tok.spent)
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    @ViewBuilder
+    private var addAccountControl: some View {
+        if candidatesToAdd.isEmpty {
+            Text("+ add account…")
+                .font(Tok.secondaryFont)
+                .foregroundStyle(.tertiary)
+        } else {
+            Menu {
+                ForEach(candidatesToAdd, id: \.id) { candidate in
+                    Button(candidate.name) {
+                        Task { await groupController.add(account: candidate.name, to: detail.name) }
+                    }
+                }
+            } label: {
+                Text("+ add account…")
+                    .font(Tok.secondaryFont)
+                    .foregroundStyle(Tok.accent)
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+        }
+    }
+}
+
+/// One member of an expanded group: name, a quota bar, its percentage, and a
+/// remove control.
+struct GroupMemberRow: View {
+    let account: Account
+    let group: String
+    @ObservedObject var groupController: GroupController
+
+    /// Same "no reading vs a real one" tint rule `AccountRow` uses for its
+    /// composite bar — this is the group view's compact equivalent, one bar
+    /// per member rather than two per-window bars.
+    private var tint: Color {
+        account.hasQuotaEvidence ? Tok.color(for: account.quotaState) : Tok.unmeasured
+    }
+
+    private var removeKey: String { "\(group)/\(account.name)" }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Tok.rowLineSpacing) {
+            HStack(spacing: Tok.tightSpacing) {
+                Text(account.name)
+                    .font(Tok.secondaryFont)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                QuotaBar(fraction: account.fiveHour, tint: tint, label: "\(account.name) 5-hour quota")
+                    .frame(width: 60)
+                Text(QuotaFormat.percent(account.fiveHour))
+                    .font(Tok.secondaryDigitFont)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 34, alignment: .trailing)
+                Spacer(minLength: 0)
+                Button {
+                    Task { await groupController.remove(account: account.name, from: group) }
+                } label: {
+                    if groupController.isPending(removeKey) {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Image(systemName: "minus.circle")
+                    }
+                }
+                .buttonStyle(.plain)
+                .disabled(groupController.isPending(removeKey))
+                .help("Remove \(account.name) from \(group) — tcr group rm \(group) \(account.name)")
+                .accessibilityLabel("Remove \(account.name) from \(group)")
+            }
+            if let failure = groupController.failure(for: removeKey) {
+                Text(failure.summary)
+                    .font(Tok.detailFont)
+                    .foregroundStyle(Tok.spent)
+            }
+        }
+    }
+}

--- a/apps/macos/Sources/TcrBar/GroupsView.swift
+++ b/apps/macos/Sources/TcrBar/GroupsView.swift
@@ -157,9 +157,11 @@ struct GroupSectionView: View {
     @Binding var confirmRemoveGroup: String?
 
     private var isExpanded: Bool {
-        // Collapsed by default, except a starved group (`free == 0`) starts
-        // expanded — that is the one an operator opened the panel for.
-        expandedOverrides[detail.name] ?? (detail.free == 0)
+        // Collapsed by default, except a starved group starts expanded —
+        // that is the one an operator opened the panel for. The default
+        // itself lives on the model (`GroupDetail.startsExpanded`) so a test
+        // can assert it directly; this only adds the per-open override.
+        expandedOverrides[detail.name] ?? detail.startsExpanded
     }
 
     /// `ungrouped` is synthetic — nobody "removes" it, and there is nothing

--- a/apps/macos/Sources/TcrBar/MenuBarShell.swift
+++ b/apps/macos/Sources/TcrBar/MenuBarShell.swift
@@ -36,6 +36,13 @@ final class MenuBarShell {
     /// control that keeps nothing awake.
     let awake: AwakeController
     let preference: LaunchPreference
+    /// Group-membership mutations for the Groups view, owned here for the
+    /// same reason as `accounts`: an in-flight/failure/restart-notice state
+    /// that reset every time the panel opened would lose the "restart the
+    /// proxy to apply" note the moment the operator closed it.
+    let groupController: GroupController
+    /// Which of Accounts/Groups the panel shows, persisted across opens.
+    let viewMode: FleetViewModePreference
     /// Owned here for the same reason as the rest, plus one of its own: the
     /// delegate's `tcrbar://check-for-updates` handler reaches through the shell
     /// to find it, so an updater that only existed while the panel was open would
@@ -60,7 +67,9 @@ final class MenuBarShell {
         control: ControlAccountController? = nil,
         awake: AwakeController? = nil,
         preference: LaunchPreference? = nil,
-        updater: Updater? = nil
+        updater: Updater? = nil,
+        groupController: GroupController? = nil,
+        viewMode: FleetViewModePreference? = nil
     ) {
         self.poller = poller ?? StatusPoller()
         self.server = server ?? ServerController()
@@ -70,6 +79,8 @@ final class MenuBarShell {
         self.awake = awake ?? AwakeController()
         self.preference = preference ?? LaunchPreference()
         self.updater = updater ?? Updater()
+        self.groupController = groupController ?? GroupController()
+        self.viewMode = viewMode ?? FleetViewModePreference()
 
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         // An `NSStatusItem`'s visibility is *persisted*, and the app must never
@@ -105,7 +116,8 @@ final class MenuBarShell {
             rootView: FleetPanel(
                 poller: self.poller, server: self.server, loginItem: self.loginItem,
                 accounts: self.accounts, control: self.control, awake: self.awake,
-                preference: self.preference, updater: self.updater))
+                preference: self.preference, updater: self.updater,
+                groupController: self.groupController, viewMode: self.viewMode))
         // Without this the popover takes a default size and the panel is clipped.
         //
         // This is the specific thing `MenuBarExtra` did for free. `FleetView`
@@ -317,6 +329,8 @@ struct FleetPanel: View {
     @ObservedObject var awake: AwakeController
     @ObservedObject var preference: LaunchPreference
     @ObservedObject var updater: Updater
+    @ObservedObject var groupController: GroupController
+    @ObservedObject var viewMode: FleetViewModePreference
 
     var body: some View {
         FleetView(
@@ -327,6 +341,8 @@ struct FleetPanel: View {
             control: control,
             awake: awake,
             updater: updater,
+            groupController: groupController,
+            viewMode: viewMode,
             startServerAtLaunch: $preference.startServerAtLaunch
         )
     }

--- a/apps/macos/Sources/TcrBar/RenderStates.swift
+++ b/apps/macos/Sources/TcrBar/RenderStates.swift
@@ -157,6 +157,8 @@ enum RenderStates {
                 // started updater schedules background checks and can put a
                 // window on screen, neither of which belongs in a render run.
                 updater: Updater(startingUpdater: false),
+                groupController: GroupController(),
+                viewMode: FleetViewModePreference(),
                 startServerAtLaunch: .constant(false),
                 snapshotMode: true
             )

--- a/apps/macos/Sources/TcrBarCore/FleetStatus.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetStatus.swift
@@ -1144,42 +1144,7 @@ public struct Fleet: Equatable, Sendable {
     /// in several groups counts in each — mirroring ``breakdown``'s bucket
     /// idiom rather than inventing a second one.
     public var groupBreakdown: [GroupTally] {
-        // No account anywhere carries a label: a fleet that does not use
-        // groups renders nothing at all, not an all-`ungrouped` line.
-        guard accounts.contains(where: { !($0.groups ?? []).isEmpty }) else { return [] }
-
-        var totals: [String: Int] = [:]
-        var frees: [String: Int] = [:]
-        var ungroupedTotal = 0
-        var ungroupedFree = 0
-        for account in accounts {
-            let groups = account.groups ?? []
-            // `free` classifies with the same `FleetTally.Kind(account:)` this
-            // struct already uses for the top-line breakdown — a `.near`
-            // account still serves, so it counts as free exactly as it does
-            // there; only `.disabled` accounts are excluded from `free`
-            // (`total` counts them).
-            let isFree =
-                !account.disabled
-                && [.ok, .near].contains(FleetTally.Kind(account: account))
-            if groups.isEmpty {
-                ungroupedTotal += 1
-                if isFree { ungroupedFree += 1 }
-                continue
-            }
-            for group in groups {
-                totals[group, default: 0] += 1
-                if isFree { frees[group, default: 0] += 1 }
-            }
-        }
-
-        var result = totals.keys.sorted().map { name in
-            GroupTally(name: name, free: frees[name, default: 0], total: totals[name]!)
-        }
-        if ungroupedTotal > 0 {
-            result.append(GroupTally(name: "ungrouped", free: ungroupedFree, total: ungroupedTotal))
-        }
-        return result
+        groupDetails.map(\.tally)
     }
 
     /// `"codereview 0/3 · dev 4/5 · ungrouped 5/6"` — the same content as
@@ -1187,6 +1152,117 @@ public struct Fleet: Equatable, Sendable {
     /// ``breakdownLabel``'s idiom.
     public var groupBreakdownLabel: String {
         groupBreakdown.map(\.label).joined(separator: " · ")
+    }
+
+    /// ``groupBreakdown``, elaborated with the member list each group's row
+    /// needs to expand — the Groups view's source of truth. Same population,
+    /// same free/total counting, same alphabetical-then-`ungrouped` ordering;
+    /// ``groupBreakdown`` is now defined in terms of this rather than
+    /// duplicating the grouping pass.
+    public var groupDetails: [GroupDetail] {
+        // No account anywhere carries a label: a fleet that does not use
+        // groups renders nothing at all, not an all-`ungrouped` line.
+        guard accounts.contains(where: { !($0.groups ?? []).isEmpty }) else { return [] }
+
+        // `free` classifies with the same `FleetTally.Kind(account:)` this
+        // struct already uses for the top-line breakdown — a `.near`
+        // account still serves, so it counts as free exactly as it does
+        // there; only `.disabled` accounts are excluded from `free`
+        // (`total` counts them).
+        func isFree(_ account: Account) -> Bool {
+            !account.disabled && [.ok, .near].contains(FleetTally.Kind(account: account))
+        }
+
+        var members: [String: [Account]] = [:]
+        var ungroupedMembers: [Account] = []
+        for account in accounts {
+            let groups = account.groups ?? []
+            if groups.isEmpty {
+                ungroupedMembers.append(account)
+                continue
+            }
+            for group in groups {
+                members[group, default: []].append(account)
+            }
+        }
+
+        var result = members.keys.sorted().map { name -> GroupDetail in
+            let group = members[name]!
+            return GroupDetail(
+                name: name,
+                free: group.filter(isFree).count,
+                total: group.count,
+                members: group
+            )
+        }
+        if !ungroupedMembers.isEmpty {
+            result.append(
+                GroupDetail(
+                    name: "ungrouped",
+                    free: ungroupedMembers.filter(isFree).count,
+                    total: ungroupedMembers.count,
+                    members: ungroupedMembers
+                )
+            )
+        }
+        return result
+    }
+}
+
+/// ``GroupTally`` elaborated with the accounts that make it up, for the Groups
+/// view's expanded row. Membership is a SET like ``GroupTally``'s: an account
+/// in several groups appears in each detail's ``members``, unmodified.
+public struct GroupDetail: Equatable, Sendable, Identifiable {
+    public let name: String
+    /// Same counting as ``GroupTally/free``.
+    public let free: Int
+    /// Same counting as ``GroupTally/total`` — includes disabled members.
+    public let total: Int
+    /// Every account carrying this label (or, for `"ungrouped"`, every account
+    /// carrying none) — the same population ``total`` counts, disabled
+    /// included, so the view can list a parked member rather than hide it.
+    public let members: [Account]
+
+    public init(name: String, free: Int, total: Int, members: [Account]) {
+        self.name = name
+        self.free = free
+        self.total = total
+        self.members = members
+    }
+
+    public var id: String { name }
+
+    /// The plain ``GroupTally`` this detail elaborates.
+    public var tally: GroupTally { GroupTally(name: name, free: free, total: total) }
+
+    /// `"dev 4/5"` — same as ``GroupTally/label``.
+    public var label: String { tally.label }
+
+    /// The worst (highest) 5-hour utilization among members that have one —
+    /// the window that gates the group next. `nil` when no member has ever
+    /// reported a 5h fraction.
+    public var max5hUtilization: Double? {
+        members.compactMap(\.fiveHour).max()
+    }
+
+    /// The soonest reset among members currently held. `nil` when nothing in
+    /// the group is held.
+    public var soonestReset: HeldWindow? {
+        members.compactMap(\.soonestHold).min(by: { $0.minutesUntilReset < $1.minutesUntilReset })
+    }
+
+    /// `"5h 12% max · resets in 2h 14m"`. Either half is omitted — never
+    /// replaced with a placeholder — when its member data has nothing to say,
+    /// the same honesty rule ``QuotaFormat`` encodes for a single account;
+    /// `nil` when neither half has anything. Routes the reset half through
+    /// ``HeldWindow/duration(minutes:)``, this codebase's one duration
+    /// formatter, rather than growing a second one.
+    public var statLine: String? {
+        let utilization = max5hUtilization.map { "5h \(QuotaFormat.percent($0)) max" }
+        let reset = soonestReset.map { "resets in \(HeldWindow.duration(minutes: $0.minutesUntilReset))" }
+        let parts = [utilization, reset].compactMap { $0 }
+        guard !parts.isEmpty else { return nil }
+        return parts.joined(separator: " · ")
     }
 }
 

--- a/apps/macos/Sources/TcrBarCore/FleetStatus.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetStatus.swift
@@ -1238,6 +1238,15 @@ public struct GroupDetail: Equatable, Sendable, Identifiable {
     /// `"dev 4/5"` — same as ``GroupTally/label``.
     public var label: String { tally.label }
 
+    /// Whether the Groups view's disclosure row for this group starts
+    /// expanded. A property of the model, not a view-private computation, so
+    /// a test can assert it directly — the house rule this file already
+    /// follows for ``statLine``. A starved group (`free == 0`) is the one an
+    /// operator opened the panel for, so it starts open; every other group
+    /// starts collapsed. The view still lets an explicit click override this
+    /// per group — this is only the DEFAULT.
+    public var startsExpanded: Bool { free == 0 }
+
     /// The worst (highest) 5-hour utilization among members that have one —
     /// the window that gates the group next. `nil` when no member has ever
     /// reported a 5h fraction.

--- a/apps/macos/Sources/TcrBarCore/FleetViewModePreference.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetViewModePreference.swift
@@ -1,0 +1,43 @@
+import Combine
+import Foundation
+
+/// Which of the panel's two lists is showing — `Accounts` or `Groups` —
+/// persisted in `UserDefaults`.
+///
+/// Same shape as ``LaunchPreference`` and for the same reason: there is no
+/// SwiftUI `App`/`View` to hang an `@AppStorage` off (the shell is a
+/// hand-managed `NSStatusItem`, see ``LaunchPreference``'s own doc-comment),
+/// and a plain `UserDefaults` read publishes nothing, so the toggle would
+/// appear not to move when clicked.
+@MainActor
+public final class FleetViewModePreference: ObservableObject {
+    /// The `UserDefaults` key. Do not change it — renaming silently resets a
+    /// choice the operator made, the same failure mode
+    /// ``LaunchPreference/startServerAtLaunchKey``'s doc-comment names.
+    public static let modeKey = "fleetViewMode"
+
+    public enum Mode: String, Equatable, Sendable {
+        case accounts
+        case groups
+    }
+
+    private let defaults: UserDefaults
+
+    /// Written through to `UserDefaults` on every change.
+    @Published public var mode: Mode {
+        didSet { defaults.set(mode.rawValue, forKey: Self.modeKey) }
+    }
+
+    /// - Parameter defaults: injected so a test can use a scratch suite
+    ///   rather than writing to the operator's real preferences.
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        // Property initialisation in `init` does not fire `didSet`, so
+        // reading the stored value here cannot write it straight back.
+        if let raw = defaults.string(forKey: Self.modeKey), let stored = Mode(rawValue: raw) {
+            self.mode = stored
+        } else {
+            self.mode = .accounts
+        }
+    }
+}

--- a/apps/macos/Sources/TcrBarCore/GroupControl.swift
+++ b/apps/macos/Sources/TcrBarCore/GroupControl.swift
@@ -1,0 +1,203 @@
+import Combine
+import Foundation
+
+/// Mutating group membership: adding an account to a group, removing one
+/// from a group, or removing a whole group. Same two rules as
+/// ``AccountCommand``/``ControlAccountCommand``, and for the same reasons:
+///
+///  1. **This app never writes the tcr config.** Every change is a
+///     subprocess — `tcr group add <group> <account>`,
+///     `tcr group rm <group> <account>`, `tcr group rm <group> --all` —
+///     never a direct edit of `~/.config/teamclaude.json`. There is also no
+///     live config reload: a successful call here changes nothing until the
+///     proxy restarts, which the view surfaces, and this type never claims
+///     otherwise.
+///  2. **Exit 0 with anything on stderr is not a clean success.** Same
+///     three-arm `Outcome` as ``AccountCommand``, for the same reason: `tcr`
+///     can apply a change to the file only and warn that a running proxy was
+///     too old for the control route.
+public enum GroupCommand {
+    /// `tcr group add <group> <account>`. Both arguments positional and
+    /// verbatim — no flags, nothing that could be mistaken for one.
+    public static func addArguments(group: String, account: String) -> [String] {
+        ["group", "add", group, account]
+    }
+
+    /// `tcr group rm <group> <account>`.
+    public static func removeArguments(group: String, account: String) -> [String] {
+        ["group", "rm", group, account]
+    }
+
+    /// `tcr group rm <group> --all` — removes the whole group.
+    public static func removeAllArguments(group: String) -> [String] {
+        ["group", "rm", group, "--all"]
+    }
+
+    /// Why a group command did not happen. Carries `tcr`'s own words verbatim,
+    /// same posture as ``AccountCommand/Failure``.
+    public struct Failure: Error, Equatable, Sendable {
+        public let exitCode: Int32
+        public let message: String
+
+        public init(exitCode: Int32, message: String) {
+            self.exitCode = exitCode
+            self.message = message
+        }
+
+        /// One line, always non-empty, safe to render in the row.
+        public var summary: String {
+            let detail = message.isEmpty ? "no output" : message
+            return "group command failed (exit \(exitCode)): \(detail)"
+        }
+    }
+
+    /// Mirrors ``AccountCommand/Outcome`` exactly, same three arms and same
+    /// reason: exit 0 has two meanings.
+    public enum Outcome: Equatable, Sendable {
+        case clean
+        case spoke(notice: String)
+        case failed(Failure)
+    }
+
+    /// Pure classification of a finished invocation.
+    public static func classify(exitCode: Int32, stderr: String) -> Outcome {
+        let text = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard exitCode == 0 else {
+            return .failed(Failure(exitCode: exitCode, message: text))
+        }
+        return text.isEmpty ? .clean : .spoke(notice: text)
+    }
+
+    /// Blocking invocation — always called off the main actor.
+    nonisolated static func perform(arguments: [String]) -> Outcome {
+        switch TcrTool.resolve() {
+        case .failure(let notFound):
+            return .failed(
+                Failure(
+                    exitCode: -1,
+                    message: "tcr not found (searched \(notFound.searched.count) locations)"
+                ))
+        case .success(let executable):
+            do {
+                let output = try TcrTool.run(executable: executable, arguments: arguments)
+                return classify(exitCode: output.exitCode, stderr: output.stderr)
+            } catch {
+                return .failed(Failure(exitCode: -1, message: error.localizedDescription))
+            }
+        }
+    }
+}
+
+/// Client-side validation for a typed group name, mirroring the rule the CLI
+/// itself enforces so a bad name is caught before a subprocess ever runs
+/// rather than surfacing as `tcr`'s stderr after the fact.
+public enum GroupNameValidation {
+    public enum Failure: Equatable, Sendable {
+        /// Nothing typed, or only whitespace.
+        case empty
+        /// A C0 control character or DEL (`U+0000`-`U+001F`, `U+007F`).
+        case controlCharacter
+        /// A codepoint above `U+00FF` — the CLI's name charset is Latin-1.
+        case aboveLatin1
+    }
+
+    /// `nil` means the name is acceptable.
+    public static func validate(_ name: String) -> Failure? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .empty }
+        for scalar in name.unicodeScalars {
+            if scalar.value < 0x20 || scalar.value == 0x7F { return .controlCharacter }
+            if scalar.value > 0xFF { return .aboveLatin1 }
+        }
+        return nil
+    }
+
+    /// One line, safe to render beside the text field.
+    public static func message(for failure: Failure) -> String {
+        switch failure {
+        case .empty: return "Group name cannot be empty."
+        case .controlCharacter: return "Group name cannot contain control characters."
+        case .aboveLatin1: return "Group name cannot contain characters above U+00FF."
+        }
+    }
+}
+
+/// Panel-facing state for group mutations: which calls are in flight, and
+/// which have a failure that has not been superseded by a later attempt.
+/// Mirrors ``AccountController``'s shape.
+///
+/// Keyed by a caller-chosen string rather than by account name alone —
+/// `"<group>/<account>"` for a member add/remove, the bare group name for a
+/// whole-group removal — so two different members of the same group, or an
+/// add and a remove on two different rows, never share in-flight/failure
+/// state.
+@MainActor
+public final class GroupController: ObservableObject {
+    @Published public private(set) var pending: Set<String> = []
+    @Published public private(set) var failures: [String: GroupCommand.Failure] = [:]
+    /// Group names that have had at least one successful mutation this
+    /// session — drives the "restart the proxy to apply" note. Never
+    /// cleared: there is no live config reload, so once true it stays true
+    /// until the app relaunches, which matches reality.
+    @Published public private(set) var appliedPendingRestart: Set<String> = []
+
+    public init() {}
+
+    public func isPending(_ key: String) -> Bool { pending.contains(key) }
+    public func failure(for key: String) -> GroupCommand.Failure? { failures[key] }
+    public func needsRestart(_ group: String) -> Bool { appliedPendingRestart.contains(group) }
+
+    /// What a call did, as far as the subprocess can say — mirrors
+    /// ``AccountController/Attempt``.
+    public enum Attempt: Equatable, Sendable {
+        case skipped
+        case refused
+        case accepted(notice: String?)
+    }
+
+    @discardableResult
+    private func run(key: String, group: String, arguments: [String]) async -> Attempt {
+        guard !pending.contains(key) else { return .skipped }
+        pending.insert(key)
+        failures[key] = nil
+        defer { pending.remove(key) }
+
+        let outcome = await Task.detached(priority: .userInitiated) {
+            GroupCommand.perform(arguments: arguments)
+        }.value
+
+        switch outcome {
+        case .clean:
+            appliedPendingRestart.insert(group)
+            return .accepted(notice: nil)
+        case .spoke(let notice):
+            appliedPendingRestart.insert(group)
+            return .accepted(notice: notice)
+        case .failed(let failure):
+            failures[key] = failure
+            return .refused
+        }
+    }
+
+    /// `tcr group add <group> <account>`.
+    @discardableResult
+    public func add(account: String, to group: String) async -> Attempt {
+        await run(
+            key: "\(group)/\(account)", group: group,
+            arguments: GroupCommand.addArguments(group: group, account: account))
+    }
+
+    /// `tcr group rm <group> <account>`.
+    @discardableResult
+    public func remove(account: String, from group: String) async -> Attempt {
+        await run(
+            key: "\(group)/\(account)", group: group,
+            arguments: GroupCommand.removeArguments(group: group, account: account))
+    }
+
+    /// `tcr group rm <group> --all`.
+    @discardableResult
+    public func removeAll(group: String) async -> Attempt {
+        await run(key: group, group: group, arguments: GroupCommand.removeAllArguments(group: group))
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/FleetViewModePreferenceTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetViewModePreferenceTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+
+@testable import TcrBarCore
+
+/// Same shape and same reasons as `LaunchPreferenceTests`: no `@AppStorage`
+/// available outside a SwiftUI `View`/`App`, so this is a plain
+/// `UserDefaults`-backed `ObservableObject` instead.
+@MainActor
+final class FleetViewModePreferenceTests: XCTestCase {
+
+    private var suiteName = ""
+    private var defaults = UserDefaults.standard
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "tcrbar.tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName) ?? .standard
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    func testDefaultsToAccounts() {
+        XCTAssertEqual(FleetViewModePreference(defaults: defaults).mode, .accounts)
+    }
+
+    func testAStoredValueIsRead() {
+        defaults.set("groups", forKey: FleetViewModePreference.modeKey)
+        XCTAssertEqual(FleetViewModePreference(defaults: defaults).mode, .groups)
+    }
+
+    /// An unrecognised stored value — a future case this build does not know,
+    /// or corrupted defaults — must fall back to `.accounts` rather than
+    /// crash or read as `nil`.
+    func testUnrecognisedStoredValueFallsBackToAccounts() {
+        defaults.set("nonsense", forKey: FleetViewModePreference.modeKey)
+        XCTAssertEqual(FleetViewModePreference(defaults: defaults).mode, .accounts)
+    }
+
+    func testSettingItWritesThroughAndSurvivesANewInstance() {
+        let preference = FleetViewModePreference(defaults: defaults)
+        preference.mode = .groups
+
+        XCTAssertEqual(defaults.string(forKey: FleetViewModePreference.modeKey), "groups")
+        XCTAssertEqual(FleetViewModePreference(defaults: defaults).mode, .groups)
+
+        preference.mode = .accounts
+        XCTAssertEqual(defaults.string(forKey: FleetViewModePreference.modeKey), "accounts")
+    }
+
+    func testConstructingItDoesNotWriteTheKey() {
+        _ = FleetViewModePreference(defaults: defaults)
+        XCTAssertNil(defaults.object(forKey: FleetViewModePreference.modeKey))
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/GroupControlTests.swift
+++ b/apps/macos/Tests/TcrBarTests/GroupControlTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+import XCTest
+
+@testable import TcrBarCore
+
+/// Pure argument-building and classification for `tcr group`. Same posture as
+/// `ControlAccountCommandTests`: nothing here spawns a process.
+///
+/// Account and group names are obviously fake — this repository is public.
+final class GroupCommandTests: XCTestCase {
+
+    private let group = "codereview"
+    private let account = "henry7@example.com"
+
+    // MARK: - argument shape (bridge Unit 1)
+
+    func testAddArguments() {
+        XCTAssertEqual(
+            GroupCommand.addArguments(group: group, account: account),
+            ["group", "add", "codereview", "henry7@example.com"]
+        )
+    }
+
+    func testRemoveArguments() {
+        XCTAssertEqual(
+            GroupCommand.removeArguments(group: group, account: account),
+            ["group", "rm", "codereview", "henry7@example.com"]
+        )
+    }
+
+    func testRemoveAllArguments() {
+        XCTAssertEqual(
+            GroupCommand.removeAllArguments(group: group),
+            ["group", "rm", "codereview", "--all"]
+        )
+    }
+
+    // MARK: - classification
+
+    func testCleanExitZeroNoStderr() {
+        XCTAssertEqual(GroupCommand.classify(exitCode: 0, stderr: ""), .clean)
+    }
+
+    func testExitZeroWithStderrIsSpokeNotClean() {
+        XCTAssertEqual(
+            GroupCommand.classify(exitCode: 0, stderr: "warning: proxy too old for this route\n"),
+            .spoke(notice: "warning: proxy too old for this route")
+        )
+    }
+
+    func testNonZeroExitIsFailed() {
+        let outcome = GroupCommand.classify(exitCode: 1, stderr: "error: unknown group\n")
+        guard case .failed(let failure) = outcome else {
+            return XCTFail("expected .failed, got \(outcome)")
+        }
+        XCTAssertEqual(failure.exitCode, 1)
+        XCTAssertEqual(failure.message, "error: unknown group")
+    }
+
+    func testFailureSummaryIsNeverEmpty() {
+        let failure = GroupCommand.Failure(exitCode: 1, message: "")
+        XCTAssertEqual(failure.summary, "group command failed (exit 1): no output")
+    }
+}
+
+/// Client-side group-name validation, mirroring the CLI's own rule (bridge
+/// Unit 3).
+final class GroupNameValidationTests: XCTestCase {
+
+    func testEmptyNameIsRejected() {
+        XCTAssertEqual(GroupNameValidation.validate(""), .empty)
+    }
+
+    func testWhitespaceOnlyNameIsRejected() {
+        XCTAssertEqual(GroupNameValidation.validate("   "), .empty)
+    }
+
+    func testControlCharacterIsRejected() {
+        XCTAssertEqual(GroupNameValidation.validate("dev\u{0007}team"), .controlCharacter)
+    }
+
+    func testDeleteCharacterIsRejected() {
+        XCTAssertEqual(GroupNameValidation.validate("dev\u{007F}team"), .controlCharacter)
+    }
+
+    func testCharacterAboveLatin1IsRejected() {
+        // U+1F600 — well above the Latin-1 ceiling the CLI enforces.
+        XCTAssertEqual(GroupNameValidation.validate("dev😀"), .aboveLatin1)
+    }
+
+    func testOrdinaryNameIsAccepted() {
+        XCTAssertNil(GroupNameValidation.validate("codereview"))
+    }
+
+    func testLatin1ExtendedCharacterIsAccepted() {
+        // U+00E9 (é) sits exactly at the Latin-1 boundary — must not be
+        // rejected as "above" it.
+        XCTAssertNil(GroupNameValidation.validate("café"))
+    }
+}
+
+/// The mutation controller: in-flight tracking, failure surfacing, and the
+/// "restart the proxy to apply" note.
+@MainActor
+final class GroupControllerTests: XCTestCase {
+
+    private let group = "codereview"
+    private let account = "henry7@example.com"
+
+    func testNeverAppliedByDefault() {
+        let controller = GroupController()
+        XCTAssertFalse(controller.needsRestart(group))
+    }
+
+    func testNoFailureByDefault() {
+        let controller = GroupController()
+        XCTAssertNil(controller.failure(for: "\(group)/\(account)"))
+        XCTAssertFalse(controller.isPending("\(group)/\(account)"))
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/GroupDetailTests.swift
+++ b/apps/macos/Tests/TcrBarTests/GroupDetailTests.swift
@@ -144,7 +144,7 @@ final class GroupDetailTests: XCTestCase {
         XCTAssertEqual(fleet.groupDetails.map(\.tally), fleet.groupBreakdown)
     }
 
-    // MARK: - default expansion (bridge Unit 5) — `free` itself, which the view keys off
+    // MARK: - default expansion (bridge Unit 5)
 
     func testFreeIsZeroWhenEveryEnabledMemberIsSpent() {
         let fleet = Fleet(accounts: [
@@ -158,6 +158,47 @@ final class GroupDetailTests: XCTestCase {
             groupAccount("a@example.com", quotaState: .ok, groups: ["codereview"])
         ])
         XCTAssertNotEqual(fleet.groupDetails.first?.free, 0)
+    }
+
+    /// A starved group (`free == 0`) starts expanded — the model property the
+    /// view's disclosure row reads directly, per this file's house rule that
+    /// a rendered/behavioural fact is a property of the model, not a
+    /// view-private computation.
+    func testStarvedGroupStartsExpanded() {
+        let fleet = Fleet(accounts: [
+            groupAccount("a@example.com", quotaState: .spent, groups: ["codereview"])
+        ])
+        XCTAssertEqual(fleet.groupDetails.first?.startsExpanded, true)
+    }
+
+    func testNonStarvedGroupStartsCollapsed() {
+        let fleet = Fleet(accounts: [
+            groupAccount("a@example.com", quotaState: .ok, groups: ["codereview"])
+        ])
+        XCTAssertEqual(fleet.groupDetails.first?.startsExpanded, false)
+    }
+
+    // MARK: - ungrouped ordering and absence (bridge Unit 4, continued)
+
+    /// `ungrouped` is not just sorted alphabetically among real groups — it
+    /// is forced to the end regardless of its own name, which would sort
+    /// before every group in this fixture if it were treated as an ordinary
+    /// key.
+    func testUngroupedSortsLastEvenWhenItWouldSortFirstAlphabetically() {
+        let fleet = Fleet(accounts: [
+            groupAccount("a@example.com", groups: ["zzz-last-alphabetically"]),
+            groupAccount("b@example.com", groups: nil),
+        ])
+        XCTAssertEqual(fleet.groupDetails.map(\.name), ["zzz-last-alphabetically", "ungrouped"])
+    }
+
+    /// No account anywhere carries a label: the whole list is absent, not an
+    /// all-`ungrouped` list of one.
+    func testGroupDetailsAbsentWhenNothingIsLabelled() {
+        let fleet = Fleet(accounts: [
+            groupAccount("a@example.com", groups: nil)
+        ])
+        XCTAssertEqual(fleet.groupDetails, [])
     }
 }
 

--- a/apps/macos/Tests/TcrBarTests/GroupDetailTests.swift
+++ b/apps/macos/Tests/TcrBarTests/GroupDetailTests.swift
@@ -1,0 +1,201 @@
+import XCTest
+
+@testable import TcrBarCore
+
+/// `Fleet.groupDetails` / `GroupDetail` — the Groups view's model layer.
+/// Account names are obviously fake — this repository is public.
+final class GroupDetailTests: XCTestCase {
+
+    // MARK: - membership (bridge Unit 2)
+
+    /// An account in two groups appears as a member of both.
+    func testAccountInTwoGroupsAppearsInBothMemberLists() {
+        let fleet = Fleet(accounts: [
+            groupAccount("a@example.com", groups: ["codereview", "dev"])
+        ])
+        let byName = Dictionary(uniqueKeysWithValues: fleet.groupDetails.map { ($0.name, $0) })
+        XCTAssertEqual(byName["codereview"]?.members.map(\.name), ["a@example.com"])
+        XCTAssertEqual(byName["dev"]?.members.map(\.name), ["a@example.com"])
+    }
+
+    func testMembersIncludeDisabledAccounts() {
+        let fleet = Fleet(accounts: [
+            groupAccount("a@example.com", disabled: true, groups: ["dev"])
+        ])
+        XCTAssertEqual(fleet.groupDetails.first?.members.map(\.name), ["a@example.com"])
+    }
+
+    // MARK: - max 5h utilization
+
+    /// The worst (highest) 5h fraction among members wins.
+    func testMax5hPicksTheWorstMember() {
+        let fleet = Fleet(accounts: [
+            groupAccount("low@example.com", fiveHour: 0.10, groups: ["dev"]),
+            groupAccount("high@example.com", fiveHour: 0.62, groups: ["dev"]),
+        ])
+        XCTAssertEqual(fleet.groupDetails.first?.max5hUtilization, 0.62)
+    }
+
+    func testMax5hIsNilWhenNoMemberHasEverReported() {
+        let fleet = Fleet(accounts: [
+            groupAccount("a@example.com", fiveHour: nil, groups: ["dev"])
+        ])
+        XCTAssertNil(fleet.groupDetails.first?.max5hUtilization)
+    }
+
+    // MARK: - soonest reset
+
+    /// The earliest reset among held members wins, not the latest.
+    func testSoonestResetPicksTheEarliest() {
+        let fleet = Fleet(accounts: [
+            groupAccount(
+                "later@example.com",
+                held: [HeldWindow(window: "5h", minutesUntilReset: 300, resetAtMs: 2)],
+                groups: ["dev"]
+            ),
+            groupAccount(
+                "sooner@example.com",
+                held: [HeldWindow(window: "5h", minutesUntilReset: 134, resetAtMs: 1)],
+                groups: ["dev"]
+            ),
+        ])
+        XCTAssertEqual(fleet.groupDetails.first?.soonestReset?.minutesUntilReset, 134)
+    }
+
+    /// Omitted, not defaulted to some sentinel, when nothing in the group is
+    /// held.
+    func testSoonestResetIsNilWhenNoMemberIsHeld() {
+        let fleet = Fleet(accounts: [
+            groupAccount("a@example.com", groups: ["dev"])
+        ])
+        XCTAssertNil(fleet.groupDetails.first?.soonestReset)
+    }
+
+    // MARK: - stat line (bridge Unit 3): omit a missing half, never a placeholder
+
+    func testStatLineJoinsBothHalvesWhenBothPresent() {
+        let fleet = Fleet(accounts: [
+            groupAccount(
+                "a@example.com",
+                fiveHour: 0.12,
+                held: [HeldWindow(window: "5h", minutesUntilReset: 134, resetAtMs: 1)],
+                groups: ["codereview"]
+            )
+        ])
+        XCTAssertEqual(fleet.groupDetails.first?.statLine, "5h 12% max · resets in 2h 14m")
+    }
+
+    func testStatLineOmitsUtilizationHalfWhenNoMemberHasOne() {
+        let fleet = Fleet(accounts: [
+            groupAccount(
+                "a@example.com",
+                fiveHour: nil,
+                held: [HeldWindow(window: "5h", minutesUntilReset: 60, resetAtMs: 1)],
+                groups: ["dev"]
+            )
+        ])
+        XCTAssertEqual(fleet.groupDetails.first?.statLine, "resets in 1h")
+    }
+
+    func testStatLineOmitsResetHalfWhenNothingIsHeld() {
+        let fleet = Fleet(accounts: [
+            groupAccount("a@example.com", fiveHour: 0.5, groups: ["dev"])
+        ])
+        XCTAssertEqual(fleet.groupDetails.first?.statLine, "5h 50% max")
+    }
+
+    /// Neither half has anything to say — the whole line is `nil`, not an
+    /// empty string or a placeholder.
+    func testStatLineIsNilWhenNeitherHalfHasAnything() {
+        let fleet = Fleet(accounts: [
+            groupAccount("a@example.com", fiveHour: nil, groups: ["dev"])
+        ])
+        XCTAssertNil(fleet.groupDetails.first?.statLine)
+    }
+
+    // MARK: - ordering (bridge Unit 4) — same as `groupBreakdown`'s existing rule
+
+    func testGroupDetailsSortAlphabeticallyBeforeUngrouped() {
+        let fleet = Fleet(accounts: [
+            groupAccount("a@example.com", groups: ["zebra"]),
+            groupAccount("b@example.com", groups: ["alpha"]),
+            groupAccount("c@example.com", groups: nil),
+        ])
+        XCTAssertEqual(fleet.groupDetails.map(\.name), ["alpha", "zebra", "ungrouped"])
+    }
+
+    func testGroupDetailsAreEmptyWhenNoAccountAnywhereCarriesALabel() {
+        let fleet = Fleet(accounts: [
+            groupAccount("a@example.com", groups: nil),
+            groupAccount("b@example.com", groups: []),
+        ])
+        XCTAssertEqual(fleet.groupDetails, [])
+    }
+
+    /// `groupBreakdown` — the pre-existing top-line summary — must still
+    /// report the same free/total pairs now that it is derived from
+    /// `groupDetails` instead of its own pass.
+    func testGroupBreakdownStillMatchesGroupDetails() {
+        let fleet = Fleet(accounts: [
+            groupAccount("a@example.com", quotaState: .spent, groups: ["codereview"]),
+            groupAccount("b@example.com", disabled: true, groups: ["codereview"]),
+        ])
+        XCTAssertEqual(fleet.groupBreakdown, [GroupTally(name: "codereview", free: 0, total: 2)])
+        XCTAssertEqual(fleet.groupDetails.map(\.tally), fleet.groupBreakdown)
+    }
+
+    // MARK: - default expansion (bridge Unit 5) — `free` itself, which the view keys off
+
+    func testFreeIsZeroWhenEveryEnabledMemberIsSpent() {
+        let fleet = Fleet(accounts: [
+            groupAccount("a@example.com", quotaState: .spent, groups: ["codereview"])
+        ])
+        XCTAssertEqual(fleet.groupDetails.first?.free, 0)
+    }
+
+    func testFreeIsNonzeroWhenAMemberCanServe() {
+        let fleet = Fleet(accounts: [
+            groupAccount("a@example.com", quotaState: .ok, groups: ["codereview"])
+        ])
+        XCTAssertNotEqual(fleet.groupDetails.first?.free, 0)
+    }
+}
+
+/// Hand-built accounts with the group-detail-relevant fields exposed. Kept
+/// separate from `FleetStatusTests`' own `account(...)` helper (private to
+/// that file) rather than widening it — this file needs `fiveHour` and
+/// `quotaState` control that helper does not expose.
+private func groupAccount(
+    _ name: String,
+    quotaState: QuotaState = .ok,
+    disabled: Bool = false,
+    fiveHour: Double? = 0,
+    held: [HeldWindow] = [],
+    groups: [String]?
+) -> Account {
+    Account(
+        name: name,
+        priority: 1,
+        status: "active",
+        disabled: disabled,
+        quota: 0,
+        quotaState: quotaState,
+        fiveHour: fiveHour,
+        sevenDay: 0,
+        sevenDayOi: 0,
+        held: held,
+        requests: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheHitRatio: nil,
+        probeStatus: .ok,
+        probeError: nil,
+        lastStreamError: nil,
+        streamErrorCount: 0,
+        source: .live,
+        serverSha: "abc1234",
+        serverDirty: false,
+        groups: groups
+    )
+}


### PR DESCRIPTION
A Groups view in TcrBar: open a group, see its real state, change its membership.

The panel previously showed a one-line group tally and row chips. That is enough to notice a group is starved and not enough to do anything about it.

```
┌─ TcrBar ─────────────────────────────┐
│ Capacity now · next in 47m           │
│ 4 ok · 1 near · 7 spent              │
│ ──────────────────────────────────── │
│  Accounts  [ Groups ]                │
│ ▼ codereview   3/3 free   ⋯          │
│     5h 12% max · resets in 2h 14m    │
│     henry7   ██░░░░░░  12%   ⊖       │
│     henry8   █░░░░░░░   3%   ⊖       │
│     + add account…                   │
│ ▶ dev          3/3 free   ⋯          │
│ ▶ ungrouped    5/9                   │
│ + New group…                         │
└──────────────────────────────────────┘
```

## Design

**A toggle, not a replacement.** `Accounts` keeps today's list unchanged. The toggle hides itself entirely when no account carries a label, so nothing changes for anyone not using groups. The choice persists across panel opens.

**A starved group starts expanded**, everything else collapsed — a `0/N` group is the reason you opened the panel.

**Group stats are model properties, not view code**, following the house rule that a rendered value belongs on the model so a test can assert it directly. Each group carries free/total, worst-window (max 5h) utilization, and soonest reset, reusing `HeldWindow.duration(minutes:)` — there is exactly one duration formatter in this codebase and this does not add a second. A half with nothing to say is omitted rather than rendered as a placeholder, following `QuotaFormat.percent` / `resetCaption`.

**Chips, not sections, on the Accounts view.** An account can be in several groups; sectioning a flat list would duplicate rows or invent a false primary group. Inside the Groups view, where you have deliberately drilled into one group, showing that account under each of its groups is correct.

**Controls shell out.** TcrBar never writes config — mutations invoke `tcr group add|rm`, following the `AccountControl` / `ControlAccountController` pattern, with a pure `arguments(...)` builder that is unit-tested without spawning anything. A non-zero exit surfaces its stderr rather than being swallowed.

**Creating a group requires choosing an account**, because groups are implicit — an "empty group" would not exist. The UI makes that explicit instead of letting someone create something that silently isn't there.

**After a successful change the view says the proxy must restart to apply**, because there is no live config reload. It deliberately does **not** offer to restart: that is the most expensive action in this system and has its own guarded path.

## Verification

`swift-format lint --strict -r apps/macos/Sources/TcrBarCore apps/macos/Tests`, `swift build`, `swift test` — all exit 0; 275 tests, zero failures.

The default-expansion rule originally lived in the view where no test could reach it; the mutation pass caught that and it was moved onto the model so it could be guarded. Verified independently by mutating `ungrouped`'s ordering from append to insert-at-front, which failed exactly the two tests that claim to guard it, then restoring and confirming the file and the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114YEdZJWWvEgsTP4FvoNDL
