### PR TITLE
Collapse group sets into deck cards; right-click an account to change its groups

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -279,61 +279,35 @@ struct FleetView: View {
         }
     }
 
-    /// The sectioned accounts list: one ``AccountGroupSectionHeader`` per
-    /// distinct group SET (``Fleet/groupSections``), each followed by its
-    /// members in the panel's normal display order — an account in two
-    /// groups appears once, under the combined header, never twice.
+    /// One ``GroupDeckCard`` per ``Fleet/groupSections`` entry — the
+    /// sectioned list collapsed to one card per group SET instead of a
+    /// header followed by every member's full row (see `GroupDeckCard.swift`
+    /// for the interaction and the `RowHeightsKey` sizing hazard it was
+    /// built around).
     ///
-    /// Rows are today's ``AccountRow``, unchanged, with group chips
-    /// suppressed: the section header already says what the chips said, so
-    /// keeping both would be the same fact rendered twice.
-    /// One row of the sectioned list, plus the header (if any) that sits
-    /// directly above it — precomputed as plain data, not decided inside the
-    /// `ForEach` closure, so the "have we drawn this section's header yet"
-    /// bookkeeping is a pure function of `fleet` rather than a mutation a
-    /// SwiftUI body re-evaluates on every render.
-    private struct SectionedRow: Identifiable {
-        let account: Account
-        let header: GroupSection?
-        var id: String { account.id }
-    }
-
-    /// Walks the panel's normal display order once, attaching each section's
-    /// header to the first row (in that order) that belongs to it — so
-    /// sections read top-to-bottom in ``Fleet/groupSections``' own order
-    /// without a second, independent sort of the rows themselves.
-    private func sectionedRows(_ fleet: Fleet) -> [SectionedRow] {
-        let sectionByAccountName: [String: GroupSection] = fleet.groupSections.reduce(into: [:]) {
-            result, section in
-            for member in section.members { result[member.name] = section }
-        }
-        var seenSections: Set<String> = []
-        return fleet.rowsInDisplayOrder(pinning: control.current).map { account in
-            guard let section = sectionByAccountName[account.name], !seenSections.contains(section.id)
-            else {
-                return SectionedRow(account: account, header: nil)
-            }
-            seenSections.insert(section.id)
-            return SectionedRow(account: account, header: section)
-        }
-    }
-
+    /// This drops the old `sectionedRows(fleet)` walk's mid-list `Hairline`
+    /// after a pinned control-account row: that separator marked "index 0 of
+    /// one flat list is the control account", and a set of cards has no
+    /// single flat index zero to attach it to — the control account can sit
+    /// in any card, open or collapsed, same as any other member. No bridge
+    /// requirement asked this survive; only "keep the fragmentation
+    /// fallback" and "keep the header tally line" did, and both do — the
+    /// fallback still renders through `rowStack`, unchanged, and each card's
+    /// header still carries `section.label`.
     private func sectionedRowStack(_ fleet: Fleet) -> some View {
-        let rows = sectionedRows(fleet)
-        return VStack(alignment: .leading, spacing: Tok.rowSpacing) {
-            ForEach(rows) { row in
-                if let header = row.header {
-                    AccountGroupSectionHeader(
-                        section: header,
-                        allAccounts: fleet.accounts,
-                        groupController: groupController,
-                        confirmRemoveGroup: $confirmRemoveGroup
-                    )
-                }
-                accountRow(row.account, fleet: fleet, showGroupChips: false)
-                if row.account.name == control.current, rows.first?.id == row.id {
-                    Hairline()
-                }
+        VStack(alignment: .leading, spacing: Tok.rowSpacing) {
+            ForEach(fleet.groupSections) { section in
+                GroupDeckCard(
+                    section: section,
+                    allAccounts: fleet.accounts,
+                    countersAreStructural: fleet.source.countersAreStructural,
+                    accounts: accounts,
+                    control: control,
+                    groupController: groupController,
+                    onChanged: { await poller.pollOnce() },
+                    onRelogin: { reloginAccount($0) },
+                    confirmRemoveGroup: $confirmRemoveGroup
+                )
             }
             NewGroupControl(allAccounts: fleet.accounts, groupController: groupController)
                 .padding(.top, Tok.tightSpacing)
@@ -348,7 +322,9 @@ struct FleetView: View {
             control: control,
             onChanged: { await poller.pollOnce() },
             onRelogin: { reloginAccount(account.name) },
-            showGroupChips: showGroupChips
+            showGroupChips: showGroupChips,
+            groupController: groupController,
+            allAccounts: fleet.accounts
         )
         .background(
             GeometryReader { proxy in
@@ -761,7 +737,15 @@ struct FleetView: View {
 /// keyed by `Account.id`. A dictionary rather than one summed scalar because
 /// rows are not uniform height — `visibleRowsHeight(for:)` needs the first N
 /// individually, in display order, not just their total.
-private struct RowHeightsKey: PreferenceKey {
+/// Not `private`: ``GroupDeckCard`` (`GroupDeckCard.swift`) registers a
+/// member row's height into the same key from outside this file, so an
+/// open card's rows count toward `visibleRowsHeight(for:)` exactly like an
+/// ungrouped account's row does. `PreferenceKey` values bubble up through
+/// any number of intervening views regardless of which type attaches them,
+/// so `fleetRows`'s single `onPreferenceChange(RowHeightsKey.self)` still
+/// catches every row, sectioned or not, without either file needing to
+/// know about the other's view tree.
+struct RowHeightsKey: PreferenceKey {
     static let defaultValue: [String: CGFloat] = [:]
     static func reduce(value: inout [String: CGFloat], nextValue: () -> [String: CGFloat]) {
         value.merge(nextValue()) { _, new in new }
@@ -811,6 +795,15 @@ struct AccountRow: View {
     /// (``Fleet/groupSectionsFragmented``), where the chips are the only
     /// place group membership is still shown.
     var showGroupChips: Bool = true
+    /// Mutating THIS row's own group membership from its context menu — the
+    /// affordance the bridge specifically asked for: before this round,
+    /// membership could only be changed from a section-header menu, and the
+    /// instinct is to act on the account itself. See ``groupMenuItems``.
+    @ObservedObject var groupController: GroupController
+    /// The whole fleet, so ``addToGroupMenu`` can offer every group this
+    /// account is not already in, not just the ones visible in whatever
+    /// section this row happens to be drawn under.
+    let allAccounts: [Account]
 
     /// The single tint for this row's quota evidence. The bar and the
     /// percentage run both read it, so the two can never disagree about
@@ -1180,6 +1173,65 @@ struct AccountRow: View {
             let pasteboard = NSPasteboard.general
             pasteboard.clearContents()
             pasteboard.setString(account.name, forType: .string)
+        }
+        Divider()
+        groupMenuItems
+    }
+
+    /// One entry per ``Account/groupMenuActions``, wired to
+    /// ``GroupController`` exactly the way ``GroupActionsMenu`` already
+    /// wires its own — same `remove(account:from:)`/`add(account:to:)`
+    /// calls, just keyed off this row's account instead of a section's
+    /// group. Kept as a top-level `@ViewBuilder` (not folded into
+    /// `contextMenuItems`'s body) so ``Account/groupMenuActions``'s own
+    /// doc-comment, not this one, is the single place the menu's SHAPE is
+    /// explained.
+    @ViewBuilder
+    private var groupMenuItems: some View {
+        ForEach(account.groupMenuActions, id: \.self) { action in
+            switch action {
+            case .remove(let group):
+                Button("Remove from \(group)") {
+                    Task { await groupController.remove(account: account.name, from: group) }
+                }
+            case .removeAll:
+                Button("Remove from all groups") {
+                    Task {
+                        for group in (account.groups ?? []) {
+                            await groupController.remove(account: account.name, from: group)
+                        }
+                    }
+                }
+            case .addToGroup:
+                addToGroupMenu
+            }
+        }
+    }
+
+    /// Every group this account is not already a member of, fleet-wide —
+    /// the population ``groupMenuItems``'s "Add to group…" submenu offers.
+    /// Disabled rather than hidden when empty (no group exists yet anywhere
+    /// in the fleet): a missing submenu reads as "this row cannot be added
+    /// to a group", which is not the true reason.
+    private var candidateGroupsToAdd: [String] {
+        let existing = Set(account.groups ?? [])
+        let everyGroup = Set(allAccounts.flatMap { $0.groups ?? [] })
+        return everyGroup.subtracting(existing).sorted()
+    }
+
+    @ViewBuilder
+    private var addToGroupMenu: some View {
+        if candidateGroupsToAdd.isEmpty {
+            Button("Add to group…") {}
+                .disabled(true)
+        } else {
+            Menu("Add to group…") {
+                ForEach(candidateGroupsToAdd, id: \.self) { group in
+                    Button(group) {
+                        Task { await groupController.add(account: account.name, to: group) }
+                    }
+                }
+            }
         }
     }
 

--- a/apps/macos/Sources/TcrBar/GroupDeckCard.swift
+++ b/apps/macos/Sources/TcrBar/GroupDeckCard.swift
@@ -1,0 +1,290 @@
+import SwiftUI
+import TcrBarCore
+
+/// One group-SET's card in the sectioned accounts list — collapses a
+/// section down to ONE card with its members "stacked" behind it like a
+/// deck, instead of a header followed by every member's full row (bridge:
+/// `docs/plans/stacked-cards-bridge.md`). Hover peeks the deck open within a
+/// fixed footprint, a click pins it open to today's real ``AccountRow``
+/// list, and hovering a row inside the open list lifts it while its
+/// neighbours recede.
+///
+/// ## The `RowHeightsKey` sizing hazard — read before changing this file
+///
+/// `FleetView` sizes the whole scroll viewport from summed, MEASURED row
+/// heights (`RowHeightsKey`, `FleetView.visibleRowsHeight(for:)`), so the
+/// popover grows with the fleet. A card whose footprint changed on **hover**
+/// would move that sum — and the popover's height with it — while the
+/// pointer sat inside it, which reads as the panel jumping under the
+/// cursor. The bridge's own words: "a panel that jumps under the pointer is
+/// a worse outcome than a slightly less magical one."
+///
+/// This view resolves that by never letting hover touch layout at all.
+/// `isHovering`-gated code below (``collapsedContent``, ``peekIndicator``)
+/// only ever applies `scaleEffect`/`shadow`/`opacity` — it never toggles
+/// `isOpen`, never adds or removes a view, and never registers a different
+/// value with `RowHeightsKey`: the collapsed body always renders exactly
+/// ``topMember``'s row plus a constant decorative peek strip, at exactly
+/// the same size, whether or not the pointer is over it. Only ``isOpen`` —
+/// set by a click, never by `onHover` — swaps that fixed one-row body for
+/// the real per-member list, which DOES resize the panel. That is a
+/// deliberate, discrete action, not a value drifting while the pointer
+/// merely rests over the card, so it does not carry the hazard's defect:
+/// this is the "ship click-to-expand with a non-resizing hover peek" branch
+/// the bridge asked for when hover-driven expansion cannot be made stable,
+/// and hover-driven expansion was never attempted here for exactly that
+/// reason — not attempted and found unstable, judged unstable by
+/// construction (a `ScrollView` sized from summed child heights has no
+/// stable way to grow toward the pointer without moving content under it)
+/// and designed around from the start.
+///
+/// Verifiable by inspection rather than a screenshot harness: grep this
+/// file for `isOpen =` — the only assignment is in ``toggleOpen()``, reached
+/// only from the header's `Button` action, never from an `onHover` closure.
+struct GroupDeckCard: View {
+    let section: GroupSection
+    /// The whole fleet, threaded down to ``GroupActionsMenu`` and each
+    /// member row's own "Add to group…" menu, same reason
+    /// `AccountGroupSectionHeader` already needed it.
+    let allAccounts: [Account]
+    let countersAreStructural: Bool
+    @ObservedObject var accounts: AccountController
+    @ObservedObject var control: ControlAccountController
+    @ObservedObject var groupController: GroupController
+    let onChanged: () async -> PollState
+    let onRelogin: (String) -> Void
+    @Binding var confirmRemoveGroup: String?
+
+    @State private var isOpen = false
+    @State private var isHovering = false
+    @State private var hoveredMemberID: String?
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private var isUngrouped: Bool { section.groups.isEmpty }
+    private var topMember: Account? { section.members.first }
+    private var restMembers: ArraySlice<Account> { section.members.dropFirst() }
+    /// At most 3 decorative lines, matching the mock — deliberately NOT one
+    /// per hidden member: past 3 the strip stops being a legible "there is
+    /// more behind this" hint and starts being clutter, the same reasoning
+    /// `Fleet.groupSetFragmentationThreshold` applies one level up.
+    private var peekLineCount: Int { min(restMembers.count, 3) }
+
+    /// `nil` under Reduce Motion: SwiftUI does not suppress an explicit
+    /// `.animation`/`withAnimation` call for you (`QuotaBar` already
+    /// documents this same rule), so every animated modifier below routes
+    /// through this rather than `Tok.deckAnimation` directly. A `nil`
+    /// animation still changes the STATE, so open/closed and hovered/not
+    /// still read correctly — only the travel between them, not the states
+    /// themselves, ever depends on this: the bridge's "keep the states and
+    /// drop the travel" rule.
+    private var animation: Animation? { reduceMotion ? nil : Tok.deckAnimation }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            if isOpen {
+                openStack
+            } else {
+                collapsedContent
+            }
+        }
+        .padding(Tok.tightSpacing)
+        .background(RoundedRectangle(cornerRadius: Tok.radiusLarge).fill(Tok.raised))
+        .overlay(
+            RoundedRectangle(cornerRadius: Tok.radiusLarge)
+                .strokeBorder(Tok.hairlineStrong, lineWidth: Tok.hairlineWidth)
+        )
+        .onHover { isHovering = $0 }
+    }
+
+    private func toggleOpen() {
+        withAnimation(animation) { isOpen.toggle() }
+    }
+
+    // MARK: Header
+
+    /// The name/free-total/summary block is the ONLY part wrapped in the
+    /// toggling `Button` — the group-actions menus beside it stay outside
+    /// it. A `Menu` nested inside a `Button`'s label is a real AppKit
+    /// hit-testing hazard (the outer button can steal the inner menu's
+    /// click), so this is a bespoke layout rather than a reuse of
+    /// ``AccountGroupSectionHeader`` wholesale; the restart/failure notice
+    /// lines below duplicate that view's own logic for the same reason.
+    private var header: some View {
+        VStack(alignment: .leading, spacing: Tok.tightSpacing) {
+            HStack(spacing: Tok.tightSpacing) {
+                Button(action: toggleOpen) {
+                    HStack(spacing: Tok.tightSpacing) {
+                        if section.isReserved {
+                            Image(systemName: "lock.fill")
+                                .font(.caption)
+                                .foregroundStyle(Tok.near)
+                                .accessibilityLabel("Reserved")
+                        }
+                        VStack(alignment: .leading, spacing: Tok.rowLineSpacing) {
+                            HStack(spacing: Tok.tightSpacing) {
+                                Text(section.header)
+                                    .font(Tok.secondaryFont.weight(.semibold))
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                                Text("\(section.free)/\(section.total)")
+                                    .font(Tok.secondaryDigitFont)
+                                    .foregroundStyle(
+                                        Tok.color(for: section.free == 0 ? FleetTally.Kind.spent : .ok)
+                                    )
+                            }
+                            Text(section.summaryLine)
+                                .font(Tok.detailFont)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer(minLength: 0)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(DeckHeaderButtonStyle())
+                .accessibilityLabel(
+                    "\(section.header), \(section.summaryLine). \(isOpen ? "Collapse" : "Expand")."
+                )
+                if !isUngrouped {
+                    HStack(spacing: Tok.tightSpacing) {
+                        ForEach(section.groups, id: \.self) { group in
+                            GroupActionsMenu(
+                                group: group,
+                                allAccounts: allAccounts,
+                                groupController: groupController,
+                                confirmRemoveGroup: $confirmRemoveGroup
+                            )
+                        }
+                    }
+                }
+            }
+            if section.groups.contains(where: { groupController.needsRestart($0) }) {
+                Text("restart the proxy to apply")
+                    .font(Tok.detailFont)
+                    .foregroundStyle(Tok.near)
+            }
+            if let failure = section.groups.compactMap({ groupController.failure(for: $0) }).first {
+                Text(failure.summary)
+                    .font(Tok.detailFont)
+                    .foregroundStyle(Tok.spent)
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    // MARK: Collapsed — fixed footprint, hover-safe (see the type doc-comment)
+
+    private var collapsedContent: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let topMember {
+                registeredAccountRow(topMember)
+                    .scaleEffect(reduceMotion ? 1 : (isHovering ? 1.008 : 1))
+                    .shadow(
+                        color: .black.opacity(isHovering ? 0.28 : 0),
+                        radius: isHovering ? 10 : 0,
+                        y: isHovering ? 4 : 0
+                    )
+            }
+            peekIndicator
+        }
+        .padding(.top, Tok.tightSpacing)
+        .animation(animation, value: isHovering)
+    }
+
+    /// The "there is more behind this" hint — a constant strip of short
+    /// bars, present whenever the section has more than one member,
+    /// regardless of hover. Hover only raises their opacity, hinting the
+    /// outcome of a click without moving anything (see the type doc-comment
+    /// on why this must never resize).
+    @ViewBuilder
+    private var peekIndicator: some View {
+        if peekLineCount > 0 {
+            VStack(alignment: .leading, spacing: 3) {
+                ForEach(0..<peekLineCount, id: \.self) { index in
+                    Capsule()
+                        .fill(Tok.hairlineStrong)
+                        .frame(height: 2)
+                        .frame(maxWidth: .infinity)
+                        .padding(.leading, CGFloat(index) * 5)
+                }
+            }
+            .padding(.top, Tok.tightSpacing)
+            .opacity(isHovering ? 0.42 : 0.16)
+        }
+    }
+
+    // MARK: Open — the real per-member list
+
+    private var openStack: some View {
+        VStack(alignment: .leading, spacing: Tok.rowSpacing) {
+            ForEach(section.members, id: \.id) { member in
+                memberRow(member)
+            }
+        }
+        .padding(.top, Tok.tightSpacing)
+    }
+
+    /// A hovered row lifts; every other row in the SAME open card recedes
+    /// slightly, so the eye stays on the pointed-at row — the bridge's own
+    /// "dock" description. `hoveredMemberID` is this card's own state, so
+    /// two open cards never fight over which row is "the" hovered one.
+    private func memberRow(_ member: Account) -> some View {
+        let isHoveredRow = hoveredMemberID == member.id
+        let anyHover = hoveredMemberID != nil
+        return registeredAccountRow(member)
+            .scaleEffect(reduceMotion ? 1 : (isHoveredRow ? 1.012 : (anyHover ? 0.995 : 1)))
+            .opacity(anyHover ? (isHoveredRow ? 1 : 0.72) : 1)
+            .zIndex(isHoveredRow ? 1 : 0)
+            .animation(animation, value: hoveredMemberID)
+            .onHover { hovering in
+                if hovering {
+                    hoveredMemberID = member.id
+                } else if hoveredMemberID == member.id {
+                    hoveredMemberID = nil
+                }
+            }
+    }
+
+    /// One member's ``AccountRow``, wrapped with the same `RowHeightsKey`
+    /// registration `FleetView.accountRow(_:fleet:showGroupChips:)` attaches
+    /// to every other row in the panel — mirrored here rather than shared,
+    /// since the two call sites differ in exactly one thing (this one never
+    /// draws group chips: the card's own header already says what they
+    /// would). Used by both ``collapsedContent`` (``topMember`` only) and
+    /// ``openStack`` (every member) — see the type doc-comment for why only
+    /// the rows actually in flow register a height at all.
+    private func registeredAccountRow(_ member: Account) -> some View {
+        AccountRow(
+            account: member,
+            countersAreStructural: countersAreStructural,
+            accounts: accounts,
+            control: control,
+            onChanged: onChanged,
+            onRelogin: { onRelogin(member.name) },
+            showGroupChips: false,
+            groupController: groupController,
+            allAccounts: allAccounts
+        )
+        .background(
+            GeometryReader { proxy in
+                Color.clear.preference(
+                    key: RowHeightsKey.self, value: [member.id: proxy.size.height])
+            }
+        )
+    }
+}
+
+/// Press feedback for the deck-card header's toggling `Button`.
+/// `configuration.isPressed` reflects the pointer being DOWN, not the tap
+/// having completed — SwiftUI updates it on press before `action` fires on
+/// release — which is what satisfies the bridge's "respond on press, not
+/// release" rule for the VISIBLE feedback while leaving the actual `isOpen`
+/// commit on release, the same moment every other button in this panel
+/// commits.
+private struct DeckHeaderButtonStyle: ButtonStyle {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(reduceMotion ? 1 : (configuration.isPressed ? 0.99 : 1))
+    }
+}

--- a/apps/macos/Sources/TcrBar/Tokens.swift
+++ b/apps/macos/Sources/TcrBar/Tokens.swift
@@ -287,6 +287,19 @@ public enum Tok {
         .timingCurve(0.22, 1, 0.36, 1, duration: duration)
     }
 
+    /// The stacked group-deck card's hover/click motion (bridge:
+    /// `docs/plans/stacked-cards-bridge.md`) — deliberately a SEPARATE
+    /// animation from ``standardAnimation``, not a reuse. `standardAnimation`
+    /// is an ease curve tuned for a bar filling toward a value it is going
+    /// to reach and hold; a deck card's hover states are pointer-driven with
+    /// no momentum behind them; per the bridge, that means critically damped
+    /// and NEVER overshooting (`dampingFraction: 1`), where `standardAnimation`
+    /// itself has no overshoot control at all because a fill bar never needed
+    /// one. `response` sits inside the bridge's stated 0.3-0.4s window.
+    public static var deckAnimation: Animation {
+        .spring(response: 0.34, dampingFraction: 1.0, blendDuration: 0)
+    }
+
     // MARK: - Mapping
 
     public static func color(for state: QuotaState) -> Color {

--- a/apps/macos/Sources/TcrBarCore/FleetStatus.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetStatus.swift
@@ -764,6 +764,44 @@ public struct Account: Decodable, Equatable, Identifiable, Sendable {
         guard fraction != nil else { return .unmeasured }
         return .state(effectiveQuotaState(for: window))
     }
+
+    /// The row-level "change this account's groups" menu — derived purely
+    /// from ``groups``, so a test can assert its shape without touching
+    /// SwiftUI (bridge: `docs/plans/stacked-cards-bridge.md`, "put rendered
+    /// values and state rules on the model, not in the view"). One
+    /// ``AccountGroupMenuAction/remove(group:)`` per membership,
+    /// ``AccountGroupMenuAction/removeAll`` only once there is more than one
+    /// membership to collapse — a single membership already has its own
+    /// removal action, and a second control that does the exact same thing
+    /// is noise, not a convenience — and ``AccountGroupMenuAction/addToGroup``
+    /// always last. `[.addToGroup]` alone for an account in no group at all:
+    /// the missing affordance this round exists to add, so an ungrouped
+    /// account gets exactly the one action that applies to it.
+    public var groupMenuActions: [AccountGroupMenuAction] {
+        let sortedGroups = (groups ?? []).sorted()
+        var actions: [AccountGroupMenuAction] = sortedGroups.map { .remove(group: $0) }
+        if sortedGroups.count > 1 {
+            actions.append(.removeAll)
+        }
+        actions.append(.addToGroup)
+        return actions
+    }
+}
+
+/// One entry in ``Account/groupMenuActions``, the row-level context menu
+/// that changes which groups an account belongs to — right-click on the
+/// account itself, the affordance the bridge specifically asked for because
+/// membership used to be reachable only from a section-header menu.
+public enum AccountGroupMenuAction: Equatable, Hashable, Sendable {
+    /// `tcr group rm <group> <account>` for exactly this one membership.
+    case remove(group: String)
+    /// One `tcr group rm <group> <account>` per current membership — there
+    /// is no server-side "remove this account from every group" call, so
+    /// the view issues the same single-membership command this case's
+    /// sibling does, once per group.
+    case removeAll
+    /// Opens the "add to an existing group" submenu.
+    case addToGroup
 }
 
 /// The two things a quota bar's fill/outline can honestly show: no reading
@@ -1355,6 +1393,34 @@ public struct GroupSection: Equatable, Sendable, Identifiable {
     /// the "is this section special" check and the "which groups exactly"
     /// detail stay two separate questions.
     public var isReserved: Bool { !reservedGroups.isEmpty }
+
+    /// `"2 accounts"` / `"1 account"` — the collapsed deck card's account
+    /// count, singular/plural. `total`, not `free`: the card's job is to say
+    /// how big the deck behind it is, the same count ``header`` already
+    /// answers with `free/total` right beside it.
+    public var accountCountLabel: String { "\(total) account\(total == 1 ? "" : "s")" }
+
+    /// The worst (highest) 5-hour utilization among this section's members —
+    /// the window that gates the SET next. Same rule as
+    /// ``GroupDetail/max5hUtilization``, kept separate rather than shared
+    /// because the two types have no common member-holding protocol and
+    /// duplicating one `.compactMap(\.fiveHour).max()` is cheaper than
+    /// inventing one for a single call site each.
+    public var max5hUtilization: Double? {
+        members.compactMap(\.fiveHour).max()
+    }
+
+    /// `"2 accounts · 5h 33% max"` — the collapsed deck card's one line of
+    /// context beneath the header, matching the mock this round was built
+    /// from. The worst-window half is OMITTED, not replaced with a
+    /// placeholder, when no member has ever reported a 5h fraction — the
+    /// same honesty rule ``GroupDetail/statLine`` and ``QuotaFormat`` already
+    /// follow. The count half is never omitted: a section always has at
+    /// least one member.
+    public var summaryLine: String {
+        let worst = max5hUtilization.map { "5h \(QuotaFormat.percent($0)) max" }
+        return [accountCountLabel, worst].compactMap { $0 }.joined(separator: " · ")
+    }
 }
 
 /// ``GroupTally`` elaborated with the accounts that make it up, for the Groups

--- a/apps/macos/Tests/TcrBarTests/StackedCardsTests.swift
+++ b/apps/macos/Tests/TcrBarTests/StackedCardsTests.swift
@@ -1,0 +1,135 @@
+import XCTest
+
+@testable import TcrBarCore
+
+/// `GroupSection.summaryLine`/`accountCountLabel`/`max5hUtilization` — the
+/// stacked deck card's collapsed summary line — and
+/// `Account.groupMenuActions` — the row-level right-click menu that changes
+/// group membership (bridge: `docs/plans/stacked-cards-bridge.md`). Account
+/// names are obviously fake — this repository is public.
+final class StackedCardsTests: XCTestCase {
+
+    // MARK: - collapsed card summary: count, free/total, worst-window
+
+    /// Both halves present: count and worst-window join with " · ", the
+    /// same idiom `GroupDetail.statLine` already uses.
+    func testSummaryLineJoinsCountAndWorstWindowWhenBothPresent() {
+        let fleet = Fleet(accounts: [
+            deckAccount("low@example.com", fiveHour: 0.10, groups: ["dev"]),
+            deckAccount("high@example.com", fiveHour: 0.33, groups: ["dev"]),
+        ])
+        let section = fleet.groupSections.first { $0.header == "dev" }
+        XCTAssertEqual(section?.accountCountLabel, "2 accounts")
+        XCTAssertEqual(section?.summaryLine, "2 accounts · 5h 33% max")
+    }
+
+    /// The worst-window half is OMITTED, not printed as a placeholder, when
+    /// no member has ever reported a 5h fraction — the count half never
+    /// disappears, since a section always has at least one member.
+    func testSummaryLineOmitsWorstWindowWhenNoMemberHasEverReported() {
+        let fleet = Fleet(accounts: [
+            deckAccount("a@example.com", fiveHour: nil, groups: ["dev"])
+        ])
+        let section = fleet.groupSections.first { $0.header == "dev" }
+        XCTAssertNil(section?.max5hUtilization)
+        XCTAssertEqual(section?.summaryLine, "1 account")
+    }
+
+    /// A single-account set still renders sensibly: singular noun, and the
+    /// worst-window half present when that one member has a reading.
+    func testSingleAccountSetRendersSensibly() {
+        let fleet = Fleet(accounts: [
+            deckAccount("solo@example.com", fiveHour: 0.10, groups: ["codereview", "dev"])
+        ])
+        let section = fleet.groupSections.first { $0.header == "codereview + dev" }
+        XCTAssertEqual(section?.total, 1)
+        XCTAssertEqual(section?.accountCountLabel, "1 account")
+        XCTAssertEqual(section?.summaryLine, "1 account · 5h 10% max")
+    }
+
+    /// The worst (highest) 5h fraction among members wins, same rule
+    /// `GroupDetail.max5hUtilization` already applies.
+    func testMax5hUtilizationPicksTheWorstMember() {
+        let fleet = Fleet(accounts: [
+            deckAccount("low@example.com", fiveHour: 0.05, groups: ["dev"]),
+            deckAccount("high@example.com", fiveHour: 0.97, groups: ["dev"]),
+        ])
+        let section = fleet.groupSections.first { $0.header == "dev" }
+        XCTAssertEqual(section?.max5hUtilization, 0.97)
+    }
+
+    // MARK: - right-click row menu (bridge: the missing affordance)
+
+    /// An account in two groups lists a "Remove from <group>" for each,
+    /// plus "Remove from all groups", plus "Add to group…" last.
+    func testAccountInTwoGroupsListsBothRemovalsPlusRemoveAllPlusAdd() {
+        let account = deckAccount("a@example.com", groups: ["dev", "codereview"])
+        XCTAssertEqual(
+            account.groupMenuActions,
+            [
+                .remove(group: "codereview"),
+                .remove(group: "dev"),
+                .removeAll,
+                .addToGroup,
+            ]
+        )
+    }
+
+    /// A single membership gets its own removal action but NOT
+    /// "Remove from all groups" — a second control doing the exact same
+    /// thing as the first is noise, not a convenience.
+    func testAccountInOneGroupOffersNoRemoveAll() {
+        let account = deckAccount("a@example.com", groups: ["dev"])
+        XCTAssertEqual(account.groupMenuActions, [.remove(group: "dev"), .addToGroup])
+    }
+
+    /// An account in no group offers only "Add to group…" — the missing
+    /// affordance the bridge exists to add, with nothing to remove.
+    func testAccountInNoGroupOffersOnlyAddToGroup() {
+        let account = deckAccount("a@example.com", groups: nil)
+        XCTAssertEqual(account.groupMenuActions, [.addToGroup])
+    }
+
+    /// Same for an explicitly empty (not nil) groups array — the wire's
+    /// other spelling of "no membership".
+    func testAccountWithEmptyGroupsArrayOffersOnlyAddToGroup() {
+        let account = deckAccount("a@example.com", groups: [])
+        XCTAssertEqual(account.groupMenuActions, [.addToGroup])
+    }
+}
+
+/// Hand-built accounts with the fields this file's assertions touch.
+/// Mirrors `GroupSectionTests`' own `sectionAccount(...)` helper, kept
+/// separate because this file additionally needs `fiveHour` control that
+/// helper does not expose.
+private func deckAccount(
+    _ name: String,
+    fiveHour: Double? = 0,
+    groups: [String]?
+) -> Account {
+    Account(
+        name: name,
+        priority: 1,
+        status: "active",
+        disabled: false,
+        quota: 0,
+        quotaState: .ok,
+        fiveHour: fiveHour,
+        sevenDay: 0,
+        sevenDayOi: 0,
+        held: [],
+        requests: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheHitRatio: nil,
+        probeStatus: .ok,
+        probeError: nil,
+        lastStreamError: nil,
+        streamErrorCount: 0,
+        source: .live,
+        serverSha: "abc1234",
+        serverDirty: false,
+        groups: groups
+    )
+}


### PR DESCRIPTION
Collapse each group set into a single deck card. Hover peeks, click opens, right-click an account changes its groups.

The list was sectioned by group set but still rendered a full card per account, so 14 accounts was a long scroll — and most accounts are in no group and rarely need individual attention.

Now each group set is one card showing the set name, `free/total`, member count and worst-window `5h N% max`. Hover fans the deck and lifts the top card. Click pins it open to the real per-member `AccountRow` list.

## Right-click an account to change its groups

The affordance that was missing: membership could only be changed from a section-header menu, but the instinct is to act on the account. `Account.groupMenuActions` yields one "Remove from <group>" per membership, "Remove from all groups" only past one membership, and "Add to group…" last — an ungrouped account offers only the latter. Wired to the existing `GroupController`, argv unchanged.

## Hover deliberately does NOT expand — and why

`FleetView` sizes its `ScrollView` from summed child heights (`visibleRowsHeight(for:)`), so there is no way for a card to grow toward the pointer without moving content *under* the pointer. Hover-expansion was judged unstable by construction rather than attempted and abandoned.

So the collapsed body is a **fixed footprint** — the topmost member's real row plus a short decorative peek strip — and hover only drives `scaleEffect`, `shadow` and `opacity`, never layout. Expansion is a discrete click, never a value drifting because the pointer happened to rest somewhere. `isOpen` is assigned in exactly one place (`toggleOpen()`), and `onHover` never touches it — grep-verifiable, and stated as a doc-comment on the type so the constraint survives the next edit.

A panel that jumps under the cursor would be worse than the static list it replaces.

## Motion

`Tok.deckAnimation` is a critically damped spring (`response 0.34`, `dampingFraction 1.0`) kept separate from the pre-existing ease-only `standardAnimation`. No overshoot: a hover carries no momentum, so bounce would read as wrong. Nulled under `accessibilityReduceMotion`, which keeps the states and drops the travel.

## Verification

`swift-format lint --strict -r apps/macos/Sources/TcrBarCore apps/macos/Tests`, `swift build`, `swift test` — all exit 0; 291 tests (283 pre-existing + 8 new).

Three mutations covering every distinct branch of the new model logic: the summary line forced to always print its worst-window half (caught by the omission test), the `removeAll` threshold flipped from `> 1` to `>= 1`, and the nil-groups fallback changed from `[]` to a non-empty list. Each observed red with the expected assertion, then restored green. The remaining new tests share those code paths rather than adding branches, and no separate mutation was claimed for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114YEdZJWWvEgsTP4FvoNDL
