### PR TITLE
Hot-reload group config, fix the derived color band, add create/copy to the row menu

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -1057,9 +1057,7 @@ struct AccountRow: View {
         }
         Divider()
         Button("Copy Account Name") {
-            let pasteboard = NSPasteboard.general
-            pasteboard.clearContents()
-            pasteboard.setString(account.name, forType: .string)
+            copyToPasteboard(account.name)
         }
         Divider()
         groupMenuItems
@@ -1079,6 +1077,11 @@ struct AccountRow: View {
             case .remove(let group):
                 Button("Remove from \(group)") {
                     Task { await groupController.remove(account: account.name, from: group) }
+                }
+                Button("Copy tcr group Command") {
+                    copyToPasteboard(
+                        GroupCommand.commandLine(
+                            arguments: GroupCommand.removeArguments(group: group, account: account.name)))
                 }
             case .removeAll:
                 Button("Remove from all groups") {
@@ -1105,13 +1108,15 @@ struct AccountRow: View {
         return everyGroup.subtracting(existing).sorted()
     }
 
+    /// Never disabled, unlike before this round: "New group…" is always a
+    /// usable entry even for a fleet with no groups at all yet, which is the
+    /// exact gap this menu exists to close.
     @ViewBuilder
     private var addToGroupMenu: some View {
-        if candidateGroupsToAdd.isEmpty {
-            Button("Add to group…") {}
-                .disabled(true)
-        } else {
-            Menu("Add to group…") {
+        Menu("Add to group…") {
+            Button("New group…") { presentNewGroupPrompt() }
+            if !candidateGroupsToAdd.isEmpty {
+                Divider()
                 ForEach(candidateGroupsToAdd, id: \.self) { group in
                     Button(group) {
                         Task { await groupController.add(account: account.name, to: group) }
@@ -1119,6 +1124,58 @@ struct AccountRow: View {
                 }
             }
         }
+    }
+
+    /// Every group anywhere in the fleet, not just this account's own —
+    /// what ``NewGroupName/evaluate(_:existingGroups:)`` checks a typed name
+    /// against so creating a group can never silently become a plain add
+    /// into one that already exists.
+    private var everyGroupFleetWide: Set<String> {
+        Set(allAccounts.flatMap { $0.groups ?? [] })
+    }
+
+    /// Prompts for a new group's name with the same accessory-text-field
+    /// `NSAlert` shape as ``confirmTakeover()`` elsewhere in this file —
+    /// there is no other text-entry affordance in this panel to reuse.
+    /// Re-prompts on an invalid or duplicate name so a typo does not have to
+    /// be re-triggered from the context menu; Escape or Cancel back out with
+    /// no call made.
+    private func presentNewGroupPrompt() {
+        let alert = NSAlert()
+        alert.messageText = "New group"
+        alert.informativeText = "This account is added to the group as soon as it's created."
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 220, height: 24))
+        field.placeholderString = "Group name"
+        alert.accessoryView = field
+        alert.window.initialFirstResponder = field
+        let create = alert.addButton(withTitle: "Create")
+        alert.addButton(withTitle: "Cancel")
+        alert.buttons.last?.keyEquivalent = "\u{1b}"
+        create.keyEquivalent = "\r"
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        let typed = field.stringValue
+        let outcome = NewGroupName.evaluate(typed, existingGroups: everyGroupFleetWide)
+        switch outcome {
+        case .valid(let name):
+            Task { await groupController.add(account: account.name, to: name) }
+        case .rejected, .duplicate:
+            let failureAlert = NSAlert()
+            failureAlert.alertStyle = .warning
+            failureAlert.messageText = "Can't create that group"
+            failureAlert.informativeText = outcome.rejectionMessage ?? "That name isn't usable."
+            failureAlert.addButton(withTitle: "OK")
+            failureAlert.runModal()
+        }
+    }
+
+    /// Shared by "Copy Account Name" and the per-group command copy — one
+    /// place that clears then sets, so every copy in this menu behaves the
+    /// same way.
+    private func copyToPasteboard(_ text: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
     }
 
     /// The one place `tcr control` is actually run for this row — set when

--- a/apps/macos/Sources/TcrBarCore/GroupControl.swift
+++ b/apps/macos/Sources/TcrBarCore/GroupControl.swift
@@ -33,6 +33,29 @@ public enum GroupCommand {
         ["group", "rm", group, "--all"]
     }
 
+    /// Shell-quotes a single argument for a copy-pasteable command line.
+    /// Left bare when it is already safe unquoted (an email like
+    /// `alice@example.com` reads better that way) — otherwise wrapped in
+    /// single quotes with any embedded single quote escaped the POSIX way.
+    /// The function must not simply assume an account name is safe: this is
+    /// the one place that decides, not the call site.
+    public static func shellQuote(_ argument: String) -> String {
+        let safe = argument.range(of: "^[A-Za-z0-9_.@%+=:,/-]+$", options: .regularExpression) != nil
+        if safe { return argument }
+        let escaped = argument.replacingOccurrences(of: "'", with: "'\\''")
+        return "'\(escaped)'"
+    }
+
+    /// The full command line a user can paste into a shell, e.g.
+    /// `tcr group rm dev henry2@example.com`. Built by quoting the SAME argv
+    /// an actual call runs — ``removeArguments(group:account:)`` and friends
+    /// — never formatted from the group/account strings a second time, so
+    /// this text and the action sitting next to it in the menu can never
+    /// drift apart.
+    public static func commandLine(arguments: [String]) -> String {
+        (["tcr"] + arguments).map(shellQuote).joined(separator: " ")
+    }
+
     /// Why a group command did not happen. Carries `tcr`'s own words verbatim,
     /// same posture as ``AccountCommand/Failure``.
     public struct Failure: Error, Equatable, Sendable {
@@ -118,6 +141,43 @@ public enum GroupNameValidation {
         case .empty: return "Group name cannot be empty."
         case .controlCharacter: return "Group name cannot contain control characters."
         case .aboveLatin1: return "Group name cannot contain characters above U+00FF."
+        }
+    }
+}
+
+/// Whether a typed name can be used to CREATE a new group — the CLI's
+/// character rule, plus one more check only this call site needs: since a
+/// group exists only while some account carries its label, "create a group"
+/// and "add this account to an existing group" are the same server call
+/// (`GroupCommand.addArguments`). Typing a name that already names a group
+/// must not be allowed to silently take that second path — the account would
+/// join an existing group while the operator believes they made a new one.
+public enum NewGroupName: Equatable, Sendable {
+    case rejected(GroupNameValidation.Failure)
+    case duplicate
+    case valid(String)
+
+    /// `existingGroups` is the fleet-wide set, not just this account's own —
+    /// the whole point is to catch a name that already belongs to someone
+    /// else's membership.
+    public static func evaluate(_ raw: String, existingGroups: Set<String>) -> NewGroupName {
+        if let failure = GroupNameValidation.validate(raw) {
+            return .rejected(failure)
+        }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if existingGroups.contains(trimmed) {
+            return .duplicate
+        }
+        return .valid(trimmed)
+    }
+
+    /// `nil` when the name is usable; otherwise the reason, safe to render
+    /// beside the text field.
+    public var rejectionMessage: String? {
+        switch self {
+        case .rejected(let failure): return GroupNameValidation.message(for: failure)
+        case .duplicate: return "A group named that already exists."
+        case .valid: return nil
         }
     }
 }

--- a/apps/macos/Tests/TcrBarTests/GroupControlTests.swift
+++ b/apps/macos/Tests/TcrBarTests/GroupControlTests.swift
@@ -61,6 +61,109 @@ final class GroupCommandTests: XCTestCase {
         let failure = GroupCommand.Failure(exitCode: 1, message: "")
         XCTAssertEqual(failure.summary, "group command failed (exit 1): no output")
     }
+
+    // MARK: - copy-command text derives from the same argv the action runs
+
+    /// The copied text and the argv the "Remove from <group>" button actually
+    /// runs must agree — asserted by deriving one from the other, not by
+    /// comparing two hand-typed strings, so a change to `removeArguments`
+    /// can never leave the copy button lying about what it does.
+    func testCopyCommandTextAgreesWithTheRemoveArgumentsItIsBuiltFrom() {
+        let arguments = GroupCommand.removeArguments(group: group, account: account)
+        XCTAssertEqual(
+            GroupCommand.commandLine(arguments: arguments),
+            "tcr " + arguments.joined(separator: " ")
+        )
+    }
+
+    func testCopyCommandTextMatchesTheDocumentedExample() {
+        let arguments = GroupCommand.removeArguments(group: "dev", account: "henry2@example.com")
+        XCTAssertEqual(
+            GroupCommand.commandLine(arguments: arguments),
+            "tcr group rm dev henry2@example.com"
+        )
+    }
+
+    func testShellQuoteLeavesAnEmailBare() {
+        XCTAssertEqual(GroupCommand.shellQuote("henry2@example.com"), "henry2@example.com")
+    }
+
+    /// An account or group name is not guaranteed to be shell-safe — this is
+    /// the one place that must not assume it is.
+    func testShellQuoteQuotesANameContainingASpace() {
+        XCTAssertEqual(GroupCommand.shellQuote("dev team"), "'dev team'")
+    }
+
+    func testShellQuoteEscapesAnEmbeddedSingleQuote() {
+        XCTAssertEqual(GroupCommand.shellQuote("o'brien"), "'o'\\''brien'")
+    }
+
+    func testCommandLineQuotesAGroupNameThatNeedsIt() {
+        let arguments = GroupCommand.removeArguments(group: "dev team", account: account)
+        XCTAssertEqual(
+            GroupCommand.commandLine(arguments: arguments),
+            "tcr group rm 'dev team' henry7@example.com"
+        )
+    }
+}
+
+/// Whether a typed name can be used to create a brand new group (bridge
+/// Unit 1: create-a-group).
+final class NewGroupNameTests: XCTestCase {
+
+    func testEmptyNameIsRejected() {
+        XCTAssertEqual(
+            NewGroupName.evaluate("", existingGroups: []),
+            .rejected(.empty)
+        )
+    }
+
+    func testControlCharacterIsRejected() {
+        XCTAssertEqual(
+            NewGroupName.evaluate("dev\u{0007}team", existingGroups: []),
+            .rejected(.controlCharacter)
+        )
+    }
+
+    func testNameAboveLatin1IsRejected() {
+        XCTAssertEqual(
+            NewGroupName.evaluate("dev😀", existingGroups: []),
+            .rejected(.aboveLatin1)
+        )
+    }
+
+    /// The gap this feature exists to close: without this check, typing an
+    /// existing group's name would silently perform a plain add into it
+    /// instead of the "create a new group" the operator asked for.
+    func testDuplicateOfAnExistingGroupIsRejected() {
+        XCTAssertEqual(
+            NewGroupName.evaluate("dev", existingGroups: ["dev", "codereview"]),
+            .duplicate
+        )
+    }
+
+    func testNovelValidNameIsAccepted() {
+        XCTAssertEqual(
+            NewGroupName.evaluate("staging", existingGroups: ["dev"]),
+            .valid("staging")
+        )
+    }
+
+    func testAcceptedNameIsTrimmed() {
+        XCTAssertEqual(
+            NewGroupName.evaluate("  staging  ", existingGroups: []),
+            .valid("staging")
+        )
+    }
+
+    func testRejectionMessageIsNilForAValidName() {
+        XCTAssertNil(NewGroupName.evaluate("staging", existingGroups: []).rejectionMessage)
+    }
+
+    func testRejectionMessageNamesTheDuplicateReason() {
+        let outcome = NewGroupName.evaluate("dev", existingGroups: ["dev"])
+        XCTAssertEqual(outcome.rejectionMessage, "A group named that already exists.")
+    }
 }
 
 /// Client-side group-name validation, mirroring the CLI's own rule (bridge

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -232,14 +232,20 @@ pub fn set_priority(
     Ok(())
 }
 
-/// Printed after every group mutation that actually changed the file. There is
-/// no live route to push a `groups` edit into a running proxy — it reads
-/// `groups` once, at boot, exactly like `disabled` before the live-control
-/// routes existed for it — so a successful `tcr group add`/`rm` that silently
-/// looked live would be the same class of bug `set_enabled`'s doc-comment
-/// describes: two accounts measured on the live fleet with a config saying one
-/// thing and the serving process doing another.
-const GROUP_RESTART_NOTE: &str = "note: the running proxy will not see this until it restarts";
+/// Printed after every group mutation that actually changed the file.
+///
+/// Used to say "will not see this until it restarts" — true before
+/// `Manager::reload_groups_if_changed` existed (`groups`/`groupSettings` were
+/// read once, at boot, exactly like `disabled` before the live-control routes
+/// existed for it). It is FALSE now: a running proxy hot-reloads group
+/// membership, reservation and color from this same file's mtime on its next
+/// natural cadence tick (a served request or a status/TUI read) — no restart.
+/// Left in place rather than deleted because the CLI and the running proxy
+/// are still two separate processes with no synchronous handshake, so
+/// "already applied" is still not quite true either — this says what IS true
+/// without over-promising instant propagation.
+const GROUP_LIVE_RELOAD_NOTE: &str =
+    "note: the running proxy picks this up automatically (next request or status check) — no restart needed";
 
 /// Resolve `name` to exactly one configured account by EXACT match on
 /// `Account.name` (which IS the email — see [`resolve_account`]'s doc-comment).
@@ -294,7 +300,7 @@ pub fn add_to_group(config_path: &Path, group: &str, account: &str) -> anyhow::R
     match outcome {
         config::GroupWrite::Updated => {
             println!("Added '{account}' to group '{group}'.");
-            println!("{GROUP_RESTART_NOTE}");
+            println!("{GROUP_LIVE_RELOAD_NOTE}");
         }
         config::GroupWrite::Unchanged => {
             println!("'{account}' is already in group '{group}'; nothing changed.");
@@ -369,7 +375,7 @@ pub fn remove_from_group(
                 removed_from.len(),
                 removed_from.join(", ")
             );
-            println!("{GROUP_RESTART_NOTE}");
+            println!("{GROUP_LIVE_RELOAD_NOTE}");
         }
         return Ok(());
     }
@@ -384,7 +390,7 @@ pub fn remove_from_group(
     match outcome {
         config::GroupWrite::Updated => {
             println!("Removed '{account}' from group '{group}'.");
-            println!("{GROUP_RESTART_NOTE}");
+            println!("{GROUP_LIVE_RELOAD_NOTE}");
         }
         config::GroupWrite::Unchanged => {
             println!("'{account}' was not in group '{group}'; nothing changed.");
@@ -448,7 +454,7 @@ pub fn reserve_group(config_path: &Path, group: &str) -> anyhow::Result<()> {
                     "warning: only {remaining} unreserved enabled account(s) remain — ordinary (unrequested) traffic may starve."
                 );
             }
-            println!("{GROUP_RESTART_NOTE}");
+            println!("{GROUP_LIVE_RELOAD_NOTE}");
         }
         config::GroupReserveWrite::Unchanged => {
             println!("group '{group}' is already reserved; nothing changed. {remaining} unreserved enabled account(s) remain.");
@@ -466,7 +472,7 @@ pub fn unreserve_group(config_path: &Path, group: &str) -> anyhow::Result<()> {
     match outcome {
         config::GroupReserveWrite::Updated => {
             println!("group '{group}' unreserved.");
-            println!("{GROUP_RESTART_NOTE}");
+            println!("{GROUP_LIVE_RELOAD_NOTE}");
         }
         config::GroupReserveWrite::Unchanged => {
             println!("group '{group}' was not reserved; nothing changed.");
@@ -483,6 +489,12 @@ pub fn unreserve_group(config_path: &Path, group: &str) -> anyhow::Result<()> {
 /// (`find_account_by_name`'s error), applied here to the group name instead:
 /// a color for a label nothing carries could never appear on any account
 /// row, so setting one would silently do nothing and look like success.
+///
+/// An explicit hex with no readable foreground in either text polarity
+/// (`APCA |Lc| < 60` for both black and white text —
+/// [`config::best_readable_apca`]) **warns, never refuses**: it is the
+/// operator's chip to pick badly if they want to. `--clear` never warns — a
+/// derived color always clears the floor by construction.
 pub fn set_group_color(config_path: &Path, group: &str, hex: Option<&str>) -> anyhow::Result<()> {
     // Validate the hex BEFORE touching the config, same ordering `reserve_group`
     // uses for its safety rail: a rejected write must leave the file untouched.
@@ -525,7 +537,7 @@ pub fn set_group_color(config_path: &Path, group: &str, hex: Option<&str>) -> an
                 "group '{group}' color set to {resolved} ({}).",
                 source.as_str()
             );
-            println!("{GROUP_RESTART_NOTE}");
+            println!("{GROUP_LIVE_RELOAD_NOTE}");
         }
         config::GroupColorWrite::Unchanged => {
             println!(
@@ -534,7 +546,36 @@ pub fn set_group_color(config_path: &Path, group: &str, hex: Option<&str>) -> an
             );
         }
     }
+    // Warn (never refuse — it is the operator's call) when neither text
+    // polarity clears the APCA readability floor. Only for an EXPLICIT
+    // `--clear`d/set color: a `Derived` color always clears the floor by
+    // construction (`derive_group_color`'s own worst-case-≥60 test), so
+    // checking it here would be dead code, never firing.
+    if source == config::ColorSource::Set {
+        if let Some(warning) = low_contrast_color_warning(&resolved, group) {
+            eprintln!("{warning}");
+        }
+    }
     Ok(())
+}
+
+/// The low-contrast warning [`set_group_color`] prints for an explicit hex
+/// with no readable foreground in either text polarity — `None` when
+/// `resolved` clears the APCA floor. Factored out as a pure function (input
+/// -> `Option<String>`, no I/O) so the warning's TRIGGER condition and
+/// CONTENT are both unit-testable without capturing stderr.
+fn low_contrast_color_warning(resolved: &str, group: &str) -> Option<String> {
+    let apca = config::best_readable_apca(resolved);
+    if apca >= 60.0 {
+        return None;
+    }
+    let alternative = config::derive_group_color(group);
+    Some(format!(
+        "warning: '{resolved}' has no readable foreground for group '{group}' \
+         (best achievable APCA |Lc| {apca:.1}, need >= 60 in either polarity). \
+         Set anyway, per your choice. A derived alternative that clears the \
+         floor: {alternative}."
+    ))
 }
 
 /// `tcr group ls [--json]` — list every group and its members, plus the
@@ -2596,6 +2637,68 @@ mod tests {
             .expect("codereview row");
         assert_eq!(row["color"], serde_json::json!("#32d74b"));
         assert_eq!(row["colorSource"], serde_json::json!("set"));
+        fs::remove_file(&path).ok();
+    }
+
+    /// THE test for problem 3's trigger condition: a known low-contrast pick
+    /// (`#d69451`, `config::best_readable_apca` measures ~54.1, below the 60
+    /// floor) produces a warning naming the measured value and a derived
+    /// alternative that itself clears the floor — driving
+    /// `low_contrast_color_warning`'s actual branch, not just checking it
+    /// compiles.
+    #[test]
+    fn low_contrast_color_warning_fires_and_names_a_good_alternative() {
+        let low_contrast = "#d69451";
+        assert!(
+            config::best_readable_apca(low_contrast) < 60.0,
+            "test fixture assumption broken: {low_contrast} must score below the APCA floor"
+        );
+        let warning = low_contrast_color_warning(low_contrast, "codereview").expect("must warn");
+        assert!(warning.contains(low_contrast), "names the color: {warning}");
+        assert!(warning.contains("codereview"), "names the group: {warning}");
+        let alternative = config::derive_group_color("codereview");
+        assert!(
+            warning.contains(&alternative),
+            "names a derived alternative ({alternative}): {warning}"
+        );
+        assert!(
+            config::best_readable_apca(&alternative) >= 60.0,
+            "the alternative named in the warning must itself be readable"
+        );
+    }
+
+    /// Control for the test above: a color that DOES clear the APCA floor
+    /// gets no warning at all — the low-contrast test is exercising the
+    /// warning branch specifically, not a function that always returns `Some`.
+    #[test]
+    fn low_contrast_color_warning_is_silent_for_a_readable_pick() {
+        let readable = "#32d74b";
+        assert!(
+            config::best_readable_apca(readable) >= 60.0,
+            "test fixture assumption broken: {readable} must clear the APCA floor"
+        );
+        assert_eq!(low_contrast_color_warning(readable, "codereview"), None);
+    }
+
+    /// `set_group_color` itself must still SUCCEED (never refuse) and
+    /// actually persist a low-contrast pick to disk — the warning is
+    /// advisory, not a gate. Exercises the real CLI entry point end to end,
+    /// distinct from the two pure-function tests above.
+    #[test]
+    fn set_group_color_accepts_a_low_contrast_pick_instead_of_refusing() {
+        let low_contrast = "#d69451";
+        let path = write_config("color-low-contrast", GROUPED_ACCOUNTS);
+        let result = set_group_color(&path, "codereview", Some(low_contrast));
+        assert!(
+            result.is_ok(),
+            "a low-contrast color must warn, not be refused: {result:?}"
+        );
+        let config = load(&path);
+        assert_eq!(
+            config.group_color("codereview"),
+            (low_contrast.to_string(), config::ColorSource::Set),
+            "the low-contrast color must actually be set, not silently dropped"
+        );
         fs::remove_file(&path).ok();
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -195,16 +195,24 @@ impl ColorSource {
 /// the bytes, not randomness or insertion order), and different names spread
 /// around the hue wheel so adjacent groups are visually distinguishable.
 ///
-/// The saturation/lightness band (62% / 58%) is fixed rather than derived,
-/// because only hue is meant to vary: the panel this feeds is DARK
-/// (`docs/plans/group-colors-bridge.md`), so a color chip needs enough
-/// lightness to read against a near-black background (below ~40% starts
-/// disappearing into it) without climbing so high it washes out to pastel
-/// and loses hue distinctiveness (above ~70% several hues start reading as
-/// "off-white"); saturation sits mid-high so the chip reads as a color, not
-/// a shade of grey, while staying short of neon. 62/58 is the middle of
-/// both safe ranges, not a magic number — a reasonable UI author picking a
-/// dark-mode accent by eye lands in the same neighborhood.
+/// Derived in **OKLCH** at a **fixed lightness** (`L = 0.80`), varying only
+/// hue — not HSL, which this replaced. HSL's `L` is not perceptual: the old
+/// `HSL(hue, 62%, 58%)` band measured **L 0.518–0.852 in OKLCH**, so chips
+/// carried wildly different visual weight for no reason, and around hue 30 it
+/// was unreadable in BOTH text polarities (APCA `|Lc|` 52.5 white / 56.5
+/// black, against the ≥60 threshold non-body text needs) — roughly one group
+/// name in twelve. Fixed `L` is what makes every chip carry the same visual
+/// weight, and it also keeps a single foreground choice correct for every
+/// derived color at once: at `L = 0.80` black text beats white for every hue
+/// on this wheel (measured worst case APCA ≥ 60, see this module's
+/// `derived_colors_clear_the_apca_floor_at_every_hue` test).
+///
+/// Chroma targets `0.12` but is **reduced (never clipped)** per hue to stay
+/// inside the sRGB gamut: at `L = 0.80, C = 0.12` several hues would clip a
+/// channel to 255, which silently distorts the hue rather than dimming it —
+/// see [`oklch_to_gamut_srgb`]. Still emits plain `#rrggbb`: OKLCH is the
+/// math used to pick the byte values, never a notation this crate writes to
+/// the wire, the config file, or anywhere else.
 pub fn derive_group_color(group: &str) -> String {
     // FNV-1a: no dependency, good-enough avalanche for hashing short ASCII
     // labels into a hue — this is a display color, not a security boundary,
@@ -215,26 +223,188 @@ pub fn derive_group_color(group: &str) -> String {
         hash = hash.wrapping_mul(0x100000001b3);
     }
     let hue = (hash % 360) as f64;
-    hsl_to_hex(hue, 0.62, 0.58)
+    oklch_to_hex(DERIVED_GROUP_COLOR_L, DERIVED_GROUP_COLOR_C, hue)
 }
 
-/// `H` in degrees [0, 360), `S`/`L` in [0.0, 1.0] — standard HSL-to-RGB,
-/// returned as a lowercase `#rrggbb`.
-fn hsl_to_hex(h: f64, s: f64, l: f64) -> String {
-    let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
-    let h_prime = h / 60.0;
-    let x = c * (1.0 - (h_prime.rem_euclid(2.0) - 1.0).abs());
-    let (r1, g1, b1) = match h_prime as u32 {
-        0 => (c, x, 0.0),
-        1 => (x, c, 0.0),
-        2 => (0.0, c, x),
-        3 => (0.0, x, c),
-        4 => (x, 0.0, c),
-        _ => (c, 0.0, x),
+/// Fixed OKLCH lightness [`derive_group_color`] varies hue against — see its
+/// doc-comment for why this specific value.
+const DERIVED_GROUP_COLOR_L: f64 = 0.80;
+/// Target OKLCH chroma [`derive_group_color`] aims for before per-hue gamut
+/// reduction — see [`oklch_to_gamut_srgb`].
+const DERIVED_GROUP_COLOR_C: f64 = 0.12;
+
+/// OKLCH(`l`, `c`, `h`-degrees) to a lowercase `#rrggbb`, reducing `c` per hue
+/// to stay in the sRGB gamut — see [`oklch_to_gamut_srgb`].
+fn oklch_to_hex(l: f64, c: f64, h_deg: f64) -> String {
+    let (r, g, b) = oklch_to_gamut_srgb(l, c, h_deg);
+    let to_byte = |v: f64| (v * 255.0).round().clamp(0.0, 255.0) as u8;
+    format!("#{:02x}{:02x}{:02x}", to_byte(r), to_byte(g), to_byte(b))
+}
+
+/// OKLCH(`l`, `c`, `h`-degrees) to gamma-encoded sRGB `(r, g, b)` in `[0, 1]`,
+/// reducing `c` toward 0 in small steps until the linear-sRGB result has no
+/// channel outside `[0, 1]` — i.e. no clipping. Clipping a channel instead
+/// (the naive approach) silently shifts the HUE, not just the brightness,
+/// which is exactly the distortion the bridge asked this to avoid. `c <= 0`
+/// (grey at `l`) is always in gamut, so this always terminates.
+fn oklch_to_gamut_srgb(l: f64, c: f64, h_deg: f64) -> (f64, f64, f64) {
+    let mut chroma = c;
+    loop {
+        if let Some(rgb) = oklch_to_srgb_if_in_gamut(l, chroma, h_deg) {
+            return rgb;
+        }
+        if chroma <= 0.0 {
+            return oklch_to_srgb_clamped(l, 0.0, h_deg);
+        }
+        chroma = (chroma - 0.0005).max(0.0);
+    }
+}
+
+/// A tiny slack on the `[0, 1]` gamut bound — linear-sRGB round-trips through
+/// `powf` and cube roots, so an in-gamut color can land at `1.0000000003`
+/// from floating-point noise alone; without slack that would be rejected as
+/// "out of gamut" and needlessly desaturated.
+const GAMUT_EPS: f64 = 1e-4;
+
+/// `Some((r, g, b))` (gamma-encoded, in `[0, 1]`) when OKLCH(`l`, `c`,
+/// `h`-degrees) converts to linear sRGB with every channel inside
+/// `[-GAMUT_EPS, 1 + GAMUT_EPS]`; `None` when a channel would clip.
+fn oklch_to_srgb_if_in_gamut(l: f64, c: f64, h_deg: f64) -> Option<(f64, f64, f64)> {
+    let (lr, lg, lb) = oklch_to_linear_srgb(l, c, h_deg);
+    if !(-GAMUT_EPS..=1.0 + GAMUT_EPS).contains(&lr)
+        || !(-GAMUT_EPS..=1.0 + GAMUT_EPS).contains(&lg)
+        || !(-GAMUT_EPS..=1.0 + GAMUT_EPS).contains(&lb)
+    {
+        return None;
+    }
+    Some((
+        linear_to_srgb_component(lr.clamp(0.0, 1.0)),
+        linear_to_srgb_component(lg.clamp(0.0, 1.0)),
+        linear_to_srgb_component(lb.clamp(0.0, 1.0)),
+    ))
+}
+
+/// Same conversion as [`oklch_to_srgb_if_in_gamut`], but clamps unconditionally
+/// instead of reporting an out-of-gamut channel — only ever called at `c = 0`
+/// (a grey), which is always representable, by [`oklch_to_gamut_srgb`]'s
+/// terminating case.
+fn oklch_to_srgb_clamped(l: f64, c: f64, h_deg: f64) -> (f64, f64, f64) {
+    let (lr, lg, lb) = oklch_to_linear_srgb(l, c, h_deg);
+    (
+        linear_to_srgb_component(lr.clamp(0.0, 1.0)),
+        linear_to_srgb_component(lg.clamp(0.0, 1.0)),
+        linear_to_srgb_component(lb.clamp(0.0, 1.0)),
+    )
+}
+
+/// OKLCH(`l`, `c`, `h`-degrees) to linear sRGB, via OKLab — Björn Ottosson's
+/// published matrices (https://bottosson.github.io/posts/oklab/), the
+/// reference conversion every OKLCH implementation uses. Channels are NOT
+/// clamped here; the caller decides what an out-of-`[0,1]` channel means.
+fn oklch_to_linear_srgb(l: f64, c: f64, h_deg: f64) -> (f64, f64, f64) {
+    let h = h_deg.to_radians();
+    let a = c * h.cos();
+    let b = c * h.sin();
+
+    let l_ = l + 0.3963377774 * a + 0.2158037573 * b;
+    let m_ = l - 0.1055613458 * a - 0.0638541728 * b;
+    let s_ = l - 0.0894841775 * a - 1.2914855480 * b;
+
+    let l3 = l_ * l_ * l_;
+    let m3 = m_ * m_ * m_;
+    let s3 = s_ * s_ * s_;
+
+    let r = 4.0767416621 * l3 - 3.3077115913 * m3 + 0.2309699292 * s3;
+    let g = -1.2684380046 * l3 + 2.6097574011 * m3 - 0.3413193965 * s3;
+    let b = -0.0041960863 * l3 - 0.7034186147 * m3 + 1.7076147010 * s3;
+    (r, g, b)
+}
+
+/// Linear-light sRGB component in `[0, 1]` to gamma-encoded sRGB in `[0, 1]`
+/// — the standard piecewise sRGB EOTF inverse.
+fn linear_to_srgb_component(v: f64) -> f64 {
+    if v <= 0.0031308 {
+        12.92 * v
+    } else {
+        1.055 * v.powf(1.0 / 2.4) - 0.055
+    }
+}
+
+/// APCA-W3 (SAPC-8) perceptual contrast `Lc`, signed: positive is dark text
+/// on a light background, negative is light text on a dark one — only the
+/// magnitude (`|Lc|`) matters for "is this readable" and that is what every
+/// caller here takes. Ported from the public APCA-W3 0.1.9 reference
+/// algorithm (https://github.com/Myndex/apca-w3) — not WCAG 2's ratio, which
+/// is a poor predictor of perceived contrast for exactly the kind of
+/// mid-lightness saturated color this module generates.
+fn apca_contrast(text_rgb: (u8, u8, u8), bg_rgb: (u8, u8, u8)) -> f64 {
+    const BLACK_THRESHOLD: f64 = 0.022;
+    const BLACK_CLAMP: f64 = 1.414;
+    const DELTA_Y_MIN: f64 = 0.0005;
+    const SCALE: f64 = 1.14;
+    const LO_CLIP: f64 = 0.1;
+    const LO_OFFSET: f64 = 0.027;
+
+    let y = |rgb: (u8, u8, u8)| -> f64 {
+        let f = |v: u8| (v as f64 / 255.0).powf(2.4);
+        0.2126729 * f(rgb.0) + 0.7151522 * f(rgb.1) + 0.0721750 * f(rgb.2)
     };
-    let m = l - c / 2.0;
-    let to_byte = |v: f64| ((v + m) * 255.0).round().clamp(0.0, 255.0) as u8;
-    format!("#{:02x}{:02x}{:02x}", to_byte(r1), to_byte(g1), to_byte(b1))
+    let soft_black_clamp = |y: f64| -> f64 {
+        if y > BLACK_THRESHOLD {
+            y
+        } else {
+            y + (BLACK_THRESHOLD - y).powf(BLACK_CLAMP)
+        }
+    };
+
+    let txt_y = soft_black_clamp(y(text_rgb));
+    let bg_y = soft_black_clamp(y(bg_rgb));
+    if (bg_y - txt_y).abs() < DELTA_Y_MIN {
+        return 0.0;
+    }
+
+    if bg_y > txt_y {
+        // Normal polarity: dark(er) text on a light(er) background.
+        let sapc = (bg_y.powf(0.56) - txt_y.powf(0.57)) * SCALE;
+        if sapc < LO_CLIP {
+            0.0
+        } else {
+            sapc - LO_OFFSET
+        }
+    } else {
+        // Reverse polarity: light(er) text on a dark(er) background.
+        let sapc = (bg_y.powf(0.62) - txt_y.powf(0.65)) * SCALE;
+        if sapc > -LO_CLIP {
+            0.0
+        } else {
+            sapc + LO_OFFSET
+        }
+    }
+    .abs()
+        * 100.0
+}
+
+/// `(r, g, b)` bytes of a `#rrggbb`/`#rgb`-shaped hex string, as already
+/// normalized by [`validate_hex_color`]. `unwrap_or(0)` rather than a
+/// `Result`: every caller here passes a string that already round-tripped
+/// through `validate_hex_color`, so a parse failure would mean that
+/// normalization itself is broken — not something a color-contrast helper
+/// should surface as its own error type.
+fn hex_to_rgb(hex: &str) -> (u8, u8, u8) {
+    let digits = hex.trim_start_matches('#');
+    let byte_at = |start: usize| u8::from_str_radix(&digits[start..start + 2], 16).unwrap_or(0);
+    (byte_at(0), byte_at(2), byte_at(4))
+}
+
+/// The best achievable APCA `|Lc|` for `bg_hex` — whichever of pure white or
+/// pure black text reads better against it. This is the same "which
+/// foreground wins" question the panel asks per color chip, and the number
+/// [`crate::cli::set_group_color`]'s low-contrast warning names.
+pub fn best_readable_apca(bg_hex: &str) -> f64 {
+    let bg = hex_to_rgb(bg_hex);
+    let white = apca_contrast((255, 255, 255), bg);
+    let black = apca_contrast((0, 0, 0), bg);
+    white.max(black)
 }
 
 /// Strictly validate a user-supplied hex color and normalize it to lowercase
@@ -2061,6 +2231,193 @@ mod tests {
         ] {
             assert!(validate_hex_color(bad).is_err(), "{bad:?} must be rejected");
         }
+    }
+
+    // --- derived color band: OKLCH lightness/gamut/APCA (problem 2) ---------
+
+    fn srgb_byte_to_linear(v: u8) -> f64 {
+        let v = v as f64 / 255.0;
+        if v <= 0.04045 {
+            v / 12.92
+        } else {
+            ((v + 0.055) / 1.055).powf(2.4)
+        }
+    }
+
+    /// The OKLab `(L, a, b)` a produced `#rrggbb` ACTUALLY measures at —
+    /// independent of [`oklch_to_linear_srgb`] (the FORWARD conversion under
+    /// test), via a standalone inverse. So a test built on this is not merely
+    /// checking that the forward function returns the constant/hue it was
+    /// told to return; it checks what the byte-quantized output really is.
+    fn measured_oklab_lab(hex: &str) -> (f64, f64, f64) {
+        let (r, g, b) = hex_to_rgb(hex);
+        let (r, g, b) = (
+            srgb_byte_to_linear(r),
+            srgb_byte_to_linear(g),
+            srgb_byte_to_linear(b),
+        );
+        let l_ = (0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b).cbrt();
+        let m_ = (0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b).cbrt();
+        let s_ = (0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b).cbrt();
+        let l = 0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720468 * s_;
+        let a = 1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_;
+        let b = 0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_;
+        (l, a, b)
+    }
+
+    fn measured_oklab_l(hex: &str) -> f64 {
+        measured_oklab_lab(hex).0
+    }
+
+    /// Wiring check: [`derive_group_color`] itself (not just the
+    /// `oklch_to_hex`/`DERIVED_GROUP_COLOR_*` machinery the tests below probe
+    /// directly) actually emits the fixed-lightness band for real group
+    /// names, so a regression that decouples `derive_group_color` from that
+    /// machinery — e.g. reintroducing a per-hue-varying lightness inside
+    /// `derive_group_color`'s own body while leaving the constants and
+    /// `oklch_to_hex` untouched — is caught here even though the other
+    /// OKLCH tests below would not see it.
+    #[test]
+    fn derive_group_color_actually_uses_the_fixed_lightness_band() {
+        for name in ["codereview", "dev", "burst", "ops", "night-shift", "qa"] {
+            let hex = derive_group_color(name);
+            let l = measured_oklab_l(&hex);
+            assert!(
+                (l - DERIVED_GROUP_COLOR_L).abs() < 0.02,
+                "derive_group_color({name:?}) = {hex} measures OKLab L={l:.4}, \
+                 expected ~{DERIVED_GROUP_COLOR_L}"
+            );
+        }
+    }
+
+    /// THE test for the perceptual-uniformity half of problem 2: every hue on
+    /// the derived-color wheel measures the SAME OKLab `L` (up to 8-bit
+    /// rounding noise), unlike the old HSL band which measured L 0.518–0.852.
+    /// Measured (via `measured_oklab_l`, an independent inverse conversion,
+    /// not `derive_group_color`'s own forward math): spread is ~0.003, so
+    /// 0.02 is a generous margin over quantization noise while still catching
+    /// a real regression back toward HSL's ~0.33 spread.
+    #[test]
+    fn derived_colors_share_one_oklch_lightness_across_the_wheel() {
+        let mut min_l = f64::MAX;
+        let mut max_l = f64::MIN;
+        for hue in 0..360u32 {
+            let hex = oklch_to_hex(DERIVED_GROUP_COLOR_L, DERIVED_GROUP_COLOR_C, hue as f64);
+            let l = measured_oklab_l(&hex);
+            min_l = min_l.min(l);
+            max_l = max_l.max(l);
+        }
+        let spread = max_l - min_l;
+        assert!(
+            spread < 0.02,
+            "OKLCH lightness spread across the wheel is {spread:.4}, expected near-zero \
+             (measured L range {min_l:.4}..{max_l:.4})"
+        );
+    }
+
+    /// THE test for the readability half of problem 2: black text over every
+    /// derived color on the wheel clears the APCA `|Lc| >= 60` floor —
+    /// unlike the old HSL band, whose hue-30 slice scored 52.5/56.5 in
+    /// EITHER text polarity. Measured worst case with this implementation is
+    /// ~65.9 and best case ~71.7 (the bridge's own APCA implementation
+    /// measured 67.8–72.9 on the same design; the two-point difference is
+    /// implementation variance in the two independently-derived reference
+    /// algorithms, not a gamut/lightness defect — both clear the floor by a
+    /// wide margin).
+    #[test]
+    fn derived_colors_clear_the_apca_floor_at_every_hue() {
+        let mut worst = f64::MAX;
+        let mut worst_hue = 0u32;
+        for hue in 0..360u32 {
+            let hex = oklch_to_hex(DERIVED_GROUP_COLOR_L, DERIVED_GROUP_COLOR_C, hue as f64);
+            let apca = best_readable_apca(&hex);
+            if apca < worst {
+                worst = apca;
+                worst_hue = hue;
+            }
+        }
+        assert!(
+            worst >= 60.0,
+            "hue {worst_hue} scores APCA |Lc| {worst:.1}, below the 60 floor for non-body text"
+        );
+    }
+
+    /// Every derived color is fully in-gamut: converting it BACK through the
+    /// same OKLab math it was derived from must not require clamping any
+    /// linear-sRGB channel outside `[0, 1]` (beyond `GAMUT_EPS` float noise).
+    /// Guards against a regression back to clipping (which silently shifts
+    /// hue) rather than reducing chroma.
+    #[test]
+    fn derived_colors_are_fully_in_gamut_no_channel_clipped() {
+        for hue in 0..360u32 {
+            let hex = oklch_to_hex(DERIVED_GROUP_COLOR_L, DERIVED_GROUP_COLOR_C, hue as f64);
+            // Independent of `oklch_to_gamut_srgb`'s own internals (comparing
+            // its output to itself would be tautological and blind to a bug
+            // INSIDE that function, e.g. a naive clamp instead of a chroma
+            // reduction): reconstruct the EMITTED color's actual OKLab (a, b)
+            // by inverting the byte-quantized hex, and check its hue matches
+            // the requested hue. A naive per-channel clamp distorts hue (it
+            // moves a/b independently); a correct chroma reduction scales a
+            // and b together, which by construction preserves
+            // `atan2(b, a)`. So a hue mismatch here is direct, independent
+            // evidence of clipping regardless of how the implementation
+            // reached it.
+            let (_, a, b) = measured_oklab_lab(&hex);
+            let chroma = a.hypot(b);
+            assert!(
+                chroma > 1e-4,
+                "hue {hue}: emitted color {hex} is achromatic (chroma {chroma:.5}) — \
+                 the fixed-lightness band should never fully desaturate"
+            );
+            let measured_hue = b.atan2(a).to_degrees().rem_euclid(360.0);
+            let mut delta = (measured_hue - hue as f64).abs();
+            if delta > 180.0 {
+                delta = 360.0 - delta;
+            }
+            assert!(
+                delta < 1.0,
+                "hue {hue}: emitted color {hex} measures hue {measured_hue:.2}° \
+                 (drifted {delta:.2}°) — a channel was clipped instead of chroma reduced"
+            );
+        }
+    }
+
+    /// [`best_readable_apca`] against a known-bad color from the OLD HSL band
+    /// (hue 30, S 62%, L 58% — the bridge's own illegible example) actually
+    /// scores below the 60 floor with this implementation too — otherwise the
+    /// two tests above would be trivially true no matter how the floor is
+    /// computed.
+    #[test]
+    fn best_readable_apca_flags_the_old_bands_illegible_hue() {
+        // Recompute the OLD HSL(30, 0.62, 0.58) color — the removed
+        // `hsl_to_hex(30.0, 0.62, 0.58)` this replaced — via a standalone
+        // HSL-to-RGB, so this test does not hand-guess the hex and instead
+        // proves the NEW APCA implementation genuinely rejects the OLD band's
+        // documented illegible hue, not just that it agrees with the
+        // bridge's own numbers.
+        fn old_hsl_to_hex(h: f64, s: f64, l: f64) -> String {
+            let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
+            let h_prime = h / 60.0;
+            let x = c * (1.0 - (h_prime.rem_euclid(2.0) - 1.0).abs());
+            let (r1, g1, b1) = match h_prime as u32 {
+                0 => (c, x, 0.0),
+                1 => (x, c, 0.0),
+                2 => (0.0, c, x),
+                3 => (0.0, x, c),
+                4 => (x, 0.0, c),
+                _ => (c, 0.0, x),
+            };
+            let m = l - c / 2.0;
+            let to_byte = |v: f64| ((v + m) * 255.0).round().clamp(0.0, 255.0) as u8;
+            format!("#{:02x}{:02x}{:02x}", to_byte(r1), to_byte(g1), to_byte(b1))
+        }
+        let old_hsl_hue_30 = old_hsl_to_hex(30.0, 0.62, 0.58);
+        let apca = best_readable_apca(&old_hsl_hue_30);
+        assert!(
+            apca < 60.0,
+            "the known-illegible old-band color {old_hsl_hue_30} scored {apca:.1}, expected < 60 \
+             (sanity check that best_readable_apca is a real gate, not a rubber stamp)"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,8 +177,9 @@ enum GroupAction {
     Add(GroupAddArgs),
     /// Remove one account from one group, or `--all` to delete the group.
     Rm(GroupRmArgs),
-    /// Reserve a group: from the next restart, an account carrying it is
-    /// off-limits to traffic that did not ask for one of its groups.
+    /// Reserve a group: an account carrying it becomes off-limits to traffic
+    /// that did not ask for one of its groups. A running proxy picks this up
+    /// live (no restart) on its next natural cadence check.
     Reserve(GroupReserveArgs),
     /// Clear a group's reserved flag.
     Unreserve(GroupUnreserveArgs),

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -840,18 +840,30 @@ pub struct Manager {
     upstream: String,
     proxy_api_key: Option<String>,
     global_threshold: f64,
-    /// The set of group labels marked `reserved` (`tcr group reserve`),
-    /// snapshotted from the config at construction — same restart-to-take-effect
-    /// contract as [`config::Account::groups`] itself (`tcr group add`/`rm`
-    /// print the same note). See [`Manager::eligible`]'s `reserved_group` doc
-    /// for the rule this drives.
-    reserved_groups: HashSet<String>,
+    /// The set of group labels marked `reserved` (`tcr group reserve`).
+    /// Seeded from the config at construction and **hot-reloaded** from the
+    /// config file's `groupSettings` thereafter — see
+    /// [`Self::reload_groups_if_changed`] for when and how. `RwLock` (not a
+    /// plain field) precisely because it is no longer construction-only: a
+    /// reader takes a short read lock and clones ([`Self::reserved_groups`]),
+    /// never held across the accounts/affinity locks. See
+    /// [`Manager::eligible`]'s `reserved_group` doc for the rule this drives.
+    reserved_groups: RwLock<HashSet<String>>,
     /// Every group on the fleet mapped to its resolved color
-    /// (`config::Config::group_colors`), snapshotted from the config at
-    /// construction — same restart-to-take-effect contract as
-    /// [`Self::reserved_groups`] above. `BTreeMap` for deterministic wire
-    /// order, matching [`config::Config::group_colors`]'s own return type.
-    group_colors: BTreeMap<String, String>,
+    /// (`config::Config::group_colors`). Seeded at construction and
+    /// hot-reloaded alongside [`Self::reserved_groups`] — same
+    /// [`Self::reload_groups_if_changed`] cadence, same `RwLock` reasoning.
+    /// `BTreeMap` for deterministic wire order, matching
+    /// [`config::Config::group_colors`]'s own return type.
+    group_colors: RwLock<BTreeMap<String, String>>,
+    /// The config file's mtime as of the last successful (or unmodified-since)
+    /// [`Self::reload_groups_if_changed`] check. `None` before the first check.
+    /// Guarded by `config_write` at every access — see that lock's doc and
+    /// `reload_groups_if_changed`'s for why: this and the file read it gates
+    /// must move together, or two racing reload calls could both see a stale
+    /// `None`/old value and redundantly re-parse (harmless) or, worse, one
+    /// could advance it past a write the other hasn't applied yet.
+    groups_reload_mtime: Mutex<Option<std::time::SystemTime>>,
     /// Per-account request pacing knobs, snapshotted from the config at
     /// construction. Default (all `None`) → inert → selection is byte-identical to
     /// the no-pacing build. See [`config::PacingConfig`].
@@ -1031,6 +1043,16 @@ fn cooldown_elapsed(deadline_ms: Option<i64>, now_ms: i64) -> bool {
     deadline_ms.is_some_and(|until| now_ms >= until)
 }
 
+/// A sorted `Vec` of `set`'s members, for a deterministic (and readable)
+/// before/after in [`Manager::apply_group_reload`]'s change log — `HashSet`'s
+/// own iteration order is unspecified and would make the same reload log
+/// differently run to run.
+fn sorted_groups(set: &HashSet<String>) -> Vec<String> {
+    let mut v: Vec<String> = set.iter().cloned().collect();
+    v.sort();
+    v
+}
+
 impl Manager {
     /// Build a manager over `config`, using `refresher` for token refresh,
     /// `prober` for background usage reads, and persisting refreshes to
@@ -1117,8 +1139,9 @@ impl Manager {
             upstream,
             proxy_api_key,
             global_threshold,
-            reserved_groups,
-            group_colors,
+            reserved_groups: RwLock::new(reserved_groups),
+            group_colors: RwLock::new(group_colors),
+            groups_reload_mtime: Mutex::new(None),
             pacing,
             throttle,
             locked_idx,
@@ -1230,6 +1253,7 @@ impl Manager {
     /// traffic ignores it.
     pub fn retry_after_hint(&self, now: OffsetDateTime, is_fable: bool) -> i64 {
         let now_ms = odt_to_ms(now);
+        let reserved_groups = self.reserved_groups();
         let accounts = self.accounts.read().expect("accounts lock poisoned");
         let soonest = accounts
             .iter()
@@ -1245,7 +1269,7 @@ impl Manager {
                     now_ms,
                     is_fable,
                     None,
-                    &self.reserved_groups,
+                    &reserved_groups,
                 );
                 free_at.map(odt_to_ms)
             })
@@ -1382,6 +1406,175 @@ impl Manager {
         // it whole would stamp stale settings over the user's live file.
         if let Err(err) = config::save_tokens(path, &snapshot) {
             tracing::error!(error = %err, "failed to persist refreshed token to config");
+        }
+    }
+
+    /// A cloned snapshot of the currently-reserved group names. Clones rather
+    /// than returning a guard so a caller never holds this lock across a
+    /// second lock acquisition (`accounts`, `affinity`) — the set is a
+    /// handful of short strings, so the clone costs nothing worth avoiding.
+    /// See the field's own doc for the hot-reload contract this serves.
+    fn reserved_groups(&self) -> HashSet<String> {
+        self.reserved_groups
+            .read()
+            .expect("reserved_groups lock poisoned")
+            .clone()
+    }
+
+    /// Re-read [`config::Account::groups`] and `groupSettings` (`reserved`,
+    /// `color`) from `self.config_path` when the file's mtime has moved since
+    /// the last check — the fix for group edits appearing to do nothing
+    /// (`docs/plans/live-reload-bridge.md`, problem 1). Called from a natural
+    /// cadence point ([`Self::select_with_group`], [`Self::select_revalidation`],
+    /// [`Self::snapshot`]) rather than a dedicated watcher thread — one more
+    /// background task is one more thing to keep alive, and every one of
+    /// those call sites already runs on every request or every TUI tick.
+    ///
+    /// Touches ONLY the fields named above. Every other field of `self.config`
+    /// — accounts, credentials, tokens, every unmodelled top-level key — is
+    /// left exactly as booted: the in-memory snapshot stays authoritative for
+    /// those, or this would fight [`Self::persist_now`] / [`Self::persist_tokens`]
+    /// / [`Self::persist_disabled`]'s read-modify-write of the SAME file.
+    ///
+    /// Takes `config_write` (INV1, see that field's doc) across the mtime
+    /// check AND the file read/parse — the same discipline every writer of
+    /// this file already uses, so a reload can never straddle a concurrent
+    /// persist's write. [`config::write_atomic`]'s temp-file-then-rename
+    /// already rules out a torn read on its own; this keeps reload from being
+    /// the one reader that does not bother.
+    ///
+    /// A file that cannot be stat'd, read, or parsed **keeps every current
+    /// in-memory value** and logs a warning — never blanks the fleet's groups
+    /// — and, unlike a successful reload, does NOT advance the remembered
+    /// mtime, so a transient or malformed edit self-heals on the very next
+    /// natural-cadence check rather than waiting for the file to change
+    /// again.
+    pub(super) fn reload_groups_if_changed(&self) {
+        let Some(path) = &self.config_path else {
+            return;
+        };
+        let _writing = self
+            .config_write
+            .lock()
+            .expect("config write lock poisoned");
+        let mtime = match std::fs::metadata(path).and_then(|m| m.modified()) {
+            Ok(m) => m,
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    path = %path.display(),
+                    "group reload: could not stat config file, keeping current groups"
+                );
+                return;
+            }
+        };
+        {
+            let last = self
+                .groups_reload_mtime
+                .lock()
+                .expect("groups reload mtime lock poisoned");
+            if *last == Some(mtime) {
+                return;
+            }
+        }
+        match config::load(path) {
+            Ok(fresh) => {
+                self.apply_group_reload(&fresh);
+                *self
+                    .groups_reload_mtime
+                    .lock()
+                    .expect("groups reload mtime lock poisoned") = Some(mtime);
+            }
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    path = %path.display(),
+                    "group reload: config is unreadable/malformed, keeping current groups"
+                );
+            }
+        }
+    }
+
+    /// Apply `fresh`'s group membership/settings onto the running server and
+    /// log exactly what changed — the line an operator greps for after
+    /// editing groups to ask "did it pick up my edit". Silent when nothing
+    /// actually differs (the common case: most cadence ticks see an unchanged
+    /// file, or a mtime bump from an unrelated write). Called only from
+    /// [`Self::reload_groups_if_changed`], under `config_write`.
+    ///
+    /// Reserved-group membership is applied BEFORE per-account `groups`, so
+    /// that by the time this returns and the caller re-tests a pinned
+    /// session's hard gate, a session on an account whose group just became
+    /// reserved is judged against the fresh reservation — the existing
+    /// pin-reclaim-on-reservation test (`pin_reclaim_when_the_pinned_accounts_group_is_reserved`)
+    /// extends to the reload path for free, because [`Self::select_with_group`]
+    /// re-tests [`Self::account_hard_ok`] against a fresh [`Self::reserved_groups`]
+    /// snapshot on every call — reservation was never cached PAST one call, only
+    /// ACROSS them until this reload existed.
+    ///
+    /// Matches each running [`AccountRuntime`] to `fresh.accounts` by
+    /// [`crate::identity::same_identity`] — the SAME identity rule
+    /// [`Self::persist_tokens`] uses — rather than by name, so a config
+    /// mid-way through a login churn (a display name changed, an org backfilled)
+    /// still reloads the right row instead of silently dropping its groups.
+    fn apply_group_reload(&self, fresh: &Config) {
+        let new_reserved = fresh.reserved_group_names();
+        let new_colors = fresh.group_colors();
+        let mut changed: Vec<String> = Vec::new();
+
+        {
+            let mut reserved = self
+                .reserved_groups
+                .write()
+                .expect("reserved_groups lock poisoned");
+            if *reserved != new_reserved {
+                changed.push(format!(
+                    "reserved groups: {:?} -> {:?}",
+                    sorted_groups(&reserved),
+                    sorted_groups(&new_reserved)
+                ));
+                *reserved = new_reserved;
+            }
+        }
+        {
+            let mut colors = self
+                .group_colors
+                .write()
+                .expect("group_colors lock poisoned");
+            if *colors != new_colors {
+                changed.push(format!("group colors: {:?} -> {:?}", *colors, new_colors));
+                *colors = new_colors;
+            }
+        }
+        {
+            let mut accounts = self.accounts.write().expect("accounts lock poisoned");
+            for account in accounts.iter_mut() {
+                let probe = crate::identity::probe(
+                    &account.name,
+                    account.account_uuid.clone(),
+                    account.org_uuid.clone(),
+                    account.org_name.clone(),
+                );
+                let Some(matched) = fresh
+                    .accounts
+                    .iter()
+                    .find(|a| crate::identity::same_identity(&probe, a))
+                else {
+                    continue;
+                };
+                let new_groups = matched.groups.clone().unwrap_or_default();
+                if new_groups != account.groups {
+                    changed.push(format!(
+                        "{}: groups {:?} -> {:?}",
+                        account.name, account.groups, new_groups
+                    ));
+                    account.groups = new_groups;
+                }
+            }
+        }
+
+        if !changed.is_empty() {
+            tracing::info!(changes = ?changed, "config reload: picked up a group edit");
         }
     }
 
@@ -3097,6 +3290,190 @@ mod tests {
             Some(1),
             "the pin itself must move off the reserved account, not merely divert one request"
         );
+    }
+
+    // ---- live group reload (problem 1: group edits appear to do nothing) ------
+
+    /// A `Config` with one account per `(name, priority, groups)` tuple —
+    /// `groups = &[]` means no `groups` key, matching [`account`]/
+    /// [`account_in_groups`]'s own split. Shared setup for every reload test
+    /// below: called once to build the manager's BOOT config, and called
+    /// again (saved straight to `path`, never through the manager) to
+    /// simulate an out-of-band edit — a hand edit, or a sibling `tcr group`
+    /// invocation — while the manager keeps running.
+    fn reload_config(accounts: &[(&str, i64, &[&str])]) -> Config {
+        let built: Vec<Account> = accounts
+            .iter()
+            .map(|&(name, priority, groups)| {
+                if groups.is_empty() {
+                    account(name, priority)
+                } else {
+                    account_in_groups(name, priority, groups)
+                }
+            })
+            .collect();
+        config_with(built)
+    }
+
+    /// THE test for problem 1: editing a temp config's group membership and
+    /// touching its mtime makes a SUBSEQUENT snapshot report the new groups —
+    /// without rebuilding the `Manager`. If only one test in this section
+    /// survives, this is it.
+    #[test]
+    fn snapshot_picks_up_a_group_edit_without_rebuilding_the_manager() {
+        let path = tmp_config_path("reload-feature");
+        let boot = reload_config(&[("acct", 0, &["dev"])]);
+        config::save(&path, &boot).expect("write initial reload config");
+        let manager = build_manager_with_path(boot, path.clone());
+
+        let before = manager.snapshot(OffsetDateTime::now_utc());
+        assert_eq!(before.accounts[0].groups, vec!["dev".to_string()]);
+
+        // A fast filesystem can produce two writes with the SAME mtime at
+        // whole-second resolution; sleep past that so the edit is actually
+        // observable via mtime, the same concern any mtime-triggered reload
+        // design has.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let edited = reload_config(&[("acct", 0, &["ops", "burst"])]);
+        config::save(&path, &edited).expect("write edited reload config");
+
+        let after = manager.snapshot(OffsetDateTime::now_utc());
+        let mut groups = after.accounts[0].groups.clone();
+        groups.sort();
+        assert_eq!(
+            groups,
+            vec!["burst".to_string(), "ops".to_string()],
+            "a snapshot after the file changed must report the NEW groups, without \
+             rebuilding the Manager"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// A reload does NOT disturb accounts, credentials or tokens — only
+    /// `groups`/`groupSettings` move. Rewrites the file with the SAME account
+    /// identity (name match), a DIFFERENT access token, AND a group change in
+    /// one write, then asserts the in-memory access token is untouched while
+    /// the group DID move — proving the scope, not just the happy path.
+    #[test]
+    fn reload_never_touches_accounts_credentials_or_tokens() {
+        let path = tmp_config_path("reload-scope");
+        let boot = reload_config(&[("acct", 0, &["dev"])]);
+        config::save(&path, &boot).expect("write initial reload config");
+        let manager = build_manager_with_path(boot, path.clone());
+
+        let original_token = {
+            let accounts = manager.accounts.read().expect("accounts lock poisoned");
+            accounts[0].access_token.clone()
+        };
+
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let mut tampered = reload_config(&[("acct", 0, &["ops"])]);
+        tampered.accounts[0].access_token = "at-DIFFERENT-token-must-not-apply".to_string();
+        config::save(&path, &tampered).expect("write tampered reload config");
+
+        manager.reload_groups_if_changed();
+
+        let accounts = manager.accounts.read().expect("accounts lock poisoned");
+        assert_eq!(
+            accounts[0].access_token, original_token,
+            "reload must never touch the access token — only group fields"
+        );
+        assert_eq!(
+            accounts[0].groups,
+            vec!["ops".to_string()],
+            "the group change in the SAME file write must still apply"
+        );
+        drop(accounts);
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// A malformed config at reload time keeps the previous in-memory groups
+    /// (never blanks the fleet) and does not advance the remembered mtime, so
+    /// a subsequent FIX self-heals without the file needing to change again
+    /// after that.
+    #[test]
+    fn reload_keeps_current_groups_on_a_malformed_config() {
+        let path = tmp_config_path("reload-malformed");
+        let boot = reload_config(&[("acct", 0, &["dev"])]);
+        config::save(&path, &boot).expect("write initial reload config");
+        let manager = build_manager_with_path(boot, path.clone());
+
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        std::fs::write(&path, b"{ this is not valid json").expect("write malformed config");
+        manager.reload_groups_if_changed();
+
+        let accounts = manager.accounts.read().expect("accounts lock poisoned");
+        assert_eq!(
+            accounts[0].groups,
+            vec!["dev".to_string()],
+            "a malformed config at reload time must keep the previous groups, not blank them"
+        );
+        drop(accounts);
+
+        // Self-heal: fixing the file (mtime necessarily advances again, since
+        // this write follows the malformed one) makes the NEXT reload apply.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let fixed = reload_config(&[("acct", 0, &["fixed"])]);
+        config::save(&path, &fixed).expect("write fixed reload config");
+        manager.reload_groups_if_changed();
+        let accounts = manager.accounts.read().expect("accounts lock poisoned");
+        assert_eq!(accounts[0].groups, vec!["fixed".to_string()]);
+        drop(accounts);
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// A session pinned to an account that becomes reserved VIA RELOAD (not
+    /// construction-time, unlike
+    /// [`pin_reclaim_when_the_pinned_accounts_group_is_reserved`]) is
+    /// re-keyed on its next unrequested `select`.
+    #[test]
+    fn reload_re_keys_a_pin_when_its_group_becomes_reserved() {
+        let path = tmp_config_path("reload-pin-reclaim");
+        let boot = reload_config(&[("acct", 0, &["codereview"]), ("other", 5, &[])]);
+        config::save(&path, &boot).expect("write initial reload config");
+        let manager = build_manager_with_path(boot, path.clone());
+
+        let now = OffsetDateTime::now_utc();
+        let now_ms = odt_to_ms(now);
+        let key = 9191u64;
+        {
+            let mut affinity = manager.affinity.lock().expect("affinity lock poisoned");
+            affinity.insert(key, (0, now_ms));
+        }
+
+        // Reserve 'codereview' via a fresh file write — no construction-time
+        // reservation at all, unlike the sibling test above.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let reserved_config = config_with_reserved(
+            vec![
+                account_in_groups("acct", 0, &["codereview"]),
+                account("other", 5),
+            ],
+            &["codereview"],
+        );
+        config::save(&path, &reserved_config).expect("write reserved reload config");
+
+        let served = manager
+            .select(&HashSet::new(), now, None, Some(key), "/v1/messages", None)
+            .expect("the plain account is still eligible");
+        assert_eq!(
+            served, 1,
+            "a group reserved via RELOAD must not keep serving an unrequested pinned session"
+        );
+        let pinned_now = manager
+            .affinity
+            .lock()
+            .expect("affinity lock poisoned")
+            .get(&key)
+            .map(|&(idx, _)| idx);
+        assert_eq!(
+            pinned_now,
+            Some(1),
+            "the pin must move off the newly-reserved account, not merely divert one request"
+        );
+
+        std::fs::remove_file(&path).ok();
     }
 
     // ---- hard account lock (`lockAccount`; no failover) -----------------------

--- a/src/manager/select.rs
+++ b/src/manager/select.rs
@@ -264,6 +264,11 @@ impl Manager {
         conn_key: Option<u64>,
         group: Option<&str>,
     ) -> Option<usize> {
+        // Live-reload group membership/settings before anything below reads them —
+        // see `Self::reload_groups_if_changed`'s doc. Cheap no-op when the config
+        // file's mtime has not moved since the last check.
+        self.reload_groups_if_changed();
+
         // Hard account lock: pin ALL traffic to the configured account, bypassing
         // rotation/affinity/migration. `tried` still ends the rotation loop — once the
         // locked account has failed this request, return None (no failover to the pool).
@@ -271,6 +276,10 @@ impl Manager {
             return if tried.contains(&li) { None } else { Some(li) };
         }
 
+        // A single point-in-time snapshot for the whole call — see
+        // `Self::reserved_groups`'s doc for why this clones rather than holding
+        // the lock across the accounts/affinity locks taken below.
+        let reserved_groups = self.reserved_groups();
         let now_ms = odt_to_ms(now);
         // Compute the Fable classification ONCE, not per-account.
         let is_fable = model.is_some_and(crate::model::is_fable_model);
@@ -335,9 +344,10 @@ impl Manager {
                     // THIS request, so a Fable-exhausted pin that a Fable request
                     // already tried still keeps its pin for the session's Opus turns.
                     let accounts = self.accounts.read().expect("accounts lock poisoned");
-                    if accounts.get(idx).is_some_and(|a| {
-                        Self::account_hard_ok(a, now_ms, group, &self.reserved_groups)
-                    }) {
+                    if accounts
+                        .get(idx)
+                        .is_some_and(|a| Self::account_hard_ok(a, now_ms, group, &reserved_groups))
+                    {
                         keep_pin = Some(idx);
                         divert_reason = Some("pin-tried");
                         divert_until_ms = accounts
@@ -379,7 +389,7 @@ impl Manager {
                                 is_fable,
                                 None,  // no group PREFERENCE — honouring an existing pin
                                 group, // but reservation is not a preference — real ask
-                                &self.reserved_groups,
+                                &reserved_groups,
                             )
                         });
                         if !x_usable {
@@ -432,7 +442,7 @@ impl Manager {
                             //    already had, hoisted to where it is reachable; both
                             //    log the identical line so they grep together.
                             let account_alive = accounts.get(idx).is_some_and(|a| {
-                                Self::account_hard_ok(a, now_ms, group, &self.reserved_groups)
+                                Self::account_hard_ok(a, now_ms, group, &reserved_groups)
                             });
                             let model_blocked = accounts.get(idx).is_some_and(|a| {
                                 Self::model_blocked(a, self.global_threshold, now, is_fable)
@@ -522,7 +532,7 @@ impl Manager {
                                         is_fable,
                                         None,  // no group PREFERENCE — honouring an existing pin
                                         group, // but reservation is not a preference — real ask
-                                        &self.reserved_groups,
+                                        &reserved_groups,
                                     ) {
                                         continue;
                                     }
@@ -648,7 +658,7 @@ impl Manager {
                                             is_fable,
                                             None, // no group PREFERENCE — honouring an existing connection
                                             group, // but reservation is not a preference — real ask
-                                            &self.reserved_groups,
+                                            &reserved_groups,
                                         )
                                     })
                                 };
@@ -744,7 +754,7 @@ impl Manager {
                             is_fable,
                             None,  // no group PREFERENCE — honouring a sticky destination
                             group, // but reservation is not a preference — real ask
-                            &self.reserved_groups,
+                            &reserved_groups,
                         )
                     });
                     usable.then_some(sticky)
@@ -996,12 +1006,18 @@ impl Manager {
         model: Option<&str>,
         affinity: Option<u64>,
     ) -> Option<usize> {
+        // Live-reload group membership/settings — same call `select_with_group`
+        // makes, so a session revalidated through THIS path also sees a just-
+        // reserved group and re-keys (bridge's pin-reclaim-via-reload case).
+        self.reload_groups_if_changed();
+
         // Anti-storm spacing on the FALLBACK path only: the upstream 429→hold and the
         // global egress throttle are the real backstops; this just stops a
         // synchronized burst from slamming one over-threshold account when the fleet
         // saturates. The pin-honor path is never throttled here.
         const REVALIDATION_MIN_SPACING_MS: i64 = 2000;
 
+        let reserved_groups = self.reserved_groups();
         let now_ms = odt_to_ms(now);
         let is_fable = model.is_some_and(crate::model::is_fable_model);
 
@@ -1022,7 +1038,7 @@ impl Manager {
                 now_ms,
                 is_fable,
                 None,
-                &self.reserved_groups,
+                &reserved_groups,
             )
         };
 
@@ -1086,7 +1102,7 @@ impl Manager {
                 // (see its affinity fast-path); the two now agree.
                 if accounts
                     .get(idx)
-                    .is_some_and(|a| Self::account_hard_ok(a, now_ms, None, &self.reserved_groups))
+                    .is_some_and(|a| Self::account_hard_ok(a, now_ms, None, &reserved_groups))
                 {
                     keep_pin = Some(idx);
                     pin_until_ms = accounts
@@ -1770,6 +1786,7 @@ impl Manager {
         respect_pacing: bool,
         group: Option<&str>,
     ) -> Option<usize> {
+        let reserved_groups = self.reserved_groups();
         let mut best: Option<usize> = None;
         let mut best_key: Option<(i64, u64, i128)> = None;
         for (idx, account) in accounts.iter().enumerate() {
@@ -1786,7 +1803,7 @@ impl Manager {
                 is_fable,
                 group,
                 group, // this pass's own real ask — see `eligible`'s `reserved_group` doc
-                &self.reserved_groups,
+                &reserved_groups,
             ) {
                 // Distinguish a pacing skip (healthy but capped/spaced) from a real
                 // ineligibility (disabled/error/quota) so the log names only the former.
@@ -1802,7 +1819,7 @@ impl Manager {
                         is_fable,
                         group,
                         group,
-                        &self.reserved_groups,
+                        &reserved_groups,
                     )
                 {
                     tracing::info!(
@@ -1845,6 +1862,7 @@ impl Manager {
         is_fable: bool,
         group: Option<&str>,
     ) -> Option<usize> {
+        let reserved_groups = self.reserved_groups();
         let mut best: Option<usize> = None;
         let mut best_key: Option<(u32, i64, u64, i128)> = None;
         for (idx, account) in accounts.iter().enumerate() {
@@ -1861,7 +1879,7 @@ impl Manager {
                 is_fable,
                 group,
                 group,
-                &self.reserved_groups,
+                &reserved_groups,
             ) {
                 continue;
             }

--- a/src/manager/snapshot.rs
+++ b/src/manager/snapshot.rs
@@ -96,18 +96,26 @@ impl Manager {
         self.config.lock().expect("config lock poisoned").http1_only
     }
 
-    /// Every group on the fleet mapped to its resolved color, as snapshotted
-    /// at construction — see [`Self::reserved_groups`]'s field doc for why
-    /// this is cached rather than re-derived from `self.config` per call: a
-    /// `tcr group color` write needs a restart before this running process's
-    /// wire reflects it, matching every other group-settings knob.
+    /// Every group on the fleet mapped to its resolved color — hot-reloaded
+    /// from `groupSettings` on the same cadence [`Self::snapshot`] and
+    /// selection reload (see [`Self::reload_groups_if_changed`]'s doc); a
+    /// `tcr group color` write is picked up on this process's next natural
+    /// check, no restart required.
     pub fn group_colors(&self) -> BTreeMap<String, String> {
-        self.group_colors.clone()
+        self.group_colors
+            .read()
+            .expect("group_colors lock poisoned")
+            .clone()
     }
 
     /// Compute the live snapshot the TUI renders. Every quota figure is evaluated
     /// at `now` so the display can never show a past-reset window as still full.
     pub fn snapshot(&self, now: OffsetDateTime) -> StatsSnapshot {
+        // Live-reload group membership/settings before this snapshot reads them
+        // — see `Self::reload_groups_if_changed`'s doc. Cheap no-op when the
+        // config file's mtime has not moved.
+        self.reload_groups_if_changed();
+        let reserved = self.reserved_groups();
         let now_ms = odt_to_ms(now);
         // (1) UNDER THE AFFINITY LOCK ONLY: copy every session's PIN out into a
         // local, then DROP the lock before the accounts lock below is taken — the
@@ -147,19 +155,12 @@ impl Manager {
                 // `group: None` — the fleet view answers "what would UNREQUESTED
                 // traffic see right now", the same question `retry_after_hint`
                 // asks (see `Self::account_gate`'s doc-comment).
-                let (gate, free_at) = Self::account_gate(
-                    a,
-                    threshold,
-                    now,
-                    now_ms,
-                    false,
-                    None,
-                    &self.reserved_groups,
-                );
+                let (gate, free_at) =
+                    Self::account_gate(a, threshold, now, now_ms, false, None, &reserved);
                 let mut reserved_groups: Vec<String> = a
                     .groups
                     .iter()
-                    .filter(|g| self.reserved_groups.contains(*g))
+                    .filter(|g| reserved.contains(*g))
                     .cloned()
                     .collect();
                 reserved_groups.sort();

--- a/tests/fixtures/status-contract.json
+++ b/tests/fixtures/status-contract.json
@@ -10,7 +10,7 @@
     "freeAtMs": null,
     "gate": "ok",
     "groupColors": {
-      "codereview": "#5163d6",
+      "codereview": "#63cbfe",
       "dev": "#0a84ff"
     },
     "groups": [
@@ -54,7 +54,7 @@
     "freeAtMs": null,
     "gate": "ok",
     "groupColors": {
-      "codereview": "#5163d6",
+      "codereview": "#63cbfe",
       "dev": "#0a84ff"
     },
     "groups": [],
@@ -106,7 +106,7 @@
     "freeAtMs": 1767312000000,
     "gate": "ok",
     "groupColors": {
-      "codereview": "#5163d6",
+      "codereview": "#63cbfe",
       "dev": "#0a84ff"
     },
     "groups": [],
@@ -158,7 +158,7 @@
     "freeAtMs": null,
     "gate": "ok",
     "groupColors": {
-      "codereview": "#5163d6",
+      "codereview": "#63cbfe",
       "dev": "#0a84ff"
     },
     "groups": [],


### PR DESCRIPTION
Group edits now take effect without a restart, the derived palette becomes perceptually uniform and legible, and the row menu gains create-a-group and copy-the-command.

## 1. Group edits appeared to do nothing

The reported symptom was "remove from group doesnt update or work". It worked every time — and was invisible:

```
$ tcr group rm dev henry2@…   → Removed
$ tcr group ls                 → dev accounts=1        (config updated)
$ tcr status --json            → henry2 groups=["dev"] (server disagrees)
```

`Manager` held a boot-time `Config` snapshot and never re-read it. The CLI printed "restart to apply", which documented the defect rather than fixing it — and restarting this proxy is the most expensive action in the system.

`reload_groups_if_changed` now watches the config's mtime and re-reads **only** `Account::groups` and `groupSettings`, matching accounts by `identity::same_identity` rather than by name — the same rule `persist_tokens` uses. It takes the `config_write` lock across the mtime check and read, matching `persist_now`'s INV1 discipline, so a reload can never interleave with a token flush. Accounts, credentials and tokens are never re-read; the in-memory config stays authoritative for those.

A malformed config keeps the current values, logs, and deliberately **does not advance the remembered mtime**, so a transient bad edit self-heals on the next tick without needing another file change.

Pin reclaim on a newly-reserved group needed no new code: selection already re-tests `account_hard_ok` against a fresh snapshot every call. A test now proves it via a pure file rewrite with no construction-time reservation.

`GROUP_RESTART_NOTE` → `GROUP_LIVE_RELOAD_NOTE`: the note now says the proxy picks it up automatically, because leaving a message that contradicts the behaviour is its own defect.

## 2. The derived palette had an illegible slice

`HSL(hash, 62%, 58%)` is not perceptually uniform: measured in OKLCH the wheel spanned **L 0.518–0.852**, so chips carried wildly different visual weight — and around **hue 30** the result was unreadable in *both* polarities (APCA 52.5 white / 56.5 black against a ≥60 floor). Roughly one group name in twelve hashes there.

Now derived at fixed **OKLCH L=0.80**, target chroma 0.12 **reduced — never clipped — per hue** to the sRGB gamut. Measured across all 360 hues: worst-case APCA **65.94**, lightness spread **0.0028**. Output stays plain hex; OKLCH is the math, not a new notation.

`tcr group color` now warns (never refuses) when an operator's pick clears no polarity, naming the measured value and a readable alternative.

## 3. Row menu

"New group…" — a group exists only while an account carries its label, so creating one *is* adding the first account to a new name. Validated client-side against the CLI's own rule, with a distinct message for a duplicate.

"Copy `tcr group` command" — puts e.g. `tcr group rm dev alice@example.com` on the clipboard, built from the **same argv** the adjacent action runs (`commandLine(arguments:)` prefixes `tcr` onto it) so the text cannot drift from the button.

## Verification

All four Rust gates and all three Swift gates exit 0 on the **merged** tree: 790 Rust tests, 274 Swift, zero failures.

Every new test was watched fail against its own production line and restored. Three of those tests were rewritten after they were found unable to fail: a gamut check that compared the function's output to itself, a contrast test that only asserted "did not refuse" rather than exercising the warning logic, and a lightness test that called an internal helper directly and so could not catch `derive_group_color` decoupling from its own constants. A fixture hex was hand-guessed wrong (`#cc8040`) and corrected to the measured `#d69451` before use.

The `status-contract.json` fixture's embedded derived color changed as an intended consequence of §2, regenerated by its documented procedure and cross-checked by running the Swift decode suite the fixture names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114YEdZJWWvEgsTP4FvoNDL
