### PR TITLE
Show update availability, put the command in the copy label, make group deletion reachable

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -105,6 +105,31 @@ struct FleetView: View {
                     .font(Tok.detailDigitFont)
                     .foregroundStyle(.tertiary)
             }
+            updateStateLine
+        }
+    }
+
+    /// Renders only for ``UpdateState/available(version:)`` and
+    /// ``UpdateState/failed(_:)`` — see ``UpdateState/headerMessage``, which
+    /// is what actually decides that; this view just draws whatever it
+    /// returns. `.unknown` and `.upToDate` add no row: a permanent
+    /// "you're up to date" line has no place in a 380pt panel.
+    ///
+    /// `.available` is a button so clicking it runs the same
+    /// `checkForUpdates()` the footer's own button does — Sparkle drives the
+    /// rest of the install flow from there, never this view.
+    @ViewBuilder
+    private var updateStateLine: some View {
+        if let message = updater.updateState.headerMessage {
+            let isFailure: Bool = {
+                if case .failed = updater.updateState { return true }
+                return false
+            }()
+            Button(message) { updater.checkForUpdates() }
+                .buttonStyle(.plain)
+                .font(Tok.secondaryFont)
+                .foregroundStyle(isFailure ? Tok.spent : Tok.accent)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 
@@ -1078,10 +1103,13 @@ struct AccountRow: View {
                 Button("Remove from \(group)") {
                     Task { await groupController.remove(account: account.name, from: group) }
                 }
-                Button("Copy tcr group Command") {
-                    copyToPasteboard(
-                        GroupCommand.commandLine(
-                            arguments: GroupCommand.removeArguments(group: group, account: account.name)))
+                let copyRemove = GroupCommand.CopyCommandMenuEntry(
+                    arguments: GroupCommand.removeArguments(group: group, account: account.name))
+                Button(copyRemove.title) {
+                    copyToPasteboard(copyRemove.copiedText)
+                }
+                Button("Delete group “\(group)” for everyone…") {
+                    confirmDeleteGroup(group)
                 }
             case .removeAll:
                 Button("Remove from all groups") {
@@ -1120,6 +1148,11 @@ struct AccountRow: View {
                 ForEach(candidateGroupsToAdd, id: \.self) { group in
                     Button(group) {
                         Task { await groupController.add(account: account.name, to: group) }
+                    }
+                    let copyAdd = GroupCommand.CopyCommandMenuEntry(
+                        arguments: GroupCommand.addArguments(group: group, account: account.name))
+                    Button(copyAdd.title) {
+                        copyToPasteboard(copyAdd.copiedText)
                     }
                 }
             }
@@ -1167,6 +1200,33 @@ struct AccountRow: View {
             failureAlert.addButton(withTitle: "OK")
             failureAlert.runModal()
         }
+    }
+
+    /// Confirms before ``GroupController/removeAll(group:)`` — same
+    /// destructive-`NSAlert` shape as ``confirmTakeover()`` (critical style,
+    /// destructive button unlabeled-as-default, Cancel as the actual
+    /// default). This is the one group action that reaches past this row:
+    /// it removes `group` from every account on the fleet, not just
+    /// ``account``, so the alert text says that explicitly rather than
+    /// reading like an ordinary "remove from this group."
+    private func confirmDeleteGroup(_ group: String) {
+        let alert = NSAlert()
+        alert.alertStyle = .critical
+        alert.messageText = "Delete group “\(group)” for every account?"
+        alert.informativeText = """
+            This removes “\(group)” from every account on the fleet, not just \
+            \(account.name) — every row currently tagged with it loses the tag.
+            """
+        let delete = alert.addButton(withTitle: "Delete Group")
+        delete.hasDestructiveAction = true
+        alert.addButton(withTitle: "Cancel")
+        // Cancel is the default: Return and Escape both back out.
+        alert.window.defaultButtonCell = nil
+        alert.buttons.last?.keyEquivalent = "\r"
+        delete.keyEquivalent = ""
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        Task { await groupController.removeAll(group: group) }
     }
 
     /// Shared by "Copy Account Name" and the per-group command copy — one

--- a/apps/macos/Sources/TcrBar/Updater.swift
+++ b/apps/macos/Sources/TcrBar/Updater.swift
@@ -1,6 +1,7 @@
 import Combine
 import Sparkle
 import SwiftUI
+import TcrBarCore
 
 /// Self-update, owned by the app the same way `poller` / `server` / `loginItem` /
 /// `accounts` are: one instance created in `TcrBarApp` and handed down. Not a
@@ -19,22 +20,32 @@ import SwiftUI
 /// it would make that number go backwards, and an updater comparing versions
 /// would conclude there is nothing to install.
 @MainActor
-final class Updater: ObservableObject {
+final class Updater: NSObject, ObservableObject {
     /// Mirrors Sparkle's own gate. It is false while a check is already in
     /// flight, so the button is disabled rather than silently no-op — the same
     /// rule the rest of this panel follows.
     @Published private(set) var canCheckForUpdates = false
+    /// The outcome of the last completed check, published from Sparkle's own
+    /// delegate callbacks below — never inferred by comparing version strings.
+    /// Starts `.unknown`: see ``UpdateState`` for why that is the honest
+    /// starting value rather than `.upToDate`.
+    @Published private(set) var updateState: UpdateState = .unknown
 
-    private let controller: SPUStandardUpdaterController
+    /// Implicitly-unwrapped and set after `super.init()`: `self` cannot be
+    /// handed to Sparkle as `updaterDelegate` until this instance is fully
+    /// initialized, and `SPUStandardUpdaterController` takes its delegate only
+    /// at construction — there is no settable property to wire it afterward.
+    private var controller: SPUStandardUpdaterController!
     private var observation: AnyCancellable?
 
     /// `startingUpdater: false` exists for the render harness. Starting the
     /// updater schedules background checks and can put UI on screen; a process
     /// invoked with `--render-states` must do neither.
     init(startingUpdater: Bool = true) {
+        super.init()
         controller = SPUStandardUpdaterController(
             startingUpdater: startingUpdater,
-            updaterDelegate: nil,
+            updaterDelegate: self,
             userDriverDelegate: nil
         )
         observation = controller.updater.publisher(for: \.canCheckForUpdates)
@@ -49,5 +60,30 @@ final class Updater: ObservableObject {
     /// check deliberately stays silent about.
     func checkForUpdates() {
         controller.updater.checkForUpdates()
+    }
+}
+
+/// Real Sparkle callbacks, not a stubbed indicator. Each method here does
+/// nothing but extract a plain value out of what Sparkle handed it and set
+/// ``Updater/updateState`` — the mapping itself lives on ``UpdateState`` in
+/// `TcrBarCore` and is unit-tested there; these three methods are not,
+/// because `TcrBarCore`'s test target deliberately excludes Sparkle
+/// (`Package.swift`), so `SUAppcastItem`/`SPUUpdater` are not constructible
+/// from a test. `nonisolated` plus a hop to the main actor because Sparkle
+/// does not promise which thread calls a delegate method, matching the
+/// existing `canCheckForUpdates` publisher above.
+extension Updater: SPUUpdaterDelegate {
+    nonisolated func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+        let version = item.displayVersionString
+        Task { @MainActor in self.updateState = .available(version: version) }
+    }
+
+    nonisolated func updaterDidNotFindUpdate(_ updater: SPUUpdater, error: Error) {
+        Task { @MainActor in self.updateState = .upToDate }
+    }
+
+    nonisolated func updater(_ updater: SPUUpdater, didAbortWithError error: Error) {
+        let message = error.localizedDescription
+        Task { @MainActor in self.updateState = .failed(message) }
     }
 }

--- a/apps/macos/Sources/TcrBarCore/GroupControl.swift
+++ b/apps/macos/Sources/TcrBarCore/GroupControl.swift
@@ -56,6 +56,26 @@ public enum GroupCommand {
         (["tcr"] + arguments).map(shellQuote).joined(separator: " ")
     }
 
+    /// A menu item's title and the text it copies to the pasteboard, both
+    /// derived from the same argv via ``commandLine(arguments:)`` — so the
+    /// title can never say one thing and the clipboard hold another. Used
+    /// for both the remove form (`Copy "tcr group rm dev alice@example.com"`)
+    /// and the add form offered for a group the account is not yet in.
+    public struct CopyCommandMenuEntry: Equatable, Sendable {
+        /// What the menu item reads. Never truncated here — only the
+        /// rendered menu is free to clip it visually; the underlying string
+        /// stays complete so `copiedText` can be derived from it unambiguously.
+        public let title: String
+        /// What lands on the pasteboard when the item is chosen.
+        public let copiedText: String
+
+        public init(arguments: [String]) {
+            let line = commandLine(arguments: arguments)
+            self.title = "Copy “\(line)”"
+            self.copiedText = line
+        }
+    }
+
     /// Why a group command did not happen. Carries `tcr`'s own words verbatim,
     /// same posture as ``AccountCommand/Failure``.
     public struct Failure: Error, Equatable, Sendable {

--- a/apps/macos/Sources/TcrBarCore/UpdateState.swift
+++ b/apps/macos/Sources/TcrBarCore/UpdateState.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// What Sparkle's last update check actually found — not a `Bool`, because
+/// this codebase's whole idiom is that "no" and "don't know" are different
+/// facts. `.unknown` is the honest value before any check has completed;
+/// rendering that as "up to date" would be the same class of lie as an
+/// unmeasured `0` (see the doc-comments in `FleetStatus.swift`).
+///
+/// This type carries no Sparkle types on purpose: `TcrBarCore` stays
+/// framework-free (`Package.swift` documents why — the test target links
+/// only this library), so the `TcrBar` executable's `Updater` extracts plain
+/// values (a version string, an error's message) out of Sparkle's delegate
+/// callbacks and hands them to this enum. That boundary is also why this
+/// state's own semantics — what each case means, and what the header shows
+/// for it — are unit-testable, while the delegate methods that populate it
+/// are not: see ``headerMessage``.
+public enum UpdateState: Equatable, Sendable {
+    /// No check has completed yet. The starting value, and the only honest
+    /// one before Sparkle has said anything at all.
+    case unknown
+    /// The last completed check found nothing newer than what is running.
+    case upToDate
+    /// The last completed check found a newer release, reported by Sparkle's
+    /// own `didFindValidUpdate` callback — never inferred by comparing
+    /// version strings here.
+    case available(version: String)
+    /// The last check could not complete — Sparkle's `didAbortWithError`,
+    /// carrying its message verbatim so a silently broken feed is visible.
+    case failed(String)
+
+    /// What the panel header shows for this state, or `nil` to show nothing.
+    /// `.unknown` and `.upToDate` render nothing — this panel is 380pt wide
+    /// and does not get a permanent "you're up to date" row; `.available`
+    /// and `.failed` are the only two facts worth a line, because both are
+    /// something the user should act on or at least notice.
+    public var headerMessage: String? {
+        switch self {
+        case .unknown, .upToDate:
+            return nil
+        case .available(let version):
+            return "Update available: \(version)"
+        case .failed(let reason):
+            return "Update check failed: \(reason)"
+        }
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/GroupControlTests.swift
+++ b/apps/macos/Tests/TcrBarTests/GroupControlTests.swift
@@ -105,6 +105,44 @@ final class GroupCommandTests: XCTestCase {
             "tcr group rm 'dev team' henry7@example.com"
         )
     }
+
+    // MARK: - CopyCommandMenuEntry (bridge Unit 1: unambiguous copy)
+
+    /// The whole point of ``GroupCommand/CopyCommandMenuEntry``: the title a
+    /// user reads and the text that lands on the clipboard both come out of
+    /// the same `commandLine(arguments:)` call, so they can never drift.
+    /// Asserted by deriving the expectation from that function too, not by
+    /// comparing two hand-typed literals.
+    func testCopyEntryTitleAndCopiedTextAreBothDerivedFromCommandLine() {
+        let arguments = GroupCommand.removeArguments(group: group, account: account)
+        let entry = GroupCommand.CopyCommandMenuEntry(arguments: arguments)
+        let expected = GroupCommand.commandLine(arguments: arguments)
+        XCTAssertEqual(entry.copiedText, expected)
+        XCTAssertEqual(entry.title, "Copy \u{201C}\(expected)\u{201D}")
+    }
+
+    /// Same relationship, but for the add form offered on a group the
+    /// account is not yet in — remove-only was half the affordance the
+    /// bridge asked to close.
+    func testCopyEntryForTheAddFormAlsoDerivesFromCommandLine() {
+        let arguments = GroupCommand.addArguments(group: "dev", account: "henry2@example.com")
+        let entry = GroupCommand.CopyCommandMenuEntry(arguments: arguments)
+        XCTAssertEqual(entry.copiedText, "tcr group add dev henry2@example.com")
+        XCTAssertEqual(entry.title, "Copy \u{201C}tcr group add dev henry2@example.com\u{201D}")
+    }
+
+    /// A remove-form entry and an add-form entry for the exact same
+    /// group/account never collide — this is the failure mode that made
+    /// "Copy tcr group Command" ambiguous in the first place (bridge: two
+    /// identically-labelled items with no way to tell which one is which).
+    func testRemoveAndAddCopyEntriesForTheSameGroupAndAccountDiffer() {
+        let removeEntry = GroupCommand.CopyCommandMenuEntry(
+            arguments: GroupCommand.removeArguments(group: group, account: account))
+        let addEntry = GroupCommand.CopyCommandMenuEntry(
+            arguments: GroupCommand.addArguments(group: group, account: account))
+        XCTAssertNotEqual(removeEntry.title, addEntry.title)
+        XCTAssertNotEqual(removeEntry.copiedText, addEntry.copiedText)
+    }
 }
 
 /// Whether a typed name can be used to create a brand new group (bridge

--- a/apps/macos/Tests/TcrBarTests/UpdateStateTests.swift
+++ b/apps/macos/Tests/TcrBarTests/UpdateStateTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+
+@testable import TcrBarCore
+
+/// `UpdateState` — the enum ``Updater`` (in the `TcrBar` executable target)
+/// populates from Sparkle's real delegate callbacks. This file tests the
+/// state's own semantics: what each case means and what the header shows
+/// for it (bridge: `docs/plans/menu-and-update-bridge.md`, "Nothing shows
+/// whether an update is available").
+///
+/// It cannot exercise `Updater`'s Sparkle wiring itself: `Package.swift`
+/// deliberately keeps `TcrBarCore` (and therefore this test target, which
+/// only depends on it) free of Sparkle, so `SPUUpdater`/`SUAppcastItem`
+/// are not constructible here. That boundary is exactly why the mapping
+/// logic lives on this framework-free enum rather than inline in the
+/// delegate methods — this is the part of "did the callback map to the
+/// right case" that a test in this target can actually reach.
+final class UpdateStateTests: XCTestCase {
+
+    /// `.unknown` is the honest starting value — before any check has
+    /// completed the app does not know, and it must not render as though it
+    /// does.
+    func testUnknownRendersNothing() {
+        XCTAssertNil(UpdateState.unknown.headerMessage)
+    }
+
+    /// `.upToDate` also renders nothing — no permanent "you're up to date"
+    /// row in a 380pt panel.
+    func testUpToDateRendersNothing() {
+        XCTAssertNil(UpdateState.upToDate.headerMessage)
+    }
+
+    /// `.available` is the one state actually worth a line, and it carries
+    /// the version Sparkle reported.
+    func testAvailableRendersTheVersion() {
+        XCTAssertEqual(
+            UpdateState.available(version: "1.2.3").headerMessage,
+            "Update available: 1.2.3"
+        )
+    }
+
+    /// `.failed` also renders — a silently broken feed must stay visible —
+    /// carrying Sparkle's own error text verbatim.
+    func testFailedRendersTheReason() {
+        XCTAssertEqual(
+            UpdateState.failed("feed unreachable").headerMessage,
+            "Update check failed: feed unreachable"
+        )
+    }
+
+    /// The four cases are pairwise distinct so a state transition is never
+    /// silently absorbed into another case.
+    func testCasesAreDistinct() {
+        let states: [UpdateState] = [
+            .unknown, .upToDate, .available(version: "1.0"), .failed("x"),
+        ]
+        for (i, a) in states.enumerated() {
+            for (j, b) in states.enumerated() where i != j {
+                XCTAssertNotEqual(a, b, "\(a) should not equal \(b)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Three fixes to the account row menu and the panel header.

## 1. "Copy tcr group Command" surprised the user

The copied string was correct — `tcr group rm dev alice@example.com`, built from the same argv the adjacent button runs, asserted by a test. The defect was the **label**: one identically-titled item per group, saying neither which group nor which operation. You picked one and got something you didn't expect, which reads exactly like a copying bug.

The command now goes *in* the title — `Copy "tcr group rm dev alice@example.com"` — so what you read is what lands on the clipboard. Title and copied text are both derived from a single `commandLine(arguments:)` call inside one `CopyCommandMenuEntry`, so they cannot drift; a test asserts the equality rather than comparing two literals.

The **add** form is now offered too, beside each candidate group in "Add to group…" — copy was previously remove-only, which covered half the use.

## 2. Nothing showed whether an update was available

`Updater` exposed only `canCheckForUpdates`, which is Sparkle reporting *the checker is idle* — not that an update exists. Nothing surfaced availability at all.

`UpdateState` is now `unknown` / `upToDate` / `available(version)` / `failed(reason)` — an enum, not a `Bool`, because "no update" and "haven't checked" are different facts and this codebase treats that distinction as load-bearing everywhere else. `unknown` is the honest starting value; rendering "up to date" before a check completes would be the same class of lie as an unmeasured `0`.

The header renders a line only for `available` and `failed` — nothing for the other two, rather than adding a permanent "you're up to date" row to a 380pt panel. A failed feed stays visible instead of looking identical to no update.

The state comes from Sparkle's real delegate callbacks (`didFindValidUpdate`, `updaterDidNotFindUpdate`, `didAbortWithError`), with `updaterDelegate: self` passed at construction — signatures taken from Sparkle 2.9.5's own `SPUUpdaterDelegate.h` rather than guessed.

**Known test gap, stated rather than papered over:** `Package.swift` deliberately keeps `TcrBarCore` — and therefore the test target — free of Sparkle, so those three one-line delegate bodies cannot be exercised by XCTest without changing the build graph, which is out of scope here. The mapping they call into is fully unit tested; the callbacks themselves are verified by reading Sparkle's header and will be verified at runtime by the next release.

## 3. Group deletion was implemented but unreachable

`GroupControl.removeAll(group:)` existed and was tested, but the menu that called it went with the deleted group sections. There is now a "Delete group … for everyone" item per membership, behind a confirmation built to the same shape as the file's existing `confirmTakeover()` — critical style, destructive button with no default key equivalent, Cancel as the Return default. The title says it affects every account, because it does.

## Verification

`swift-format lint --strict`, `swift build`, `swift test` — all exit 0; 282 tests, zero failures.

Mutations, each observed red then restored: `CopyCommandMenuEntry.init` hardcoded to a fixed title (all three copy tests failed with the literal-vs-derived mismatch), and `UpdateState.headerMessage` returning a string for `.upToDate` (the render-nothing test failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114YEdZJWWvEgsTP4FvoNDL
