### PR TITLE
No update found is not a failure, and never build without the Sparkle key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaude-rs"
-version = "0.2.21"
+version = "0.2.22"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/apps/macos/Sources/TcrBar/Updater.swift
+++ b/apps/macos/Sources/TcrBar/Updater.swift
@@ -82,8 +82,29 @@ extension Updater: SPUUpdaterDelegate {
         Task { @MainActor in self.updateState = .upToDate }
     }
 
+    /// Sparkle aborts a check it completed successfully but found nothing for,
+    /// reporting `SUError.noUpdateError` — and it does so AFTER
+    /// ``updaterDidNotFindUpdate(_:error:)`` has already set `.upToDate`, so a
+    /// naive mapping here overwrites the good state with a failure carrying
+    /// Sparkle's own cheerful text. That shipped, and rendered in red as
+    /// "Update check failed: You're up to date!".
+    ///
+    /// "No update" is an outcome, not an error. Only a genuine abort is a
+    /// failure.
     nonisolated func updater(_ updater: SPUUpdater, didAbortWithError error: Error) {
+        if Self.isNoUpdateError(error) {
+            Task { @MainActor in self.updateState = .upToDate }
+            return
+        }
         let message = error.localizedDescription
         Task { @MainActor in self.updateState = .failed(message) }
+    }
+
+    /// Whether an abort is Sparkle's benign "there was nothing to install".
+    /// Matched on the error domain and code rather than its message, which is
+    /// user-facing and localised.
+    nonisolated static func isNoUpdateError(_ error: Error) -> Bool {
+        let ns = error as NSError
+        return ns.domain == SUSparkleErrorDomain && ns.code == Int(SUError.noUpdateError.rawValue)
     }
 }

--- a/apps/macos/scripts/build-tcrbar.sh
+++ b/apps/macos/scripts/build-tcrbar.sh
@@ -222,6 +222,17 @@ fi
 # It is read from the environment rather than written down because the private
 # half signs releases: only the release pipeline should have to know it, and this
 # repository is public.
+# The PUBLIC half is published in docs/RELEASING.md ("Publishing it is the
+# point") and ships in every Info.plist, so defaulting to it is not a leak — it
+# is the same value any installed copy already carries. Only the PRIVATE half is
+# a secret, and that lives in the keychain and never appears here.
+#
+# It used to be env-only, and the omission was silent: six locally-built bundles
+# shipped without SUPublicEDKey, and Sparkle then failed the update CHECK
+# outright on every one of them. The warning below claimed such a build "can
+# check the feed", which was measured false. An env override still wins, for a
+# build that must carry a different key.
+: "${TCRBAR_SPARKLE_PUBLIC_KEY:=1WZWEwzSEijRarey7qE0a+n4AO/+7e4Fj/nW8Y8ZKMM=}"
 sparkle_public_key_entry=""
 if [ -n "${TCRBAR_SPARKLE_PUBLIC_KEY:-}" ]; then
   sparkle_public_key_entry="	<key>SUPublicEDKey</key>
@@ -230,8 +241,8 @@ else
   {
     echo
     echo "WARNING: TCRBAR_SPARKLE_PUBLIC_KEY is not set, so SUPublicEDKey is OMITTED."
-    echo "WARNING: this build can check the feed but cannot verify a downloaded"
-    echo "WARNING: update, so Sparkle will refuse to install one. That is deliberate:"
+    echo "WARNING: Sparkle fails the update CHECK outright without it - measured,"
+    echo "WARNING: not merely refusing to install. That is deliberate:"
     echo "WARNING: a placeholder key would fail the same way while looking configured."
     echo "WARNING: Fix: export TCRBAR_SPARKLE_PUBLIC_KEY=<the EdDSA public key> and rebuild."
     echo


### PR DESCRIPTION
Two bugs from tonight's release, both user-visible, both mine.

## 1. "Update check failed: You're up to date!"

Rendered in red, in the panel header. Sparkle calls `updaterDidNotFindUpdate` — which correctly set `.upToDate` — and *then* aborts the same check with `SUError.noUpdateError`. The abort handler mapped any abort to `.failed`, overwriting the good state with a failure carrying Sparkle's own cheerful text.

"No update" is an **outcome**, not an error. `didAbortWithError` now recognises that specific error and maps it to `.upToDate`; every other abort is still a genuine failure. Matched on error domain and code, never on the message, which is user-facing and localised.

## 2. Every locally-built bundle silently lost update capability

`build-tcrbar.sh` omitted `SUPublicEDKey` unless `TCRBAR_SPARKLE_PUBLIC_KEY` was exported, and only the release path exports it. Six bundles were built and installed tonight; not one could check for updates.

The stated reason was that the key shouldn't be "written down" because the repo is public — but that argument is about the **private** half. The public half is already published in `docs/RELEASING.md`, verbatim, under the words *"Publishing it is the point"*, and ships inside every `Info.plist` anyway. The script was withholding a value the repo publishes two files away.

It now defaults to that published key, with the env var still overriding for a build that needs a different one.

The warning text was also wrong. It claimed such a build *"can check the feed but cannot verify a downloaded update"*. Measured: Sparkle fails the **check** outright — it never gets as far as verifying anything. Corrected.

Verified the way that matters: a plain `build-tcrbar.sh` run with no environment set now produces a bundle carrying the key, and emits no omission warning.

## Test gap, stated plainly

`Package.swift` deliberately keeps `TcrBarCore` — and so the test target — free of Sparkle, so the delegate mapping cannot be exercised by XCTest without changing the build graph. `isNoUpdateError` uses Sparkle's own `SUSparkleErrorDomain` and `SUError.noUpdateError` rather than hardcoded strings, and the fix was verified at runtime in the installed panel. The existing 282 tests still pass.

Version bumped to 0.2.22 because v0.2.21 is already tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114YEdZJWWvEgsTP4FvoNDL
