### PR TITLE
Derive session-affinity pin TTL from the client's own cache_control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamclaude-rs"
-version = "0.2.22"
+version = "0.2.23"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/src/affinity.rs
+++ b/src/affinity.rs
@@ -70,6 +70,15 @@ use crate::identity::{self, Resolved};
 /// property (1) above, not a slightly stale preference.
 pub const PIN_TTL_MS: i64 = 15 * 60 * 1000;
 
+/// Restore window for a pin whose client explicitly asked Anthropic's cache for
+/// the extended `"ttl":"1h"` window (see [`StoredPin::extended_ttl`]), measured
+/// 2026-08-21 against 52,951 real `request usage` records: gaps of 15-60 minutes
+/// hit the cache 73-88% of the time and the hit rate does not fall off a cliff
+/// until past 60 minutes (12%). 55 minutes is that 60-minute warm window minus
+/// room for the restart itself, mirroring how [`PIN_TTL_MS`]'s 15 minutes is
+/// derived from the 5-minute default window plus the same margin.
+pub const EXTENDED_PIN_TTL_MS: i64 = 55 * 60 * 1000;
+
 /// Maximum pins written to disk, mirroring the in-memory `AFFINITY_CAP`. On
 /// overflow the freshest are kept, matching the in-memory LRU-by-last-touch
 /// eviction, so a restore can never produce a map larger than the process would
@@ -102,8 +111,19 @@ pub struct StoredPin {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub org_name: Option<String>,
     /// Epoch ms of the last request served on this pin. Compared against
-    /// [`PIN_TTL_MS`] at load.
+    /// [`PIN_TTL_MS`] (or [`EXTENDED_PIN_TTL_MS`] below) at load.
     pub touched_at_ms: i64,
+    /// Whether the client's own request carried Anthropic's extended
+    /// `"cache_control": {"ttl": "1h"}` — see [`crate::cache_ttl`]. When `true`,
+    /// [`load`] compares this pin's age against [`EXTENDED_PIN_TTL_MS`] instead
+    /// of the caller's `ttl_ms`. A plain `bool` rather than a raw millisecond
+    /// value: the only two windows Anthropic's cache actually offers are the
+    /// 5-minute default and the 1-hour extended tier, so there is nothing an
+    /// arbitrary number would express that this doesn't, and a bad file can only
+    /// ever produce `false` (`#[serde(default)]`) — never a longer window than
+    /// the caller intended.
+    #[serde(default)]
+    pub extended_ttl: bool,
 }
 
 impl StoredPin {
@@ -136,6 +156,10 @@ pub struct LoadReport {
     /// Restored pins, in the in-memory map's own shape: key → (account index,
     /// last-touch ms).
     pub pins: HashMap<u64, (usize, i64)>,
+    /// The subset of `pins` whose [`StoredPin::extended_ttl`] was `true` — so
+    /// the caller can re-seed its own extended-TTL bookkeeping across a restart
+    /// rather than losing it until that session's next request.
+    pub extended: std::collections::HashSet<u64>,
     /// Dropped because their last touch was older than the TTL.
     pub expired: usize,
     /// Dropped because no live account carries that identity (removed, renamed).
@@ -237,13 +261,25 @@ pub fn load(path: &Path, accounts: &[Account], now_ms: i64, ttl_ms: i64) -> Load
 
     let mut report = LoadReport::default();
     for pin in file.pins {
-        if now_ms.saturating_sub(pin.touched_at_ms) > ttl_ms {
+        // Per-pin TTL: a client that asked for the extended 1h cache window gets
+        // the wider restore window; everything else (including a malformed or
+        // unrecognised recording) falls back to the caller's `ttl_ms` — never
+        // wider than what was actually requested.
+        let effective_ttl_ms = if pin.extended_ttl {
+            EXTENDED_PIN_TTL_MS
+        } else {
+            ttl_ms
+        };
+        if now_ms.saturating_sub(pin.touched_at_ms) > effective_ttl_ms {
             report.expired += 1;
             continue;
         }
         match identity::resolve(accounts.iter().enumerate(), &pin.probe()) {
             Resolved::One(index) => {
                 report.pins.insert(pin.key, (index, pin.touched_at_ms));
+                if pin.extended_ttl {
+                    report.extended.insert(pin.key);
+                }
             }
             Resolved::None => report.unresolved += 1,
             Resolved::Many => report.ambiguous += 1,
@@ -269,6 +305,17 @@ mod tests {
     }
 
     fn pin(key: u64, name: &str, uuid: Option<&str>, org: Option<&str>, touched: i64) -> StoredPin {
+        pin_with_ttl(key, name, uuid, org, touched, false)
+    }
+
+    fn pin_with_ttl(
+        key: u64,
+        name: &str,
+        uuid: Option<&str>,
+        org: Option<&str>,
+        touched: i64,
+        extended_ttl: bool,
+    ) -> StoredPin {
         StoredPin {
             key,
             name: name.to_string(),
@@ -276,6 +323,7 @@ mod tests {
             org_uuid: org.map(str::to_string),
             org_name: None,
             touched_at_ms: touched,
+            extended_ttl,
         }
     }
 
@@ -434,6 +482,74 @@ mod tests {
         assert_eq!(report.expired, 1);
         assert!(report.pins.contains_key(&11), "a minute old is warm");
         assert!(!report.pins.contains_key(&22), "past the TTL is cold");
+    }
+
+    /// The adaptive-TTL gate: a pin the client asked to cache for 1h gets the
+    /// extended (~55min) restore window instead of the 15-minute default, a pin
+    /// with no recorded TTL is still held to the default, and NEITHER survives
+    /// past the extended ceiling. Malformed/absent TTL must never grant a
+    /// LONGER window than the default — only ever the same or shorter.
+    #[test]
+    fn extended_ttl_pin_restores_a_30_minute_gap_the_default_would_drop() {
+        let path = tmp("extended-ttl");
+        let now = 10 * PIN_TTL_MS;
+        let thirty_min_ago = now - 30 * 60 * 1000;
+        let ninety_min_ago = now - 90 * 60 * 1000;
+        save(
+            &path,
+            &[
+                // 30 minutes old, recorded 1h TTL: must restore.
+                pin_with_ttl(
+                    11,
+                    "a@example.com",
+                    Some("uuid-a"),
+                    Some("org-1"),
+                    thirty_min_ago,
+                    true,
+                ),
+                // Same age, no recorded TTL: must NOT restore under the 15-min
+                // default.
+                pin_with_ttl(
+                    22,
+                    "b@example.com",
+                    Some("uuid-b"),
+                    Some("org-1"),
+                    thirty_min_ago,
+                    false,
+                ),
+                // 90 minutes old with the extended TTL: past even the ~55-minute
+                // extended ceiling, so it must not restore either.
+                pin_with_ttl(
+                    33,
+                    "c@example.com",
+                    Some("uuid-c"),
+                    Some("org-1"),
+                    ninety_min_ago,
+                    true,
+                ),
+            ],
+            now,
+        )
+        .expect("save");
+
+        let accounts = [
+            acct("a@example.com", Some("uuid-a"), Some("org-1")),
+            acct("b@example.com", Some("uuid-b"), Some("org-1")),
+            acct("c@example.com", Some("uuid-c"), Some("org-1")),
+        ];
+        let report = load(&path, &accounts, now, PIN_TTL_MS);
+        assert!(
+            report.pins.contains_key(&11),
+            "a 1h-TTL pin 30 minutes old must restore"
+        );
+        assert!(
+            !report.pins.contains_key(&22),
+            "no recorded TTL falls back to the 15-minute default and must not restore"
+        );
+        assert!(
+            !report.pins.contains_key(&33),
+            "90 minutes exceeds even the extended ceiling"
+        );
     }
 
     /// Every read failure degrades to "no pins" plus a stated reason. None of

--- a/src/cache_ttl.rs
+++ b/src/cache_ttl.rs
@@ -7,37 +7,74 @@
 //! shape shares one property that matters here: the client only ever sets
 //! `"ttl"` at all to ask for the NON-default window (`"1h"`; the field is
 //! omitted entirely for the ordinary 5-minute default). So rather than modelling
-//! every place a `cache_control` object can appear, this is a bounded byte scan
-//! for the literal `"ttl":"1h"` immediately following a `"cache_control"` key —
-//! no second JSON parse of the body (nothing here allocates a `Value` tree),
-//! and a short window so a `ttl`-shaped string anywhere else in a large body
-//! (message content, a tool's own output) can never be mistaken for the field.
+//! every place a `cache_control` object can appear, this is a bounded byte scan:
+//! find a `"cache_control"` key, then look for a `"ttl"` key anywhere in the
+//! window that follows (key ORDER inside the object is not assumed — `"ttl"`
+//! may come before or after `"type"`) and, only once `"ttl"` itself is found,
+//! require `:` with optional JSON whitespace (space/tab/CR/LF) on either side
+//! and the literal value `"1h"`. No second JSON parse of the body (nothing here
+//! allocates a `Value` tree), and a short window so a `ttl`-shaped string
+//! anywhere else in a large body (message content, a tool's own output) can
+//! never be mistaken for the field.
 
 /// How far past a `"cache_control"` key to look for its `ttl` value before
-/// giving up — comfortably past `{"type":"ephemeral","ttl":"1h"}` (~40 bytes,
-/// pretty-printed or not) with margin for whitespace and key reordering,
-/// without being wide enough to reach into unrelated JSON.
+/// giving up — comfortably past `{"type":"ephemeral","ttl":"1h"}` even
+/// pretty-printed with indentation, with margin for key reordering, without
+/// being wide enough to reach into unrelated JSON.
 const SCAN_WINDOW: usize = 128;
 
 const CACHE_CONTROL_KEY: &[u8] = br#""cache_control""#;
-const EXTENDED_TTL_VALUE: &[u8] = br#""ttl":"1h""#;
+const TTL_KEY: &[u8] = br#""ttl""#;
+const EXTENDED_TTL_LITERAL: &[u8] = br#""1h""#;
 
 /// `true` iff `body` contains at least one `cache_control` object whose `ttl`
 /// is the extended `"1h"` window. Anything else — absent, `"5m"`, malformed,
 /// truncated, not JSON at all — is `false`, which is today's 15-minute pin
 /// behaviour. This must never be a way to get a LONGER pin from a malformed
-/// body: the only path to `true` is the exact literal Anthropic's API expects.
+/// body: the only path to `true` is a `"ttl"` key, JSON-whitespace-tolerant
+/// `:`, and the exact literal `"1h"` — nothing looser than that.
 pub fn requests_extended_ttl(body: &[u8]) -> bool {
     let mut start = 0;
     while let Some(rel) = find(&body[start..], CACHE_CONTROL_KEY) {
         let key_end = start + rel + CACHE_CONTROL_KEY.len();
         let window_end = (key_end + SCAN_WINDOW).min(body.len());
-        if find(&body[key_end..window_end], EXTENDED_TTL_VALUE).is_some() {
+        if ttl_1h_in_window(&body[key_end..window_end]) {
             return true;
         }
         start = key_end;
     }
     false
+}
+
+/// Within `window` (already bounded to [`SCAN_WINDOW`] bytes past a
+/// `"cache_control"` key), find a `"ttl"` key and check whether ITS value —
+/// skipping whitespace, then `:`, then whitespace again, exactly as JSON
+/// permits between any token and the next — is the literal `"1h"`.
+fn ttl_1h_in_window(window: &[u8]) -> bool {
+    let mut start = 0;
+    while let Some(rel) = find(&window[start..], TTL_KEY) {
+        let after_key = start + rel + TTL_KEY.len();
+        let mut pos = skip_json_whitespace(window, after_key);
+        if window.get(pos) == Some(&b':') {
+            pos = skip_json_whitespace(window, pos + 1);
+            if window[pos..].starts_with(EXTENDED_TTL_LITERAL) {
+                return true;
+            }
+        }
+        start = after_key;
+    }
+    false
+}
+
+/// Advance `pos` past any run of JSON whitespace (space, tab, CR, LF) —
+/// the same four characters the JSON grammar itself treats as insignificant
+/// between tokens, so this tolerates any client's pretty-printing without
+/// tolerating anything JSON wouldn't.
+fn skip_json_whitespace(body: &[u8], mut pos: usize) -> usize {
+    while matches!(body.get(pos), Some(b' ' | b'\t' | b'\r' | b'\n')) {
+        pos += 1;
+    }
+    pos
 }
 
 fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
@@ -96,5 +133,39 @@ mod tests {
     fn extended_ttl_on_a_tool_definition_is_detected() {
         let body = br#"{"tools":[{"name":"x","cache_control":{"type":"ephemeral","ttl":"1h"}}]}"#;
         assert!(requests_extended_ttl(body));
+    }
+
+    #[test]
+    fn spaced_json_ttl_1h_is_detected() {
+        let body = br#"{"cache_control": {"type": "ephemeral", "ttl": "1h"}}"#;
+        assert!(requests_extended_ttl(body));
+    }
+
+    #[test]
+    fn pretty_printed_ttl_1h_across_newlines_is_detected() {
+        let body =
+            b"{\n  \"cache_control\": {\n    \"type\": \"ephemeral\",\n    \"ttl\": \"1h\"\n  }\n}";
+        assert!(requests_extended_ttl(body));
+    }
+
+    #[test]
+    fn reordered_and_spaced_keys_are_detected() {
+        let body = br#"{"cache_control": {"ttl": "1h", "type": "ephemeral"}}"#;
+        assert!(requests_extended_ttl(body));
+    }
+
+    #[test]
+    fn spaced_5m_ttl_is_not_extended() {
+        let body = br#"{"cache_control": {"type": "ephemeral", "ttl": "5m"}}"#;
+        assert!(!requests_extended_ttl(body));
+    }
+
+    #[test]
+    fn a_spaced_ttl_1h_in_message_content_far_from_cache_control_does_not_count() {
+        let filler = "x".repeat(SCAN_WINDOW + 10);
+        let body = format!(
+            r#"{{"cache_control": {{"type": "ephemeral"}}, "note": "{filler}", "ttl": "1h"}}"#
+        );
+        assert!(!requests_extended_ttl(body.as_bytes()));
     }
 }

--- a/src/cache_ttl.rs
+++ b/src/cache_ttl.rs
@@ -1,0 +1,100 @@
+//! Whether a request asked Anthropic's prompt cache for the EXTENDED (1-hour)
+//! TTL, read straight off the buffered body bytes already parsed once for
+//! [`crate::model::parse_request_model`].
+//!
+//! Anthropic's `cache_control` breakpoints can appear at several depths — the
+//! last `system` block, a tool definition, a message content block — and every
+//! shape shares one property that matters here: the client only ever sets
+//! `"ttl"` at all to ask for the NON-default window (`"1h"`; the field is
+//! omitted entirely for the ordinary 5-minute default). So rather than modelling
+//! every place a `cache_control` object can appear, this is a bounded byte scan
+//! for the literal `"ttl":"1h"` immediately following a `"cache_control"` key —
+//! no second JSON parse of the body (nothing here allocates a `Value` tree),
+//! and a short window so a `ttl`-shaped string anywhere else in a large body
+//! (message content, a tool's own output) can never be mistaken for the field.
+
+/// How far past a `"cache_control"` key to look for its `ttl` value before
+/// giving up — comfortably past `{"type":"ephemeral","ttl":"1h"}` (~40 bytes,
+/// pretty-printed or not) with margin for whitespace and key reordering,
+/// without being wide enough to reach into unrelated JSON.
+const SCAN_WINDOW: usize = 128;
+
+const CACHE_CONTROL_KEY: &[u8] = br#""cache_control""#;
+const EXTENDED_TTL_VALUE: &[u8] = br#""ttl":"1h""#;
+
+/// `true` iff `body` contains at least one `cache_control` object whose `ttl`
+/// is the extended `"1h"` window. Anything else — absent, `"5m"`, malformed,
+/// truncated, not JSON at all — is `false`, which is today's 15-minute pin
+/// behaviour. This must never be a way to get a LONGER pin from a malformed
+/// body: the only path to `true` is the exact literal Anthropic's API expects.
+pub fn requests_extended_ttl(body: &[u8]) -> bool {
+    let mut start = 0;
+    while let Some(rel) = find(&body[start..], CACHE_CONTROL_KEY) {
+        let key_end = start + rel + CACHE_CONTROL_KEY.len();
+        let window_end = (key_end + SCAN_WINDOW).min(body.len());
+        if find(&body[key_end..window_end], EXTENDED_TTL_VALUE).is_some() {
+            return true;
+        }
+        start = key_end;
+    }
+    false
+}
+
+fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_extended_ttl_on_a_system_block() {
+        let body = br#"{"system":[{"type":"text","text":"x","cache_control":{"type":"ephemeral","ttl":"1h"}}]}"#;
+        assert!(requests_extended_ttl(body));
+    }
+
+    #[test]
+    fn default_cache_control_with_no_ttl_is_not_extended() {
+        let body =
+            br#"{"system":[{"type":"text","text":"x","cache_control":{"type":"ephemeral"}}]}"#;
+        assert!(!requests_extended_ttl(body));
+    }
+
+    #[test]
+    fn explicit_5m_ttl_is_not_extended() {
+        let body = br#"{"cache_control":{"type":"ephemeral","ttl":"5m"}}"#;
+        assert!(!requests_extended_ttl(body));
+    }
+
+    #[test]
+    fn absent_cache_control_is_not_extended() {
+        let body = br#"{"model":"claude-x","messages":[]}"#;
+        assert!(!requests_extended_ttl(body));
+    }
+
+    #[test]
+    fn malformed_json_is_not_extended() {
+        assert!(!requests_extended_ttl(b"not json { at all"));
+        assert!(!requests_extended_ttl(b""));
+    }
+
+    #[test]
+    fn a_ttl_1h_string_far_from_any_cache_control_key_does_not_count() {
+        // The literal appears in unrelated content, well past the scan window
+        // from any `cache_control` key — must not false-positive.
+        let filler = "x".repeat(SCAN_WINDOW + 10);
+        let body =
+            format!(r#"{{"cache_control":{{"type":"ephemeral"}},"note":"{filler}","ttl":"1h"}}"#);
+        assert!(!requests_extended_ttl(body.as_bytes()));
+    }
+
+    #[test]
+    fn extended_ttl_on_a_tool_definition_is_detected() {
+        let body = br#"{"tools":[{"name":"x","cache_control":{"type":"ephemeral","ttl":"1h"}}]}"#;
+        assert!(requests_extended_ttl(body));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 pub mod account_uuid;
 pub mod affinity;
 pub mod build_info;
+pub mod cache_ttl;
 pub mod cli;
 pub mod config;
 pub mod demo;

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -910,6 +910,19 @@ pub struct Manager {
     /// held while the accounts lock is taken (read the pin, drop this lock, then do
     /// eligibility) so the two can never deadlock.
     affinity: Mutex<HashMap<u64, (usize, i64)>>,
+    /// Session keys whose MOST RECENT request carried Anthropic's extended
+    /// `"cache_control": {"ttl": "1h"}` (see [`crate::cache_ttl`]), so
+    /// [`crate::manager::pins::affinity_pin_snapshot`] knows which persisted
+    /// pins get [`crate::affinity::EXTENDED_PIN_TTL_MS`] instead of the
+    /// default at the next restart. Deliberately a side map rather than a third
+    /// tuple field on `affinity` itself: nothing on the selection path
+    /// (`select.rs`) needs to read it, only the snapshot/restore bridge does, so
+    /// widening the hot map's value type for every read site there would be
+    /// blast radius this doesn't need. Written directly from the request path
+    /// (`crate::proxy`, alongside where `session_key` is computed) rather than
+    /// through `select()`, guarded and pruned the same way `affinity` is —
+    /// never held while the accounts lock is taken.
+    affinity_extended: Mutex<HashSet<u64>>,
     /// Set whenever `affinity` is mutated, cleared by the flusher task that
     /// writes the map to disk (see [`Manager::mark_affinity_dirty`] and
     /// [`crate::affinity`]). A relaxed atomic rather than a channel because the
@@ -1151,6 +1164,7 @@ impl Manager {
             current: Mutex::new(None),
             select_seq: AtomicU64::new(1),
             affinity: Mutex::new(HashMap::new()),
+            affinity_extended: Mutex::new(HashSet::new()),
             affinity_dirty: AtomicBool::new(false),
             sessions: Mutex::new(HashMap::new()),
             session_seq: AtomicU64::new(1),

--- a/src/manager/pins.rs
+++ b/src/manager/pins.rs
@@ -37,6 +37,25 @@ impl Manager {
         self.affinity_dirty.swap(false, Ordering::Relaxed)
     }
 
+    /// Record whether `key`'s most recent request asked Anthropic's cache for
+    /// the extended `"ttl":"1h"` window (see [`crate::cache_ttl`]). Called from
+    /// the request path once per request, independent of `select()` — nothing
+    /// on the selection/routing path needs this bit, only the persistence
+    /// bridge below. A request that does NOT ask for the extended window clears
+    /// any prior record for that key: this always reflects the LATEST request,
+    /// same as `touched_at_ms` does for the pin itself.
+    pub fn note_affinity_ttl(&self, key: u64, extended: bool) {
+        let mut ext = self
+            .affinity_extended
+            .lock()
+            .expect("affinity_extended lock poisoned");
+        if extended {
+            ext.insert(key);
+        } else {
+            ext.remove(&key);
+        }
+    }
+
     /// The pin map as persistable records — each live pin's index replaced by the
     /// identity of the account at that index.
     ///
@@ -52,8 +71,28 @@ impl Manager {
                 .collect()
         };
         if pins.is_empty() {
+            // Nothing live — prune the extended-TTL side map too rather than
+            // let it accumulate keys no snapshot will ever consult again.
+            self.affinity_extended
+                .lock()
+                .expect("affinity_extended lock poisoned")
+                .clear();
             return Vec::new();
         }
+        let live_keys: std::collections::HashSet<u64> =
+            pins.iter().map(|&(key, _, _)| key).collect();
+        let extended: std::collections::HashSet<u64> = {
+            let mut ext = self
+                .affinity_extended
+                .lock()
+                .expect("affinity_extended lock poisoned");
+            // A key can only fall out of `affinity` via the same LRU eviction
+            // `select()` already applies; once gone there, its extended-TTL
+            // record is dead weight — drop it here so this side map is bounded
+            // by exactly the same set `affinity` is.
+            ext.retain(|key| live_keys.contains(key));
+            ext.clone()
+        };
         let accounts = self.accounts.read().expect("accounts lock poisoned");
         pins.into_iter()
             .filter_map(|(key, index, touched_at_ms)| {
@@ -65,6 +104,7 @@ impl Manager {
                     org_uuid: account.org_uuid.clone(),
                     org_name: account.org_name.clone(),
                     touched_at_ms,
+                    extended_ttl: extended.contains(&key),
                 })
             })
             .collect()
@@ -109,6 +149,18 @@ impl Manager {
             let mut map = self.affinity.lock().expect("affinity lock poisoned");
             for (&key, &value) in &report.pins {
                 map.entry(key).or_insert(value);
+            }
+        }
+        {
+            // Re-seed the extended-TTL record too, so a second restart before
+            // this session's next request still sees the wider window rather
+            // than silently falling back to the default on the very next flush.
+            let mut ext = self
+                .affinity_extended
+                .lock()
+                .expect("affinity_extended lock poisoned");
+            for &key in &report.extended {
+                ext.insert(key);
             }
         }
         report

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1990,6 +1990,15 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
         None => (None, SessionKind::Fallback),
     };
 
+    // Record whether THIS request asked Anthropic's cache for the extended 1h
+    // window, same body bytes as `request_model` above and no second full
+    // parse of the document (see `crate::cache_ttl`). Only meaningful with a
+    // session key: it drives nothing on the routing path, only what TTL this
+    // session's persisted pin gets at the next restart.
+    if let Some(key) = session_key {
+        manager.note_affinity_ttl(key, crate::cache_ttl::requests_extended_ttl(&body_bytes));
+    }
+
     // 3. Selection + rotation loop.
     let account_count = manager.account_count();
     let mut tried: HashSet<usize> = HashSet::new();


### PR DESCRIPTION
## The bug, measured

`affinity::PIN_TTL_MS` is 15 minutes, derived in its own doc-comment from
"Anthropic's default `cache_control` TTL is 5 minutes."

That derivation does not match this fleet's traffic. Bucketing **52,951**
`request usage` records across **1,073 sessions** by the gap since that
session's previous request, and asking whether `cache_read_tokens > 1024`:

| gap since previous request | cache hit rate |
|---|---|
| under 5m | 98.6% |
| 5–15m | 76.1% |
| 15–30m | 88.3% |
| 30–60m | 73.1% |
| **over 60m** | **12.0%** |

The warm window is **60 minutes, not 5** — the cliff is at 60. Concrete cases:
17-minute gaps reading 48,000–58,000 cached tokens with near-zero cache
creation, which a 5-minute TTL cannot produce.

**Where it bites.** `PIN_TTL_MS` is consulted only at *restore*; in-memory pins
are evicted by count, not age. So this affects exactly one event — a proxy
restart. A restart 15–60 minutes after a session's last request currently drops
a pin whose upstream cache is still warm ~73–88% of the time, then rotates that
session onto a different account, guaranteeing the miss the pin existed to
prevent.

## The change

Per-pin TTL derived from what the client actually asked for. `"ttl":"1h"` present
⇒ ~55-minute pin window; absent, `"5m"`, malformed, or truncated ⇒ today's 15
minutes. `StoredPin.extended_ttl` is `#[serde(default)]`, so an older pin file
degrades to `false` — a malformed body can never buy a *longer* pin.

Detection is a bounded byte scan over the body already buffered for
`parse_request_model`. No second JSON parse, no `Value` allocation.

## One defect caught in review

The first implementation matched the byte-exact literal `"ttl":"1h"`. A body
serialized as `"ttl": "1h"` would have returned false, leaving the pin at 15
minutes with the feature silently inert — and every test still passing, because
they all used compact JSON. It now finds `"ttl"` as its own key, skips JSON
whitespace, requires `:`, skips whitespace, then matches `"1h"`, order-agnostic
within the window.

The three new spacing tests were run against the pre-fix code first and watched
to fail, confirming the defect was real rather than hypothetical. Negative
controls verify a stray `"ttl": "1h"` in message content far from any
`cache_control` key still does not count.

## Gates

`cargo fmt --check`, `cargo test --all --locked` (803 lib tests + integration
suites), and `cargo clippy --all-targets --locked -- -D warnings` all exit 0.

Version bumped because `src/` is a shippable path and v0.2.22 is released; two
sibling branches carry the same one-line bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLVQgcdM97jkxW9V7LEWaU
