### PR TITLE
Add tcr-status-wire, the missing type behind tcr status --json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2494,8 +2494,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tcr-status-wire"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "teamclaude-rs"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "axum",
@@ -2517,6 +2525,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sysinfo",
+ "tcr-status-wire",
  "tempfile",
  "thiserror 2.0.20",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,15 @@
+# Explicit workspace, added alongside `crates/tcr-status-wire` (the shared
+# `tcr status --json` wire type). Keep `apps/macos/**` OUT of `members` forever
+# — `.github/workflows/ci.yml` runs `cargo test --all` / `cargo clippy
+# --all-targets --locked` on ubuntu, and `--all` means `--workspace`: anything
+# listed here compiles on Linux.
+[workspace]
+members = [".", "crates/tcr-status-wire"]
+resolver = "2"
+
 [package]
 name = "teamclaude-rs"
-version = "0.2.22"
+version = "0.2.23"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms
@@ -22,6 +31,9 @@ name = "tcr"
 path = "src/main.rs"
 
 [dependencies]
+# The shared `tcr status --json` wire type (`AccountStatusRow`), consumed by
+# `render_accounts_json` in `src/cli.rs`.
+tcr-status-wire = { path = "crates/tcr-status-wire" }
 # async runtime + HTTP
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "io-std", "sync", "time", "signal"] }
 axum = { version = "0.8", features = ["http2"] }

--- a/crates/tcr-status-wire/Cargo.toml
+++ b/crates/tcr-status-wire/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "tcr-status-wire"
+version = "0.1.0"
+edition = "2021"
+license = "PolyForm-Noncommercial-1.0.0"
+publish = false
+description = "Serde types for the `tcr status --json` wire contract, shared between the CLI and the macOS app"
+
+# Serde only. This crate is built by `cargo test --all` / `cargo clippy --all-targets`
+# on the ubuntu CI runner (see .github/workflows/ci.yml, `--all` = `--workspace`),
+# so it must stay Linux-clean forever: no macOS-only dependency, no `unsafe`.
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/tcr-status-wire/src/lib.rs
+++ b/crates/tcr-status-wire/src/lib.rs
@@ -1,0 +1,107 @@
+//! Serde types for the `tcr status --json` wire contract.
+//!
+//! This is the type that `render_accounts_json` (`src/cli.rs` in the main crate)
+//! builds and serializes, and that the macOS app's `FleetStatus.swift` decodes.
+//! Before this crate existed, the Rust side had no type at all for this shape —
+//! only an ad-hoc `serde_json::json!` literal — so the two sides could drift
+//! with nothing to catch it beyond the committed fixture
+//! (`tests/fixtures/status-contract.json`) that both sides read.
+//!
+//! Serde-only: no `unsafe`, no macOS dependency. `cargo test --all` / `cargo
+//! clippy --all-targets --locked` (`.github/workflows/ci.yml`) build this crate
+//! on the ubuntu runner, so it must stay Linux-clean forever.
+//!
+//! # Row-at-a-time decode
+//!
+//! The wire is a bare JSON array, one object per account, and it must stay
+//! decodable one element at a time: `FleetStatus.swift` decodes row-by-row so a
+//! single malformed row (its doc-comment names an actual `"quota": null`
+//! incident) cannot take down the whole fleet's view. [`AccountStatusRow`]
+//! keeps that property expressible on the Rust side too — decode with
+//! [`AccountStatusRow::from_value`] against one already-parsed `serde_json::Value`
+//! at a time, never `serde_json::from_slice::<Vec<AccountStatusRow>>` against the
+//! whole payload in one shot, which fails the entire batch on one bad row.
+
+#![forbid(unsafe_code)]
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// A gating window (`5h` or `7d`) currently holding an account out of rotation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HeldWindowRow {
+    /// `"5h"` or `"7d"`.
+    pub window: String,
+    pub reset_at_ms: i64,
+    pub minutes_until_reset: i64,
+}
+
+/// One account's row on the `tcr status --json` wire.
+///
+/// Field-for-field mirror of what `render_accounts_json` emits today — see that
+/// function's doc-comments in `src/cli.rs` for why each field is shaped the way
+/// it is (in particular, why several are `Option` rather than a fabricated `0`
+/// or `false` on the offline path). This type does not change the contract; it
+/// gives the existing contract a name.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountStatusRow {
+    /// `"live"` or `"offline"` — which process's numbers this row carries.
+    pub source: String,
+    /// Short git sha of the serving build, `None` when there is no serving
+    /// process to report one (offline path).
+    pub server_sha: Option<String>,
+    pub server_dirty: Option<bool>,
+    pub http1_only: bool,
+    pub name: String,
+    pub priority: i64,
+    pub status: String,
+    pub disabled: bool,
+    pub control: bool,
+    pub quota: Option<f64>,
+    /// `"ok"`, `"near"`, or `"spent"` — see `quota_state_token`.
+    pub quota_state: String,
+    /// Kebab-case `GateReason` token: `"ok"`, `"hold"`, `"five-hour"`,
+    /// `"seven-day"`, `"fable-weekly"`, `"standard"`, `"login"`, `"rejected"`,
+    /// `"disabled"`, or `"reserved"`.
+    pub gate: String,
+    pub five_hour: Option<f64>,
+    pub seven_day: Option<f64>,
+    pub seven_day_oi: Option<f64>,
+    pub five_hour_state: Option<String>,
+    pub seven_day_state: Option<String>,
+    pub five_hour_reset_at_ms: Option<i64>,
+    pub seven_day_reset_at_ms: Option<i64>,
+    /// `None` on the offline path — a structural "not measured", never `0`.
+    pub requests: Option<u64>,
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub cache_read_tokens: Option<u64>,
+    pub cache_hit_ratio: Option<f64>,
+    pub last_probe_ms: Option<i64>,
+    pub probe_status: String,
+    pub probe_error: Option<String>,
+    pub stream_error_count: Option<u64>,
+    pub last_stream_error: Option<String>,
+    pub held: Vec<HeldWindowRow>,
+    pub free_at_ms: Option<i64>,
+    pub seconds_until_free: Option<i64>,
+    pub rate_limited_until_ms: Option<i64>,
+    pub groups: Vec<String>,
+    pub reserved_groups: Vec<String>,
+    /// Every group on the fleet mapped to its resolved color, repeated per row.
+    pub group_colors: BTreeMap<String, String>,
+}
+
+impl AccountStatusRow {
+    /// Decode one already-parsed row. This is the row-at-a-time entry point —
+    /// call it per-element over the array (`serde_json::Value::Array` iterated
+    /// one item at a time, or one line of a JSONL rendering), never
+    /// `serde_json::from_slice::<Vec<AccountStatusRow>>` against the whole
+    /// payload, which lets one malformed row fail every row alongside it.
+    pub fn from_value(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        serde_json::from_value(value)
+    }
+}

--- a/crates/tcr-status-wire/tests/round_trip.rs
+++ b/crates/tcr-status-wire/tests/round_trip.rs
@@ -1,0 +1,44 @@
+//! Fixture -> struct -> JSON -> equals fixture, for the shared contract type.
+//!
+//! This is this crate's half of the byte-identical contract; the other half
+//! (`cli::tests::status_contract_fixture_matches_committed` in the main
+//! crate) proves `render_accounts_json` itself still emits the committed
+//! bytes. Reads the SAME committed fixture both sides already read
+//! (`tests/fixtures/status-contract.json`, the "only arrangement in which a
+//! silent rename is impossible" per its doc-comment) — never a private copy.
+
+use tcr_status_wire::AccountStatusRow;
+
+fn fixture_path() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/fixtures/status-contract.json")
+}
+
+#[test]
+fn fixture_round_trips_through_account_status_row() {
+    let committed =
+        std::fs::read_to_string(fixture_path()).expect("committed contract fixture is readable");
+    let rows: Vec<serde_json::Value> =
+        serde_json::from_str(&committed).expect("fixture is a bare JSON array");
+    assert!(!rows.is_empty(), "fixture must carry at least one row");
+
+    // Row-at-a-time, per this crate's decode contract — never
+    // `serde_json::from_str::<Vec<AccountStatusRow>>` against the whole file.
+    let decoded: Vec<AccountStatusRow> = rows
+        .iter()
+        .cloned()
+        .map(|v| AccountStatusRow::from_value(v).expect("fixture row decodes"))
+        .collect();
+
+    let reencoded: Vec<serde_json::Value> = decoded
+        .into_iter()
+        .map(|row| serde_json::to_value(row).expect("row re-encodes"))
+        .collect();
+    let rendered =
+        serde_json::to_string_pretty(&reencoded).expect("re-encoded rows serialize") + "\n";
+
+    assert_eq!(
+        committed, rendered,
+        "AccountStatusRow does not round-trip the committed fixture byte-for-byte"
+    );
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1611,41 +1611,39 @@ fn render_accounts_json(
         .map(|(i, a)| {
             let quota = gating_quota(a);
             let threshold = thresholds.get(i).copied().unwrap_or(1.0);
-            let held: Vec<serde_json::Value> = held_windows(a, threshold)
+            let held: Vec<tcr_status_wire::HeldWindowRow> = held_windows(a, threshold)
                 .into_iter()
-                .map(|h| {
-                    serde_json::json!({
-                        "window": h.label,
-                        "resetAtMs": (h.reset.unix_timestamp_nanos() / 1_000_000) as i64,
-                        "minutesUntilReset": (h.reset - now).whole_minutes().max(0),
-                    })
+                .map(|h| tcr_status_wire::HeldWindowRow {
+                    window: h.label.to_string(),
+                    reset_at_ms: (h.reset.unix_timestamp_nanos() / 1_000_000) as i64,
+                    minutes_until_reset: (h.reset - now).whole_minutes().max(0),
                 })
                 .collect();
-            serde_json::json!({
-                "source": source.as_str(),
+            let row = tcr_status_wire::AccountStatusRow {
+                source: source.as_str().to_string(),
                 // Which build produced these numbers. A script watching this
                 // output can diff it against `git rev-parse --short HEAD` and
                 // know, without an `lsof`, whether the server predates the fix
                 // it is verifying.
-                "serverSha": server.map(|b| b.sha.as_str()),
-                "serverDirty": server.and_then(|b| b.dirty),
+                server_sha: server.map(|b| b.sha.clone()),
+                server_dirty: server.and_then(|b| b.dirty),
                 // Server-wide, repeated per row like `serverSha` above — whether
                 // this server's upstream clients are forced onto HTTP/1.1. See
                 // `Config::http1_only` and `Manager::http1_only`.
-                "http1Only": http1_only,
-                "name": a.name,
-                "priority": a.priority,
-                "status": a.status,
-                "disabled": a.disabled,
+                http1_only,
+                name: a.name.clone(),
+                priority: a.priority,
+                status: a.status.clone(),
+                disabled: a.disabled,
                 // Whether THIS row is the identity-bound control account
                 // (`Config::control_account` / `Manager::control_name`). Reported
                 // on the offline path too, deliberately — it is a config fact,
                 // not a serving counter, so it does NOT get the
                 // null-when-offline treatment `streamErrorCount` gets below;
                 // see `StatusPayload::control`'s doc-comment for why.
-                "control": control == Some(a.name.as_str()),
-                "quota": quota,
-                "quotaState": quota_state_token(a.quota_state),
+                control: control == Some(a.name.as_str()),
+                quota,
+                quota_state: quota_state_token(a.quota_state).to_string(),
                 // The server's own terminal-gate verdict
                 // (`Manager::account_terminal_gate`/`account_gate`), including the
                 // one TcrBar could not otherwise see: `rejected` (Anthropic's own
@@ -1658,10 +1656,10 @@ fn render_accounts_json(
                 // "disabled") via `GateReason`'s own `Serialize`. New field, so an
                 // older reader on either end is unaffected: a client built before
                 // this shipped simply never looks at it.
-                "gate": a.gate,
-                "fiveHour": a.five_hour,
-                "sevenDay": a.seven_day,
-                "sevenDayOi": a.seven_day_oi,
+                gate: gate_reason_token(a.gate),
+                five_hour: a.five_hour,
+                seven_day: a.seven_day,
+                seven_day_oi: a.seven_day_oi,
                 // Per-window state, additive alongside the existing combined
                 // `quotaState` above (which stays the most-spent-of-both gating
                 // verdict and is UNCHANGED by this field's addition — nothing
@@ -1672,11 +1670,19 @@ fn render_accounts_json(
                 // the two per-window quota bars independently instead of both
                 // by the shared gating state, so a 7d-red account with an empty
                 // 5h window doesn't paint its 5h bar red.
-                "fiveHourState": a.five_hour.map(|u| {
-                    quota_state_token(crate::stats::QuotaState::from_utilization(Some(u), threshold))
+                five_hour_state: a.five_hour.map(|u| {
+                    quota_state_token(crate::stats::QuotaState::from_utilization(
+                        Some(u),
+                        threshold,
+                    ))
+                    .to_string()
                 }),
-                "sevenDayState": a.seven_day.map(|u| {
-                    quota_state_token(crate::stats::QuotaState::from_utilization(Some(u), threshold))
+                seven_day_state: a.seven_day.map(|u| {
+                    quota_state_token(crate::stats::QuotaState::from_utilization(
+                        Some(u),
+                        threshold,
+                    ))
+                    .to_string()
                 }),
                 // A window's reset is a property of the window, not of whether
                 // it is currently pinning the account — UNCONDITIONAL, no
@@ -1691,9 +1697,13 @@ fn render_accounts_json(
                 // `held[]`) — a server-computed relative figure goes stale
                 // between polls, so the client derives the countdown from the
                 // timestamp against its own clock instead.
-                "fiveHourResetAtMs": a.five_hour_reset.map(|r| (r.unix_timestamp_nanos() / 1_000_000) as i64),
-                "sevenDayResetAtMs": a.seven_day_reset.map(|r| (r.unix_timestamp_nanos() / 1_000_000) as i64),
-                // `null` — NEVER `0` — on the OFFLINE path, same idiom as
+                five_hour_reset_at_ms: a
+                    .five_hour_reset
+                    .map(|r| (r.unix_timestamp_nanos() / 1_000_000) as i64),
+                seven_day_reset_at_ms: a
+                    .seven_day_reset
+                    .map(|r| (r.unix_timestamp_nanos() / 1_000_000) as i64),
+                // `None` — NEVER `0` — on the OFFLINE path, same idiom as
                 // `streamErrorCount`/`cacheHitRatio` below and for the same
                 // reason: these four are pure serving counters that live in
                 // the SERVING process, so a fresh offline `Manager` reads
@@ -1708,21 +1718,21 @@ fn render_accounts_json(
                 // they come from a live probe the offline path genuinely runs
                 // itself, not from the serving Manager's counters, so they are
                 // real numbers on both paths.
-                "requests": match source {
-                    StatusSource::Offline => serde_json::Value::Null,
-                    StatusSource::Live => serde_json::json!(a.requests),
+                requests: match source {
+                    StatusSource::Offline => None,
+                    StatusSource::Live => Some(a.requests),
                 },
-                "inputTokens": match source {
-                    StatusSource::Offline => serde_json::Value::Null,
-                    StatusSource::Live => serde_json::json!(a.input_tokens),
+                input_tokens: match source {
+                    StatusSource::Offline => None,
+                    StatusSource::Live => Some(a.input_tokens),
                 },
-                "outputTokens": match source {
-                    StatusSource::Offline => serde_json::Value::Null,
-                    StatusSource::Live => serde_json::json!(a.output_tokens),
+                output_tokens: match source {
+                    StatusSource::Offline => None,
+                    StatusSource::Live => Some(a.output_tokens),
                 },
-                "cacheReadTokens": match source {
-                    StatusSource::Offline => serde_json::Value::Null,
-                    StatusSource::Live => serde_json::json!(a.cache_read_tokens),
+                cache_read_tokens: match source {
+                    StatusSource::Offline => None,
+                    StatusSource::Live => Some(a.cache_read_tokens),
                 },
                 // Prompt-cache hit ratio (0.0-1.0): cache_read / input_total, and
                 // `null` — NEVER a literal 0.0 — when there is no reliable signal:
@@ -1743,10 +1753,7 @@ fn render_accounts_json(
                 // low ratio reads exactly like "the cache is broken" to anyone
                 // watching this field. `null` says "not measured"; `source` says
                 // which process would have measured it, when it could have.
-                "cacheHitRatio": match cache_hit_ratio(a, source) {
-                    None => serde_json::Value::Null,
-                    Some(ratio) => serde_json::json!(ratio),
-                },
+                cache_hit_ratio: cache_hit_ratio(a, source),
                 // When the background quota probe last ran for this account
                 // (`AccountSnapshot::last_probe`), Unix milliseconds like every
                 // other timestamp on this wire. Already crosses the
@@ -1762,11 +1769,11 @@ fn render_accounts_json(
                 // Real on BOTH paths, like `fiveHour`/`quota` above: the
                 // offline path runs its own live probe, so this is not a
                 // serving counter and gets no null-on-offline guard.
-                "lastProbeMs": a
+                last_probe_ms: a
                     .last_probe
                     .map(|t| (t.unix_timestamp_nanos() / 1_000_000) as i64),
-                "probeStatus": a.probe_status.as_str(),
-                "probeError": a.probe_error,
+                probe_status: a.probe_status.as_str().to_string(),
+                probe_error: a.probe_error.clone(),
                 // Decayed count of stream failures — an in-band SSE `error` event,
                 // or a stream that hit EOF without `message_stop` (recorded as
                 // `"truncated"`). `null`, NEVER 0, on the offline
@@ -1775,17 +1782,17 @@ fn render_accounts_json(
                 // publishes an all-clear nobody measured. Same "not measured"
                 // idiom as `cacheHitRatio`; `source` says which process would
                 // have measured it.
-                "streamErrorCount": match source {
-                    StatusSource::Offline => serde_json::Value::Null,
-                    StatusSource::Live => serde_json::json!(a.stream_error_count),
+                stream_error_count: match source {
+                    StatusSource::Offline => None,
+                    StatusSource::Live => Some(a.stream_error_count as u64),
                 },
                 // The latest error's `error.type` (e.g. "overloaded_error"), or
                 // null when none has been observed / nothing measured.
-                "lastStreamError": match source {
+                last_stream_error: match source {
                     StatusSource::Offline => None,
                     StatusSource::Live => a.last_stream_error.clone(),
                 },
-                "held": held,
+                held,
                 // WHEN THE ACCOUNT COMES BACK — the question `status` cannot
                 // answer. `status: "throttled"` is a state; this is the instant.
                 //
@@ -1801,28 +1808,30 @@ fn render_accounts_json(
                 // only a human clears those) and for a gate whose reset upstream
                 // never reported. Absent means "no time can be promised", never
                 // "returns now".
-                "freeAtMs": a.free_at.map(|f| (f.unix_timestamp_nanos() / 1_000_000) as i64),
-                "secondsUntilFree": a
+                free_at_ms: a
+                    .free_at
+                    .map(|f| (f.unix_timestamp_nanos() / 1_000_000) as i64),
+                seconds_until_free: a
                     .free_at
                     .filter(|f| *f > now)
                     .map(|f| (f - now).whole_seconds()),
                 // The 429 hold specifically, so an operator can tell a short
                 // transient park from a week-scale quota cap without inferring it
                 // from `gate`.
-                "rateLimitedUntilMs": a
+                rate_limited_until_ms: a
                     .rate_limited_until
                     .map(|t| (t.unix_timestamp_nanos() / 1_000_000) as i64),
                 // Group labels (config fact, not a serving counter) — always an
                 // array, `[]` when unlabelled, real on BOTH paths like `control`
                 // above. Never `null`: "this account has no groups" is known,
                 // not unmeasured.
-                "groups": a.groups,
+                groups: a.groups.clone(),
                 // The subset of `groups` currently RESERVED (`tcr group
                 // reserve`), sorted. Same never-`null` contract as `groups`
                 // above — this is the field the sibling macOS panel decodes to
                 // mark a section reserved; name and shape are a fixed contract,
                 // do not change them.
-                "reservedGroups": a.reserved_groups,
+                reserved_groups: a.reserved_groups.clone(),
                 // Every group on the FLEET (not just this row's own groups)
                 // mapped to its resolved color — server-wide like `http1Only`
                 // above, repeated per row so the panel can tint any account's
@@ -1831,11 +1840,32 @@ fn render_accounts_json(
                 // `Config::group_colors`'s doc-comment. Name and shape are a
                 // fixed contract with the sibling macOS panel — do not change
                 // them.
-                "groupColors": group_colors,
-            })
+                group_colors: group_colors.clone(),
+            };
+            // Round-trip through `Value` rather than serializing the struct
+            // directly: `serde_json::Value`'s map is a `BTreeMap`, so keys come
+            // out alphabetically ordered — matching this wire's output before
+            // this struct existed (the committed fixture's key order) — while
+            // `AccountStatusRow`'s own field order stays whatever reads best in
+            // this source file.
+            serde_json::to_value(row).unwrap_or(serde_json::Value::Null)
         })
         .collect();
     serde_json::to_string_pretty(&rows).unwrap_or_else(|_| "[]".to_string())
+}
+
+/// The wire's kebab-case `gate` token for a [`crate::stats::GateReason`] —
+/// `GateReason` itself is `#[serde(rename_all = "kebab-case")]`, so this reuses
+/// that `Serialize` impl rather than hand-duplicating the mapping. Infallible:
+/// an enum-to-string serialization has no failure mode, so the `expect` names
+/// that invariant rather than guessing at a fallback token that could silently
+/// paper over a future variant nobody wired up.
+fn gate_reason_token(gate: crate::stats::GateReason) -> String {
+    serde_json::to_value(gate)
+        .expect("GateReason serializes infallibly")
+        .as_str()
+        .expect("GateReason serializes to a JSON string")
+        .to_string()
 }
 
 /// `tcr accounts [--probe]` — list configured accounts (offline). With


### PR DESCRIPTION
## Why this exists

The macOS app decodes `tcr status --json` through a hand-written Swift mirror
(`FleetStatus.swift`, 1,305 lines). That mirror has already produced a shipped
crash — `RealWorldDecodeTests.swift` records the `valueNotFound` on a
never-probed account's null `quota`.

The obvious fix is "share the Rust type" — except **the type did not exist**:

- `AccountStatus` (`src/status.rs:164`) is the *server↔CLI* wire. It carries
  `gate`, `threshold`, `lastUsedMs`, `rateLimitedUntilMs`, `cacheCreationTokens`,
  and has **no** `quota`, `cacheHitRatio`, `serverSha`, `held`, `source`,
  `control` or `groupColors`.
- The wire the app actually decodes was an ad-hoc `serde_json::json!` literal
  inside `render_accounts_json` — with no Rust type at all.

This adds that missing type.

## What changed

`crates/tcr-status-wire` — serde only, `#![forbid(unsafe_code)]`, no macOS
dependencies — with `AccountStatusRow` / `HeldWindowRow` mirroring every field
`render_accounts_json` previously built by hand. That function now builds the
struct and serializes it.

Row-at-a-time decode is preserved via `AccountStatusRow::from_value`. That
property is load-bearing, not incidental: `FleetStatus.swift:1029-1075` decodes
one element at a time so a single malformed row cannot kill the whole fleet, and
its doc-comment names the exact `"quota": null` incident.

## Output is byte-identical

`tests/fixtures/status-contract.json` is verified from both the Rust and Swift
sides, and its own doc-comment calls that "the only arrangement in which a
silent rename is impossible." The existing
`cli::tests::status_contract_fixture_matches_committed` passes **unchanged** —
the fixture was not regenerated. Rows are converted through `serde_json::to_value`
so the fixture's alphabetical key order does not depend on struct field order.

Both that test and the new round-trip test were watched failing on a renamed
field before being trusted.

## Note for reviewers

`ci.yml` runs `cargo clippy --all-targets --locked` and `cargo test --all --locked`
on **ubuntu**, and `--all` is `--workspace`. Workspace members are `.` and
`crates/tcr-status-wire` only — deliberately not `apps/macos/**`, which would put
AppKit on a Linux runner.

`apps/macos/` is untouched; Swift keeps building and decoding exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLVQgcdM97jkxW9V7LEWaU
