### PR TITLE
Restore actions/checkout@v6 in the dist-generated release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
@@ -116,7 +116,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
@@ -175,7 +175,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
@@ -225,7 +225,7 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
@@ -290,7 +290,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive


### PR DESCRIPTION
`.github/workflows/release.yml` is **generated by cargo-dist**, and dist verifies on every run that the file still matches what it would emit. dist 0.32.0 pins `actions/checkout@v6`, so #135's bump to `@v7` made the `plan` job die with `release.yml has out of date contents and needs to be regenerated` — exit 255. A tag pushed in that state produces **no release at all**.

`.github/dependabot.yml` already documents this exactly, including the required action: *"EXPECT A RECURRING PR HERE THAT MUST BE CLOSED, NOT MERGED"*. It was handled correctly once before, as #30.

This reverts **only** `.github/workflows/release.yml`. `ci.yml` is hand-maintained, is correctly on `@v7`, and is untouched — the two files sit on different versions deliberately, because only one of them is dist's to own.

## Why the documented instruction did not hold

Nothing enforced it. Main's required checks are `ci`, `audit` and `macos`, so **#135 merged while `plan` was already `FAILURE`** and `ci`/`macos` were still in progress. The dependabot comment predicted precisely that trap: *"only `plan` goes red, and it is the one that matters."*

Reverting fixes today. Adding `plan` to main's required checks is what stops it recurring — that is a branch-protection change, so it is proposed separately rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLVQgcdM97jkxW9V7LEWaU