### PR TITLE
Apply a live disable before deleting an account

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -991,7 +991,7 @@ struct AccountRow: View {
         // gets no other signal that the delete landed but the row did not
         // change, since nothing here re-derives the fleet from the config.
         if removeController.needsRestart(account.name) {
-            parts.append("removed from config, restart the proxy to apply")
+            parts.append("removed from config and stopped, stays listed as disabled until the proxy restarts")
         }
         return parts.joined(separator: ", ")
     }
@@ -1259,8 +1259,8 @@ struct AccountRow: View {
     /// actual default). Names the account, states the consequence in plain
     /// language (this is not reversible from the UI — the saved OAuth tokens
     /// are gone and getting the account back needs a fresh `tcr login`), and
-    /// mentions the restart requirement up front rather than letting the
-    /// operator discover it by wondering why the row is still there.
+    /// states up front that the row stays listed as disabled until the proxy
+    /// restarts, even though the account itself stops serving right away.
     private func confirmDeleteAccount() {
         let alert = NSAlert()
         alert.alertStyle = .critical
@@ -1270,8 +1270,8 @@ struct AccountRow: View {
             It is not reversible from here — getting it back means running `tcr login` \
             again from scratch.
 
-            The change does not take effect until the proxy restarts, so this row \
-            stays visible until then.
+            The account stops serving immediately, but this row stays listed here as \
+            disabled until the proxy restarts.
             """
         let delete = alert.addButton(withTitle: "Delete Account")
         delete.hasDestructiveAction = true
@@ -1592,14 +1592,17 @@ struct AccountRow: View {
 
     /// Drawn after a successful ``RemoveAccountController/remove(account:org:)``
     /// and never cleared while the panel stays open — the whole reason it
-    /// exists. Deleting an account is a boot-time config change (see
-    /// ``RemoveAccountControl``'s doc-comment): the call lands and the file is
-    /// correct, but this row keeps rendering exactly as it did before, because
-    /// nothing here re-derives the fleet from a config the running proxy has
-    /// not re-read. A silent success here is the exact bug this codebase
+    /// exists. `remove_account` now disables the account in the running proxy
+    /// before deleting it from the config, so the account itself stops
+    /// serving immediately — but this row keeps rendering exactly as it did
+    /// before, because nothing here re-derives the fleet from a config the
+    /// running proxy has not re-read, and the row's membership in the fleet
+    /// list is itself a boot-time snapshot (see ``RemoveAccountControl``'s
+    /// doc-comment). A silent success here is the exact bug this codebase
     /// already lost an evening to for the enable/disable toggle — so this
-    /// line is what makes the true state (deleted, pending a restart) visible
-    /// instead of leaving the operator to wonder why the row never left.
+    /// line says what is actually true: stopped now, listed as disabled until
+    /// the next restart. It must not claim the row will disappear, because it
+    /// will not.
     ///
     /// `Tok.near`, matching `verdictLine`'s `.notHonoured`/`.spokeUp` tint:
     /// nothing failed — the delete landed — so this must not wear the error
@@ -1608,7 +1611,7 @@ struct AccountRow: View {
     private var removalNoticeLine: some View {
         if removeController.needsRestart(account.name) {
             Label(
-                "Removed from config. Restart the proxy to apply.",
+                "Removed from config and stopped. Stays listed as disabled until the proxy restarts.",
                 systemImage: "arrow.triangle.2.circlepath"
             )
             .font(Tok.detailFont)

--- a/apps/macos/Sources/TcrBarCore/RemoveAccountControl.swift
+++ b/apps/macos/Sources/TcrBarCore/RemoveAccountControl.swift
@@ -13,12 +13,15 @@ import Foundation
 ///     matched entry outright — there is no `tcr un-remove`. Getting the
 ///     account back means `tcr login` from scratch, which is why the panel
 ///     confirms before calling this at all.
-///  3. **This does not take effect in a running proxy.** The account list is
-///     a boot-time snapshot (`CLAUDE.md`'s config-reload rule): `tcr remove`
-///     changes the file and exits 0, but the row stays on screen, unchanged,
-///     until the proxy restarts. ``RemoveAccountController`` tracks that a
-///     removal landed so the panel can say so, and never claims the row is
-///     actually gone.
+///  3. **The account stops serving immediately, but the row does not leave
+///     the panel until restart.** `remove_account` now disables the account
+///     in the running proxy before deleting it from the config, so rotation
+///     stops right away — no restart needed for that half. The fleet row
+///     list is still a boot-time snapshot (`CLAUDE.md`'s config-reload rule)
+///     though, so the row itself keeps rendering, unchanged, until the proxy
+///     restarts. ``RemoveAccountController`` tracks that a removal landed so
+///     the panel can say exactly that, and never claims the row will
+///     disappear — it will not.
 ///  4. **Exit 0 with anything on stderr is not a clean success.** Same
 ///     three-arm ``Outcome`` as ``AccountCommand``/``GroupCommand``.
 public enum RemoveAccountCommand {
@@ -87,9 +90,9 @@ public enum RemoveAccountCommand {
 
 /// Panel-facing state for account deletion: which calls are in flight, which
 /// have an unsuperseded failure, and which accounts have been successfully
-/// deleted this session — the last of which drives the "restart the proxy to
-/// apply" notice, since the row itself has no way to reflect a boot-time
-/// config change on its own.
+/// deleted this session — the last of which drives the "stopped, stays
+/// listed until restart" notice, since the row itself has no way to reflect
+/// a boot-time config change on its own.
 ///
 /// Keyed by account name, same as ``AccountController``. Never cleared: like
 /// ``GroupController/appliedPendingRestart``, there is no live config reload

--- a/apps/macos/Tests/TcrBarTests/RemoveAccountControlTests.swift
+++ b/apps/macos/Tests/TcrBarTests/RemoveAccountControlTests.swift
@@ -70,8 +70,8 @@ final class RemoveAccountCommandTests: XCTestCase {
 }
 
 /// The mutation controller: in-flight tracking, failure surfacing, and the
-/// "restart the proxy to apply" note that never clears itself — same shape
-/// as `GroupControllerTests`.
+/// "stopped, stays listed until restart" note that never clears itself —
+/// same shape as `GroupControllerTests`.
 @MainActor
 final class RemoveAccountControllerTests: XCTestCase {
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -177,11 +177,89 @@ fn edit_account<T>(
     Ok(out)
 }
 
-/// Remove the account matching `query` from the config and save.
+/// Remove the account matching `query` from the config and save — live-first,
+/// same discipline as [`set_enabled`].
 ///
 /// Resolution happens BEFORE any mutation, so a non-matching query returns an
-/// error with the file left byte-identical (no partial write).
-pub fn remove_account(config_path: &Path, query: &str, org: Option<&str>) -> anyhow::Result<()> {
+/// error with the file left byte-identical (no partial write). Order is now
+/// resolve -> live-disable -> delete-from-config: deleting first and disabling
+/// second would leave a window (or, on a failed live call, a permanent state)
+/// where the config says the account does not exist while the running proxy
+/// keeps rotating it — the exact lie this change exists to eliminate, except
+/// now the record is gone too and unrecoverable.
+///
+/// `Unauthorized` and `Rejected` bail with the config untouched, for the same
+/// reasons as `set_enabled` — see its doc-comment — sharpened: a removal
+/// applied on top of a live disagreement cannot be undone by re-adding, since
+/// the account's credentials are gone from the file being edited.
+pub async fn remove_account(
+    config_path: &Path,
+    query: &str,
+    org: Option<&str>,
+) -> anyhow::Result<()> {
+    if let Ok(config) = config::load(config_path) {
+        match post_set_disabled(&config, query, org, true).await {
+            Ok(_) => {
+                let removed = edit_account(config_path, query, org, |config, idx| {
+                    config.accounts.remove(idx).name
+                })?;
+                println!("Removed account '{removed}'.");
+                return Ok(());
+            }
+            // Nothing is listening: no live rotation to disagree with the file.
+            Err(LiveControlError::NoServer) => {}
+            // A server is there and refused our key. Deleting the record now
+            // would leave the running proxy still rotating an account that no
+            // longer exists on disk — worse than the disable case, because
+            // there is no record left to reconcile against on restart.
+            Err(LiveControlError::Unauthorized) => {
+                bail!(
+                    "the proxy on :{} rejected the api-key in {} — the config was NOT changed, because deleting it would leave the running proxy still rotating this account. Fix `proxy.apiKey` and retry.",
+                    config.proxy.port,
+                    config_path.display()
+                );
+            }
+            // The route resolved our query to nothing, or to more than one
+            // account. The file's own resolution could land on a different
+            // row than the server matched — a removal applied to the wrong
+            // account is unrecoverable, so this bails rather than falling back.
+            Err(LiveControlError::Rejected(message)) => {
+                bail!(
+                    "the proxy running on :{} refused this: {message} Nothing was changed.",
+                    config.proxy.port
+                );
+            }
+            // An older tcr with no account-control route. The file half is all
+            // we can do; say loudly that the proxy keeps using the account
+            // until it restarts.
+            Err(LiveControlError::NoRoute) => {
+                let removed = edit_account(config_path, query, org, |config, idx| {
+                    config.accounts.remove(idx).name
+                })?;
+                eprintln!(
+                    "[tcr] WARNING: the proxy running on :{} is too old to accept live account control (no {} route), so only the config file was changed. It will KEEP routing to '{removed}' until it restarts. Run `tcr restart` when a cold prompt cache is acceptable.",
+                    config.proxy.port,
+                    crate::proxy::DISABLED_PATH,
+                );
+                println!("Removed account '{removed}'.");
+                return Ok(());
+            }
+            // It answered something we cannot use, or did not answer at all.
+            Err(other) => {
+                let removed = edit_account(config_path, query, org, |config, idx| {
+                    config.accounts.remove(idx).name
+                })?;
+                eprintln!(
+                    "[tcr] WARNING: could not apply this to the proxy running on :{} ({}), so only the config file was changed. It may KEEP routing to '{removed}' until it restarts.",
+                    config.proxy.port,
+                    other.why(),
+                );
+                println!("Removed account '{removed}'.");
+                return Ok(());
+            }
+        }
+    }
+
     let removed = edit_account(config_path, query, org, |config, idx| {
         config.accounts.remove(idx).name
     })?;
@@ -2270,21 +2348,31 @@ mod tests {
     }
 
     // --- remove ------------------------------------------------------------
+    //
+    // Every one of these uses `config_on_a_dead_port`, never `TWO_ACCOUNTS`'
+    // literal 3456 directly — `remove_account` now dials the configured proxy
+    // port for real, and 3456 is where the live fleet proxy actually listens
+    // on this machine. Landing on the real port would mean this test suite
+    // silently disabling a real account.
 
-    #[test]
-    fn remove_deletes_named_account_leaving_siblings() {
-        let path = write_config("remove", TWO_ACCOUNTS);
-        remove_account(&path, "alice@example.com", None).unwrap();
+    #[tokio::test]
+    async fn remove_deletes_named_account_leaving_siblings() {
+        let path = config_on_a_dead_port("remove").await;
+        remove_account(&path, "alice@example.com", None)
+            .await
+            .unwrap();
         let config = load(&path);
         assert_eq!(config.accounts.len(), 1);
         assert_eq!(config.accounts[0].name, "bob@example.com");
         fs::remove_file(&path).ok();
     }
 
-    #[test]
-    fn remove_preserves_unmodelled_extra_fields() {
-        let path = write_config("remove-extra", TWO_ACCOUNTS);
-        remove_account(&path, "alice@example.com", None).unwrap();
+    #[tokio::test]
+    async fn remove_preserves_unmodelled_extra_fields() {
+        let path = config_on_a_dead_port("remove-extra").await;
+        remove_account(&path, "alice@example.com", None)
+            .await
+            .unwrap();
         let raw = fs::read_to_string(&path).unwrap();
         let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
         // The #1 silent-loss risk: unmodelled top-level keys survive the edit.
@@ -2293,14 +2381,130 @@ mod tests {
         fs::remove_file(&path).ok();
     }
 
-    #[test]
-    fn remove_nonexistent_errors_and_leaves_file_byte_identical() {
-        let path = write_config("remove-miss", TWO_ACCOUNTS);
+    #[tokio::test]
+    async fn remove_nonexistent_errors_and_leaves_file_byte_identical() {
+        let path = config_on_a_dead_port("remove-miss").await;
         let before = fs::read_to_string(&path).unwrap();
-        let result = remove_account(&path, "nobody@example.com", None);
+        let result = remove_account(&path, "nobody@example.com", None).await;
         assert!(result.is_err());
         let after = fs::read_to_string(&path).unwrap();
         assert_eq!(before, after, "a failed resolve must not write the config");
+        fs::remove_file(&path).ok();
+    }
+
+    /// THE BITING TEST for remove, end to end through the PRODUCTION path: a
+    /// real hybrid listener, a real socket, the real router. Pre-change
+    /// `remove_account` only ever touched the file, so the running manager's
+    /// rotation kept serving the deleted account's identity until restart —
+    /// the same defect `set_enabled_parks_the_account_in_the_running_proxy`
+    /// exists to catch, one level more destructive here because the record is
+    /// also gone.
+    #[tokio::test]
+    async fn remove_parks_the_account_in_the_running_proxy_before_deleting() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let path = config_on_a_dead_port("live-remove").await;
+        let mut config = load(&path);
+        config.proxy.port = port;
+
+        let manager = Manager::with_live_refresher(config.clone(), Some(path.clone()));
+        let served = Arc::clone(&manager);
+        tokio::spawn(async move { crate::mitm::serve(listener, served, None).await });
+
+        let raw = fs::read_to_string(&path).unwrap();
+        let mut doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        doc["proxy"]["port"] = serde_json::json!(port);
+        fs::write(&path, serde_json::to_string_pretty(&doc).unwrap()).unwrap();
+
+        remove_account(&path, "alice@example.com", None)
+            .await
+            .unwrap();
+
+        // 1. THE RUNNING ROTATION: parked immediately, not just at next boot.
+        let live = manager.snapshot(OffsetDateTime::now_utc());
+        assert_eq!(live.accounts[0].name, "alice@example.com");
+        assert!(
+            live.accounts[0].disabled,
+            "the account is parked IN THE SERVING PROCESS before deletion"
+        );
+
+        // 2. …and the file no longer carries the record at all.
+        let config = load(&path);
+        assert_eq!(config.accounts.len(), 1);
+        assert_eq!(config.accounts[0].name, "bob@example.com");
+        fs::remove_file(&path).ok();
+    }
+
+    /// The proxy rejected our api-key: the one arm that must NOT write. If
+    /// this arm wrote instead, the config would say the account is gone while
+    /// the running proxy — the one we couldn't even authenticate to, let
+    /// alone confirm parked the account — keeps rotating it, permanently.
+    #[tokio::test]
+    async fn remove_refuses_on_unauthorized_without_writing() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server_config: Config = serde_json::from_str(&format!(
+            r#"{{ "proxy": {{ "port": {port}, "apiKey": "correct-key" }}, "accounts": [] }}"#
+        ))
+        .unwrap();
+        let manager = Manager::with_live_refresher(server_config, None);
+        tokio::spawn(async move { crate::mitm::serve(listener, manager, None).await });
+
+        let path = config_on_a_dead_port("remove-unauth").await;
+        let raw = fs::read_to_string(&path).unwrap();
+        let mut doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        doc["proxy"]["port"] = serde_json::json!(port);
+        doc["proxy"]["apiKey"] = serde_json::json!("wrong-key");
+        fs::write(&path, serde_json::to_string_pretty(&doc).unwrap()).unwrap();
+        let before = fs::read_to_string(&path).unwrap();
+
+        let err = remove_account(&path, "alice@example.com", None)
+            .await
+            .expect_err("a rejected api-key must refuse the removal");
+        assert!(
+            err.to_string().contains("NOT changed"),
+            "the refusal must say nothing changed: {err}"
+        );
+        assert_eq!(
+            before,
+            fs::read_to_string(&path).unwrap(),
+            "an Unauthorized removal must leave the config byte-identical"
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    /// An ambiguous query is refused by the SERVER and the CLI does not fall
+    /// back to the file's own resolution — a removal applied to the wrong row
+    /// is unrecoverable, unlike a mis-applied disable.
+    #[tokio::test]
+    async fn remove_refuses_an_ambiguous_query_without_writing() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let path = config_on_a_dead_port("remove-ambiguous").await;
+        let raw = fs::read_to_string(&path).unwrap();
+        let mut doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        doc["proxy"]["port"] = serde_json::json!(port);
+        doc["accounts"][1]["name"] = serde_json::json!("alice@example.com");
+        fs::write(&path, serde_json::to_string_pretty(&doc).unwrap()).unwrap();
+        let before = fs::read_to_string(&path).unwrap();
+
+        let config = load(&path);
+        let manager = Manager::with_live_refresher(config, Some(path.clone()));
+        tokio::spawn(async move { crate::mitm::serve(listener, manager, None).await });
+
+        let err = remove_account(&path, "alice@example.com", None)
+            .await
+            .expect_err("an ambiguous query must not be applied");
+        let text = err.to_string();
+        assert!(
+            text.contains("ambiguous") && text.contains("--org"),
+            "the refusal names the candidates and the fix: {text}"
+        );
+        assert_eq!(
+            before,
+            fs::read_to_string(&path).unwrap(),
+            "a refused removal leaves the config byte-identical"
+        );
         fs::remove_file(&path).ok();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -366,7 +366,7 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Run(args)) => run_claude(args),
         Some(Command::Login(args)) => run_login(args).await,
         Some(Command::Accounts(args)) => run_accounts(args).await,
-        Some(Command::Remove(args)) => run_remove(args),
+        Some(Command::Remove(args)) => run_remove(args).await,
         Some(Command::Priority(args)) => run_priority(args),
         Some(Command::Enable(args)) => run_enable(args).await,
         Some(Command::Disable(args)) => run_disable(args).await,
@@ -386,10 +386,11 @@ async fn run_accounts(args: AccountsArgs) -> anyhow::Result<()> {
     cli::list_accounts(&config_path, args.probe).await
 }
 
-/// `tcr remove <query> [--org]` — delete an account from the config.
-fn run_remove(args: RemoveArgs) -> anyhow::Result<()> {
+/// `tcr remove <query> [--org]` — delete an account from the config, applying
+/// a live disable through the RUNNING proxy first where there is one.
+async fn run_remove(args: RemoveArgs) -> anyhow::Result<()> {
     let config_path = args.config.unwrap_or_else(config::default_path);
-    cli::remove_account(&config_path, &args.query, args.org.as_deref())
+    cli::remove_account(&config_path, &args.query, args.org.as_deref()).await
 }
 
 /// `tcr priority <query> [N|--first|--last] [--org]` — set rotation priority.


### PR DESCRIPTION
Deleting an account wrote the config and the running proxy never noticed, because
the account list is a **boot-time snapshot** — only group membership and
`groupSettings` hot-reload. So Delete Account produced a config change with no
observable effect and had to tell you to restart.

That was never a fundamental constraint. It was an asymmetry between two functions:

```rust
pub fn       remove_account(config_path, query, org)           // file only
pub async fn set_enabled   (config_path, query, org, disabled) // LIVE first
```

`set_enabled` posts to the running proxy via `post_set_disabled`, so it applies
instantly and the file write is just persistence. Removal simply never got the
same treatment.

## What changes

`remove_account` is now async and applies a **live disable through the existing
endpoint before deleting the record**. The account stops being selected
immediately — the thing you actually want when you hit Delete — and the record is
gone for good.

Error handling mirrors `set_enabled`'s arms, with one sharpened for destructiveness:

| | behaviour |
|---|---|
| `NoServer` | delete from config; nothing live to disagree |
| `Unauthorized` | **bail, change nothing** |
| `Rejected` | **bail, change nothing** |
| `NoRoute` / other | delete + loud warning that the proxy keeps using it until restart |

`Unauthorized` and `Rejected` refusing to write is the safety property. Deleting
the record while the proxy keeps rotating that account would be a worse version of
the exact bug this fixes — and for `Rejected`, the file's own resolution could land
on a *different* row than the server matched, which is unrecoverable.

`remove_account`'s existing guarantee is preserved: resolution happens before any
mutation, so a failure at any step leaves the config byte-identical.

## Honest UI copy

The confirmation and the row notice previously said "Restart the proxy to apply."
They now say the account stops serving immediately but the row stays listed as
disabled until the next restart — which is what actually happens. It deliberately
does **not** claim the row disappears, because it will not; `tcr status` reports
the running manager's account list.

## Gates

`cargo test --all --locked`, `cargo clippy --all-targets --locked -- -D warnings`,
`swift build`, `swift test` — all exit 0.

The two refuse-to-write tests were verified by breaking the arm they guard:
making `Unauthorized` fall through to the file write turns
`remove_refuses_on_unauthorized_without_writing` red, and restoring it returns
green.

## Not in scope

Full live removal — dropping the account from the rotation structure while pins
point at it and requests may be in flight — is a larger job. Live-disable-then-
delete gets the user-visible behaviour right without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLVQgcdM97jkxW9V7LEWaU
