### PR TITLE
Say when a group cannot route, and copy the command that uses it

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -1124,13 +1124,32 @@ struct AccountRow: View {
         ForEach(account.groupMenuActions, id: \.self) { action in
             switch action {
             case .remove(let group):
+                // First, and disabled because there is nothing to click — this
+                // states a fact about the group, it does not offer to change it.
+                // Without it the panel renders a group that serves nothing
+                // exactly like one that works: a member, a colour, a healthy
+                // row. That is how a group whose only member was the control
+                // account survived on the live fleet, silently falling back on
+                // every request.
+                if !GroupRouting.routes(
+                    group: group, accounts: allAccounts, controlName: control.current)
+                {
+                    Button("⚠︎ “\(group)” routes nothing — control account only") {}
+                        .disabled(true)
+                }
+                // The USE command, above the two removals. This slot used to copy
+                // `tcr group rm <group> <account>` — the twin of the button
+                // right below it — which made three consecutive entries all
+                // spell a deletion and offered no way at all to start a session
+                // on the group. Copying the command that administers a label was
+                // never what anyone wanted off a row that already carries it.
+                let copyRun = GroupCommand.CopyCommandMenuEntry(
+                    arguments: GroupCommand.runArguments(group: group))
+                Button(copyRun.title) {
+                    copyToPasteboard(copyRun.copiedText)
+                }
                 Button("Remove from \(group)") {
                     Task { await groupController.remove(account: account.name, from: group) }
-                }
-                let copyRemove = GroupCommand.CopyCommandMenuEntry(
-                    arguments: GroupCommand.removeArguments(group: group, account: account.name))
-                Button(copyRemove.title) {
-                    copyToPasteboard(copyRemove.copiedText)
                 }
                 Button("Delete group “\(group)” for everyone…") {
                     confirmDeleteGroup(group)

--- a/apps/macos/Sources/TcrBarCore/GroupControl.swift
+++ b/apps/macos/Sources/TcrBarCore/GroupControl.swift
@@ -1,6 +1,33 @@
 import Combine
 import Foundation
 
+/// Whether a group can actually serve traffic, as opposed to merely existing
+/// with a member and a colour.
+///
+/// **Mirrors a proxy rule and must not drift from it.** The authority is
+/// `Manager::classify_group_miss`'s `GroupMiss::OnlyControl` arm
+/// (`src/manager/select.rs`): an inference pick excludes the control account
+/// unconditionally, so a group with no other member can never be selected, and
+/// every request asking for it is served from the whole pool instead. The `tcr`
+/// CLI computes the same fact for `tcr group ls`'s `routes=` field; this is the
+/// panel's copy, computed from data the panel already has (`Account.groups` plus
+/// the name `ControlAccountController` resolves) rather than a new wire field.
+///
+/// Deliberately NOT a health check: a member that is merely disabled or
+/// rate-limited right now still counts as routable, because that is transient and
+/// this is about the group's permanent shape.
+public enum GroupRouting {
+    /// `false` when the group has no members at all, or when every member is the
+    /// control account. `controlName == nil` means no control account is set (or
+    /// the panel could not resolve one), in which case membership alone decides.
+    public static func routes(group: String, accounts: [Account], controlName: String?) -> Bool {
+        let members = accounts.filter { ($0.groups ?? []).contains(group) }
+        guard !members.isEmpty else { return false }
+        guard let controlName else { return true }
+        return members.contains { $0.name != controlName }
+    }
+}
+
 /// Mutating group membership: adding an account to a group, removing one
 /// from a group, or removing a whole group. Same two rules as
 /// ``AccountCommand``/``ControlAccountCommand``, and for the same reasons:
@@ -31,6 +58,20 @@ public enum GroupCommand {
     /// `tcr group rm <group> --all` — removes the whole group.
     public static func removeAllArguments(group: String) -> [String] {
         ["group", "rm", group, "--all"]
+    }
+
+    /// `tcr run --group <group>` — start a Claude Code session that PREFERS this
+    /// group. The only argv here that is not a mutation, and the only one a
+    /// person actually wants off a group row: every other entry in this menu
+    /// administers the label, and none of them used it.
+    ///
+    /// **Copy-only. Never pass this to ``perform(arguments:)``.** That helper
+    /// runs argv to completion and reads its exit code; `tcr run` launches an
+    /// interactive Claude Code session, so running it from a menubar app would
+    /// hang the app on a process with no terminal. It exists to be rendered by
+    /// ``CopyCommandMenuEntry`` and put on the pasteboard, nothing else.
+    public static func runArguments(group: String) -> [String] {
+        ["run", "--group", group]
     }
 
     /// Shell-quotes a single argument for a copy-pasteable command line.

--- a/apps/macos/Tests/TcrBarTests/GroupControlTests.swift
+++ b/apps/macos/Tests/TcrBarTests/GroupControlTests.swift
@@ -84,6 +84,32 @@ final class GroupCommandTests: XCTestCase {
         )
     }
 
+    /// The group row's copy entry is the command that USES the group, not one
+    /// that administers it. Pinned as an exact string because this text is what
+    /// lands on a person's pasteboard and gets pasted into a shell — if it
+    /// drifts from `tcr run`'s real flag, the paste fails at their prompt, not
+    /// in a test.
+    func testCopyRunCommandIsTheUseCommandNotAMutation() {
+        let arguments = GroupCommand.runArguments(group: "research")
+        XCTAssertEqual(
+            GroupCommand.commandLine(arguments: arguments),
+            "tcr run --group research"
+        )
+        XCTAssertFalse(
+            arguments.contains("rm"),
+            "the group row's copy entry must never spell a removal"
+        )
+    }
+
+    /// Same quoting discipline as every other copied command — a group name
+    /// with a space must survive the round trip into a shell.
+    func testCopyRunCommandQuotesAGroupNameThatNeedsIt() {
+        XCTAssertEqual(
+            GroupCommand.commandLine(arguments: GroupCommand.runArguments(group: "dev team")),
+            "tcr run --group 'dev team'"
+        )
+    }
+
     func testShellQuoteLeavesAnEmailBare() {
         XCTAssertEqual(GroupCommand.shellQuote("henry2@example.com"), "henry2@example.com")
     }

--- a/apps/macos/Tests/TcrBarTests/GroupRoutingTests.swift
+++ b/apps/macos/Tests/TcrBarTests/GroupRoutingTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+
+@testable import TcrBarCore
+
+/// ``GroupRouting/routes(group:accounts:controlName:)`` — the panel's copy of a
+/// proxy rule: an inference pick never selects the control account, so a group
+/// with no other member serves nothing.
+///
+/// The shape these guard is one that shipped on a live fleet and looked healthy
+/// from every surface — one member, a colour, an `active` row — while every
+/// request asking for the group was served from the whole pool instead.
+///
+/// Account names are obviously fake — this repository is public.
+final class GroupRoutingTests: XCTestCase {
+
+    /// The defect, on the panel side. `research` has exactly one member and it
+    /// is the control account.
+    func testAGroupHoldingOnlyTheControlAccountDoesNotRoute() {
+        let accounts = [
+            routingAccount("gil@example.com", groups: ["research"]),
+            routingAccount("worker@example.com", groups: ["dev"]),
+        ]
+        XCTAssertFalse(
+            GroupRouting.routes(
+                group: "research", accounts: accounts, controlName: "gil@example.com"))
+    }
+
+    /// The remedy the warning points at: one ordinary account joining the group
+    /// makes it routable again. Without this, the check could be a constant
+    /// `false` for any group the control account is in and still pass the test
+    /// above.
+    func testASecondOrdinaryMemberMakesTheGroupRoute() {
+        let accounts = [
+            routingAccount("gil@example.com", groups: ["research"]),
+            routingAccount("worker@example.com", groups: ["research"]),
+        ]
+        XCTAssertTrue(
+            GroupRouting.routes(
+                group: "research", accounts: accounts, controlName: "gil@example.com"))
+    }
+
+    /// An ordinary group is never flagged — the other direction of the same
+    /// control, so neither a constant `true` nor a constant `false` survives.
+    func testAnOrdinaryGroupRoutes() {
+        let accounts = [
+            routingAccount("a@example.com", groups: ["dev"]),
+            routingAccount("b@example.com", groups: ["dev"]),
+        ]
+        XCTAssertTrue(
+            GroupRouting.routes(group: "dev", accounts: accounts, controlName: "gil@example.com"))
+    }
+
+    /// No control account set (or the panel could not resolve one): membership
+    /// alone decides, and the same fleet that failed above now routes. The panel
+    /// must not invent a block it cannot see.
+    func testWithNoControlAccountMembershipAloneDecides() {
+        let accounts = [routingAccount("gil@example.com", groups: ["research"])]
+        XCTAssertTrue(
+            GroupRouting.routes(group: "research", accounts: accounts, controlName: nil))
+    }
+
+    /// A label nobody carries routes nothing — there is no member to serve it.
+    func testALabelNoAccountCarriesDoesNotRoute() {
+        let accounts = [routingAccount("a@example.com", groups: ["dev"])]
+        XCTAssertFalse(
+            GroupRouting.routes(group: "resarch", accounts: accounts, controlName: nil))
+    }
+}
+
+/// Hand-built accounts with the fields this file's assertions touch.
+private func routingAccount(_ name: String, groups: [String]?) -> Account {
+    Account(
+        name: name,
+        priority: 1,
+        status: "active",
+        disabled: false,
+        quota: 0,
+        quotaState: .ok,
+        fiveHour: 0,
+        sevenDay: 0,
+        sevenDayOi: 0,
+        held: [],
+        requests: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheHitRatio: nil,
+        probeStatus: .ok,
+        probeError: nil,
+        lastStreamError: nil,
+        streamErrorCount: 0,
+        source: .live,
+        serverSha: "abc1234",
+        serverDirty: false,
+        groups: groups
+    )
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -262,6 +262,39 @@ A name matching no account is not a startup failure: the proxy logs an error nam
 available accounts and runs **unlocked**. So a typo'd `lockAccount` looks exactly like an
 ordinary rotating proxy unless you read the log at boot.
 
+## `groups[]` and `controlAccount`: the combination that routes nothing
+
+`accounts[].groups` labels an account. A client asks for a label with `tcr run --group
+<label>`, which sets the `x-tcr-group` header on its requests, and selection then **prefers**
+accounts carrying that label.
+
+Prefers, not requires. If no account in the group can serve the request, the proxy does not
+queue and does not fail — it falls back to the whole pool and serves from any account,
+because dropping a servable request is worse than serving it from the wrong place. The
+fallback logs one line naming the group and the reason, at the moment it happens.
+
+The trap is `controlAccount`. That account is the identity plane's designated account, and
+inference requests **never** select it — not when it is enabled, not when it is idle, not
+ever. So a group whose only member is the control account can never serve inference. Every
+request asking for it falls back, on every request, permanently. Nothing about the group
+looks wrong: it has a member, a colour, and a healthy line in `tcr status`.
+
+`tcr group ls` names this directly:
+
+```
+group research accounts=1 members=gil@example.com reserved=no routes=no route_block=control-account-only ...
+group dev      accounts=2 members=a@example.com,b@example.com reserved=no routes=yes ...
+```
+
+`routes=no` means the group exists and serves nothing. Two ways out: add a second, ordinary
+account to the group, or move the control account elsewhere with `tcr control --clear`.
+`tcr group add` prints the same warning at the moment you create the situation.
+
+Reserving is the other half and solves a different problem. `tcr group reserve <label>` makes
+an account carrying that label off-limits to traffic that did *not* ask for one of its
+groups. That keeps other sessions off the account; it does **not** make `--group` strict, and
+a reserved group with no available member still falls back to the pool.
+
 ## `http1Only`: caps blast radius, costs multiplexing
 
 A connection-level fault on HTTP/2 (GOAWAY, a framing error) kills **every** multiplexed

--- a/scripts/group-routing-e2e.py
+++ b/scripts/group-routing-e2e.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""End-to-end probe: does `x-tcr-group: <g>` actually route to that group?
+
+Sends real (1-token) /v1/messages requests through the RUNNING proxy, each with a
+fresh metadata.user_id so it gets a fresh affinity key (no pre-existing pin), then
+attributes each one from the proxy log by finding the session key whose FIRST-EVER
+usage line lands inside that probe's window.
+
+Read-only with respect to config: it never writes ~/.config/teamclaude.json and
+never signals the proxy.
+"""
+import json, os, re, subprocess, sys, time, uuid
+
+HAIKU = "claude-haiku-4-5-20251001"
+
+LOG = os.path.expanduser("~/.cache/teamclaude/logs/teamclaude-rs.log.%s"
+                         % time.strftime("%Y-%m-%d"))
+CA = os.path.expanduser("~/.config/tcr-ca.pem")
+PROXY = os.environ.get("HTTPS_PROXY") or "http://127.0.0.1:3456"
+USAGE = re.compile(r'^(\S+)Z\s+INFO teamclaude_rs::proxy: request usage '
+                   r'account="([^"]+)" session=Some\((\d+)\)')
+
+def known_keys():
+    keys = set()
+    with open(LOG, errors="ignore") as fh:
+        for line in fh:
+            m = USAGE.match(line)
+            if m:
+                keys.add(m.group(3))
+    return keys
+
+def attribute(since_iso, before_keys):
+    """Accounts that served a session key never seen before `since_iso`."""
+    found = []
+    with open(LOG, errors="ignore") as fh:
+        for line in fh:
+            m = USAGE.match(line)
+            if not m:
+                continue
+            ts, acct, key = m.groups()
+            if ts >= since_iso and key not in before_keys:
+                found.append((ts, acct, key))
+    return found
+
+def probe(group, model, label):
+    sess = str(uuid.uuid4())
+    body = {
+        "model": model,
+        "max_tokens": 1,
+        "messages": [{"role": "user", "content": "hi"}],
+        "metadata": {"user_id": "user_e2e_account__session_%s" % sess},
+    }
+    headers = ["-H", "content-type: application/json",
+               "-H", "anthropic-version: 2023-06-01"]
+    if group:
+        headers += ["-H", "x-tcr-group: %s" % group]
+    before = known_keys()
+    t0 = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())
+    cmd = (["curl", "-sS", "--max-time", "60", "--proxy", PROXY, "--cacert", CA,
+            "https://api.anthropic.com/v1/messages", "-X", "POST"]
+           + headers + ["-d", json.dumps(body)])
+    out = subprocess.run(cmd, capture_output=True, text=True)
+    status = "ok"
+    try:
+        resp = json.loads(out.stdout)
+        if resp.get("type") == "error":
+            status = "upstream-error: %s" % resp["error"].get("message", "")[:80]
+    except Exception:
+        status = "unparsed: %s" % (out.stdout[:80] or out.stderr[:80])
+    time.sleep(1.5)          # let the usage line land
+    hits = attribute(t0, before)
+    served = hits[-1][1] if hits else "UNATTRIBUTED"
+    return {"label": label, "group": group, "model": model,
+            "served_by": served, "status": status, "new_keys": len(hits)}
+
+def main():
+    groups = json.loads(subprocess.run(
+        ["tcr", "status", "--json"], capture_output=True, text=True).stdout)
+    member = {}
+    for a in groups:
+        for g in (a.get("groups") or []):
+            member.setdefault(g, []).append(a["name"])
+    print("group membership per the RUNNING proxy: %s\n" % member)
+
+    plan = [(None, HAIKU, "control: no group header")]
+    for g in sorted(member):
+        for i in range(3):
+            plan.append((g, HAIKU, "group=%s #%d" % (g, i + 1)))
+
+    rows = []
+    for group, model, label in plan:
+        r = probe(group, model, label)
+        expect = member.get(group, []) if group else None
+        r["expected"] = expect
+        r["verdict"] = ("NO DATA" if r["served_by"] == "UNATTRIBUTED"
+                        else "n/a" if expect is None
+                        else "IN GROUP" if r["served_by"] in expect else "OFF GROUP")
+        rows.append(r)
+        print("%-22s served_by=%-26s %-9s %s"
+              % (label, r["served_by"], r["verdict"], r["status"]))
+
+    print()
+    for g in sorted(member):
+        rs = [r for r in rows if r["group"] == g]
+        good = sum(1 for r in rs if r["verdict"] == "IN GROUP")
+        nodata = sum(1 for r in rs if r["verdict"] == "NO DATA")
+        scored = len(rs) - nodata
+        print("group %-12s %d/%d attributed probes landed in the group%s (members: %s)"
+              % (g, good, scored, " [%d unattributed]" % nodata if nodata else "",
+                 ", ".join(member[g])))
+    json.dump(rows, open("/tmp/group-routing-e2e.json", "w"), indent=2)
+
+if __name__ == "__main__":
+    main()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -346,6 +346,23 @@ fn find_account_by_name(accounts: &[Account], name: &str) -> anyhow::Result<usiz
     }
 }
 
+/// The warning [`add_to_group`] prints when the account being labelled is the
+/// control account. Split out as a pure function so a test can assert the text
+/// without capturing stderr — the notice IS the fix here, so it needs a gate of
+/// its own rather than riding along untested inside an `eprintln!`.
+///
+/// `None` when there is nothing to say, which is every ordinary add.
+fn control_account_group_notice(config: &Config, account: &str, group: &str) -> Option<String> {
+    if config.control_account.as_deref() != Some(account) {
+        return None;
+    }
+    Some(format!(
+        "warning: '{account}' is the control account, which inference requests never select. \
+         A group whose only member is the control account routes nothing — add another account \
+         to '{group}', or clear the control account with `tcr control --clear`."
+    ))
+}
+
 /// `tcr group add <group> <account>` — label `account` with `group`.
 ///
 /// Idempotent: adding a label an account already carries succeeds and says so,
@@ -373,6 +390,24 @@ pub fn add_to_group(config_path: &Path, group: &str, account: &str) -> anyhow::R
         .with_context(|| format!("load config at {}", config_path.display()))?;
     let idx = find_account_by_name(&config.accounts, account)?;
     let target = &config.accounts[idx];
+    // The label itself is real and the write below is correct — but on the
+    // CONTROL account it buys nothing, because `Manager::select_with_group`
+    // excludes that account from every inference pick
+    // (`select.rs`'s `control_excluded`). A group whose only member is the
+    // control account therefore serves NOTHING: every request asking for it
+    // falls back to the whole pool, silently, forever. Measured on the live
+    // fleet 2026-08-23 — 0 of 3 probes landed in such a group, 3 of 3 landed in
+    // an ordinary two-account one.
+    //
+    // Warn rather than refuse: the label is legitimate (the panel colours it,
+    // `tcr status` reports it, and a second account joining the group makes it
+    // route), and refusing would break this command's idempotence contract with
+    // TcrBar. stderr is the channel TcrBar already surfaces verbatim — see
+    // `GroupCommand::classify`'s `spoke` arm, which exists for exactly this
+    // "exit 0 but you should read something" case.
+    if let Some(notice) = control_account_group_notice(&config, &target.name, group) {
+        eprintln!("{notice}");
+    }
     let outcome = config::save_group_membership(config_path, target, group, true)
         .with_context(|| format!("save config at {}", config_path.display()))?;
     match outcome {
@@ -697,6 +732,33 @@ fn group_membership(config: &Config) -> (std::collections::BTreeMap<&str, Vec<&s
     (groups, ungrouped)
 }
 
+/// Whether a group can serve an inference request at all, as opposed to merely
+/// existing with members and a colour.
+///
+/// **This mirrors a runtime rule and must not drift from it.** The authority is
+/// `Manager::classify_group_miss`'s `GroupMiss::OnlyControl` arm
+/// (`src/manager/select.rs`): an inference pick excludes the control account
+/// unconditionally, so a group with no other member can never be selected. This
+/// is the config-side view of that same fact — the only one `tcr group ls` can
+/// compute, since it reads the file and not the running proxy. If the exclusion
+/// rule changes there, this changes with it.
+///
+/// Deliberately NOT a general health check: an account that is merely disabled or
+/// rate-limited right now still counts as routable here, because that is
+/// transient and this line is about the group's permanent shape.
+/// The one reason a group can exist and still route nothing, spelled ONCE.
+/// Both `ls` surfaces render this same token — a text `route_block=` field and a
+/// JSON `routeBlock` value — so a script keying on one cannot be surprised by
+/// the other. Two spellings of one fact is how they drift.
+const ROUTE_BLOCK_CONTROL_ONLY: &str = "control-account-only";
+
+fn group_routes(config: &Config, members: &[&str]) -> bool {
+    match config.control_account.as_deref() {
+        Some(control) => members.iter().any(|member| *member != control),
+        None => !members.is_empty(),
+    }
+}
+
 /// `tcr group ls` text: one greppable line per group, then `ungrouped`.
 fn render_groups_text(config: &Config) -> String {
     use std::fmt::Write as _;
@@ -705,15 +767,22 @@ fn render_groups_text(config: &Config) -> String {
     let mut out = String::new();
     for (group, members) in &groups {
         let (color, source) = config.group_color(group);
+        let routes = group_routes(config, members);
         let _ = writeln!(
             out,
-            "group {group:width$} accounts={} members={} reserved={} color={color} color_source={}",
+            "group {group:width$} accounts={} members={} reserved={} routes={}{} color={color} color_source={}",
             members.len(),
             members.join(","),
             if config.is_group_reserved(group) {
                 "yes"
             } else {
                 "no"
+            },
+            if routes { "yes" } else { "no" },
+            if routes {
+                String::new()
+            } else {
+                format!(" route_block={ROUTE_BLOCK_CONTROL_ONLY}")
             },
             source.as_str(),
         );
@@ -730,11 +799,18 @@ fn render_groups_json(config: &Config) -> anyhow::Result<String> {
         .iter()
         .map(|(group, members)| {
             let (color, source) = config.group_color(group);
+            let routes = group_routes(config, members);
             serde_json::json!({
                 "group": group,
                 "accounts": members.len(),
                 "members": members,
                 "reserved": config.is_group_reserved(group),
+                "routes": routes,
+                "routeBlock": if routes {
+                    serde_json::Value::Null
+                } else {
+                    serde_json::Value::String(ROUTE_BLOCK_CONTROL_ONLY.to_string())
+                },
                 "color": color,
                 "colorSource": source.as_str(),
             })
@@ -2835,6 +2911,121 @@ mod tests {
         let path = write_config("reserve-bad-label", TWO_ACCOUNTS);
         let result = reserve_group(&path, "bad\nlabel");
         assert!(result.is_err(), "a newline in the label must be rejected");
+        fs::remove_file(&path).ok();
+    }
+
+    // --- unroutable groups ---------------------------------------------------
+
+    /// A fleet where the control account is the ONLY member of a group. This is
+    /// the shape that shipped on the live fleet and served nothing: inference
+    /// never picks the control account, so `research` could not route, while
+    /// `tcr group ls` reported a healthy one-member group.
+    const CONTROL_ONLY_GROUP: &str = r#"{
+      "proxy": { "port": 3456 },
+      "controlAccount": "gil@example.com",
+      "accounts": [
+        { "name": "gil@example.com", "type": "oauth", "accessToken": "at-g",
+          "expiresAt": 1893456000000, "priority": 0, "groups": ["research"] },
+        { "name": "worker@example.com", "type": "oauth", "accessToken": "at-w",
+          "expiresAt": 1893456000000, "priority": 1, "groups": ["dev"] },
+        { "name": "worker2@example.com", "type": "oauth", "accessToken": "at-w2",
+          "expiresAt": 1893456000000, "priority": 2, "groups": ["dev"] }
+      ]
+    }"#;
+
+    fn group_line(text: &str, group: &str) -> String {
+        text.lines()
+            .find(|l| {
+                l.starts_with(&format!("group {group} "))
+                    || l.starts_with(&format!("group {group}"))
+            })
+            .unwrap_or_else(|| panic!("no line for group {group} in:\n{text}"))
+            .to_string()
+    }
+
+    /// `ls` must distinguish a group that cannot route from one that can — the
+    /// whole point of the field. `dev` (two ordinary accounts) routes; `research`
+    /// (control account only) does not, and says why.
+    #[test]
+    fn ls_marks_a_control_only_group_as_not_routing() {
+        let path = write_config("routes-control-only", CONTROL_ONLY_GROUP);
+        let config = load(&path);
+        let research = group_line(&render_groups_text(&config), "research");
+        assert!(
+            research.contains("routes=no") && research.contains("route_block=control-account-only"),
+            "a control-account-only group must say it routes nothing: {research}"
+        );
+        let dev = group_line(&render_groups_text(&config), "dev");
+        assert!(
+            dev.contains("routes=yes") && !dev.contains("route_block="),
+            "an ordinary group must not be flagged: {dev}"
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    /// The remedy the warning tells an operator to apply must actually clear the
+    /// flag — otherwise the message sends them somewhere that does not help.
+    #[test]
+    fn a_second_member_makes_the_group_route_again() {
+        let path = write_config("routes-second-member", CONTROL_ONLY_GROUP);
+        add_to_group(&path, "research", "worker@example.com").unwrap();
+        let config = load(&path);
+        let research = group_line(&render_groups_text(&config), "research");
+        assert!(
+            research.contains("routes=yes") && !research.contains("route_block="),
+            "adding a non-control account must make the group routable: {research}"
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    /// Same fact on the JSON surface, which the panel and scripts read.
+    #[test]
+    fn ls_json_carries_routes_and_route_block() {
+        let path = write_config("routes-json", CONTROL_ONLY_GROUP);
+        let config = load(&path);
+        let value: serde_json::Value =
+            serde_json::from_str(&render_groups_json(&config).unwrap()).unwrap();
+        let row = |name: &str| -> serde_json::Value {
+            value["groups"]
+                .as_array()
+                .expect("groups array")
+                .iter()
+                .find(|r| r["group"] == name)
+                .expect("group row")
+                .clone()
+        };
+        assert_eq!(row("research")["routes"], serde_json::json!(false));
+        assert_eq!(
+            row("research")["routeBlock"],
+            serde_json::json!(ROUTE_BLOCK_CONTROL_ONLY),
+            "the JSON reason must be the same token the text surface prints"
+        );
+        assert_eq!(row("dev")["routes"], serde_json::json!(true));
+        assert_eq!(row("dev")["routeBlock"], serde_json::Value::Null);
+        fs::remove_file(&path).ok();
+    }
+
+    /// The warning `group add` prints. It fires only for the control account,
+    /// and it names both remedies — otherwise it is just an alarm with no exit.
+    #[test]
+    fn labelling_the_control_account_warns_and_names_a_remedy() {
+        let path = write_config("routes-notice", CONTROL_ONLY_GROUP);
+        let config = load(&path);
+        let notice = control_account_group_notice(&config, "gil@example.com", "research")
+            .expect("labelling the control account must produce a notice");
+        assert!(notice.contains("control account"), "{notice}");
+        assert!(
+            notice.contains("research"),
+            "the notice names the group: {notice}"
+        );
+        assert!(
+            notice.contains("tcr control --clear"),
+            "the notice names a runnable remedy: {notice}"
+        );
+        assert!(
+            control_account_group_notice(&config, "worker@example.com", "dev").is_none(),
+            "an ordinary account must not be warned about"
+        );
         fs::remove_file(&path).ok();
     }
 

--- a/src/manager/select.rs
+++ b/src/manager/select.rs
@@ -35,6 +35,64 @@ pub(super) enum RequestClass {
     ControlPreferred,
 }
 
+/// Why the group-respecting first pass of [`Manager::select_with_group`] came up
+/// empty, so the soft fallback had to drop the group and serve from the whole
+/// pool.
+///
+/// Exists because the log line at that fallback used to hardcode "under pacing"
+/// for every group miss. Pacing ships OFF ([`crate::config::default_pacing`]), so
+/// on a default install that sentence named the one constraint that was NOT in
+/// play and hid the one that was. Measured on the live fleet 2026-08-23: a group
+/// whose only member was the control account fell back on 3 of 3 probes (a
+/// two-account group landed in-group 3 of 3), and every one of the nine log lines
+/// produced while diagnosing it blamed pacing, which was unconfigured.
+///
+/// [`Self::OnlyControl`] is the arm that matters: it is not a transient miss. No
+/// retry, no quota recovering and no restart fixes it, because the exclusion is
+/// unconditional for [`RequestClass::Inference`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum GroupMiss {
+    /// No configured account carries this label at all — a typo, or a label
+    /// removed from every account while a client still asks for it.
+    Unknown,
+    /// Every member is the control account, which an inference request never
+    /// selects. This group can NEVER serve inference.
+    OnlyControl,
+    /// Members exist and are selectable in principle, but every one is held out
+    /// right now by a hard gate: disabled, errored, rate-limited, over its
+    /// switch threshold, model-blocked, or reserved away from this caller.
+    AllGated,
+    /// At least one member would serve but for the SOFT pacing gate — the only
+    /// arm the old message was ever right about.
+    Paced,
+}
+
+impl GroupMiss {
+    /// One greppable token for the `reason=` log field, so an operator can count
+    /// group misses by cause without parsing prose.
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "no-such-group",
+            Self::OnlyControl => "control-account-only",
+            Self::AllGated => "all-members-unavailable",
+            Self::Paced => "all-members-paced",
+        }
+    }
+
+    /// The sentence a human reads in the log. Says what to DO about it in the
+    /// one case that has a remedy the operator must apply by hand.
+    pub(super) fn explain(self) -> &'static str {
+        match self {
+            Self::Unknown => "no configured account carries the requested group",
+            Self::OnlyControl => {
+                "the requested group's only member is the control account, which inference never selects — no request will ever route to this group until another account joins it or the control account is cleared"
+            }
+            Self::AllGated => "every account in the requested group is currently unavailable",
+            Self::Paced => "every account in the requested group is paced out",
+        }
+    }
+}
+
 /// Classify an unpinned request's path into the three-way split. Exact match
 /// for the two inference paths (mirrors `stable_session_key`'s
 /// `/v1/messages/count_tokens must NOT prefix-match /v1/messages` guard);
@@ -786,19 +844,25 @@ impl Manager {
             // Modeled as an extra `tried` member rather than a new parameter
             // threaded through `pick_eligible`/`pick_least_loaded`, so both
             // passes (and the pacing/least-loaded fallback) honour it for free.
-            let pool_tried: std::borrow::Cow<'_, HashSet<usize>> =
-                if request_class == RequestClass::Inference {
-                    match self.control() {
-                        Some(control_idx) if !tried.contains(&control_idx) => {
-                            let mut t = tried.clone();
-                            t.insert(control_idx);
-                            std::borrow::Cow::Owned(t)
-                        }
-                        _ => std::borrow::Cow::Borrowed(tried),
-                    }
-                } else {
-                    std::borrow::Cow::Borrowed(tried)
-                };
+            //
+            // Hoisted into its own binding (it used to be inlined in the `match`
+            // below) because the group-miss classifier on the fallback path needs
+            // the SAME answer: an account held out only by this exclusion is the
+            // one case where a `--group` ask can never be satisfied by any retry,
+            // and naming it requires knowing which index was excluded and why.
+            let control_excluded: Option<usize> = if request_class == RequestClass::Inference {
+                self.control()
+            } else {
+                None
+            };
+            let pool_tried: std::borrow::Cow<'_, HashSet<usize>> = match control_excluded {
+                Some(control_idx) if !tried.contains(&control_idx) => {
+                    let mut t = tried.clone();
+                    t.insert(control_idx);
+                    std::borrow::Cow::Owned(t)
+                }
+                _ => std::borrow::Cow::Borrowed(tried),
+            };
             let pool_tried: &HashSet<usize> = &pool_tried;
 
             // First pass: honour pacing (skip accounts at the concurrency cap or
@@ -828,12 +892,28 @@ impl Manager {
                         // `--group` did not land where expected must not read a log
                         // line about pacing when pacing was never the reason.
                         match group {
-                            Some(g) => tracing::info!(
-                                account = %account.name,
-                                in_flight = account.in_flight,
-                                group = g,
-                                "group: requested group had no eligible account under pacing — falling back to the whole pool (group and pacing both ignored), serving least-loaded"
-                            ),
+                            Some(g) => {
+                                let miss = Self::classify_group_miss(
+                                    &accounts,
+                                    tried,
+                                    control_excluded,
+                                    self.global_threshold,
+                                    &self.pacing,
+                                    now,
+                                    now_ms,
+                                    is_fable,
+                                    g,
+                                    &reserved_groups,
+                                );
+                                tracing::info!(
+                                    account = %account.name,
+                                    in_flight = account.in_flight,
+                                    group = g,
+                                    reason = miss.as_str(),
+                                    "group: falling back to the whole pool (group ignored), serving least-loaded — {}",
+                                    miss.explain(),
+                                );
+                            }
                             None => tracing::info!(
                                 account = %account.name,
                                 in_flight = account.in_flight,
@@ -1528,6 +1608,79 @@ impl Manager {
             }
         }
         true
+    }
+
+    /// Why the group-respecting pass found nothing — see [`GroupMiss`].
+    ///
+    /// Called ONLY from the soft fallback, which runs after that pass already
+    /// returned `None`, so this scan costs nothing on a request that routes
+    /// normally. Pure: takes the accounts slice the caller already holds a guard
+    /// on, and reads no lock of its own.
+    ///
+    /// `control_excluded` is the index [`Self::select_with_group`] forced into
+    /// its pool-`tried` set for THIS request — `Some` only for an inference
+    /// request with a control account configured. Passed in rather than
+    /// re-derived from `self.control()` so the answer here can never disagree
+    /// with the exclusion that actually ran: the classifier's whole job is to
+    /// name that exclusion when it is the reason.
+    ///
+    /// `tried` is the caller's ORIGINAL set, deliberately not the
+    /// control-injected `pool_tried` — a member that is only in the set because
+    /// of the injection must be attributed to [`GroupMiss::OnlyControl`], not
+    /// silently counted as "already tried".
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn classify_group_miss(
+        accounts: &[AccountRuntime],
+        tried: &HashSet<usize>,
+        control_excluded: Option<usize>,
+        global_threshold: f64,
+        pacing: &PacingConfig,
+        now: OffsetDateTime,
+        now_ms: i64,
+        is_fable: bool,
+        group: &str,
+        reserved: &HashSet<String>,
+    ) -> GroupMiss {
+        let members: Vec<usize> = accounts
+            .iter()
+            .enumerate()
+            .filter(|(_, account)| account.groups.iter().any(|label| label == group))
+            .map(|(idx, _)| idx)
+            .collect();
+        if members.is_empty() {
+            return GroupMiss::Unknown;
+        }
+        if members.iter().all(|idx| Some(*idx) == control_excluded) {
+            return GroupMiss::OnlyControl;
+        }
+        // Would any member serve with the soft pacing gate lifted? If yes, pacing
+        // really was the reason and the old message was right by accident. If no,
+        // the members are hard-gated, and saying "paced" would be the same lie in
+        // the other direction — which is exactly the defect this classifier exists
+        // to end, so it must not be reintroduced here.
+        let servable_unpaced = members.iter().any(|idx| {
+            Some(*idx) != control_excluded
+                && !tried.contains(idx)
+                && accounts.get(*idx).is_some_and(|account| {
+                    Self::eligible(
+                        account,
+                        global_threshold,
+                        pacing,
+                        false,
+                        now,
+                        now_ms,
+                        is_fable,
+                        Some(group),
+                        Some(group),
+                        reserved,
+                    )
+                })
+        });
+        if servable_unpaced {
+            GroupMiss::Paced
+        } else {
+            GroupMiss::AllGated
+        }
     }
 
     /// `reserved_group` is the SESSION's real requested group, used ONLY for
@@ -2543,5 +2696,139 @@ mod reserved_gate_agreement_tests {
                 Manager::account_gate(&account, 0.90, now, now_ms, false, Some(ask), &reserved);
             assert_ne!(gate, GateReason::Reserved, "ask={ask}: account_gate agrees");
         }
+    }
+}
+
+/// Group-miss classification (`Manager::classify_group_miss`): the log line at
+/// the soft fallback must name the constraint that was actually in play.
+///
+/// The arm that earns the module is [`GroupMiss::OnlyControl`]. Before this
+/// existed, a group whose only member was the control account fell back on every
+/// single request and the log said "under pacing" — on a fleet where pacing was
+/// unconfigured. These tests pin each cause to its own answer so the message can
+/// never again describe a constraint that was switched off.
+#[cfg(test)]
+mod group_miss_tests {
+    use super::*;
+    use crate::config::{Account, PacingConfig};
+
+    fn account(name: &str, groups: &[&str], disabled: bool) -> AccountRuntime {
+        AccountRuntime::from_config(
+            &Account {
+                name: name.to_string(),
+                account_type: "oauth".to_string(),
+                account_uuid: None,
+                org_uuid: None,
+                org_name: None,
+                access_token: format!("at-{name}"),
+                refresh_token: None,
+                expires_at: Some(crate::now_ms() + 3_600_000),
+                priority: Some(0),
+                switch_threshold: None,
+                disabled: disabled.then_some(true),
+                groups: Some(groups.iter().map(|g| g.to_string()).collect()),
+                extra: serde_json::Map::new(),
+            },
+            false,
+        )
+    }
+
+    fn classify(
+        accounts: &[AccountRuntime],
+        control_excluded: Option<usize>,
+        pacing: &PacingConfig,
+        group: &str,
+    ) -> GroupMiss {
+        let now = OffsetDateTime::now_utc();
+        Manager::classify_group_miss(
+            accounts,
+            &HashSet::new(),
+            control_excluded,
+            0.95,
+            pacing,
+            now,
+            odt_to_ms(now),
+            false,
+            group,
+            &HashSet::new(),
+        )
+    }
+
+    /// The live defect, in one assertion: `research` holds exactly one account
+    /// and that account is the control one, which inference never picks. The
+    /// group is not busy and not paced — it is permanently unroutable, and the
+    /// reason must say so.
+    #[test]
+    fn a_group_holding_only_the_control_account_is_named_control_account_only() {
+        let accounts = [
+            account("gil@example.com", &["research"], false),
+            account("worker@example.com", &[], false),
+        ];
+        let miss = classify(&accounts, Some(0), &PacingConfig::default(), "research");
+        assert_eq!(miss, GroupMiss::OnlyControl, "{miss:?}");
+        assert_eq!(miss.as_str(), "control-account-only");
+        assert!(
+            miss.explain().contains("control account"),
+            "the sentence an operator reads must name the control account: {}",
+            miss.explain()
+        );
+    }
+
+    /// Same fleet, same group — but the request is NOT inference, so nothing
+    /// excluded the control account and the group is perfectly routable. Guards
+    /// against reporting `OnlyControl` from group shape alone.
+    #[test]
+    fn the_same_group_is_not_control_blocked_when_nothing_was_excluded() {
+        let accounts = [
+            account("gil@example.com", &["research"], false),
+            account("worker@example.com", &[], false),
+        ];
+        assert_ne!(
+            classify(&accounts, None, &PacingConfig::default(), "research"),
+            GroupMiss::OnlyControl
+        );
+    }
+
+    /// A label no account carries is its own cause — a typo or a label removed
+    /// from every account, not a busy group.
+    #[test]
+    fn a_label_no_account_carries_is_unknown() {
+        let accounts = [account("worker@example.com", &["dev"], false)];
+        assert_eq!(
+            classify(&accounts, None, &PacingConfig::default(), "resarch"),
+            GroupMiss::Unknown
+        );
+    }
+
+    /// A second, non-control member exists, so the group is not control-blocked
+    /// — but it is disabled, which is a hard gate and not pacing.
+    #[test]
+    fn a_hard_gated_member_is_unavailable_not_paced() {
+        let accounts = [
+            account("gil@example.com", &["research"], false),
+            account("worker@example.com", &["research"], true),
+        ];
+        assert_eq!(
+            classify(&accounts, Some(0), &PacingConfig::default(), "research"),
+            GroupMiss::AllGated
+        );
+    }
+
+    /// The one case the old hardcoded message was right about: pacing is
+    /// configured, the member is healthy, and it is inside its min-spacing
+    /// window. Pacing keeps its name — the fix is not to stop saying "paced",
+    /// it is to stop saying it when pacing is off.
+    #[test]
+    fn a_healthy_member_inside_the_spacing_window_is_paced() {
+        let pacing = PacingConfig {
+            max_in_flight_per_account: None,
+            min_spacing_ms: Some(60_000),
+        };
+        let mut accounts = [account("worker@example.com", &["research"], false)];
+        accounts[0].last_served_ms = crate::now_ms();
+        assert_eq!(
+            classify(&accounts, None, &pacing, "research"),
+            GroupMiss::Paced
+        );
     }
 }


### PR DESCRIPTION
`research` had one member, a colour, and a healthy row in `tcr status`. It served nothing.

An inference pick force-adds the control account to its `tried` set (`select.rs`'s `control_excluded`), so a group whose only member is the control account has no candidate, the soft fallback drops the group, and the request goes to the whole pool — every request, permanently. Measured live: **0 of 3** probes asking for such a group landed in it, against **3 of 3** for an ordinary two-account group. `scripts/group-routing-e2e.py` is that probe, with the two-account group as its positive control.

The one log line that fired said `under pacing`. Pacing ships off and was unconfigured, so it named the only constraint that wasn't involved — and cost the first diagnosis.

- `classify_group_miss` reports the cause actually in play, as a greppable `reason=` field
- `tcr group ls` gains `routes=yes|no` / `route_block=` on both surfaces from one token
- `tcr group add` warns when you label the control account, and names both remedies
- the panel shows a disabled line on an unroutable group, and its copy entry is now `tcr run --group <g>` instead of `tcr group rm …`
- `groups[]` and `controlAccount` were undocumented; `docs/configuration.md` now covers them

Visibility only — it does not change which account serves a group ask. Every new test was watched failing against a deliberately broken production path first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191g1oGMSqaJR4FKcndf2cw
