### PR TITLE
Skip an unusable account instead of failing the whole config

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -103,9 +103,32 @@ fn warn_if_server_running(config: &Config) {
 }
 
 /// Load the config for a management verb, warning if a server is live.
+///
+/// Refuses when [`Config::quarantined_accounts`] is non-empty. The server's
+/// `load` is deliberately lenient — it drops an `accounts[]` entry with no
+/// usable credential (e.g. an `importFrom`-shaped account) rather than take
+/// the whole fleet down. A CLI edit verb cannot share that leniency: its
+/// round-trip is `save_after_edit` → a bare `serde_json::to_string_pretty`
+/// of the typed `Config`, which has nowhere to put an entry that was never
+/// deserialized into it — so writing back after loading such a file would
+/// silently and permanently erase the quarantined entry's raw JSON (its
+/// `importFrom` pointer included) the first time any verb saved. Refusing
+/// here, before any edit happens, keeps that erasure from ever becoming
+/// reachable; the operator fixes or removes the entry by hand, then the CLI
+/// works on it same as always.
 fn load_for_edit(config_path: &Path) -> anyhow::Result<Config> {
     let config = config::load(config_path)
         .with_context(|| format!("load config at {}", config_path.display()))?;
+    if !config.quarantined_accounts.is_empty() {
+        bail!(
+            "config at {} has {} account(s) with no usable credential, so the CLI cannot safely \
+             load-edit-save it: {}. Fix or remove the entry in the file by hand (the server \
+             itself tolerates it and keeps running).",
+            config_path.display(),
+            config.quarantined_accounts.len(),
+            config.quarantined_accounts.join(", ")
+        );
+    }
     warn_if_server_running(&config);
     Ok(config)
 }
@@ -2421,6 +2444,57 @@ mod tests {
 
     fn load(path: &Path) -> Config {
         config::load(path).unwrap()
+    }
+
+    // --- load_for_edit refuses a config with a quarantined account ---------
+
+    const ONE_ACCOUNT_ONE_UNUSABLE: &str = r#"{
+      "accounts": [
+        { "name": "alice@example.com", "type": "oauth", "accessToken": "at-a" },
+        { "name": "carol@example.com", "type": "oauth", "importFrom": "/some/other/file.json" }
+      ]
+    }"#;
+
+    /// The server's own `config::load` stays lenient on this file — it drops
+    /// the unusable entry and keeps running. This is the control: proves the
+    /// fixture used by the refusal test below is exactly the kind of file the
+    /// fix was meant to keep the SERVER booting on.
+    #[test]
+    fn server_load_tolerates_a_quarantined_account() {
+        let path = write_config("server-load-quarantine", ONE_ACCOUNT_ONE_UNUSABLE);
+        let config = config::load(&path).expect("server load must not fail on this file");
+        assert_eq!(config.accounts.len(), 1);
+        assert_eq!(config.accounts[0].name, "alice@example.com");
+        assert_eq!(
+            config.quarantined_accounts,
+            vec!["carol@example.com".to_string()]
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    /// The CLI's load-edit-save round-trip cannot represent a quarantined
+    /// entry (`save` has nowhere to put it), so it refuses up front rather
+    /// than silently losing the entry's raw JSON on the next save.
+    #[test]
+    fn load_for_edit_refuses_a_config_with_a_quarantined_account() {
+        let path = write_config("cli-load-quarantine", ONE_ACCOUNT_ONE_UNUSABLE);
+        let err = load_for_edit(&path).expect_err("must refuse rather than silently drop an entry");
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("carol@example.com"),
+            "error should name the quarantined account: {message}"
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    /// A config with no quarantined accounts is unaffected: `load_for_edit`
+    /// still succeeds exactly as before this change.
+    #[test]
+    fn load_for_edit_succeeds_with_no_quarantined_accounts() {
+        let path = write_config("cli-load-no-quarantine", TWO_ACCOUNTS);
+        let config = load_for_edit(&path).expect("a clean config must still load for editing");
+        assert_eq!(config.accounts.len(), 2);
+        fs::remove_file(&path).ok();
     }
 
     // --- remove ------------------------------------------------------------

--- a/src/config.rs
+++ b/src/config.rs
@@ -603,6 +603,16 @@ pub struct Config {
     /// Any top-level keys we do not model, preserved verbatim on save.
     #[serde(flatten)]
     pub extra: Map<String, Value>,
+    /// Names of `accounts[]` entries [`load`] dropped because they carried no
+    /// usable credential ([`unusable_account`]) — see `load`'s doc-comment.
+    /// Populated ONLY by `load`; `#[serde(skip)]` so it is never read from or
+    /// written to the file — a `save()`/`save_tokens()` round-trip of a
+    /// `Config` carrying quarantined names must not fabricate an `accounts[]`
+    /// entry for them, and must not accept one from a hand-edited file either.
+    /// Empty for a `Config` built any other way (a test's
+    /// `serde_json::from_str`, `Config::default()`-shaped construction).
+    #[serde(skip)]
+    pub quarantined_accounts: Vec<String>,
 }
 
 impl Config {
@@ -753,18 +763,24 @@ fn unusable_account(entry: &Value) -> Option<(String, &'static str)> {
 /// booting silently is its own bug) — reported through the same
 /// [`ConfigError::Parse`] shape a malformed file already uses, not a new
 /// variant.
+///
+/// The names of every quarantined account land in
+/// [`Config::quarantined_accounts`] — not just the log line — so a caller
+/// that cannot tolerate a quietly-shrunk fleet (the CLI's edit verbs; see
+/// `cli::load_for_edit`) can refuse instead of writing a `save()` that would
+/// permanently drop the entry's raw JSON (its `importFrom` pointer included).
 pub fn load(path: &Path) -> Result<Config, ConfigError> {
     let data = fs::read_to_string(path)?;
     let mut doc: Value = serde_json::from_str(&data)?;
+    let mut quarantined = Vec::new();
 
     if let Some(accounts) = doc.get_mut("accounts").and_then(Value::as_array_mut) {
         let had_accounts = !accounts.is_empty();
-        let mut skipped = Vec::new();
         accounts.retain(|entry| match unusable_account(entry) {
             None => true,
             Some((name, reason)) => {
                 tracing::warn!(account = %name, missing = reason, "No token for \"{name}\", skipping");
-                skipped.push(name);
+                quarantined.push(name);
                 false
             }
         });
@@ -772,14 +788,15 @@ pub fn load(path: &Path) -> Result<Config, ConfigError> {
             return Err(ConfigError::Parse(
                 <serde_json::Error as serde::de::Error>::custom(format!(
                     "no usable accounts remain after skipping {} without a credential: {}",
-                    skipped.len(),
-                    skipped.join(", ")
+                    quarantined.len(),
+                    quarantined.join(", ")
                 )),
             ));
         }
     }
 
-    let config = serde_json::from_value(doc)?;
+    let mut config: Config = serde_json::from_value(doc)?;
+    config.quarantined_accounts = quarantined;
     Ok(config)
 }
 
@@ -2360,6 +2377,62 @@ mod tests {
         let config = load(&path).unwrap();
         assert!(config.accounts.is_empty());
         fs::remove_file(&path).ok();
+    }
+
+    /// `load` names every account it drops in
+    /// [`Config::quarantined_accounts`], not only in the log line — the CLI's
+    /// `load_for_edit` refuses on this rather than risk a `save()` that would
+    /// permanently erase the entry.
+    #[test]
+    fn load_reports_quarantined_account_names() {
+        let path = tmp_path("load-quarantine-names");
+        fs::write(
+            &path,
+            r#"{ "accounts": [
+                 { "name": "acct-good", "accessToken": "at-good" },
+                 { "name": "acct-import", "importFrom": "/some/other/file.json" }
+               ] }"#,
+        )
+        .unwrap();
+
+        let config = load(&path).unwrap();
+        assert_eq!(config.quarantined_accounts, vec!["acct-import".to_string()]);
+        fs::remove_file(&path).ok();
+    }
+
+    /// `quarantined_accounts` is `#[serde(skip)]`: a `Config` carrying names in
+    /// it must not write them anywhere on `save()`, and a hand-edited file
+    /// carrying a same-named key must not be read into it either — the field
+    /// exists purely for the in-process caller, never the file.
+    #[test]
+    fn quarantined_accounts_do_not_serialize() {
+        let path = tmp_path("load-quarantine-serialize");
+        fs::write(
+            &path,
+            r#"{ "accounts": [
+                 { "name": "acct-good", "accessToken": "at-good" },
+                 { "name": "acct-import", "importFrom": "/some/other/file.json" }
+               ] }"#,
+        )
+        .unwrap();
+        let config = load(&path).unwrap();
+        assert_eq!(config.quarantined_accounts, vec!["acct-import".to_string()]);
+
+        let out = tmp_path("load-quarantine-serialize-out");
+        save(&out, &config).unwrap();
+        let value = read_json(&out);
+        assert!(
+            value.get("quarantinedAccounts").is_none()
+                && value.get("quarantined_accounts").is_none(),
+            "quarantined_accounts leaked into the saved file: {value}"
+        );
+        // Round-tripping the SAVED file back through `load` must not resurrect
+        // a `quarantinedAccounts` key from the file into the field either.
+        let reloaded = load(&out).unwrap();
+        assert!(reloaded.quarantined_accounts.is_empty());
+
+        fs::remove_file(&path).ok();
+        fs::remove_file(&out).ok();
     }
 
     // --- group color ---------------------------------------------------------

--- a/src/config.rs
+++ b/src/config.rs
@@ -702,10 +702,84 @@ pub fn default_path() -> PathBuf {
     home.join(".config").join("teamclaude.json")
 }
 
+/// Whether an on-disk `accounts[]` entry can yield a usable credential, and if
+/// not, the account's `name` and why — for the warning [`load`] emits when it
+/// drops the entry. An `apikey` account needs `apiKey`; every other type
+/// (including the implicit `oauth` default) needs a non-empty `accessToken`.
+/// An `importFrom`-shaped entry (a bare pointer at another file, resolved by
+/// upstream at startup — not implemented here, see `config-bridge-coder.md`)
+/// has no inline token either, so it falls out through the same check.
+fn unusable_account(entry: &Value) -> Option<(String, &'static str)> {
+    let name = entry
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or("<unnamed>")
+        .to_string();
+    let has_nonempty = |key: &str| {
+        entry
+            .get(key)
+            .and_then(Value::as_str)
+            .is_some_and(|s| !s.is_empty())
+    };
+    let is_apikey = entry.get("type").and_then(Value::as_str) == Some("apikey");
+    if is_apikey {
+        if has_nonempty("apiKey") {
+            None
+        } else {
+            Some((name, "apiKey"))
+        }
+    } else if has_nonempty("accessToken") {
+        None
+    } else {
+        Some((name, "accessToken"))
+    }
+}
+
 /// Load and parse the config at `path`.
+///
+/// Deserializes leniently at the account boundary: an `accounts[]` entry that
+/// cannot yield a usable credential ([`unusable_account`]) is dropped, with a
+/// warning naming it, rather than failing the WHOLE file the way a plain
+/// `serde_json::from_str` over `Config` would — `Account::access_token` is a
+/// required `String` with no `serde(default)` (deliberately: an empty-string
+/// token must never reach rotation and send `Bearer ` upstream), so one such
+/// entry used to take every other account in the file down with it. Upstream
+/// (`resolve-accounts.js`) skips an unusable account the same way rather than
+/// crashing the fleet. Every `Account` that survives into memory still has a
+/// real, non-empty credential — the 142 call sites reading `access_token` as a
+/// plain `String` are entitled to assume that.
+///
+/// If every account entry is unusable, that is still an error (an empty fleet
+/// booting silently is its own bug) — reported through the same
+/// [`ConfigError::Parse`] shape a malformed file already uses, not a new
+/// variant.
 pub fn load(path: &Path) -> Result<Config, ConfigError> {
     let data = fs::read_to_string(path)?;
-    let config = serde_json::from_str(&data)?;
+    let mut doc: Value = serde_json::from_str(&data)?;
+
+    if let Some(accounts) = doc.get_mut("accounts").and_then(Value::as_array_mut) {
+        let had_accounts = !accounts.is_empty();
+        let mut skipped = Vec::new();
+        accounts.retain(|entry| match unusable_account(entry) {
+            None => true,
+            Some((name, reason)) => {
+                tracing::warn!(account = %name, missing = reason, "No token for \"{name}\", skipping");
+                skipped.push(name);
+                false
+            }
+        });
+        if had_accounts && accounts.is_empty() {
+            return Err(ConfigError::Parse(
+                <serde_json::Error as serde::de::Error>::custom(format!(
+                    "no usable accounts remain after skipping {} without a credential: {}",
+                    skipped.len(),
+                    skipped.join(", ")
+                )),
+            ));
+        }
+    }
+
+    let config = serde_json::from_value(doc)?;
     Ok(config)
 }
 
@@ -2207,6 +2281,85 @@ mod tests {
         let reloaded: Config = serde_json::from_str(&fs::read_to_string(&tmp).unwrap()).unwrap();
         assert_eq!(reloaded.accounts[0].groups, config.accounts[0].groups);
         fs::remove_file(&tmp).ok();
+    }
+
+    // --- load: skip unusable accounts, keep the rest -------------------------
+
+    /// One account with no `accessToken` (an `importFrom`-shaped entry, e.g.:
+    /// upstream reads the credential from another file at startup — not
+    /// implemented here) does not take the other, usable accounts down with
+    /// it, and the skipped account is named in a warning rather than silently
+    /// vanishing.
+    #[test]
+    fn load_skips_one_unusable_account_and_keeps_the_rest() {
+        let path = tmp_path("load-skip-one");
+        fs::write(
+            &path,
+            r#"{ "accounts": [
+                 { "name": "acct-good", "accessToken": "at-good" },
+                 { "name": "acct-import", "importFrom": "/some/other/file.json" }
+               ] }"#,
+        )
+        .unwrap();
+
+        let config = load(&path).unwrap();
+        assert_eq!(config.accounts.len(), 1);
+        assert_eq!(config.accounts[0].name, "acct-good");
+        assert_eq!(config.accounts[0].access_token, "at-good");
+        fs::remove_file(&path).ok();
+    }
+
+    /// An `apikey` account with no `apiKey` is unusable by the same rule an
+    /// `oauth` account with no `accessToken` is — skipped, not fatal.
+    #[test]
+    fn load_skips_apikey_account_missing_api_key() {
+        let path = tmp_path("load-skip-apikey");
+        fs::write(
+            &path,
+            r#"{ "accounts": [
+                 { "name": "acct-good", "accessToken": "at-good" },
+                 { "name": "acct-apikey", "type": "apikey" }
+               ] }"#,
+        )
+        .unwrap();
+
+        let config = load(&path).unwrap();
+        assert_eq!(config.accounts.len(), 1);
+        assert_eq!(config.accounts[0].name, "acct-good");
+        fs::remove_file(&path).ok();
+    }
+
+    /// Every account unusable is still a load error — an empty fleet must
+    /// never boot silently — reported through the same `ConfigError::Parse`
+    /// shape a malformed file already uses.
+    #[test]
+    fn load_errors_when_every_account_is_unusable() {
+        let path = tmp_path("load-all-unusable");
+        fs::write(
+            &path,
+            r#"{ "accounts": [
+                 { "name": "acct-import", "importFrom": "/some/other/file.json" }
+               ] }"#,
+        )
+        .unwrap();
+
+        let err = load(&path).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::Parse(_)),
+            "expected a Parse-shaped error, got {err:?}"
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    /// An empty `accounts` list is not "all unusable" — it is unchanged,
+    /// pre-existing, valid behaviour (no accounts configured at all).
+    #[test]
+    fn load_tolerates_empty_accounts_list() {
+        let path = tmp_path("load-empty-accounts");
+        fs::write(&path, r#"{ "accounts": [] }"#).unwrap();
+        let config = load(&path).unwrap();
+        assert!(config.accounts.is_empty());
+        fs::remove_file(&path).ok();
     }
 
     // --- group color ---------------------------------------------------------

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -2613,6 +2613,7 @@ mod tests {
 
     fn config_with(accounts: Vec<Account>) -> Config {
         Config {
+            quarantined_accounts: Vec::new(),
             proxy: ProxyConfig::default(),
             upstream: "https://api.anthropic.com".to_string(),
             switch_threshold: 0.90,

--- a/src/manager/select.rs
+++ b/src/manager/select.rs
@@ -2316,6 +2316,7 @@ mod revalidation_sticky_tests {
 
     fn config_with(accounts: Vec<Account>) -> Config {
         Config {
+            quarantined_accounts: Vec::new(),
             proxy: ProxyConfig::default(),
             upstream: "https://api.anthropic.com".to_string(),
             switch_threshold: 0.90,
@@ -2456,6 +2457,7 @@ mod sticky_divert_replay_tests {
 
     fn config_with(accounts: Vec<Account>) -> Config {
         Config {
+            quarantined_accounts: Vec::new(),
             proxy: ProxyConfig::default(),
             upstream: "https://api.anthropic.com".to_string(),
             switch_threshold: 0.90,

--- a/src/mitm.rs
+++ b/src/mitm.rs
@@ -1350,6 +1350,7 @@ mod tests {
     /// router to observe which HTTP version `serve_connection` negotiated.
     fn dummy_manager() -> Arc<Manager> {
         let config = crate::config::Config {
+            quarantined_accounts: Vec::new(),
             proxy: crate::config::ProxyConfig {
                 port: 0,
                 api_key: None,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -3603,6 +3603,7 @@ mod tests {
 
     fn dummy_config(api_key: Option<&str>, upstream: &str) -> Config {
         Config {
+            quarantined_accounts: Vec::new(),
             proxy: ProxyConfig {
                 port: 0,
                 api_key: api_key.map(str::to_string),

--- a/tests/throttle_exempt.rs
+++ b/tests/throttle_exempt.rs
@@ -118,6 +118,7 @@ fn config(upstream: &str, throttle: ThrottleConfig, throttle_exempt_noise: bool)
         serde_json::Value::Bool(throttle_exempt_noise),
     );
     Config {
+        quarantined_accounts: Vec::new(),
         proxy: ProxyConfig {
             port: 0,
             api_key: None,

--- a/tests/workload_scenarios.rs
+++ b/tests/workload_scenarios.rs
@@ -208,6 +208,7 @@ impl Fleet {
     fn new(accounts: &[(&str, i64)], pacing: PacingConfig) -> Self {
         let account_names = accounts.iter().map(|(n, _)| (*n).to_string()).collect();
         let config = Config {
+            quarantined_accounts: Vec::new(),
             proxy: ProxyConfig::default(),
             upstream: "https://api.anthropic.com".to_string(),
             switch_threshold: SWITCH_THRESHOLD,


### PR DESCRIPTION
`Account::access_token` was a required field while every neighbour was optional, and
`config::load` deserialized the file in one shot. So a single account entry without an
inline `accessToken` failed the parse and took every other account in the file with it.

The Node proxy does not do this: it skips an unusable account with a message and keeps
the rest, which matters because `importFrom` entries — credentials sourced from another
file — are ordinary there and have no inline token. A real config of that shape took the
whole fleet down here at parse time.

`load` now drops account entries that cannot yield a usable credential, names each one in
a warning, and deserializes the rest. Every `Account` that reaches memory still has a real
credential, so no call site changes and the field stays a required `String`. A config where
every account is unusable is still an error.

The field type was left alone on purpose. `Option<String>` would ripple through 142 call
sites, and `serde(default)` would let an empty token reach rotation and send `Bearer `
upstream — trading a loud parse error for a silent 401 storm.

Skipping an account creates a second hazard: `config::save` re-serializes from the typed
struct, so a CLI edit verb would have erased the skipped entry from the file permanently.
`load_for_edit` therefore refuses, naming the accounts, before any edit path can save. The
server's boot path keeps the leniency — that is where the win is. The quarantine list is
`#[serde(skip)]` and a test proves it never reaches the file.

Not included: `importFrom` support, `apikey` accounts beyond clean skipping, or any change
to the README's drop-in wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4o99x9WEgNJZax7VB7MBP
