### PR TITLE
Add the 0.2.24 appcast entry

### DIFF
--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.24</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.24</link>
+      <sparkle:version>444</sparkle:version>
+      <sparkle:shortVersionString>0.2.24</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Tue, 25 Aug 2026 11:56:11 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.24/TcrBar-0.2.24.dmg" type="application/octet-stream" sparkle:edSignature="FJ5eyLjUy9Qtb5lNEVkLQ5FLQg4XrXSGOSauomLBwMW4zpjUW1414nhFJplXnSi9g9+YANbfxneB/ZBRWfxjAA==" length="6228138" />
+    </item>
+    <item>
       <title>TcrBar 0.2.23</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.23</link>
       <sparkle:version>442</sparkle:version>


### PR DESCRIPTION
The 0.2.24 appcast entry, written by release-tcrbar.sh during today's release. The enclosure length (6,228,138) matches the TcrBar-0.2.24.dmg asset on the v0.2.24 release byte for byte, and the DMG passed notarization and stapling before upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A622xrCgxA2uL2Ej86h4sT
