### PR TITLE
Add the 0.2.25 appcast entry

### DIFF
--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.25</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.25</link>
+      <sparkle:version>449</sparkle:version>
+      <sparkle:shortVersionString>0.2.25</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Tue, 25 Aug 2026 13:25:10 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.25/TcrBar-0.2.25.dmg" type="application/octet-stream" sparkle:edSignature="EAUnjcbljm5LNuhdoTdU7LEG99+0xc0NdFsxEu9XIDuT620CXDzG4u1kIAarixJt8/8UeGsFqI9hvFN1j8JbCw==" length="6396171" />
+    </item>
+    <item>
       <title>TcrBar 0.2.24</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.24</link>
       <sparkle:version>444</sparkle:version>


### PR DESCRIPTION
The 0.2.25 appcast entry, written by release-tcrbar.sh during today's second release. The enclosure length matches the TcrBar-0.2.25.dmg asset on the v0.2.25 release byte for byte; the DMG passed notarization and stapling before upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A622xrCgxA2uL2Ej86h4sT
