### PR TITLE
feat: rank rotation by reset urgency inside a priority tier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2503,7 +2503,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "teamclaude-rs"
-version = "0.2.25"
+version = "0.2.26"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,6 +46,7 @@ section below.
 | `http1Only` | bool | **`false`** (OFF) | no | force the upstream client onto HTTP/1.1, see below |
 | `pricing` | object | `{}` → the built-in table only | no | per-model price overrides for the usage figures, see below |
 | `usageRetentionDays` | u32 | **`90`** | no | how many days of usage ledger files to keep |
+| `resetUrgencyTierHours` | u32 | **`24`** | no | width of the reset-urgency bucket rotation ranks by inside a priority tier; `0` disables it, see below |
 | `accounts` | array | `[]` | no | the rotatable accounts |
 
 `switchThreshold` is **0.95**, not 0.90. The default function is
@@ -160,6 +161,54 @@ keep-warm; any other value is treated as a static key.
 Per-account keys the proxy does not model (`models`, `upstream`, `sx`, anything inherited
 from the older Node proxy) parse fine and survive a load→save round trip untouched, but
 nothing reads them.
+
+## `resetUrgencyTierHours`: spend the quota that is about to expire
+
+Unused weekly quota is worth nothing once its window resets. Accounts do not reset together —
+measured on a 13-account fleet on 2026-08-26, every account sat at priority 0 and their weekly
+resets were spread from 2.5 hours to 152.5 hours out, with the soonest-resetting account holding
+44% of a bucket that would be gone by morning and the furthest holding 92% it had five days to
+spend. Plain least-recently-used rotation spreads requests evenly over both, which wastes the
+first account's headroom to preserve headroom that was not under any time pressure.
+
+So rotation ranks inside a priority tier by **which bucket an account's governing weekly reset
+falls into**, before the least-recently-used tick. At the default 24-hour width that fleet
+splits like this:
+
+| bucket | accounts | resets in |
+|---|---|---|
+| 0 | four | 2.5h, 11.5h, 13.5h, 18.5h |
+| 1 | two | 27.5h, 33.5h |
+| 2 | two | 49.5h, 52.5h |
+| 3–6 | five | 79.5h … 152.5h |
+
+Bucket 0 absorbs today's traffic, and the four accounts in it still fan out among themselves on
+the usual least-recently-used order. As each one crosses its threshold it gates out normally and
+bucket 1 takes over.
+
+**The width is the whole design, not a tuning detail.** A raw reset instant is millisecond-precise
+and essentially never ties, so ranking on it directly would retire the least-recently-used tiebreak
+altogether and park every unpinned request on one account until it gated — the same deterministic
+pin that ordering by quota headroom was rejected for, and the pool pick carries no in-flight term
+to dilute a burst. Bucketing re-creates the tie. Narrower widths concentrate load (at 6 hours the
+soonest account sits alone in its bucket, which is the raw behaviour with extra steps); wider ones
+weaken the signal (at 48 hours, six of those thirteen collapse into one bucket).
+
+Two behaviours are deliberate:
+
+- An account whose weekly window has **no known live reset** sorts ahead of every bucket, so it
+  gets picked and therefore probed. This is the pre-existing "unknown quota → probe it" rule, not
+  a new one.
+- Nothing starves. Spending an account does not move its reset, but crossing that reset starts a
+  fresh window about seven days out, which drops the account to the back of the bucket order. Each
+  account's window comes due in turn.
+
+Set `"resetUrgencyTierHours": 0` to disable the term entirely and restore the previous
+`(priority, least-recently-selected, reset)` ordering — a config-only rollback, no rebuild.
+
+Like every key here except `groups` and `groupSettings`, this is read **once at boot**. An edit
+needs a restart before the serving process rotates by it, and `tcr status` reports the running
+process's view rather than the file's.
 
 ## `pacing.*`: opt-in, ships OFF
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,32 @@ fn default_control_reserve() -> f64 {
     0.05
 }
 
+/// Default [`Config::reset_urgency_tier_hours`]: 24h buckets.
+///
+/// Rotation ranks an eligible account by which 24-hour bucket its governing
+/// weekly reset falls into, ahead of the LRU tick — so a fleet spends the
+/// account whose unused weekly headroom expires soonest, before the one whose
+/// window has days left to run. Unused weekly quota is worth nothing after its
+/// reset, and on the live fleet (measured 2026-08-26, 13 accounts, all at
+/// priority 0) the resets were spread from 2.5h to 152.5h out, with the
+/// soonest-resetting account sitting on 44% unspent.
+///
+/// The bucket width is what keeps this from becoming the deterministic pin that
+/// [`crate::manager::Manager::select`] already rejected headroom-ordering for. A
+/// RAW reset instant is millisecond-precision and never ties, so ranking on it
+/// directly would retire the LRU tick entirely and park every unpinned request
+/// on one account until it gated. Bucketing restores the tie: at 24h the live
+/// fleet's four soonest accounts share one bucket and still fan out inside it.
+///
+/// Wider buckets weaken the urgency signal (at 48h, six of the thirteen collapse
+/// into one bucket); narrower ones concentrate load (at 6h the soonest account
+/// is alone in its bucket, which is the raw behaviour with extra steps). `0`
+/// disables the tier term outright and restores the pre-tier ordering — the
+/// config-only rollback, no rebuild.
+fn default_reset_urgency_tier_hours() -> u32 {
+    24
+}
+
 /// Default [`Config::usage_retention_days`]: a quarter of history, which is ~180 MB
 /// at the observed ~2 MB/day and answers "how did last month compare".
 fn default_usage_retention_days() -> u32 {
@@ -590,6 +616,18 @@ pub struct Config {
     /// [`crate::manager::select::effective_threshold`].
     #[serde(default = "default_control_reserve")]
     pub control_reserve: f64,
+    /// Width, in hours, of the reset-urgency bucket rotation ranks by within a
+    /// priority tier — see [`default_reset_urgency_tier_hours`] for why this is
+    /// a bucket and not the raw reset instant. Absent → 24. `0` disables the
+    /// term and restores the pre-tier `(priority, lastSelectedSeq, reset)`
+    /// ordering.
+    ///
+    /// **Boot-time snapshot, like every field here except `groups` and
+    /// `groupSettings`** — the manager resolves it once at construction, so an
+    /// edit needs a restart before the serving process rotates by it. `tcr
+    /// status` reports the running process's view, not the file's.
+    #[serde(default = "default_reset_urgency_tier_hours")]
+    pub reset_urgency_tier_hours: u32,
     /// Force the upstream-forwarding client onto HTTP/1.1 instead of the
     /// h2-and-fall-back-to-h1 negotiation reqwest does by default. Absent →
     /// `false` (h2). OFF by default deliberately: an intermittent

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -2,12 +2,19 @@
 //!
 //! Selection order:
 //!   1. lowest `priority` value wins (operator-controlled; default 0);
-//!   2. within a priority tier, the least-recently-*selected* account goes next,
-//!      so consecutive requests fan out across the fleet instead of hammering one
+//!   2. within a priority tier, the account in the soonest reset-urgency BUCKET
+//!      goes next — the governing weekly reset floored into
+//!      `resetUrgencyTierHours`-wide buckets (default 24h; `0` disables the
+//!      term). Unused weekly quota is worth nothing once its window resets, so
+//!      the fleet spends the account whose headroom expires soonest first. A
+//!      window with no known reset sorts ahead of every bucket ("probe it").
+//!   3. within a bucket, the least-recently-*selected* account goes next, so
+//!      consecutive requests fan out across the fleet instead of hammering one
 //!      account. (A single request barely moves a weekly bar, so ordering by
-//!      quota headroom would pin one account until its bar caught up.) A
-//!      never-selected account sorts first; soonest weekly reset is the
-//!      cold-start tiebreak.
+//!      quota headroom would pin one account until its bar caught up — and
+//!      ordering by the RAW reset instant would do the same, which is why step 2
+//!      buckets rather than compares directly.) A never-selected account sorts
+//!      first; the raw weekly reset is the cold-start tiebreak below that.
 //!
 //! Eligibility = not disabled, not in an active rate-limit hold, not in a hard
 //! `error` state, and under its threshold (per-account `switchThreshold` else the
@@ -997,6 +1004,16 @@ pub struct Manager {
     /// pick before this reserve is ever consulted. It exists for the day
     /// `controlAccount` names a POOLED (non-disabled) account.
     control_reserve: f64,
+    /// Width in MILLISECONDS of the reset-urgency bucket that rotation ranks by
+    /// within a priority tier, resolved once from
+    /// [`crate::config::Config::reset_urgency_tier_hours`] at construction
+    /// (boot-time snapshot — an edit needs a restart). `0` disables the term,
+    /// restoring the pre-tier `(priority, last_selected_seq, reset)` ordering.
+    ///
+    /// Held in ms rather than hours so [`select::Manager::reset_urgency_tier`]
+    /// divides in the same unit the resets arrive in, with no repeated
+    /// hour-conversion at the top of every selection loop.
+    reset_urgency_tier_ms: i64,
 }
 
 /// Resets the keep-warm in-flight flag on drop, so a sweep that unwinds early
@@ -1147,6 +1164,15 @@ impl Manager {
         // config file is not bound by either.
         let control_reserve = config.control_reserve.clamp(0.0, 0.5);
 
+        // Hours → ms once, at construction. `i64::from` then a checked multiply:
+        // a hand-edited `resetUrgencyTierHours` of, say, 100_000_000 would
+        // overflow the product and wrap to a negative width, which would invert
+        // the bucket ordering rather than fail loudly. Saturating at i64::MAX
+        // instead degrades to "one bucket for everyone" — the same shape as the
+        // `0` disable, which is the safe direction to fall.
+        let reset_urgency_tier_ms =
+            i64::from(config.reset_urgency_tier_hours).saturating_mul(3_600_000);
+
         let control_idx = config.control_account.as_ref().and_then(|name| {
             let idx = accounts.iter().position(|a| a.name == *name);
             if idx.is_none() {
@@ -1199,6 +1225,7 @@ impl Manager {
             conn_affinity: Mutex::new(HashMap::new()),
             divert_ledger: Mutex::new(HashMap::new()),
             control_reserve,
+            reset_urgency_tier_ms,
         });
 
         if let (Some(i), Some(name)) = (locked_idx, locked_name) {
@@ -2673,6 +2700,7 @@ mod tests {
             lock_account: None,
             control_account: None,
             control_reserve: 0.05,
+            reset_urgency_tier_hours: 24,
             http1_only: false,
             accounts,
             group_settings: HashMap::new(),

--- a/src/manager/select.rs
+++ b/src/manager/select.rs
@@ -201,15 +201,21 @@ impl Manager {
     /// Pick the best eligible account not in `tried`, spreading load across the
     /// fleet, or `None` if all are exhausted/held/disabled.
     ///
-    /// Within a priority tier we pick the **least-recently-selected** account
-    /// (lowest `last_selected_seq`; a never-selected account sorts first) so
-    /// consecutive requests fan out instead of hammering one account. Ordering by
-    /// quota headroom was rejected deliberately: a single request barely moves a
-    /// weekly bar, so "most headroom first" would deterministically pin one
-    /// account until its bar caught up — the exact overload this fixes. The
-    /// winner is stamped with the next monotonic tick *before returning*, so even
-    /// a burst of concurrent selects rotates (each sees the previous stamp). The
-    /// soonest weekly reset is the final cold-start tiebreak (all-unseen startup).
+    /// Within a priority tier we pick from the soonest **reset-urgency bucket**
+    /// first ([`Self::reset_urgency_tier`] — the governing weekly reset floored
+    /// into `resetUrgencyTierHours`-wide buckets, default 24h), because unused
+    /// weekly quota is worth nothing once its window resets. Within a bucket we
+    /// pick the **least-recently-selected** account (lowest `last_selected_seq`;
+    /// a never-selected account sorts first) so consecutive requests fan out
+    /// instead of hammering one account. Ordering by quota headroom was rejected
+    /// deliberately: a single request barely moves a weekly bar, so "most
+    /// headroom first" would deterministically pin one account until its bar
+    /// caught up — the exact overload this fixes. Ranking on the RAW reset
+    /// instant would pin it the same way, which is why the urgency term buckets
+    /// instead of comparing directly. The winner is stamped with the next
+    /// monotonic tick *before returning*, so even a burst of concurrent selects
+    /// rotates within its bucket (each sees the previous stamp). The soonest
+    /// weekly reset is the final cold-start tiebreak (all-unseen startup).
     ///
     /// This mutates rotation state (the stamp), so it takes the write lock.
     ///
@@ -1921,8 +1927,10 @@ impl Manager {
     }
 
     /// The best pacing-respecting eligible account not in `tried`, by ascending
-    /// `(priority, last_selected_seq, soonest weekly reset)` — the pre-pacing LRU
-    /// order, now additionally skipping any account the soft pacing gate holds out.
+    /// `(priority, reset-urgency bucket, last_selected_seq, soonest weekly reset)`
+    /// — the pre-pacing LRU order, now bucketed by reset urgency
+    /// ([`Self::reset_urgency_tier`]) and additionally skipping any account the
+    /// soft pacing gate holds out.
     /// Read-only (no stamp); the caller stamps the winner. Emits one INFO line per
     /// account skipped *specifically because of pacing* (healthy but capped/spaced)
     /// so the knobs are tunable live.
@@ -1949,6 +1957,59 @@ impl Manager {
         !account.quota.is_near(reserved, now)
     }
 
+    /// The reset-urgency bucket `account` falls into — its governing weekly
+    /// reset, floored into [`Manager::reset_urgency_tier_ms`]-wide buckets
+    /// measured forward from `now`. **Ascending: a lower bucket is spent
+    /// first**, because unused weekly quota is worth nothing once its window
+    /// resets.
+    ///
+    /// Why a bucket and not the reset instant itself: a reset is a
+    /// millisecond-precision instant that essentially never ties, so ranking on
+    /// it directly would retire the `last_selected_seq` tiebreak entirely and
+    /// park every unpinned request on the single soonest-resetting account until
+    /// it gated. That is the same deterministic pin [`Manager::select`]'s
+    /// doc-comment rejects quota-headroom ordering for, and this pool pick
+    /// carries no `in_flight` term to dilute it (only
+    /// [`Manager::pick_least_loaded`] does), so a burst would land undiluted.
+    /// Bucketing re-creates the tie: at the default 24h, the live fleet's four
+    /// soonest-resetting accounts share one bucket and still fan out inside it.
+    ///
+    /// Two arms deliberately return a value that is NOT a bucket index:
+    ///  - **no known live reset → [`i64::MIN`]**, sorting the account ahead of
+    ///    every bucket. This preserves the pre-tier "unknown quota sorts first,
+    ///    probe it" contract byte-for-byte — the same reason the raw-`reset`
+    ///    term below maps `None` to [`i128::MIN`]. It covers both a genuinely
+    ///    unmeasured window and one whose reset has already elapsed;
+    ///    [`crate::quota::QuotaWindow::live_reset`] collapses those two into
+    ///    `None` and this does not try to tell them apart.
+    ///  - **feature disabled (`reset_urgency_tier_ms == 0`) → a constant `0`**,
+    ///    which ties for every account and hands the decision straight back to
+    ///    the LRU tick. That restores the pre-tier ordering exactly, including
+    ///    the unknown-reset-first behaviour, which survives on the raw-`reset`
+    ///    term the key still carries.
+    ///
+    /// Self-rotating by construction: spending an account does not move its
+    /// reset, but crossing that reset starts a fresh window ~7 days out, which
+    /// drops the account to the back of the bucket order. No account starves —
+    /// each one's window comes due in turn.
+    fn reset_urgency_tier(&self, account: &AccountRuntime, now: OffsetDateTime) -> i64 {
+        if self.reset_urgency_tier_ms == 0 {
+            return 0;
+        }
+        let Some(reset) = account.quota.governing_weekly_reset(now) else {
+            return i64::MIN;
+        };
+        // `live_reset` only ever hands back a FUTURE instant, so this difference
+        // is positive in practice; `max(0)` keeps a clock that stepped backwards
+        // between the two reads from producing a negative bucket that would
+        // outrank a genuinely urgent account. `try_from` saturates rather than
+        // wrapping for the same reason.
+        let remaining_ms = i64::try_from((reset - now).whole_milliseconds())
+            .unwrap_or(i64::MAX)
+            .max(0);
+        remaining_ms / self.reset_urgency_tier_ms
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn pick_eligible(
         &self,
@@ -1962,7 +2023,7 @@ impl Manager {
     ) -> Option<usize> {
         let reserved_groups = self.reserved_groups();
         let mut best: Option<usize> = None;
-        let mut best_key: Option<(i64, u64, i128)> = None;
+        let mut best_key: Option<(i64, i64, u64, i128)> = None;
         for (idx, account) in accounts.iter().enumerate() {
             if tried.contains(&idx) {
                 continue;
@@ -2012,7 +2073,12 @@ impl Manager {
                 .quota
                 .governing_weekly_reset(now)
                 .map_or(i128::MIN, |r| r.unix_timestamp() as i128);
-            let key = (account.priority, account.last_selected_seq, reset);
+            let key = (
+                account.priority,
+                self.reset_urgency_tier(account, now),
+                account.last_selected_seq,
+                reset,
+            );
             if best_key.is_none_or(|b| key < b) {
                 best = Some(idx);
                 best_key = Some(key);
@@ -2022,8 +2088,13 @@ impl Manager {
     }
 
     /// The least-loaded servable account not in `tried`, IGNORING pacing (the soft
-    /// fallback pass). Sort key ascending: `(in_flight, priority, last_selected_seq,
-    /// weekly reset)` — least concurrent load first, then the normal LRU order. All
+    /// fallback pass). Sort key ascending: `(in_flight, priority, reset-urgency
+    /// bucket, last_selected_seq, weekly reset)` — least concurrent load first,
+    /// then the normal bucketed LRU order. `in_flight` stays ahead of the urgency
+    /// bucket deliberately: this pass exists to find the COOLEST account when the
+    /// fleet is all-paced, and letting reset urgency outrank live load would send
+    /// the overflow straight back onto the busy account the fallback is trying to
+    /// relieve. All
     /// non-pacing eligibility (disabled/error/rate-limit/quota) still applies, so a
     /// genuinely exhausted fleet still yields `None` (a real 429), while a merely
     /// all-paced fleet always yields the coolest account. Read-only.
@@ -2038,7 +2109,7 @@ impl Manager {
     ) -> Option<usize> {
         let reserved_groups = self.reserved_groups();
         let mut best: Option<usize> = None;
-        let mut best_key: Option<(u32, i64, u64, i128)> = None;
+        let mut best_key: Option<(u32, i64, i64, u64, i128)> = None;
         for (idx, account) in accounts.iter().enumerate() {
             if tried.contains(&idx) {
                 continue;
@@ -2067,6 +2138,7 @@ impl Manager {
             let key = (
                 account.in_flight,
                 account.priority,
+                self.reset_urgency_tier(account, now),
                 account.last_selected_seq,
                 reset,
             );
@@ -2346,6 +2418,7 @@ mod revalidation_sticky_tests {
             lock_account: None,
             control_account: None,
             control_reserve: 0.05,
+            reset_urgency_tier_hours: 24,
             http1_only: false,
             accounts,
             group_settings: HashMap::new(),
@@ -2489,6 +2562,7 @@ mod sticky_divert_replay_tests {
             lock_account: None,
             control_account: None,
             control_reserve: 0.05,
+            reset_urgency_tier_hours: 24,
             http1_only: false,
             accounts,
             group_settings: HashMap::new(),
@@ -2857,5 +2931,245 @@ mod group_miss_tests {
             classify(&accounts, None, &pacing, "research"),
             GroupMiss::Paced
         );
+    }
+}
+
+/// Tests for the reset-urgency bucket ([`Manager::reset_urgency_tier`]) — the
+/// second ranking key inside a priority tier.
+///
+/// The headline claim every test here circles: **an account whose weekly
+/// headroom expires sooner is spent ahead of one that was selected less
+/// recently**, because unused weekly quota is worth nothing after its reset.
+/// That is a deliberate inversion of the pre-tier LRU order, so the discriminating
+/// test below is built to FAIL on the pre-tier code — it stamps the urgent
+/// account as the most-recently-selected one, which is exactly the account plain
+/// LRU sorts last.
+#[cfg(test)]
+mod reset_urgency_tests {
+    use super::*;
+    use crate::config::{Account, ProxyConfig};
+    use crate::oauth::NoRefresh;
+    use crate::probe::LiveUsageProber;
+    use crate::quota::QuotaWindow;
+    use crate::warmer::LiveWarmer;
+    use std::collections::HashSet;
+
+    fn account(name: &str) -> Account {
+        Account {
+            name: name.to_string(),
+            account_type: "oauth".to_string(),
+            account_uuid: None,
+            org_uuid: None,
+            org_name: None,
+            access_token: format!("at-{name}"),
+            refresh_token: Some(format!("rt-{name}")),
+            expires_at: Some(crate::now_ms() + 3_600_000),
+            priority: Some(0),
+            switch_threshold: None,
+            disabled: None,
+            groups: None,
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    fn config_with(accounts: Vec<Account>, tier_hours: u32) -> Config {
+        Config {
+            quarantined_accounts: Vec::new(),
+            proxy: ProxyConfig::default(),
+            upstream: "https://api.anthropic.com".to_string(),
+            switch_threshold: 0.90,
+            pacing: PacingConfig::default(),
+            throttle: ThrottleConfig::default(),
+            lock_account: None,
+            control_account: None,
+            control_reserve: 0.05,
+            reset_urgency_tier_hours: tier_hours,
+            http1_only: false,
+            accounts,
+            group_settings: HashMap::new(),
+            pricing: Default::default(),
+            usage_retention_days: 90,
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    fn build_manager(config: Config) -> Arc<Manager> {
+        Manager::new(
+            config,
+            Arc::new(NoRefresh),
+            Arc::new(LiveUsageProber::new()),
+            Arc::new(LiveWarmer::new()),
+            None,
+        )
+    }
+
+    /// Give account `idx` a weekly window resetting `hours` from `now` at a
+    /// utilization well under the fixture's 0.90 threshold, so the account is
+    /// ranked but never gated — this suite is about ORDER, and an account held
+    /// out by quota would prove nothing about it.
+    fn set_weekly(manager: &Manager, idx: usize, hours: i64, now: OffsetDateTime) {
+        let mut accounts = manager.accounts.write().expect("accounts lock poisoned");
+        accounts[idx].quota.seven_day = Some(QuotaWindow {
+            utilization: 0.10,
+            reset: Some(now + time::Duration::hours(hours)),
+        });
+    }
+
+    fn set_seq(manager: &Manager, idx: usize, seq: u64) {
+        let mut accounts = manager.accounts.write().expect("accounts lock poisoned");
+        accounts[idx].last_selected_seq = seq;
+    }
+
+    fn pick(manager: &Manager, now: OffsetDateTime) -> usize {
+        manager
+            .select(&HashSet::new(), now, None, None, "/v1/messages", None)
+            .expect("an account is eligible")
+    }
+
+    /// **The discriminating test.** Two accounts in one priority tier: `urgent`
+    /// resets in 2h (bucket 0 at the default 24h width), `roomy` in 100h
+    /// (bucket 4). `urgent` is stamped as the MOST recently selected account and
+    /// `roomy` as never-selected, so pre-tier LRU would pick `roomy` — this test
+    /// fails on the old ordering, which is the point of it.
+    ///
+    /// Mirrors the live fleet that motivated the change (measured 2026-08-26):
+    /// 13 accounts all at priority 0, resets spread 2.5h–152.5h, and the
+    /// soonest-resetting account sitting on 44% of a weekly bucket that was
+    /// worth nothing a few hours later.
+    #[test]
+    fn a_sooner_resetting_account_outranks_a_less_recently_selected_one() {
+        let manager = build_manager(config_with(vec![account("urgent"), account("roomy")], 24));
+        let now = OffsetDateTime::now_utc();
+
+        set_weekly(&manager, 0, 2, now);
+        set_weekly(&manager, 1, 100, now);
+        // Bias plain LRU as hard as possible TOWARD `roomy`: `urgent` looks
+        // most-recently-selected, `roomy` never-selected.
+        set_seq(&manager, 0, 999);
+        set_seq(&manager, 1, 0);
+
+        assert_eq!(
+            pick(&manager, now),
+            0,
+            "the account whose weekly window resets in 2h must be spent before \
+             the one with 100h left, even though it is the most recently \
+             selected of the two — its unused headroom is the only headroom \
+             about to expire"
+        );
+    }
+
+    /// The other half of the design: bucketing must NOT collapse into a
+    /// deterministic pin. Two accounts resetting 2h apart share bucket 0 at the
+    /// default 24h width, so LRU still decides between them and consecutive
+    /// picks alternate — the fan-out that ranking on the raw reset instant would
+    /// have destroyed.
+    #[test]
+    fn accounts_in_one_bucket_still_fan_out_by_lru() {
+        let manager = build_manager(config_with(vec![account("first"), account("second")], 24));
+        let now = OffsetDateTime::now_utc();
+
+        set_weekly(&manager, 0, 2, now);
+        set_weekly(&manager, 1, 4, now);
+
+        let picks: Vec<usize> = (0..4).map(|_| pick(&manager, now)).collect();
+        assert!(
+            picks.contains(&0) && picks.contains(&1),
+            "two accounts sharing one urgency bucket must both be served — \
+             got {picks:?}, which is the deterministic pin the bucket exists \
+             to prevent"
+        );
+    }
+
+    /// `resetUrgencyTierHours: 0` is the config-only rollback: the urgency term
+    /// ties for every account and the pre-tier LRU order returns. Same fixture
+    /// as the discriminating test, opposite expected winner.
+    #[test]
+    fn tier_hours_zero_restores_the_pre_tier_lru_order() {
+        let manager = build_manager(config_with(vec![account("urgent"), account("roomy")], 0));
+        let now = OffsetDateTime::now_utc();
+
+        set_weekly(&manager, 0, 2, now);
+        set_weekly(&manager, 1, 100, now);
+        set_seq(&manager, 0, 999);
+        set_seq(&manager, 1, 0);
+
+        assert_eq!(
+            pick(&manager, now),
+            1,
+            "with the tier term disabled the never-selected account wins on \
+             plain LRU, exactly as it did before this feature existed"
+        );
+    }
+
+    /// An account with no known live weekly reset keeps sorting FIRST — the
+    /// pre-tier "unknown quota → probe it" contract, which the bucket must
+    /// carry through rather than quietly re-rank. `roomy` here is both
+    /// never-selected AND resetting soon; the unmeasured account still beats it.
+    #[test]
+    fn an_unknown_weekly_reset_still_sorts_ahead_of_every_bucket() {
+        let manager = build_manager(config_with(
+            vec![account("unmeasured"), account("soon")],
+            24,
+        ));
+        let now = OffsetDateTime::now_utc();
+
+        // `unmeasured` deliberately gets NO weekly window at all.
+        set_weekly(&manager, 1, 1, now);
+        set_seq(&manager, 0, 999);
+        set_seq(&manager, 1, 0);
+
+        assert_eq!(
+            pick(&manager, now),
+            0,
+            "an account whose weekly window was never measured must be picked \
+             (and so probed) ahead of every bucketed account"
+        );
+    }
+
+    /// Unit-level check of the bucket arithmetic itself, independent of
+    /// selection: the floor division, the disabled arm, and the unknown-reset
+    /// sentinel. Widths are checked at the boundary (24h lands in bucket 1, not
+    /// 0) because an off-by-one here silently re-ranks the whole fleet.
+    #[test]
+    fn bucket_arithmetic_floors_and_handles_both_sentinels() {
+        let manager = build_manager(config_with(vec![account("a")], 24));
+        let now = OffsetDateTime::now_utc();
+
+        let tier = |hours: i64| {
+            set_weekly(&manager, 0, hours, now);
+            let accounts = manager.accounts.read().expect("accounts lock poisoned");
+            manager.reset_urgency_tier(&accounts[0], now)
+        };
+
+        assert_eq!(tier(2), 0, "2h into a 24h width is bucket 0");
+        assert_eq!(tier(23), 0, "23h is still bucket 0");
+        assert_eq!(tier(25), 1, "25h crosses into bucket 1");
+        assert_eq!(tier(100), 4, "100h floors to bucket 4");
+        assert_eq!(tier(152), 6, "the live fleet's furthest account, bucket 6");
+
+        // Unknown reset → the minimum, ahead of every bucket.
+        {
+            let mut accounts = manager.accounts.write().expect("accounts lock poisoned");
+            accounts[0].quota.seven_day = None;
+        }
+        {
+            let accounts = manager.accounts.read().expect("accounts lock poisoned");
+            assert_eq!(
+                manager.reset_urgency_tier(&accounts[0], now),
+                i64::MIN,
+                "an unmeasured weekly window sorts ahead of every bucket"
+            );
+        }
+
+        // Disabled → a constant tie for everyone, including the unknown arm.
+        let off = build_manager(config_with(vec![account("a")], 0));
+        {
+            let accounts = off.accounts.read().expect("accounts lock poisoned");
+            assert_eq!(
+                off.reset_urgency_tier(&accounts[0], now),
+                0,
+                "a disabled tier term must tie, not rank"
+            );
+        }
     }
 }

--- a/src/mitm.rs
+++ b/src/mitm.rs
@@ -1363,6 +1363,7 @@ mod tests {
             lock_account: None,
             control_account: None,
             control_reserve: 0.05,
+            reset_urgency_tier_hours: 24,
             http1_only: false,
             accounts: vec![crate::config::Account {
                 name: "dummy".to_string(),

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -3906,6 +3906,7 @@ mod tests {
             lock_account: None,
             control_account: None,
             control_reserve: 0.05,
+            reset_urgency_tier_hours: 24,
             http1_only: false,
             accounts: vec![Account {
                 name: "dummy".to_string(),

--- a/tests/throttle_exempt.rs
+++ b/tests/throttle_exempt.rs
@@ -131,6 +131,7 @@ fn config(upstream: &str, throttle: ThrottleConfig, throttle_exempt_noise: bool)
         lock_account: None,
         control_account: None,
         control_reserve: 0.05,
+        reset_urgency_tier_hours: 24,
         http1_only: false,
         accounts: (0..POOL).map(account).collect(),
         group_settings: std::collections::HashMap::new(),

--- a/tests/workload_scenarios.rs
+++ b/tests/workload_scenarios.rs
@@ -219,6 +219,7 @@ impl Fleet {
             lock_account: None,
             control_account: None,
             control_reserve: 0.05,
+            reset_urgency_tier_hours: 24,
             http1_only: false,
             accounts: accounts.iter().map(|(n, p)| account(n, *p)).collect(),
             group_settings: HashMap::new(),


### PR DESCRIPTION
Unused weekly quota is worth nothing once its window resets, and accounts
do not reset together. Measured on a 13-account fleet: every account sat at
priority 0, weekly resets spread from 2.5h to 152.5h out. The soonest-resetting
account held 44% of a bucket that would be gone by morning; the furthest held
92% it had five days to spend. Plain LRU spread requests evenly over both.

## The change

    (priority, reset-urgency bucket, last_selected_seq, reset)

The bucket width is the design, not a tuning detail. A raw reset instant is
millisecond-precise and never ties, so ranking on it directly would retire the
LRU tiebreak and park every unpinned request on one account until it gated —
the same deterministic pin that headroom-ordering was rejected for, and the
pool pick has no in_flight term to dilute a burst. Bucketing re-creates the
tie: at 24h the fleet's four soonest accounts share a bucket and still fan out.

| bucket | accounts | resets in |
|---|---|---|
| 0 | four | 2.5h … 18.5h |
| 1 | two | 27.5h, 33.5h |
| 2 | two | 49.5h, 52.5h |
| 3–6 | five | 79.5h … 152.5h |

## Preserved deliberately

- Unknown weekly reset still sorts ahead of every bucket (probe it).
- Nothing starves: crossing a reset starts a fresh window ~7d out, dropping
  that account to the back.
- `pick_least_loaded` keeps `in_flight` ahead of urgency — that pass relieves
  a busy account, so urgency must not send overflow back onto it.

## Config

`resetUrgencyTierHours`, default 24; `0` disables the term and restores the
previous ordering as a config-only rollback. Boot-time snapshot.

## Scope

Ranks on the unified weekly bucket. The Fable weekly (`seven_day_oi`) is not
consulted — on the measured fleet its reset was identical to the unified one
for all 12 accounts carrying both, so it would have changed no decision. A
Fable-aware variant is a separate change with its own test.

## Verification

Five new cases. The discriminating one stamps the urgent account as
MOST-recently-selected, so it fails on the pre-tier ordering. Break/restore per
CLAUDE.md: neutralizing the tier term failed exactly 2 of 5 with the predicted
values; file confirmed byte-identical to its pre-break backup on restore.
`cargo test` exit 0 — 7 binaries, 947 tests, 0 failed. No pre-existing test
broke, which is itself the finding that nothing had pinned the old ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CuCvRRL8vL26gewLqGBtPc
