### PR TITLE
chore: add the 0.2.27 appcast entry

### DIFF
--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.27</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.27</link>
+      <sparkle:version>453</sparkle:version>
+      <sparkle:shortVersionString>0.2.27</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Thu, 27 Aug 2026 10:10:48 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.27/TcrBar-0.2.27.dmg" type="application/octet-stream" sparkle:edSignature="DrIkZT6STgX07a4tlJ5DEvKspZK5mifNcMeghZteZnWxliJseiKBbyk4tSPntAJre6yAYcHG3wg55BppB4WhBg==" length="7052762" />
+    </item>
+    <item>
       <title>TcrBar 0.2.26</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.26</link>
       <sparkle:version>451</sparkle:version>


### PR DESCRIPTION

release-tcrbar.sh writes the entry and deliberately does not commit it, so until
this lands the appcast in the repository and the one the release serves differ.
The enclosure length matches the uploaded TcrBar-0.2.27.dmg byte for byte
(7052762), verified against the live feed after publish.

Note for whoever cuts the next release: v0.2.27 briefly BROKE the Sparkle feed.
SUFeedURL points at /releases/latest/download/appcast.xml, and v0.2.27 was first
published as a CLI-only cargo-dist release carrying no appcast asset, so the feed
404'd and every installed TcrBar showed "An error occurred in retrieving update
information". That is the fifth failure of the class release-preflight.sh exists
to catch -- and check 4 ("no assetless GitHub Release is serving the update
feed") would have caught it, had it been run before the CLI release rather than
before the app release. Any release, not just a TcrBar one, can orphan the feed.

This DMG is UNSTYLED: create-dmg's Finder AppleScript failed with -10006 on a
loaded machine and the script fell back to hdiutil. Signing, notarization,
stapling and the feed are unaffected; only the drag-to-Applications window
layout is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jTmREc74QrPn45V2yJQXj