### PR TITLE
fix: stop an aging h2 connection from costing a cold prompt cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2503,7 +2503,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "teamclaude-rs"
-version = "0.2.27"
+version = "0.2.28"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -82,6 +82,7 @@ fn base(name: &str, priority: i64) -> AccountRuntime {
         last_stream_error: None,
         refresh_lock: Arc::new(AsyncMutex::new(())),
         http: crate::manager::build_serving_client(false),
+        serves_since_client_build: 0,
     }
 }
 

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -377,7 +377,21 @@ pub struct AccountRuntime {
     /// keep) and wrapped in `Arc` so [`Manager::http_client`] can hand out
     /// cheap clones while still letting a test prove two accounts' clients are
     /// genuinely distinct instances via `Arc::ptr_eq`.
+    ///
+    /// REBUILT periodically, though — see [`MAX_SERVES_PER_CONNECTION`] and
+    /// [`Manager::recycle_client`]. "Never on every request" is not
+    /// "never": an h2 connection held open indefinitely ages into the reset
+    /// zone this field's own history describes.
     pub http: Arc<reqwest::Client>,
+    /// Upstream sends dispatched on the CURRENT [`Self::http`] since it was
+    /// built, and the trigger for retiring it (see
+    /// [`MAX_SERVES_PER_CONNECTION`]). Reset to 0 by the recycle, so it means
+    /// "age of this client in serves", never a lifetime total —
+    /// [`Self::requests`] is the lifetime counter and is deliberately NOT
+    /// reused here: it is a display statistic incremented on a different path
+    /// (`snapshot.rs`), and hanging connection lifetime off it would couple a
+    /// transport decision to a stats counter that is free to change meaning.
+    pub serves_since_client_build: u32,
 }
 
 // Test-only fault injection for `build_serving_client`: set via
@@ -401,6 +415,39 @@ thread_local! {
 pub(crate) fn fail_next_client_build() {
     FAIL_NEXT_CLIENT_BUILD.with(|f| f.set(true));
 }
+
+/// Upstream sends after which an account's HTTP client is retired and rebuilt,
+/// dropping its pooled h2 connection so the next send opens a fresh one.
+///
+/// Anthropic's edge eventually drains a long-lived h2 connection, and the
+/// settings in [`build_serving_client`] — `http2_keep_alive_while_idle` plus a
+/// 300s pool idle timeout — are deliberately chosen to keep ONE connection warm
+/// forever, so nothing retired it. Measured over one day's live log (2026-08-27,
+/// n=2136 `Reset(_, PROTOCOL_ERROR, Remote)` transport failures), the resets are
+/// concentrated by connection age, not by concurrency:
+///
+/// | stream id at reset | share |
+/// |---|---|
+/// | 1-99 (fresh connection) | 6.8% |
+/// | 100-999 | 21.5% |
+/// | 1000-4999 | 5.9% |
+/// | 5000-9999 | 21.9% |
+/// | 10000+ | 43.9% |
+///
+/// Median 9699, max 17449 — roughly 8700 requests multiplexed onto one socket.
+/// h2 client-initiated stream ids advance by 2, so N serves reaches stream id
+/// ~2N: 500 keeps a connection under ~1000, below the p25 of the observed reset
+/// distribution, while still amortising the handshake over 500 requests.
+///
+/// Retiring a connection is CHEAP and must not be confused with rotating an
+/// account. It costs one TCP+TLS handshake (~100-300ms, the cost
+/// [`build_serving_client`]'s keep-alive settings exist to avoid); it does NOT
+/// cost a prompt-cache miss, because Anthropic's prompt cache is keyed on the
+/// account and prefix server-side and has nothing to do with which socket the
+/// bytes arrived on. Account rotation is the expensive one (measured 5-10x the
+/// quota of a warm serve), and it is exactly what this constant exists to make
+/// rarer.
+const MAX_SERVES_PER_CONNECTION: u32 = 500;
 
 /// Build one upstream-forwarding HTTP client. Called once per account (see
 /// [`AccountRuntime::http`]) so every account's client is configured
@@ -580,6 +627,7 @@ impl AccountRuntime {
             last_stream_error: None,
             refresh_lock: Arc::new(AsyncMutex::new(())),
             http: build_serving_client(http1_only),
+            serves_since_client_build: 0,
         }
     }
 }
@@ -1381,19 +1429,78 @@ impl Manager {
     /// panic). For a terminal SSE (`text/event-stream`) serve the proxy MOVES the
     /// owned guard into the streamed body, so the decrement fires at stream
     /// completion — not at handler return, when axum has yet to poll the body.
-    /// Mutates only under the accounts write-lock (no second lock).
+    ///
+    /// Also ages the account's HTTP client: this is the one call taken exactly
+    /// once per upstream send, so it is where [`MAX_SERVES_PER_CONNECTION`] is
+    /// counted and where a due recycle is claimed. The accounts write-lock is
+    /// taken here and then AGAIN by [`Self::recycle_client`] — never nested, and
+    /// never held across the client build. It used to be a single uncontested
+    /// section; that is why the claim resets the counter rather than letting
+    /// `recycle_client` re-read it, which would race between the two sections.
     pub fn enter_in_flight(self: &Arc<Self>, idx: usize) -> InFlightGuard {
-        {
+        let claimed_recycle = {
             let mut accounts = self.accounts.write().expect("accounts lock poisoned");
-            if let Some(account) = accounts.get_mut(idx) {
-                account.in_flight = account.in_flight.saturating_add(1);
-                account.last_served_ms = crate::now_ms();
+            match accounts.get_mut(idx) {
+                Some(account) => {
+                    account.in_flight = account.in_flight.saturating_add(1);
+                    account.last_served_ms = crate::now_ms();
+                    account.serves_since_client_build =
+                        account.serves_since_client_build.saturating_add(1);
+                    // Claim the recycle under the SAME write lock that observes the
+                    // threshold, and reset the counter as the act of claiming it:
+                    // that is what makes the claim exclusive, so two sends crossing
+                    // the threshold concurrently cannot both rebuild — the loser
+                    // reads 0 and returns false.
+                    if account.serves_since_client_build >= MAX_SERVES_PER_CONNECTION {
+                        account.serves_since_client_build = 0;
+                        true
+                    } else {
+                        false
+                    }
+                }
+                None => false,
             }
+        };
+        if claimed_recycle {
+            self.recycle_client(idx);
         }
         InFlightGuard {
             manager: Arc::clone(self),
             idx,
         }
+    }
+
+    /// Retire account `idx`'s HTTP client and give it a fresh one, dropping the
+    /// pooled h2 connection that has now carried [`MAX_SERVES_PER_CONNECTION`]
+    /// sends before Anthropic's edge drains it out from under us.
+    ///
+    /// Requests already in flight are untouched. Each holds its own
+    /// `Arc<reqwest::Client>` clone, taken by [`Self::http_client`] before the
+    /// send, so the OLD client — and the connection carrying their streams —
+    /// stays alive until the last of them finishes and drops the final `Arc`.
+    /// Only sends selected after this point get the new pool. That is the whole
+    /// reason this swaps an `Arc` instead of reaching into the existing client.
+    ///
+    /// The replacement is built with NEITHER lock held, matching
+    /// [`Self::add_or_update_account`]'s Added path and for the same reason: a
+    /// panic in [`build_serving_client`] (which tests inject) must not poison
+    /// `self.accounts`.
+    fn recycle_client(&self, idx: usize) {
+        let fresh = build_serving_client(self.http1_only());
+        let mut accounts = self.accounts.write().expect("accounts lock poisoned");
+        let Some(account) = accounts.get_mut(idx) else {
+            // Stale index: accounts are appended, never removed, so this is not
+            // reachable on the live path — same rationale as `http_client`.
+            return;
+        };
+        account.http = fresh;
+        tracing::info!(
+            account_index = idx,
+            account = %account.name,
+            serves = MAX_SERVES_PER_CONNECTION,
+            "retiring the upstream connection after its serve budget — \
+             a fresh h2 connection costs a handshake, not a prompt-cache miss"
+        );
     }
 
     /// Flush the refreshed TOKENS to disk. Token refreshes already persist
@@ -4625,6 +4732,49 @@ mod tests {
             manager.accounts.read().expect("accounts lock poisoned")[0].in_flight,
             0,
             "dropping the guard decrements back to 0"
+        );
+    }
+
+    /// An account's upstream client is RETIRED once it has carried
+    /// [`MAX_SERVES_PER_CONNECTION`] sends, so its pooled h2 connection is
+    /// replaced before Anthropic's edge drains it (the reset distribution behind
+    /// that number is on the constant).
+    ///
+    /// The control half matters as much as the assertion: one send short of the
+    /// budget the client must be the SAME `Arc`. Without it this test would pass
+    /// against a build that recycled on EVERY send — which would throw away the
+    /// warm pool on every request, the exact thing `AccountRuntime::http`'s
+    /// doc-comment forbids.
+    #[test]
+    fn the_upstream_client_is_recycled_once_its_serve_budget_is_spent() {
+        let manager = build_manager(config_with(vec![account("a", 0)]), pacing_refresher());
+        let original = manager.http_client(0).expect("account 0 exists");
+
+        for _ in 0..(MAX_SERVES_PER_CONNECTION - 1) {
+            drop(manager.enter_in_flight(0));
+        }
+        assert!(
+            Arc::ptr_eq(
+                &original,
+                &manager.http_client(0).expect("account 0 exists")
+            ),
+            "the pool must survive right up to the budget — rebuilding earlier pays a \
+             TCP+TLS handshake the keep-alive settings exist to avoid"
+        );
+
+        drop(manager.enter_in_flight(0));
+        assert!(
+            !Arc::ptr_eq(
+                &original,
+                &manager.http_client(0).expect("account 0 exists")
+            ),
+            "crossing the serve budget must hand out a NEW client, so the next send \
+             opens a fresh h2 connection instead of one about to be drained"
+        );
+        assert_eq!(
+            manager.accounts.read().expect("accounts lock poisoned")[0].serves_since_client_build,
+            0,
+            "the recycle resets the age counter, so the next budget starts clean"
         );
     }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -325,6 +325,32 @@ fn is_offline_error(err: &reqwest::Error) -> bool {
     false
 }
 
+/// How many times one account may be retried IN PLACE on a non-CONNECT
+/// transport failure before the request gives up on it and rotates. Counts
+/// RETRIES, not attempts, matching [`MAX_SAME_ACCOUNT_429`].
+///
+/// Was effectively `1` (a `HashSet` membership test) until 2026-08-27, on the
+/// theory that "the second failure IS evidence about the account". Live
+/// measurement falsified that: over one day's log, the FIRST same-account retry
+/// landed a `200` in **94.7%** of cases (1286 of 1358) — the fault is the pooled
+/// h2 connection aging out, not the account. The cases where one retry was not
+/// enough rotated a warm session onto a cold account 841 times that day, and a
+/// rotation costs a full prompt-cache miss (measured 5-10x the quota of a warm
+/// serve) to escape a fault a second reconnect clears.
+///
+/// Why 3 and not 2 or 10: the 94.7% is measured for the FIRST retry only, and
+/// whether later retries clear at the same rate is NOT measured — a run of
+/// failures on one aging pool is plausibly correlated rather than independent.
+/// So this is sized as a small ladder that covers a short burst without
+/// pretending to a compounding-probability argument the data does not support.
+/// If the live `transport_retry=` field shows attempts 2 and 3 rarely helping,
+/// lower it; if rotations persist at 3, the ceiling is not the binding problem.
+///
+/// The ceiling still exists because a genuinely broken account must not spin
+/// here forever; it is sized to make cache-preserving recovery the common path,
+/// not to make rotation unreachable.
+const MAX_SAME_ACCOUNT_TRANSPORT_RETRIES: u32 = 3;
+
 /// The most upstream sends ONE account can absorb inside a single client
 /// request, derived from the per-account ladders rather than guessed.
 ///
@@ -332,12 +358,15 @@ fn is_offline_error(err: &reqwest::Error) -> bool {
 /// is a real ceiling and not an estimate:
 ///
 /// * `1` — the send itself.
-/// * `1` — the same-account transport retry (`transport_retried`).
+/// * [`MAX_SAME_ACCOUNT_TRANSPORT_RETRIES`] — same-account transport retries
+///   (`transport_retried`).
 /// * `1` — the 401 force-refresh retry (`forced_401`).
 /// * [`MAX_SAME_ACCOUNT_429`] — transient-429 inline waits (`retried_429`).
 /// * [`MAX_SAME_ACCOUNT_529_RETRIES`] — 529 in-place backoffs (`retried_529`).
-const MAX_SENDS_PER_ACCOUNT: usize =
-    3 + MAX_SAME_ACCOUNT_429 as usize + MAX_SAME_ACCOUNT_529_RETRIES as usize;
+const MAX_SENDS_PER_ACCOUNT: usize = 2
+    + MAX_SAME_ACCOUNT_TRANSPORT_RETRIES as usize
+    + MAX_SAME_ACCOUNT_429 as usize
+    + MAX_SAME_ACCOUNT_529_RETRIES as usize;
 
 /// The rotation loop's TOTAL attempt budget for a fleet of `account_count`: the
 /// per-account ladder ceiling times the fleet, plus a small constant for the
@@ -2077,16 +2106,22 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
     // account that already failed it, in a loop. An account leaves this set the
     // moment it is re-admitted, so membership always means "currently parked".
     let mut parked_transient: HashSet<usize> = HashSet::new();
-    // Accounts already granted their ONE same-account transport retry in this
-    // request. The failing resource in a transport error is the CONNECTION, not
-    // the account: reqwest pools by `(scheme, authority)` and the account is only a
-    // Bearer header, so it is not in the pool key at all. Benching the account for
+    // Same-account transport retries this request has spent, per account. The
+    // failing resource in a transport error is the CONNECTION, not the account:
+    // reqwest pools by `(scheme, authority)` and the account is only a Bearer
+    // header, so it is not in the pool key at all. Benching the account for
     // the whole request therefore fails over on the wrong axis — and with a small
     // eligible pool a single blip walks it to empty and answers a 502 (measured:
     // 42 of 205 client-visible 502s fired at `transport_failures == 1`). A dead
     // connection is evicted from the pool by the error itself, so the retry gets a
-    // fresh one. Bounded to one per account per request: the second failure IS
-    // evidence about the account, and `tried.insert` then behaves exactly as before.
+    // fresh one.
+    //
+    // Bounded by `MAX_SAME_ACCOUNT_TRANSPORT_RETRIES`, not by one. This used to
+    // stop after a single retry because "the second failure IS evidence about the
+    // account"; a day's live log says otherwise — the first retry succeeds 94.7%
+    // of the time, so a second failure is overwhelmingly the SAME aging-connection
+    // fault recurring, not a sick account. Rotating instead costs a cold prompt
+    // cache, which is the expensive outcome this whole arm exists to avoid.
     //
     // Gated on the error KIND. The transport-failure branch below is THREE arms,
     // evaluated in this order — read them as narrowing scope, machine → connection
@@ -2096,15 +2131,16 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
     //     the MACHINE. Every account resolves the same hostname, so there is
     //     nothing to bench and nowhere to rotate to. Holds the pin, waits, retries
     //     the same account, and after `MAX_OFFLINE_WAITS_PER_REQUEST` answers 503.
-    //  2. SAME-ACCOUNT RETRY (this set): a non-CONNECT failure, i.e. a pooled
-    //     CONNECTION died. One retry per account per request, per the rationale
-    //     above. Deliberately not taken for a CONNECT failure — there was no
-    //     connection to evict, nothing is refreshed by trying again, and the retry
-    //     only buys a second connect timeout on a route already not answering.
+    //  2. SAME-ACCOUNT RETRY (this map): a non-CONNECT failure, i.e. a pooled
+    //     CONNECTION died. Up to `MAX_SAME_ACCOUNT_TRANSPORT_RETRIES` per account
+    //     per request, per the rationale above. Deliberately not taken for a
+    //     CONNECT failure — there was no connection to evict, nothing is
+    //     refreshed by trying again, and the retry only buys a second connect
+    //     timeout on a route already not answering.
     //  3. ROTATE: everything else — a route to a resolvable host that is refused,
     //     blackholed or timing out. That IS evidence about this route, so bench the
     //     account and let the rotation do its job.
-    let mut transport_retried: HashSet<usize> = HashSet::new();
+    let mut transport_retried: HashMap<usize, u32> = HashMap::new();
     // In-place waits this request has spent on a name-resolution failure, and how
     // many such failures it saw at all. Per-REQUEST: an offline machine is one
     // condition shared by every account, so there is nothing to count per account.
@@ -2388,14 +2424,24 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
                     }
                     return offline_unavailable(offline_failures);
                 }
-                if !err.is_connect() && transport_retried.insert(idx) {
-                    // First blip on this account this request: retry it on a fresh
+                let transport_attempt = transport_retried.entry(idx).or_insert(0);
+                if !err.is_connect() && *transport_attempt < MAX_SAME_ACCOUNT_TRANSPORT_RETRIES {
+                    // A blip on this account this request: retry it on a fresh
                     // connection rather than benching an account that is probably fine.
+                    // The dead connection is already evicted from the pool by the
+                    // error, so each retry genuinely gets a new one — which is why
+                    // repeating is worth more than rotating (94.7% land a 200).
+                    *transport_attempt += 1;
+                    // Message text unchanged — `scripts/` parses it. The attempt
+                    // fields are ADDED alongside, never a replacement, so an existing
+                    // grep keeps matching while a new one can see the ladder.
                     tracing::warn!(
                         account_index = idx,
                         account = account_name.as_deref().unwrap_or("?"),
                         is_connect = err.is_connect(),
                         is_timeout = err.is_timeout(),
+                        transport_retry = *transport_attempt,
+                        max_transport_retries = MAX_SAME_ACCOUNT_TRANSPORT_RETRIES,
                         error = ?err,
                         "upstream transport failure — retrying the SAME account on a fresh connection"
                     );
@@ -9648,22 +9694,25 @@ mod tests {
     /// revalidation-serve may still use it. Reaching `c` at all requires surviving
     /// the check the bool used to fail. Old code: 502. New code: `c` serves a 200.
     ///
-    /// The script carries TWO blips because a transport failure now buys the same
-    /// account one retry on a fresh connection
-    /// (`transport_failure_retries_the_same_account_first`), so it takes two to
-    /// bench `a` and reach `b`. The scenario under test is unchanged — one account
-    /// transport-benched, one real upstream 429, one revalidation serve; only the
-    /// number of sends it takes to set it up moved. A single blip here would leave
-    /// `a` retried into the 429 slot and never exercise the revalidation ladder.
+    /// The script leads with `1 + MAX_SAME_ACCOUNT_TRANSPORT_RETRIES` blips because
+    /// a transport failure buys the same account that many retries on fresh
+    /// connections (`repeated_transport_failures_keep_retrying_the_same_account`),
+    /// so it takes all of them to bench `a` and reach `b`. The scenario under test
+    /// is unchanged — one account transport-benched, one real upstream 429, one
+    /// revalidation serve; only the number of sends it takes to set it up moves
+    /// with that constant. Too few blips here would leave `a` retried into the 429
+    /// slot and never exercise the revalidation ladder, which is why the blip count
+    /// is DERIVED from the constant rather than written out: the last time it was a
+    /// literal, raising the retry bound silently retargeted this test's assertion
+    /// from `c` to `b`.
     #[tokio::test]
     async fn transport_blip_does_not_disable_recovery() {
-        let up_addr = spawn_scripted_upstream(vec![
-            None,                        // attempt 1 — `a` fails in transport
-            None,                        // attempt 2 — `a`'s one retry fails too
-            Some(raw_429_rejected(120)), // attempt 3 — `b` answers, durably 429
-            Some(raw_200()),             // attempt 4 — `c` serves via revalidation
-        ])
-        .await;
+        // `a` blips through its whole same-account ladder, then the two real answers.
+        let mut script: Vec<Option<String>> =
+            vec![None; (MAX_SAME_ACCOUNT_TRANSPORT_RETRIES as usize) + 1];
+        script.push(Some(raw_429_rejected(120))); // `b` answers, durably 429
+        script.push(Some(raw_200())); // `c` serves via revalidation
+        let up_addr = spawn_scripted_upstream(script).await;
         let manager = fleet(up_addr, &["a", "b", "c"]);
 
         // Drive `c` OVER the soft switch threshold (0.90 in `dummy_config`) on the
@@ -9769,20 +9818,66 @@ mod tests {
         );
     }
 
-    /// The other half of the bound: the retry is ONE per account per request. A
-    /// second failure is evidence about the account rather than the connection, so
-    /// it benches it and rotates exactly as before this arm existed.
+    /// A REPEATED blip still keeps the account, up to
+    /// [`MAX_SAME_ACCOUNT_TRANSPORT_RETRIES`]. This is the case the old
+    /// one-retry bound got wrong: it rotated on the second failure, on the
+    /// theory that a second failure is evidence about the account. Live
+    /// measurement (2026-08-27) says it is evidence about the CONNECTION — the
+    /// first same-account retry alone lands a 200 in 94.7% of cases — and
+    /// rotating instead throws away a warm prompt cache for a 5-10x cold one.
+    ///
+    /// Three blips then a 200, and the whole request must still be served by
+    /// `a`: the fleet is LRU, so any rotation would show up as `b`.
+    #[tokio::test]
+    async fn repeated_transport_failures_keep_retrying_the_same_account() {
+        let (up_addr, attempts) = spawn_counted_upstream(vec![
+            None,            // attempt 1 — `a`'s connection dies
+            None,            // attempt 2 — the fresh connection dies too
+            None,            // attempt 3 — and again
+            Some(raw_200()), // attempt 4 — still `a`, and it serves
+        ])
+        .await;
+        let manager = fleet(up_addr, &["a", "b"]);
+
+        let status = post_one(manager.clone()).await;
+        assert_eq!(status, 200, "the third retry must still serve the client");
+
+        let snap = manager.snapshot(OffsetDateTime::now_utc());
+        let served: Vec<&str> = snap
+            .accounts
+            .iter()
+            .filter(|a| a.requests > 0)
+            .map(|a| a.name.as_str())
+            .collect();
+        assert_eq!(
+            served,
+            ["a"],
+            "a run of connection blips must not bench a healthy account — landing \
+             on `b` means the aging-connection fault cost us a cold prefix"
+        );
+        assert_eq!(
+            attempts.load(std::sync::atomic::Ordering::SeqCst),
+            4,
+            "one send plus three same-account retries, all on `a`"
+        );
+    }
+
+    /// The other half of the bound: the ladder is finite. Once an account has
+    /// spent [`MAX_SAME_ACCOUNT_TRANSPORT_RETRIES`] it IS benched and the request
+    /// rotates, so a genuinely broken account cannot hold a request forever.
     ///
     /// The attempt count is read from the upstream rather than inferred: exactly
-    /// three sends (`a`, `a` again, then `b`) — a fourth would mean the same-account
-    /// retry can repeat, which is how a blipping upstream would burn the whole
-    /// `max_attempts` budget on one account.
+    /// five sends (`a` four times, then `b`). A sixth would mean the same-account
+    /// ladder is unbounded, which is how a permanently blipping upstream would
+    /// burn the whole `max_attempts` budget on one account.
     #[tokio::test]
-    async fn a_second_transport_failure_benches_the_account_and_rotates() {
+    async fn transport_failures_past_the_retry_budget_bench_the_account_and_rotate() {
         let (up_addr, attempts) = spawn_counted_upstream(vec![
             None,            // attempt 1 — `a` blips
-            None,            // attempt 2 — `a`'s fresh connection blips too
-            Some(raw_200()), // attempt 3 — rotated to `b`
+            None,            // attempt 2 — retry 1
+            None,            // attempt 3 — retry 2
+            None,            // attempt 4 — retry 3, the budget is now spent
+            Some(raw_200()), // attempt 5 — rotated to `b`
         ])
         .await;
         let manager = fleet(up_addr, &["a", "b"]);
@@ -9800,12 +9895,12 @@ mod tests {
         assert_eq!(
             served,
             ["b"],
-            "twice-failed `a` is benched for the rest of the request"
+            "`a` is benched once its transport-retry budget is spent"
         );
         assert_eq!(
             attempts.load(std::sync::atomic::Ordering::SeqCst),
-            3,
-            "one retry for `a`, then a rotation — not an unbounded same-account ladder"
+            (MAX_SAME_ACCOUNT_TRANSPORT_RETRIES as usize) + 2,
+            "one send plus the full retry budget on `a`, then exactly one rotation"
         );
     }
 


### PR DESCRIPTION
## What broke

Agent sessions appeared to hang, and accounts were hitting their weekly caps far
faster than their traffic justified. Both turned out to be the tail of one chain
that starts at the transport layer.

Anthropic's edge eventually drains a long-lived HTTP/2 connection. When it does,
this proxy was throwing away a **warm account** to escape a fault that belonged
to the **socket** — and paying a cold prompt cache to do it.

## Evidence

One day's live log (2026-08-27):

| fact | value |
|---|---|
| upstream transport failures | 2136 |
| how many were `Reset(StreamId(N), PROTOCOL_ERROR, Remote)` | **all of them** |
| median stream id at reset | 9699 (max 17449 ≈ 8700 requests on one socket) |
| share of resets past stream id 5000 | 66% |
| share on a connection under stream id 100 | 6.8% |
| `reason=pin-tried` diverts onto cold accounts | 1225 |
| same-account retries that landed a `200` | **94.7%** (1286 / 1358) |
| rotations to a cold account after one retry failed | 841 |

The resets cluster by connection **age**, not concurrency — which is why this is
not fixed by capping concurrency, and why `http1Only` (which gives up
multiplexing wholesale) is the wrong instrument.

The cost of a rotation is the point. Accounts serving a warm prefix ran ~2.6%
`cache_creation`; the cold accounts the diverts landed on ran 61-86%, which is
5-10x the quota per request (335.7 vs 32.4 Ktok-equivalent). On subscription
accounts quota *is* the money, so every avoidable rotation was pulling the
weekly caps forward.

## The two fixes

**1. The same-account transport retry was capped at one.** `transport_retried`
was a `HashSet`, so `.insert(idx)` was true exactly once. That single retry
succeeds 94.7% of the time — the connection is already evicted from the pool by
the error, so retrying genuinely gets a fresh one. When one was not enough the
request rotated. It is now a counter bounded by
`MAX_SAME_ACCOUNT_TRANSPORT_RETRIES`, and `MAX_SENDS_PER_ACCOUNT` derives its
transport term from that constant rather than a literal `1`.

**2. Nothing ever retired a connection.** `build_serving_client` sets
`http2_keep_alive_while_idle` and a 300s pool idle timeout specifically to keep
one connection warm forever, and reqwest exposes no max-lifetime knob. Each
account now counts serves against its current client and swaps in a fresh one
every `MAX_SERVES_PER_CONNECTION` (500, chosen to stay under stream id ~1000 —
below the p25 of the observed reset distribution). In-flight requests hold their
own `Arc` clone and finish on the old client untouched.

Retiring a connection costs **one TCP+TLS handshake, not a prompt-cache miss** —
the cache is keyed server-side on account and prefix and is indifferent to which
socket carried the bytes. That is the trade: ~200ms every 500 requests, against
the 5-10x cold-prefix rotations above.

## Verification

- Full suite green: 962 tests, 0 failures.
- Both fixes have a test that was **watched to fail** against the old behaviour:
  - reverting the retry bound to `1` fails
    `repeated_transport_failures_keep_retrying_the_same_account` — it lands on
    the rotation account instead of holding its own;
  - disabling the recycle fails
    `the_upstream_client_is_recycled_once_its_serve_budget_is_spent` on the
    `Arc::ptr_eq`. That test also carries a **control** asserting the client
    survives right up to the budget, so a build that recycled on *every* send
    would fail it too.
- `transport_blip_does_not_disable_recovery` now derives its blip count from the
  constant. As a literal it silently retargeted its own assertion from `c` to
  `b` when the retry bound moved — it was caught by this change and is now
  immune to the next one.

## What is deliberately NOT in here

No `maxInFlightPerAccount` and no `http1Only`. Both were considered and rejected
on the measurement above: capping concurrency would push more traffic onto the
5-10x accounts, and h1 abandons multiplexing to route around a fault that is
ours to fix.

## Not yet proven

That the keep-alive configuration *causes* the edge to drain the connection is
inference from the stream-id clustering, not an isolated measurement of
Anthropic's per-connection limit — their limit is not documented and was not
probed. Fix 1 does not depend on it. Fix 2 does: if the real trigger is wall
time rather than stream count, 500 serves is the wrong unit and the recycle will
fire too early or too late. The new `transport_retry=` log field and the
retirement log line are there to answer that from production.
