### PR TITLE
chore: add the 0.2.28 appcast entry

### DIFF
--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.28</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.28</link>
+      <sparkle:version>456</sparkle:version>
+      <sparkle:shortVersionString>0.2.28</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Thu, 27 Aug 2026 12:53:14 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.28/TcrBar-0.2.28.dmg" type="application/octet-stream" sparkle:edSignature="eToI5cuG6JEGYnGrxHMA9GVdTbf77WldwXYyq77sRGS1RZFf22lBsCp6Qgxtn1CtSHjXhp7NOaJeK28sJfHiBA==" length="6396360" />
+    </item>
+    <item>
       <title>TcrBar 0.2.27</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.27</link>
       <sparkle:version>453</sparkle:version>


### PR DESCRIPTION
chore: add the 0.2.28 appcast entry

release-tcrbar.sh writes the entry and deliberately does not commit it, so until
this lands the appcast in the repository and the one the release serves differ.

That gap is not cosmetic any more. appcast-guard.yml uploads THIS file to any
release that has no appcast of its own, so a stale copy here is what a future
CLI-only release would serve as the update feed — silently rolling every
installed copy back to advertising 0.2.27.

The enclosure length matches the uploaded TcrBar-0.2.28.dmg byte for byte
(6396360), verified three ways after publish: the local DMG, the length in this
file, and the size GitHub reports for the published asset all agree.

Note for whoever cuts the next release: v0.2.28 broke the Sparkle feed the same
way v0.2.27 did, and appcast-guard.yml did NOT prevent it. The guard's
`release: published` trigger cannot fire for a cargo-dist release, because
release.yml creates that release with `gh release create` under
secrets.GITHUB_TOKEN (release.yml:279) and GitHub does not raise workflow
triggers for events caused by GITHUB_TOKEN. The guard has no job-level `if:`,
and it was on main for over two hours before the release published, so the
trigger is the only explanation left. Its manual workflow_dispatch hatch worked
and repaired the feed.

Until that trigger is fixed — a workflow_run keyed on the Release workflow, or
folding the attach step into release.yml, which needs no secrets beyond
contents: write — every CLI release will orphan the feed and need the hatch run
by hand.
