### PR TITLE
chore: add the 0.2.29 appcast entry

### DIFF
--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.29</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.29</link>
+      <sparkle:version>458</sparkle:version>
+      <sparkle:shortVersionString>0.2.29</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Thu, 27 Aug 2026 15:05:09 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.29/TcrBar-0.2.29.dmg" type="application/octet-stream" sparkle:edSignature="oSOYbPnJ0t9bblk682OzJWUzCSzHTqbOe9zeI/DtwPVX/z9EiA7ITzkO+IHCqTr2qjtAmw7M4kVgqU9tx+QBCg==" length="6401256" />
+    </item>
+    <item>
       <title>TcrBar 0.2.28</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.28</link>
       <sparkle:version>456</sparkle:version>


### PR DESCRIPTION
`release-tcrbar.sh` writes the appcast entry and deliberately does not commit it, so until this lands the appcast in the repository and the one the release serves differ.

That gap is not cosmetic. `appcast-guard.yml` uploads **this** file to any release that has no appcast of its own, so a stale copy here is what a future CLI-only release would serve as the update feed — silently rolling every installed copy back to advertising 0.2.28.

The enclosure length matches the uploaded `TcrBar-0.2.29.dmg` byte for byte (**6401256**), verified three ways after publish: the length in this file, the size GitHub reports for the published asset, and the length served by the live feed at `releases/latest/download/appcast.xml` all agree. `latest` resolves to `v0.2.29`.

## Note for whoever cuts the next release

This release did **not** orphan the Sparkle feed, unlike v0.2.27 and v0.2.28. Those broke because a CLI-only release became `latest` carrying no appcast. Here the cargo-dist CLI release and the TcrBar release share tag `v0.2.29`, so `release-tcrbar.sh`'s prerelease → upload → `--latest` ordering placed the appcast on the release *before* it became latest. No manual guard hatch was needed.

The underlying defect is unchanged: `appcast-guard.yml`'s `release: published` trigger cannot fire for a cargo-dist release, because `release.yml` creates it under `secrets.GITHUB_TOKEN` and GitHub raises no workflow triggers for GITHUB_TOKEN-caused events. **A CLI-only release remains exposed.** The fix is to fold the appcast attach into `release.yml` itself, which needs nothing beyond `contents: write`.

One more note for the next cut: `release-tcrbar.sh` waits 600s for the tag-triggered workflow to create the release. This one appeared after **470s** — inside the limit, but not by much. `TCRBAR_RELEASE_WAIT` raises it. Also worth knowing that neither `release-local.sh` nor `release-tcrbar.sh` pushes the tag; that is a separate admin-gated step (`git tag vX.Y.Z && git push origin vX.Y.Z`) and the script simply waits until someone does it.