### PR TITLE
feat: show the full model mix, tag the app's build, and remember keep-awake

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -742,6 +742,7 @@ struct FleetView: View {
         VStack(alignment: .leading, spacing: Tok.tightSpacing) {
             Hairline()
             HStack {
+                appBuildTag
                 Spacer()
                 Button("Take over port…") { confirmTakeover() }
                     .buttonStyle(.bordered)
@@ -758,6 +759,38 @@ struct FleetView: View {
             }
         }
         .padding(.top, Tok.tightSpacing)
+    }
+
+    /// Which TcrBar this is, in the last line of the panel.
+    ///
+    /// The panel names the running proxy's build (`server <sha>`) because that
+    /// process routinely lags its source. TcrBar has the same gap and, until
+    /// now, no answer for it: the bundle cannot be replaced while it runs, so
+    /// an update that looks installed can leave the old app on screen — and the
+    /// only way to find out was to quit and read About. ``AppBuild`` reads the
+    /// keys `scripts/build-tcrbar.sh` has always written.
+    ///
+    /// It rides the danger row rather than adding a line of its own because
+    /// that row is one right-aligned button with 250pt of empty space beside
+    /// it, and the panel's height is already the scarce thing here — this is
+    /// the one place a fact fits at no cost. It is not part of that group and
+    /// must not read as part of it, so it carries `.tertiary` and the detail
+    /// font, matching `server <sha>` above; every control in the danger group
+    /// is `Tok.spent`. Drawn last so it sits at the very bottom, which is where
+    /// a version tag is looked for.
+    ///
+    /// Absent rather than approximate: `swift run TcrBar` has no Info.plist, so
+    /// there is no version, so nothing is drawn.
+    @ViewBuilder
+    private var appBuildTag: some View {
+        if let label = AppBuild.label {
+            Text(label)
+                .font(Tok.detailDigitFont)
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+                .textSelection(.enabled)
+                .help(AppBuild.buildDetail(buildNumber: AppBuild.buildNumber) ?? label)
+        }
     }
 
     /// The alert names the real cost in plain language, defaults to Cancel, and

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -656,7 +656,8 @@ struct FleetView: View {
             .help(
                 "Holds the three power assertions `caffeinate -i -m -s` holds, for "
                     + "as long as this is on. Released when you untick it or quit "
-                    + "TcrBar."
+                    + "TcrBar, and taken again the next time TcrBar starts — the "
+                    + "cup in the menu bar is on whenever it is held."
             )
             if awake.isOn {
                 Text("The display still sleeps. Sleep itself is only held off on AC power.")

--- a/apps/macos/Sources/TcrBar/RenderStates.swift
+++ b/apps/macos/Sources/TcrBar/RenderStates.swift
@@ -140,11 +140,18 @@ enum RenderStates {
         NSAppearance.current = appearance.nsAppearance
         defer { NSAppearance.current = previous }
 
-        // `.inert`, never the real activity: drawing a checkbox in its ON state
-        // must not actually stop this machine sleeping. A harness with a side
-        // effect on the operator's power settings would be a worse bug than
+        // `.harness()`, never a real controller: drawing a checkbox in its ON
+        // state must not actually stop this machine sleeping. A harness with a
+        // side effect on the operator's power settings would be a worse bug than
         // anything it could catch.
-        let awake = AwakeController(activity: .inert)
+        //
+        // That sentence used to be satisfied by `activity: .inert` alone, and
+        // stopped being once the control started REMEMBERING its state: the
+        // `setOn` below would have written `keepThisMacAwake` into the
+        // operator's own defaults — true on scene 12, false on the next one —
+        // so a render would silently disarm a setting they had turned on.
+        // `.harness()` is inert on both halves.
+        let awake = AwakeController.harness()
         awake.setOn(scene.awake)
 
         let view =

--- a/apps/macos/Sources/TcrBar/RenderStates.swift
+++ b/apps/macos/Sources/TcrBar/RenderStates.swift
@@ -385,6 +385,25 @@ enum RenderStates {
     /// Measured and priced, but the server cannot name when this account's
     /// 5-hour window started, so `window` is null and the card falls back to
     /// the DAY's figures — which are still a measurement.
+    ///
+    /// Its day is split across FOUR priced models, which is what carries the
+    /// header line's own case. It was one model until the line stopped
+    /// collapsing its tail to `"+N"`; with two labels in the whole fleet, the
+    /// scene built to review that line could not show what it now does. Four
+    /// here plus the unpriced `sonnet-4-5` the other two rows carry gives the
+    /// header five entries — one more than the live fleet this was measured
+    /// against ran on 2026-08-30 — so the scene reviews the wrap at a width
+    /// past the ordinary case rather than short of it.
+    ///
+    /// `claude-haiku-4-5` is $0.0102 of $22.25 on purpose: 0.05% of the fleet's
+    /// day, which is the slice that rounds to zero. It draws `haiku-4-5 <1%`,
+    /// and a scene showing `haiku-4-5 0%` is the regression — a model that
+    /// served 2 requests reported as having spent nothing. See
+    /// ``QuotaFormat/share(_:)``.
+    ///
+    /// The buckets still sum to `today` on every field, the way the rest of
+    /// these fixtures do: 60+25+15+2 requests, and $6.90 + $2.00 + $0.50 +
+    /// $0.0102 = the $9.4102 above.
     private static let noWindowUsage = """
         {"today":{"requests":102,"inputTokens":174512,"cacheCreationTokens":1200000,
           "cacheCreation1hTokens":400000,"cacheReadTokens":7407414,"outputTokens":31860,
@@ -394,9 +413,21 @@ enum RenderStates {
           "cacheCreation1hTokens":47000,"cacheReadTokens":705000,"outputTokens":3756,
           "costUsd":1.1021,"unpricedRequests":0},
          "todayByModel":{
-           "claude-opus-5":{"requests":102,"inputTokens":174512,
-            "cacheCreationTokens":1200000,"cacheCreation1hTokens":400000,
-            "cacheReadTokens":7407414,"outputTokens":31860,"costUsd":9.4102,
+           "claude-opus-5":{"requests":60,"inputTokens":100000,
+            "cacheCreationTokens":700000,"cacheCreation1hTokens":230000,
+            "cacheReadTokens":4400000,"outputTokens":18000,"costUsd":6.9,
+            "unpricedRequests":0},
+           "claude-fable-5":{"requests":25,"inputTokens":45000,
+            "cacheCreationTokens":300000,"cacheCreation1hTokens":100000,
+            "cacheReadTokens":1900000,"outputTokens":8000,"costUsd":2.0,
+            "unpricedRequests":0},
+           "claude-sonnet-5":{"requests":15,"inputTokens":27000,
+            "cacheCreationTokens":190000,"cacheCreation1hTokens":65000,
+            "cacheReadTokens":1050000,"outputTokens":5300,"costUsd":0.5,
+            "unpricedRequests":0},
+           "claude-haiku-4-5-20251001":{"requests":2,"inputTokens":2512,
+            "cacheCreationTokens":10000,"cacheCreation1hTokens":5000,
+            "cacheReadTokens":57414,"outputTokens":560,"costUsd":0.0102,
             "unpricedRequests":0}}}
         """
 
@@ -556,14 +587,19 @@ enum RenderStates {
     ///  - `unmeasured@` — no `usage` at all: an empty slot, not a zero.
     ///
     /// The header line is the fleet's sum over the three measured rows, so it
-    /// also proves the unmeasured one contributes nothing rather than zero. Its
-    /// model share names `opus-5` with a percentage and `sonnet-4-5` with `?`:
-    /// the unpriced model has real traffic here and must not vanish from the
-    /// line, and a percentage is exactly what nobody can compute for it.
+    /// also proves the unmeasured one contributes nothing rather than zero. It
+    /// names every model: four priced ones, then `sonnet-4-5 ?` — the unpriced
+    /// model has real traffic here and must not vanish from the line, and a
+    /// percentage is exactly what nobody can compute for it.
     ///
-    /// The fully-priced card (`$5.61 · 12k out`, no marker) is scene 01's; a
-    /// second priced model in this fleet would push the `?` past the two the
-    /// header names, which is the one thing this scene exists to show.
+    /// Those five entries are also this scene's LAYOUT case, and the reason it
+    /// is worth looking at rather than only asserting on. The line wraps, and a
+    /// wrap is charged to the account list (`PanelHeight.headerOverflow`), so
+    /// what a reader must check here is that the list still has rows and the
+    /// footer has not moved. It read `opus-5 100% · sonnet-4-5 ?` while only
+    /// the top two models were named and the rest became `"+2"`.
+    ///
+    /// The fully-priced card (`$5.61 · 12k out`, no marker) is scene 01's.
     /// The same four rows also carry all four branches of the FABLE weekly
     /// slot on their 7d line, because that slot has the same shape of rule and
     /// the same way of being got wrong:

--- a/apps/macos/Sources/TcrBar/ShellProbe.swift
+++ b/apps/macos/Sources/TcrBar/ShellProbe.swift
@@ -102,7 +102,11 @@ enum ShellProbe {
         // Sparkle opening its own window underneath the measurement.
         let shell = MenuBarShell(
             poller: StatusPoller(pinnedState: .loaded(probeFleet())),
-            awake: AwakeController(activity: .inert),
+            // Inert on both halves: it holds nothing, and — because the probe
+            // drives `setOn(true)`/`setOn(false)` below to measure the two marks
+            // — it must also remember nothing, or a probe run would rewrite the
+            // operator's `keepThisMacAwake` preference. See `AwakeController.harness()`.
+            awake: AwakeController.harness(),
             updater: Updater(startingUpdater: false))
 
         var checks: [Check] = []

--- a/apps/macos/Sources/TcrBar/TcrBarApp.swift
+++ b/apps/macos/Sources/TcrBar/TcrBarApp.swift
@@ -110,6 +110,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if shell.preference.startServerAtLaunch {
             shell.server.start()
         }
+        // Same shape, same place, same once-per-process guarantee: re-take the
+        // power assertions if that is how the operator left them. A reboot is
+        // exactly when a machine meant to stay up for long runs would otherwise
+        // come back asleep-capable with nothing on screen having changed.
+        //
+        // After `poller.start()` rather than before it only because the fleet is
+        // the thing worth being quickest about; the assertions are not racing
+        // anything. `AwakeController.restoreFromPreference` is a no-op unless the
+        // stored intent is ON.
+        shell.awake.restoreFromPreference()
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/apps/macos/Sources/TcrBarCore/AppBuild.swift
+++ b/apps/macos/Sources/TcrBarCore/AppBuild.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Which build of TcrBar is on screen.
+///
+/// The panel already names the build of the *proxy* it is watching
+/// (`server <sha>`, in the footer) for a documented reason: the running process
+/// is routinely several commits behind the source, and "the fix is in `main`"
+/// and "the fix is in the thing serving traffic" are different facts. TcrBar
+/// itself has the identical gap and had no answer for it. It is arguably worse
+/// here — `/Applications/TcrBar.app` **cannot be replaced while it runs**
+/// (`TcrTool.swift` resolves the bundled `tcr` and supervises it as a child, so
+/// the bundle holds an executing image), so an update that appears to have been
+/// installed can leave the old app on screen until it is quit. Every version
+/// key needed to say so was already written into the bundle by
+/// `scripts/build-tcrbar.sh`; nothing read them.
+///
+/// Every field is `nil` when absent rather than defaulted to a plausible
+/// string, and ``label`` returns `nil` rather than inventing a version. The
+/// only case that matters is a binary run outside its bundle
+/// (`swift run TcrBar`), which has no Info.plist and therefore no version — and
+/// a panel claiming `0.0.0` there would be a fabricated build number in the one
+/// place a reader goes to check what they are running.
+public enum AppBuild {
+    /// `CFBundleShortVersionString` — the MARKETING version, which
+    /// `build-tcrbar.sh` reads from `Cargo.toml`. The number that matches
+    /// `tcr --version`, the git tag and the appcast entry.
+    public static var shortVersion: String? { string(for: "CFBundleShortVersionString") }
+
+    /// `CFBundleVersion` — the build number, the commit count. Not on the
+    /// panel: it is what macOS and Sparkle ORDER on, not what a human calls a
+    /// release, and the sha below identifies a build more usefully.
+    public static var buildNumber: String? { string(for: "CFBundleVersion") }
+
+    /// `TcrGitSHA` — the short commit, already `-dirty`-suffixed by the build
+    /// script. Written into every bundle since the app shipped and read by
+    /// nothing until now.
+    ///
+    /// `"unknown"` is what the script writes when it builds outside a git
+    /// checkout; it is mapped back to `nil` here so no caller has to know that
+    /// one magic string, and so it can never reach the panel as a word that
+    /// looks like a commit.
+    public static var gitSha: String? {
+        guard let sha = string(for: "TcrGitSHA"), sha != "unknown" else { return nil }
+        return sha
+    }
+
+    /// `"TcrBar 0.2.29 · 9582244"`, or `"TcrBar 0.2.29"` with no usable sha, or
+    /// `nil` when there is no version to state at all.
+    ///
+    /// Named, not bare: it sits one row below `server <sha>`, and two
+    /// unlabelled hashes in the same footer would be a puzzle rather than a
+    /// fact. The separator is the `·` the rest of the panel uses.
+    public static var label: String? { label(version: shortVersion, sha: gitSha) }
+
+    /// The formatting rule on its own, so a test can exercise the absent cases
+    /// without a bundle to stage them in.
+    public static func label(version: String?, sha: String?) -> String? {
+        guard let version else { return nil }
+        guard let sha else { return "TcrBar \(version)" }
+        return "TcrBar \(version) · \(sha)"
+    }
+
+    /// `"build 258"`, for the hover help — the ordering key, kept off the line
+    /// itself and one hover away for whoever is comparing two installs.
+    public static func buildDetail(buildNumber: String?) -> String? {
+        guard let buildNumber else { return nil }
+        return "build \(buildNumber)"
+    }
+
+    private static func string(for key: String) -> String? {
+        guard let value = Bundle.main.object(forInfoDictionaryKey: key) as? String,
+            !value.isEmpty
+        else { return nil }
+        return value
+    }
+}

--- a/apps/macos/Sources/TcrBarCore/AwakeController.swift
+++ b/apps/macos/Sources/TcrBarCore/AwakeController.swift
@@ -46,12 +46,33 @@ import IOKit.pwr_mgt
 /// No measurement of that exists on this machine, so neither the doc-comment
 /// nor the panel claims an answer in either direction.
 ///
-/// **Not persisted across launches.** There is deliberately no `@AppStorage`
-/// here. A Mac that silently never sleeps because of a box ticked a week ago is
-/// a worse bug than having to tick it again — the symptom (a laptop that runs
-/// hot in a bag) is nowhere near the cause. Contrast `startServerAtLaunch`,
-/// which *is* persisted: being wrong about that one costs a spawn that stands
-/// down harmlessly.
+/// **Persisted across launches**, and it was not. The reversal is Gil's call
+/// (2026-08-30) and the reasoning it overturns is worth keeping, because it was
+/// not wrong about the danger:
+///
+/// > A Mac that silently never sleeps because of a box ticked a week ago is a
+/// > worse bug than having to tick it again — the symptom (a laptop that runs
+/// > hot in a bag) is nowhere near the cause.
+///
+/// What makes it safe now is that the state is no longer silent. ``MenuBarMark``
+/// draws a tinted cup beside the gauge for exactly as long as the assertions are
+/// held, in the menu bar, on every screen the operator looks at — the shape
+/// channel survives greyscale and colour vision deficiency, and the status
+/// item's tooltip names it too. The cause is not "nowhere near the symptom"; it
+/// is the one glyph that is always on screen. A setting whose whole job is "this
+/// machine stays up for long runs" and that has to be re-armed after every
+/// reboot is a setting that is off exactly when it was needed.
+///
+/// What is stored is the operator's INTENT — what ``setOn(_:)`` was asked for —
+/// not ``isOn``, which mirrors the token and is a fact about the machine.
+/// A take that fails leaves the panel honestly OFF and the stored intent ON, so
+/// the next launch tries again rather than quietly disabling itself. That split
+/// is also what keeps ``releaseOnQuit()`` from wiping the preference on the way
+/// out: quitting ends the assertions, it does not un-ask for them.
+///
+/// ``defaults`` is optional and `nil` means REMEMBER NOTHING — the PNG harness
+/// and the shell probe both drive `setOn` to draw the ON state, and a render must
+/// not write the operator's preferences. See ``AwakeController/harness()``.
 @MainActor
 public final class AwakeController: ObservableObject {
 
@@ -171,12 +192,50 @@ public final class AwakeController: ObservableObject {
 
     private let activity: Activity
 
-    public init(activity: Activity = .powerAssertions) {
+    /// The `UserDefaults` key. Do not change it — renaming it fails nothing and
+    /// silently un-arms a setting the operator chose, the same trap
+    /// ``LaunchPreference/startServerAtLaunchKey`` documents. `AwakeControllerTests`
+    /// pins the literal.
+    public static let keepAwakeKey = "keepThisMacAwake"
+
+    /// `nil` remembers nothing. See the type's doc-comment.
+    private let defaults: UserDefaults?
+
+    public init(activity: Activity = .powerAssertions, defaults: UserDefaults? = .standard) {
         self.activity = activity
+        self.defaults = defaults
     }
 
+    /// The pairing every harness wants: hold nothing, remember nothing.
+    ///
+    /// Named rather than left to two call sites to assemble, because the second
+    /// half is the one that is easy to forget and the damage is invisible —
+    /// rendering the ON scene with real defaults would write
+    /// ``keepAwakeKey`` into the operator's own preferences.
+    public static func harness() -> AwakeController {
+        AwakeController(activity: .inert, defaults: nil)
+    }
+
+    /// Take or release the assertions, and remember which was asked for.
+    ///
+    /// The store is written BEFORE the attempt on purpose: it records what was
+    /// asked, and a take that fails is still a request to keep this Mac awake.
     public func setOn(_ on: Bool) {
+        defaults?.set(on, forKey: Self.keepAwakeKey)
         if on { begin() } else { end() }
+    }
+
+    /// Re-arm at launch from the stored intent. Called once, from
+    /// `applicationDidFinishLaunching`, beside the `startServerAtLaunch` spawn.
+    ///
+    /// Deliberately NOT done in `init`: the render harness and the shell probe
+    /// build a controller too, and a constructor that reaches for the operator's
+    /// preferences would have them silently holding — or drawing — a state
+    /// nobody asked those processes for. It also goes through ``begin()``
+    /// rather than ``setOn(_:)``, so restoring writes nothing back.
+    public func restoreFromPreference() {
+        guard defaults?.bool(forKey: Self.keepAwakeKey) == true else { return }
+        begin()
     }
 
     public func toggle() {

--- a/apps/macos/Sources/TcrBarCore/FleetStatus.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetStatus.swift
@@ -256,6 +256,23 @@ public enum QuotaFormat {
         return "\(Int((value * 100).rounded()))%"
     }
 
+    /// ``percent(_:)`` for a share of a whole, where a positive value too small
+    /// to round to one percent prints `"<1%"` rather than `"0%"`.
+    ///
+    /// The header names EVERY model now, so this case is no longer hypothetical:
+    /// a fleet spending $5,000 on opus and $1.55 on haiku puts a 0.02% slice on
+    /// the line, and `haiku-4-5 0%` claims the model served nothing today. It
+    /// served; it is simply cheap. That is the same distinction ``percent(_:)``
+    /// keeps between `nil` and zero, one level down — here both ends are
+    /// measured, and the rounding is what would invent the zero.
+    ///
+    /// A share that IS zero still prints `"0%"`, because that is what it is.
+    public static func share(_ value: Double?) -> String {
+        guard let value else { return notMeasured }
+        if value > 0 && (value * 100).rounded() == 0 { return "<1%" }
+        return percent(value)
+    }
+
     /// `102` → `"102"`; `nil` → `"n/a"`.
     ///
     /// The `Int` counterpart to ``percent(_:)``, for a serving counter that
@@ -1970,8 +1987,9 @@ public struct Fleet: Equatable, Sendable {
     /// `claude-opus-5-20250929` are ONE model wearing two ids — which is the
     /// ordinary state during a rollout, some sessions pinning the dated id and
     /// others the alias. Grouping on the raw id and shortening afterwards drew
-    /// the same name twice, split its true share in half, and let the `+N`
-    /// clause count a model that does not exist.
+    /// the same name twice and split its true share in half — and back when the
+    /// header collapsed its tail to `"+N"`, that count included a model which
+    /// does not exist.
     public var todayByModelLabel: [String: UsageTotals] {
         var merged: [String: UsageTotals] = [:]
         for (id, totals) in todayByModel {
@@ -2004,10 +2022,11 @@ public struct Fleet: Equatable, Sendable {
         }
 
         /// `"opus-5 62%"`, `"opus-5 62%+"` when the cost behind it is a floor,
+        /// `"haiku-4-5 <1%"` for a slice too small to round to a percent,
         /// `"sonnet-4-5 ?"` when nothing under it could be priced at all.
         public var label: String {
             guard let share else { return "\(model) \(QuotaFormat.unknownShare)" }
-            return "\(model) \(QuotaFormat.percent(share))\(partial ? "+" : "")"
+            return "\(model) \(QuotaFormat.share(share))\(partial ? "+" : "")"
         }
     }
 
@@ -2025,11 +2044,11 @@ public struct Fleet: Equatable, Sendable {
     /// `"?"`. It used to be filtered out entirely, so a fleet running most of
     /// its traffic on a model this build has no rate for read as
     /// `opus-5 100%` — and, because the dropped model never reached
-    /// `share.count`, the `+N` clause that exists to say "there are more
-    /// models" did not fire either. A model with traffic is never absent from
-    /// this line; what is unknown about it is its cost, and `"?"` says exactly
-    /// that. ``todayUnpricedRequests`` still says how much of the total is
-    /// missing.
+    /// `share.count`, the `"+N"` clause the header then used to say "there are
+    /// more models" did not fire either. A model with traffic is never absent
+    /// from this line; what is unknown about it is its cost, and `"?"` says
+    /// exactly that. ``todayUnpricedRequests`` still says how much of the total
+    /// is missing.
     ///
     /// A label can also be PARTLY priceable, which is the case a two-state
     /// answer hid. ``todayByModelLabel`` canonicalizes ids before grouping, so
@@ -2105,10 +2124,23 @@ public struct Fleet: Equatable, Sendable {
     /// no line at all. A line of zeros would answer a question this build
     /// cannot answer.
     ///
-    /// Two models are named and the rest collapse to `"+N"`: the panel is
-    /// 380pt wide, and the third model's share is not what anyone opens it for.
-    /// An unpriced model is named with `"?"` where its percentage would go and
-    /// counts toward that `+N` like any other — see ``todayModelShare``.
+    /// EVERY model is named, biggest share first. Two were named and the rest
+    /// collapsed to `"+N"`, on the reasoning that a 380pt panel has no room for
+    /// the third.
+    ///
+    /// What that bought was not the panel's height — the line already wraps,
+    /// and `PanelHeight.headerOverflow` charges the wrap to the account list
+    /// (floor 120pt) rather than to the bottom of the panel, so the panel is
+    /// 520pt tall either way. It bought a few rows of account list. What it
+    /// cost was the answer: `+2` names no model, sizes none, and cannot be
+    /// clicked to expand, so a reader who wants the mix has to leave the panel
+    /// to get it. A fleet running four models is the ordinary case here, and
+    /// two of the four were being withheld to save two rows.
+    ///
+    /// An unpriced model is named with `"?"` where its percentage would go —
+    /// see ``todayModelShare`` — and a slice too small to round to one percent
+    /// prints `"<1%"` rather than `"0%"`, which is a claim of no traffic; see
+    /// ``QuotaFormat/share(_:)``, which owns that.
     /// `" · N unpriced today"` is appended whenever requests are missing from
     /// the cost, so a partial total says it is partial rather than passing
     /// itself off as the whole. It names its span because the line can now
@@ -2128,11 +2160,9 @@ public struct Fleet: Equatable, Sendable {
         if let rate = burnRateSegment {
             parts.append(rate)
         }
-        let share = todayModelShare
-        for entry in share.prefix(2) {
+        for entry in todayModelShare {
             parts.append(entry.label)
         }
-        if share.count > 2 { parts.append("+\(share.count - 2)") }
         parts.append("cache \(QuotaFormat.percent(todayCacheHitRatio))")
         if let unpriced = todayUnpricedRequests, unpriced > 0 {
             parts.append("\(unpriced) unpriced today")

--- a/apps/macos/Sources/TcrBarCore/KeepAwakeProbe.swift
+++ b/apps/macos/Sources/TcrBarCore/KeepAwakeProbe.swift
@@ -94,7 +94,13 @@ public enum KeepAwakeProbe {
             exit(2)
 
         case .hold(let seconds):
-            let controller = AwakeController()
+            // REAL assertions — that is the whole point of this probe — but
+            // `defaults: nil`, so the `setOn` calls that drive it do not write
+            // `keepThisMacAwake` into the operator's preferences. A gate that
+            // proves the mechanism works must not also arm the setting, and the
+            // inverse is worse: this probe releases at the end, which would
+            // store OFF and disarm a control the operator had turned on.
+            let controller = AwakeController(activity: .powerAssertions, defaults: nil)
             controller.setOn(true)
 
             // This guard can fail, and that is why it is here.

--- a/apps/macos/Tests/TcrBarTests/AppBuildTests.swift
+++ b/apps/macos/Tests/TcrBarTests/AppBuildTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+
+@testable import TcrBarCore
+
+/// ``AppBuild``'s formatting rule, exercised through the pure entry points.
+///
+/// The `Bundle.main`-reading properties are deliberately NOT tested here: under
+/// `swift test` the main bundle is the test runner, so asserting on them would
+/// pin the harness's own Info.plist rather than TcrBar's. What is worth pinning
+/// is the rule that decides what reaches the panel — above all that an absent
+/// version draws nothing instead of a plausible-looking placeholder.
+final class AppBuildTests: XCTestCase {
+    func testTheLabelNamesTheAppSoTwoHashesInOneFooterAreTellableApart() {
+        XCTAssertEqual(AppBuild.label(version: "0.2.29", sha: "9582244"), "TcrBar 0.2.29 · 9582244")
+    }
+
+    func testAMissingShaLeavesTheVersionStandingAlone() {
+        XCTAssertEqual(AppBuild.label(version: "0.2.29", sha: nil), "TcrBar 0.2.29")
+    }
+
+    /// The whole reason these are optionals. A binary run outside its bundle
+    /// has no Info.plist and therefore no version; the panel then says nothing,
+    /// because a fabricated build number in the one place a reader goes to
+    /// check what they are running is worse than an empty corner.
+    func testNoVersionDrawsNothingRatherThanAPlaceholder() {
+        XCTAssertNil(AppBuild.label(version: nil, sha: "9582244"))
+        XCTAssertNil(AppBuild.label(version: nil, sha: nil))
+    }
+
+    func testTheBuildNumberIsHoverDetailNotALine() {
+        XCTAssertEqual(AppBuild.buildDetail(buildNumber: "258"), "build 258")
+        XCTAssertNil(AppBuild.buildDetail(buildNumber: nil))
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/AwakeControllerTests.swift
+++ b/apps/macos/Tests/TcrBarTests/AwakeControllerTests.swift
@@ -43,7 +43,7 @@ final class AwakeControllerTests: XCTestCase {
 
     func testOffToOnBeginsExactlyOneActivity() {
         let fake = RecordingActivity()
-        let controller = AwakeController(activity: fake.activity)
+        let controller = AwakeController(activity: fake.activity, defaults: nil)
 
         controller.setOn(true)
 
@@ -59,7 +59,7 @@ final class AwakeControllerTests: XCTestCase {
     /// process.
     func testOnToOnDoesNotBeginASecondActivity() {
         let fake = RecordingActivity()
-        let controller = AwakeController(activity: fake.activity)
+        let controller = AwakeController(activity: fake.activity, defaults: nil)
 
         controller.setOn(true)
         controller.setOn(true)
@@ -72,7 +72,7 @@ final class AwakeControllerTests: XCTestCase {
 
     func testOnToOffEndsExactlyTheTokenThatWasBegun() {
         let fake = RecordingActivity()
-        let controller = AwakeController(activity: fake.activity)
+        let controller = AwakeController(activity: fake.activity, defaults: nil)
 
         controller.setOn(true)
         controller.setOn(false)
@@ -90,7 +90,7 @@ final class AwakeControllerTests: XCTestCase {
     /// to reach it is a spurious off.
     func testOffToOffEndsNothing() {
         let fake = RecordingActivity()
-        let controller = AwakeController(activity: fake.activity)
+        let controller = AwakeController(activity: fake.activity, defaults: nil)
 
         controller.setOn(false)
         controller.setOn(false)
@@ -106,7 +106,7 @@ final class AwakeControllerTests: XCTestCase {
     /// that is not true.
     func testIsOnTracksTheLiveTokenAcrossEveryTransition() {
         let fake = RecordingActivity()
-        let controller = AwakeController(activity: fake.activity)
+        let controller = AwakeController(activity: fake.activity, defaults: nil)
 
         for on in [false, true, true, false, false, true, false] {
             controller.setOn(on)
@@ -118,7 +118,7 @@ final class AwakeControllerTests: XCTestCase {
 
     func testToggleFlipsAndReleases() {
         let fake = RecordingActivity()
-        let controller = AwakeController(activity: fake.activity)
+        let controller = AwakeController(activity: fake.activity, defaults: nil)
 
         controller.toggle()
         XCTAssertTrue(controller.isOn)
@@ -129,7 +129,7 @@ final class AwakeControllerTests: XCTestCase {
 
     func testReleaseOnQuitEndsAHeldActivityAndIsSafeWhenNoneIsHeld() {
         let fake = RecordingActivity()
-        let controller = AwakeController(activity: fake.activity)
+        let controller = AwakeController(activity: fake.activity, defaults: nil)
 
         controller.releaseOnQuit()
         XCTAssertEqual(fake.ended.count, 0, "nothing was held, so nothing may be ended")
@@ -148,7 +148,7 @@ final class AwakeControllerTests: XCTestCase {
     /// both that search and the README's gate.
     func testReasonNamesTheAppSoItIsGreppable() {
         let fake = RecordingActivity()
-        let controller = AwakeController(activity: fake.activity)
+        let controller = AwakeController(activity: fake.activity, defaults: nil)
 
         controller.setOn(true)
 
@@ -183,7 +183,7 @@ final class AwakeControllerTests: XCTestCase {
                 return nil
             },
             end: { _ in ended += 1 })
-        let controller = AwakeController(activity: activity)
+        let controller = AwakeController(activity: activity, defaults: nil)
 
         controller.setOn(true)
         XCTAssertFalse(controller.isOn, "nothing was taken, so the control must read OFF")
@@ -199,7 +199,7 @@ final class AwakeControllerTests: XCTestCase {
     /// The harness pair must hold nothing. If `.inert` ever became the real one,
     /// rendering PNGs would stop the machine sleeping.
     func testInertActivityIsSafeForTheRenderHarness() {
-        let controller = AwakeController(activity: .inert)
+        let controller = AwakeController(activity: .inert, defaults: nil)
         controller.setOn(true)
         XCTAssertTrue(controller.isOn, "the harness still needs the ON appearance")
         controller.setOn(false)

--- a/apps/macos/Tests/TcrBarTests/AwakePersistenceTests.swift
+++ b/apps/macos/Tests/TcrBarTests/AwakePersistenceTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+
+@testable import TcrBarCore
+
+/// "Keep this Mac awake" surviving a restart, and the four ways that can be
+/// wrong without anything looking broken.
+///
+/// A scratch suite per test, the same way `LaunchPreferenceTests` does it: these
+/// assert on stored preferences, and a suite that wrote to the operator's real
+/// domain would arm or disarm their actual setting from a test run.
+@MainActor
+final class AwakePersistenceTests: XCTestCase {
+    private var suiteName = ""
+    private var defaults = UserDefaults.standard
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "tcrbar.tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName) ?? .standard
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    /// The literal is load-bearing: renaming it fails no test and no build, and
+    /// the first symptom is a Mac that went to sleep during a long run.
+    func testTheKeyIsTheStringTheStoredPreferenceUses() {
+        XCTAssertEqual(AwakeController.keepAwakeKey, "keepThisMacAwake")
+    }
+
+    func testTickingItArmsTheNextLaunch() {
+        let fake = RecordingActivity()
+        let controller = AwakeController(activity: fake.activity, defaults: defaults)
+
+        controller.setOn(true)
+
+        XCTAssertTrue(defaults.bool(forKey: AwakeController.keepAwakeKey))
+
+        // The next launch: a fresh controller over the same stored intent.
+        let next = RecordingActivity()
+        let relaunched = AwakeController(activity: next.activity, defaults: defaults)
+        XCTAssertFalse(relaunched.isOn, "nothing is held until the restore runs")
+        relaunched.restoreFromPreference()
+        XCTAssertTrue(relaunched.isOn)
+        XCTAssertEqual(next.begun.count, 1, "restored by taking the assertions exactly once")
+    }
+
+    func testUntickingItDisarmsTheNextLaunch() {
+        let fake = RecordingActivity()
+        let controller = AwakeController(activity: fake.activity, defaults: defaults)
+
+        controller.setOn(true)
+        controller.setOn(false)
+
+        XCTAssertFalse(defaults.bool(forKey: AwakeController.keepAwakeKey))
+
+        let next = RecordingActivity()
+        let relaunched = AwakeController(activity: next.activity, defaults: defaults)
+        relaunched.restoreFromPreference()
+        XCTAssertFalse(relaunched.isOn)
+        XCTAssertEqual(next.begun.count, 0, "an unticked box takes nothing at launch")
+    }
+
+    /// The trap this whole feature dies on, silently.
+    ///
+    /// `releaseOnQuit()` ends the assertions on the way out. Had the stored
+    /// value been written from the token's own state rather than from what
+    /// ``AwakeController/setOn(_:)`` was asked for, quitting would have recorded
+    /// OFF — every single time — and the setting would have been dead on
+    /// arrival while every other test in this file still passed.
+    func testQuittingReleasesTheAssertionsWithoutUnaskingForThem() {
+        let fake = RecordingActivity()
+        let controller = AwakeController(activity: fake.activity, defaults: defaults)
+
+        controller.setOn(true)
+        controller.releaseOnQuit()
+
+        XCTAssertFalse(controller.isOn, "the assertions are released")
+        XCTAssertEqual(fake.live.count, 0)
+        XCTAssertTrue(
+            defaults.bool(forKey: AwakeController.keepAwakeKey),
+            "quitting ends the hold; it does not un-ask for it")
+
+        let next = RecordingActivity()
+        let relaunched = AwakeController(activity: next.activity, defaults: defaults)
+        relaunched.restoreFromPreference()
+        XCTAssertTrue(relaunched.isOn, "so the next launch comes back holding")
+    }
+
+    /// A take that fails leaves the panel honestly OFF — and leaves the intent
+    /// stored, so the next launch tries again instead of quietly disabling a
+    /// setting the operator never turned off.
+    func testAFailedTakeReportsOffAndStillArmsTheNextLaunch() {
+        let refusing = AwakeController.Activity(begin: { _ in nil }, end: { _ in })
+        let controller = AwakeController(activity: refusing, defaults: defaults)
+
+        controller.setOn(true)
+
+        XCTAssertFalse(controller.isOn, "nothing is held, so the control says so")
+        XCTAssertTrue(defaults.bool(forKey: AwakeController.keepAwakeKey))
+    }
+
+    /// The harness pairing. Rendering the ON scene must not reach the operator's
+    /// preferences — a PNG run would otherwise write `true` on scene 12 and
+    /// `false` on the next one, disarming a setting they had turned on.
+    func testTheHarnessControllerRemembersNothing() {
+        defaults.set(true, forKey: AwakeController.keepAwakeKey)
+
+        let harness = AwakeController.harness()
+        harness.setOn(true)
+        harness.setOn(false)
+
+        XCTAssertTrue(
+            defaults.bool(forKey: AwakeController.keepAwakeKey),
+            "the harness drove the control and wrote nothing")
+        XCTAssertFalse(
+            UserDefaults.standard.bool(forKey: AwakeController.keepAwakeKey),
+            "and it did not reach the standard domain either")
+
+        harness.restoreFromPreference()
+        XCTAssertFalse(harness.isOn, "a controller that remembers nothing restores nothing")
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/UsageStatsTests.swift
+++ b/apps/macos/Tests/TcrBarTests/UsageStatsTests.swift
@@ -252,16 +252,21 @@ final class UsageStatsTests: XCTestCase {
     /// ranking entirely, so this line named two models and collapsed nothing,
     /// while a third model with 32 of the fleet's 132 requests appeared
     /// nowhere — the panel read as "all opus" about a fleet that was not.
-    func testHeaderLineNamesTwoModelsAndSaysWhatIsMissing() throws {
+    ///
+    /// That third model is now NAMED, not counted: the `"+1"` this line used to
+    /// end its model list with said only that something was missing, without
+    /// saying what.
+    func testHeaderLineNamesEveryModelAndSaysWhatIsMissing() throws {
         let fleet = try mixedFleet()
         let line = try XCTUnwrap(fleet.usageSummaryLine)
         XCTAssertEqual(
             line,
-            "$14.0 today · $3.00/hr · opus-5 86% · sonnet-5 14% · +1 · cache 75% "
+            "$14.0 today · $3.00/hr · opus-5 86% · sonnet-5 14% · sonnet-4-5 ? · cache 75% "
                 + "· 32 unpriced today")
+        XCTAssertFalse(line.contains("+1"), "nothing is collapsed any more: \(line)")
     }
 
-    func testHeaderLineCollapsesTheThirdModel() throws {
+    func testHeaderLineNamesTheThirdModelRatherThanCountingIt() throws {
         let byModel = [
             "claude-opus-5": totals(cost: 6.0),
             "claude-sonnet-5": totals(cost: 3.0),
@@ -277,8 +282,46 @@ final class UsageStatsTests: XCTestCase {
                     todayByModel: byModel))
         ])
         let line = try XCTUnwrap(fleet.usageSummaryLine)
-        XCTAssertTrue(line.contains("opus-5 60% · sonnet-5 30% · +1"), line)
+        XCTAssertTrue(line.contains("opus-5 60% · sonnet-5 30% · haiku-5 10% · cache"), line)
         XCTAssertFalse(line.contains("unpriced"), "nothing was missing from this total: \(line)")
+    }
+
+    /// The case naming every model exposes, on the real fleet that motivated
+    /// it: $5,079 of opus beside $1.55 of haiku is a 0.03% slice, and
+    /// `Int((0.0003 * 100).rounded())` is `0`. `haiku-4-5 0%` states that a
+    /// model which served today spent nothing — the same false zero
+    /// ``QuotaFormat/percent(_:)`` refuses for a `nil`, arriving instead through
+    /// the rounding. It was unreachable while only the top two models were
+    /// named, because a slice that small is never in the top two.
+    func testATinySliceSaysLessThanOnePercentRatherThanZero() throws {
+        let fleet = Fleet(accounts: [
+            row(
+                name: "alice@example.com",
+                usage: UsageRow(
+                    today: totals(cost: 5081.20, input: 100, requests: 900),
+                    window: nil,
+                    lastHour: totals(cost: 1.0),
+                    todayByModel: [
+                        "claude-opus-5": totals(cost: 5079.65, requests: 800),
+                        "claude-haiku-4-5-20251001": totals(cost: 1.55, requests: 100),
+                    ]))
+        ])
+        let line = try XCTUnwrap(fleet.usageSummaryLine)
+        XCTAssertTrue(line.contains("opus-5 100% · haiku-4-5 <1%"), line)
+        XCTAssertFalse(
+            line.contains("haiku-4-5 0%"),
+            "this model served 100 requests and cost $1.55 — it did not spend nothing: \(line)")
+    }
+
+    /// The other side of that rule: a model that genuinely cost nothing prints
+    /// the zero, because the zero is then the measurement. `<1%` for a real
+    /// `0%` would be as wrong in the other direction.
+    func testAMeasuredZeroShareStillPrintsZero() throws {
+        XCTAssertEqual(QuotaFormat.share(0), "0%")
+        XCTAssertEqual(QuotaFormat.share(nil), "n/a")
+        XCTAssertEqual(QuotaFormat.share(0.0049), "<1%")
+        XCTAssertEqual(QuotaFormat.share(0.005), "1%", "this one rounds up on its own")
+        XCTAssertEqual(QuotaFormat.share(1), "100%")
     }
 
     // MARK: The card's 5h figures
@@ -455,7 +498,9 @@ final class UsageStatsTests: XCTestCase {
             try XCTUnwrap(share[0].share), 0.75, accuracy: 0.0001,
             "both spellings are the same model, so its share is the sum of the two")
         let line = try XCTUnwrap(fleet.usageSummaryLine)
-        XCTAssertFalse(line.contains("+1"), "there is no third model to collapse: \(line)")
+        XCTAssertTrue(
+            line.contains("opus-5 75% · sonnet-5 25% · cache"),
+            "two models ran, so the line names two — not three, one of them twice: \(line)")
         XCTAssertEqual(
             fleet.todayByModelLabel.keys.sorted(), ["opus-5", "sonnet-5"],
             "the merge happens on the label, before anything ranks or counts it")


### PR DESCRIPTION
Three things the panel would not tell you, and one it forgot.

**The model mix ended in `+2`.** That token names no model, sizes none, and cannot be clicked to expand. It was not buying panel height either — the line already wraps, and `PanelHeight.headerOverflow` charges a wrap to the account list rather than the bottom of the panel. It was buying a couple of rows of list, and a fleet running four models is the ordinary case here.

**Naming every model surfaced a false zero.** A $1.55 slice beside $5,000 of opus is 0.03%, and `Int((0.0003 * 100).rounded())` is `0` — the line would have reported a model that served today as having spent nothing. `QuotaFormat.share` prints `<1%` for a positive share below half a percent, and still prints `0%` for a share that is genuinely zero. It was unreachable while only the top two models were named, because a slice that small is never in the top two.

**The footer named the proxy's build and not TcrBar's**, despite the app having the worse version of that gap: `/Applications/TcrBar.app` cannot be replaced while it runs, so an update that looks installed can leave the old app on screen. Every key needed was already written into the bundle by `build-tcrbar.sh` and read by nothing. Run outside a bundle there is no version, so nothing is drawn rather than a placeholder.

**"Keep this Mac awake" did not survive a restart.** It was deliberately not persisted; that is reversed here, and the doc-comment keeps the original reasoning rather than quietly deleting it. What makes it safe is that the state stopped being silent — `MenuBarMark` draws a tinted cup beside the gauge for exactly as long as the assertions are held. What is stored is *intent*, not `isOn`: a take that fails leaves the panel honestly OFF and retries next launch, and `releaseOnQuit` ends the hold without un-asking for it. Persistence is an injected `UserDefaults?` where `nil` means remember nothing, which the PNG harness, the shell probe and `KeepAwakeProbe` all need — any of the three would otherwise have rewritten the operator's own preference.

Scene 14 of the render harness now carries four priced models plus the unpriced one, because it is the scene that exists to review this line and could no longer show what the line does.

## Verification

- 366 tests green; both new rules broken on purpose first and watched to fail (`haiku-4-5 0%` for the share rule, and a quit recording OFF for the persistence rule).
- The built bundle rendered and looked at in both appearances: the five-entry header wraps to two lines, the list keeps its rows, the footer holds, the version tag draws.
- End-to-end against real IOKit on a `TCRBAR_DEV_BUILD` bundle id so it could not race the running app: preference on, a fresh launch held all three assertions within 3s and released them on exit; preference off, the same launch held none.
- `swift-format lint --strict` clean on every gated file.

https://claude.ai/code/session_01MWk25qPtsmGLJqWkxgeuHB
