### PR TITLE
chore: add the 0.2.30 appcast entry

### DIFF
--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.30</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.30</link>
+      <sparkle:version>463</sparkle:version>
+      <sparkle:shortVersionString>0.2.30</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Sun, 30 Aug 2026 14:39:38 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.30/TcrBar-0.2.30.dmg" type="application/octet-stream" sparkle:edSignature="YkMRkK8VHPTYiyE0DQiLA1GsbpvQGfZyv3oZfex+eJ1zGNGpyn4W+9LsegbLjXLpiTT2LMy98+DEQelykCYcDA==" length="6410715" />
+    </item>
+    <item>
       <title>TcrBar 0.2.29</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.29</link>
       <sparkle:version>458</sparkle:version>


### PR DESCRIPTION
`release-tcrbar.sh` stage 8 writes this entry and deliberately leaves it uncommitted: it can only exist after the tag does, so committing it as part of the release would look to the version gate like code shipping under an already-released version. That is why the gate exempts `apps/macos/appcast.xml` by name, and why the entry lands in its own change every release.

Leaving it uncommitted is not harmless. The v0.2.3 entry was written, never committed, and the published feed sat on 0.2.1 for a day with a signed 0.2.3 DMG already on the release.

Nine lines, one `<item>` for 0.2.30 (build 463), inserted at the marker.

## Verification

The committed file and the response from `releases/latest/download/appcast.xml` compare **byte-identical**, so the repo's copy and the live feed cannot disagree about what 0.2.30 is.

The feed itself is healthy — `curl` on the URL every installed TcrBar fetches returns `TcrBar-0.2.30.dmg` as its top entry, and `/releases/latest` is v0.2.30 carrying both `appcast.xml` and the DMG. The assetless-`latest` window that has broken this project five times did not open on this release.

https://claude.ai/code/session_01MWk25qPtsmGLJqWkxgeuHB
