### PR TITLE
feat: accept a claude setup-token credential via tcr login --token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2503,7 +2503,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "teamclaude-rs"
-version = "0.2.30"
+version = "0.2.31"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -129,6 +129,8 @@ Runs the browser OAuth flow and adds the resulting account to the pool.
 | `--force` | bool | `false` | override a refusal and write the config file anyway — never overrides a confirmed live route or a rejected api-key |
 | `--account <name>` | string | none | re-login a specific existing account, and refuse to write anything unless the identity that comes back resolves to it |
 | `--org <name-or-uuid>` | string | none | narrow an ambiguous `--account` match to a single org — same flag `tcr enable`/`tcr disable`/`tcr remove`/`tcr priority` take |
+| `--token` | bool | `false` | add an account from a `claude setup-token` credential instead of the browser flow — see below |
+| `--name <name>` | string | none | name the account added by `--token`, when its profile fetch comes back with no email |
 
 **`--account <name> [--org <org>]` targets one existing account and refuses to fix the
 wrong one.** Without it, `login` upserts by whatever identity the browser hands back — a
@@ -206,6 +208,56 @@ hatch for a proxy that answers but misbehaves. Detection is read-only throughout
 never signalled.
 
 The callback server binds a random loopback port, and tokens are never printed or logged.
+
+### `--token`: adding a `claude setup-token` credential
+
+`claude setup-token` mints a long-lived access token for a headless or CI-style login,
+without a browser. `tcr login --token` puts that token into the pool instead of running
+the browser flow — same downstream config write, same live-proxy-vs-file routing above,
+same "tokens are never printed or logged" guarantee, replacing only the browser half.
+
+The token is **read from stdin**, prompted for when stdin is a terminal:
+
+```
+claude setup-token | tcr login --token
+# or, interactively:
+tcr login --token
+Paste the token from `claude setup-token`: <paste>
+```
+
+It is never accepted as a `--token=<value>` argument, on purpose: an argv value is
+visible to every other process on the machine via `ps`, and shells routinely persist
+argv into history files. A prompt or a pipe are the only ways in.
+
+A `claude setup-token` credential is not shaped like a browser login, and two
+consequences follow directly from that:
+
+**There is no refresh token, ever — not "sometimes missing", genuinely never.** The
+mint requests only the `user:inference` scope, not the six scopes a normal `tcr login`
+gets, and even though the token endpoint itself does return a refresh token for this
+scope, the `claude` CLI that talks to it discards it before you ever see the output.
+There is nothing for `tcr` to capture. The account this adds therefore serves until its
+access token expires and then goes dead, with nothing to renew it — `tcr login --token`
+prints that hazard on every successful add, on both the live and the file route (the
+existing live-add warning above only fires through the running proxy's own wire route,
+which this offline path never touches). Its expiry is stamped as **one year from now**:
+that is `tcr`'s ASSUMPTION about what the mint requested (`expires_in: 31536000`, the
+value the Claude CLI asks for), not something read out of the token itself — `tcr
+status` shows that stamped date so an operator has something truthful to watch, rather
+than "no expiry".
+
+**There is usually no email either.** `/api/oauth/profile` needs more than
+`user:inference` to answer, so the profile fetch this add still makes will very likely
+come back empty — that is expected, not an error. Name the account with `--name`, or
+answer the prompt when it is omitted.
+
+**`--token` refuses outright when combined with `--account` or `--org`, and writes
+nothing.** Both flags exist to confirm that the identity a fresh login authenticates as
+matches a specific existing row — see `--account`'s own section above. An
+inference-only token carries no email and no account id for that confirmation to run
+against, so the check can never be evaluated, and an assertion that cannot be evaluated
+must fail closed rather than silently pass. Drop `--token` and use the browser flow with
+`--account` instead, or use `--token` alone.
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -249,7 +249,17 @@ than "no expiry".
 **There is usually no email either.** `/api/oauth/profile` needs more than
 `user:inference` to answer, so the profile fetch this add still makes will very likely
 come back empty — that is expected, not an error. Name the account with `--name`, or
-answer the prompt when it is omitted.
+answer the prompt when it is omitted. Decline the prompt too and it is named `unnamed`,
+or the first free `unnamed-2`, `unnamed-3` when that is taken.
+
+That collision scan is load-bearing rather than cosmetic. An account added this way has
+no email and no account uuid, so it is the one kind of row `tcr` can only tell apart by
+its **name** — every other account is resolved by uuid and org. Two of them sharing one
+name would resolve to the same row, and the second `--token` login would overwrite the
+first one's credentials instead of adding an account. The browser flow's `account-N`
+fallback is derived from the account *count*, which hands out a name already in use as
+soon as a row is removed; that is harmless for a credential carrying an identity to be
+resolved by, and is exactly the bug here, which is why this path does not share it.
 
 **`--token` refuses outright when combined with `--account` or `--org`, and writes
 nothing.** Both flags exist to confirm that the identity a fresh login authenticates as

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,7 +150,7 @@ gate above; it is not a credential anything downstream of the proxy needs.
 | `orgUuid` | string | absent | no | organization identity, used to match an in-memory account back to its on-disk entry |
 | `orgName` | string | absent | no | organization display name; also what `--org` matches against |
 | `accessToken` | string | n/a | **yes** | the OAuth access token |
-| `refreshToken` | string | absent | no | used to mint a new access token before expiry |
+| `refreshToken` | string | absent | no | used to mint a new access token before expiry — absent means the account cannot refresh itself, see below |
 | `expiresAt` | i64 | absent | no | access-token expiry as **epoch milliseconds** |
 | `priority` | i64 | absent → `0` | no | rotation order, **lower value = preferred** |
 | `switchThreshold` | float | absent → the global value | no | per-account override of the top-level threshold |
@@ -162,6 +162,16 @@ keep-warm; any other value is treated as a static key.
 Per-account keys the proxy does not model (`models`, `upstream`, `sx`, anything inherited
 from the older Node proxy) parse fine and survive a load→save round trip untouched, but
 nothing reads them.
+
+**An account with no `refreshToken` is not broken, but it is on a clock.** It serves
+requests normally until `accessToken` expires, then goes dead — there is nothing for the
+refresh loop (`src/manager/refresh.rs`) to mint a new access token from, so it skips the
+account cleanly rather than erroring, and it stays skipped. The only account shape that
+produces this today is one added via `tcr login --token` (`docs/cli.md` §"`--token`: adding
+a `claude setup-token` credential"): that credential's `user:inference`-only scope means the
+token endpoint's refresh token is never surfaced to `tcr` at all, so there is genuinely
+nothing to store. `tcr login --token` prints this hazard on every successful add, and stamps
+`expiresAt` with its own best estimate of when that clock runs out.
 
 ## `resetUrgencyTierHours`: spend the quota that is about to expire
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -330,6 +330,24 @@ struct LoginArgs {
     /// the same flag `tcr enable`/`tcr disable`/`tcr remove`/`tcr priority` take.
     #[arg(long)]
     org: Option<String>,
+    /// Add an account from a `claude setup-token` credential instead of the
+    /// browser flow — no value here. The token is read from stdin (prompted
+    /// when stdin is a TTY), never from argv: an argv value is visible in
+    /// `ps` and lands in shell history, both worse leaks than a stdin prompt.
+    /// A setup-token credential carries only the `user:inference` scope, so
+    /// there is no refresh token (the account serves until the token expires,
+    /// about a year, then goes dead — see the warning `tcr login --token`
+    /// prints) and usually no email (name it with `--name`, or answer the
+    /// prompt). Refuses to combine with `--account`/`--org`: an
+    /// inference-only token carries no identity for either flag to confirm,
+    /// and an assertion that cannot be evaluated must fail closed.
+    #[arg(long)]
+    token: bool,
+    /// Name the account added by `--token`, since its profile fetch usually
+    /// comes back empty (no email to name it from). Ignored by the browser
+    /// flow, which always has an email or its own prompt.
+    #[arg(long)]
+    name: Option<String>,
 }
 
 #[derive(clap::Args)]
@@ -945,10 +963,25 @@ fn apply_capability_defaults(cmd: &mut std::process::Command) {
 }
 
 /// `tcr login` — browser OAuth PKCE flow that authenticates a Claude account
-/// and appends (or updates) it in the drop-in config. The heavy lifting lives
-/// in [`oauth::login`]; this just resolves the config path and reports.
+/// and appends (or updates) it in the drop-in config, OR (`--token`) a
+/// `claude setup-token` credential read from stdin. The heavy lifting lives
+/// in [`oauth::login`] / [`oauth::login_with_token`]; this just resolves the
+/// config path and reports.
 async fn run_login(args: LoginArgs) -> anyhow::Result<()> {
     let config_path = args.config.clone().unwrap_or_else(config::default_path);
+    if args.token {
+        let name = oauth::login_with_token(
+            &config_path,
+            args.force,
+            args.name.as_deref(),
+            args.account.as_deref(),
+            args.org.as_deref(),
+        )
+        .await
+        .context("setup-token login failed")?;
+        println!("Logged in as '{name}'.");
+        return Ok(());
+    }
     let name = oauth::login(
         &config_path,
         args.force,

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -1600,7 +1600,10 @@ impl Manager {
             if let crate::identity::Resolved::One(position) = placement {
                 if let Some(account) = config.accounts.get_mut(position) {
                     account.access_token = tokens.access_token.clone();
-                    account.refresh_token = Some(tokens.refresh_token.clone());
+                    // THE TRAP: same invariant as `apply_refresh` in
+                    // `manager/refresh.rs` — `tokens.refresh_token` must be
+                    // `Some(...)` on every reachable refresh success.
+                    account.refresh_token = tokens.refresh_token.clone();
                     account.expires_at = Some(tokens.expires_at_ms);
                 }
             }
@@ -2898,7 +2901,7 @@ mod tests {
                 tokio::time::sleep(std::time::Duration::from_millis(20)).await;
                 Ok::<Tokens, OAuthError>(Tokens {
                     access_token: "fresh-access".to_string(),
-                    refresh_token: "fresh-refresh".to_string(),
+                    refresh_token: Some("fresh-refresh".to_string()),
                     expires_at_ms: crate::now_ms() + 3_600_000,
                 })
             })
@@ -2934,7 +2937,7 @@ mod tests {
                 } else {
                     Ok(Tokens {
                         access_token: "fresh-access".to_string(),
-                        refresh_token: "fresh-refresh".to_string(),
+                        refresh_token: Some("fresh-refresh".to_string()),
                         expires_at_ms: crate::now_ms() + 3_600_000,
                     })
                 }
@@ -5140,7 +5143,7 @@ mod tests {
                         None,
                         &Tokens {
                             access_token: format!("new-at-{i}"),
-                            refresh_token: format!("new-rt-{i}"),
+                            refresh_token: Some(format!("new-rt-{i}")),
                             expires_at_ms: crate::now_ms() + 3_600_000,
                         },
                     );

--- a/src/manager/refresh.rs
+++ b/src/manager/refresh.rs
@@ -184,7 +184,11 @@ impl Manager {
         let mut accounts = self.accounts.write().expect("accounts lock poisoned");
         if let Some(account) = accounts.get_mut(idx) {
             account.access_token = tokens.access_token.clone();
-            account.refresh_token = Some(tokens.refresh_token.clone());
+            // THE TRAP: `tokens.refresh_token` must be `Some(...)` on every
+            // reachable refresh success — see [`Tokens::refresh_token`]'s doc
+            // comment. Writing a bare `None` here would silently make a
+            // healthy account unrefreshable with no error and no log line.
+            account.refresh_token = tokens.refresh_token.clone();
             account.expires_at_ms = Some(tokens.expires_at_ms);
             account.refresh_retry_after_ms = cooldown_after;
             if account.status == AccountStatus::Error {

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -29,7 +29,15 @@ const REFRESH_TIMEOUT: Duration = Duration::from_secs(30);
 #[derive(Debug, Clone)]
 pub struct Tokens {
     pub access_token: String,
-    pub refresh_token: String,
+    /// `None` only for a `claude setup-token` credential ([`login_with_token`]):
+    /// that mint carries only the `user:inference` scope, and the CLI that
+    /// produces it never surfaces a refresh token to the caller at all — so
+    /// there is nothing to store. Every OTHER producer of a `Tokens` MUST
+    /// yield `Some(...)`: [`tokens_from_exchange_body`] `bail!`s rather than
+    /// return `None`, and [`refresh_access_token_at`] falls back to the
+    /// refresh token it was just called with when the endpoint omits a
+    /// rotated one. See that fallback's doc comment before touching either.
+    pub refresh_token: Option<String>,
     /// Epoch **milliseconds** at which `access_token` expires.
     pub expires_at_ms: i64,
 }
@@ -100,6 +108,13 @@ pub fn is_expiring_soon(expires_at_ms: Option<i64>, now_ms: i64) -> bool {
 
 /// Refresh an access token against [`TOKEN_ENDPOINT`], retrying `5xx`/network
 /// failures with exponential backoff. Auth rejections are returned immediately.
+///
+/// Always returns `Some(...)` in [`Tokens::refresh_token`] — see the fallback
+/// inside [`refresh_access_token_at`] and that field's doc comment. This is a
+/// load-bearing invariant: [`crate::manager::Manager::apply_refresh`] and
+/// [`crate::manager::Manager::persist_tokens`] write this value straight onto
+/// an existing account's row, so a stray `None` here would silently make a
+/// healthy account unrefreshable on its very next rotation.
 pub async fn refresh_access_token(
     client: &reqwest::Client,
     refresh_token: &str,
@@ -172,9 +187,10 @@ pub async fn refresh_access_token_at(
 
         return Ok(Tokens {
             access_token: data.access_token,
-            refresh_token: data
-                .refresh_token
-                .unwrap_or_else(|| refresh_token.to_string()),
+            refresh_token: Some(
+                data.refresh_token
+                    .unwrap_or_else(|| refresh_token.to_string()),
+            ),
             expires_at_ms,
         });
     }
@@ -258,6 +274,7 @@ impl TokenRefresher for NoRefresh {
 // onboard without hand-editing JSON.
 // ===========================================================================
 
+use std::io::IsTerminal as _;
 use std::io::Write as _;
 use std::path::Path;
 
@@ -583,7 +600,7 @@ fn tokens_from_exchange_body(text: &str) -> anyhow::Result<Tokens> {
 
     Ok(Tokens {
         access_token: data.access_token,
-        refresh_token,
+        refresh_token: Some(refresh_token),
         expires_at_ms,
     })
 }
@@ -710,7 +727,7 @@ pub fn upsert_account(
             let account = &mut config.accounts[index];
             account.account_type = "oauth".to_string();
             account.access_token = tokens.access_token.clone();
-            account.refresh_token = Some(tokens.refresh_token.clone());
+            account.refresh_token = tokens.refresh_token.clone();
             account.expires_at = Some(tokens.expires_at_ms);
             // Backfill any identity field the stored entry was missing (e.g. a
             // legacy pre-org entry newly profiled), without overwriting known
@@ -741,7 +758,7 @@ pub fn upsert_account(
                 org_uuid,
                 org_name,
                 access_token: tokens.access_token.clone(),
-                refresh_token: Some(tokens.refresh_token.clone()),
+                refresh_token: tokens.refresh_token.clone(),
                 expires_at: Some(tokens.expires_at_ms),
                 priority: Some(next_priority),
                 switch_threshold: None,
@@ -1106,6 +1123,127 @@ pub async fn login(
     .await
 }
 
+/// Our ASSUMPTION about a `claude setup-token` credential's lifetime — one
+/// year, matching the `expires_in: 31536000` the Claude CLI requests when it
+/// mints one. Not something [`login_with_token`] can read out of the token
+/// itself (it never sees the token-endpoint response, only the finished
+/// access token pasted or piped in), so this is a best estimate, stamped so
+/// `tcr status` shows something truthful rather than "no expiry".
+const SETUP_TOKEN_ASSUMED_LIFETIME_MS: i64 = 365 * 24 * 60 * 60 * 1000;
+
+/// Read a `claude setup-token` access token from stdin — never from argv (see
+/// `--token`'s doc comment in `main.rs`: an argv value is visible in `ps` and
+/// lands in shell history). Prompts on stderr first when stdin is a
+/// terminal; reads a bare line straight through when it is piped. Never logs
+/// or prints the token back.
+fn read_setup_token() -> anyhow::Result<String> {
+    if std::io::stdin().is_terminal() {
+        eprint!("Paste the token from `claude setup-token`: ");
+        let _ = std::io::stderr().flush();
+    }
+    let mut line = String::new();
+    std::io::stdin()
+        .read_line(&mut line)
+        .context("read setup-token from stdin")?;
+    let token = line.trim().to_string();
+    if token.is_empty() {
+        bail!("no token read from stdin — pipe or paste the output of `claude setup-token`");
+    }
+    Ok(token)
+}
+
+/// Add an account from a `claude setup-token` credential instead of the
+/// browser flow. Reuses every downstream layer [`login`] does — the same
+/// [`login_route`] guard against a live server, the same [`fetch_profile`] /
+/// [`finish_login`] pipeline — and replaces only the browser half: instead of
+/// a PKCE round trip, the access token is read from stdin
+/// ([`read_setup_token`]) and wrapped in a [`Tokens`] with `refresh_token:
+/// None` — a setup-token mint carries only the `user:inference` scope, and
+/// the Claude CLI that produces it never surfaces its refresh token to the
+/// caller, so there is genuinely nothing to store.
+///
+/// `--account`/`--org` are refused up front (before the port probe or the
+/// stdin read): an inference-only token carries no identity for
+/// [`assert_requested_identity`] to confirm, and an assertion that cannot be
+/// evaluated must fail closed rather than pass — so this calls [`finish_login`]
+/// directly, never `finish_login_checked`.
+///
+/// Because the scope is inference-only, [`fetch_profile`] will very likely
+/// come back all-`None` (no email, no org) — expected, not an error. The
+/// account name falls back to `--name`, then a prompt, exactly like the
+/// browser flow's own fallback ([`prompt_account_name`]).
+///
+/// Always prints [`crate::proxy::NO_REFRESH_TOKEN_WARNING`] on success: this
+/// account serves until its (assumed) one-year expiry and then goes dead,
+/// with nothing to renew it, and — unlike the live-add wire route — this
+/// offline path has no other caller that would say so.
+/// Name a setup-token account: the profile's email when the (usually failed)
+/// fetch happened to carry one, else `name` (`--name`), else a prompt —
+/// split out of [`login_with_token`] so the fallback chain is directly
+/// testable without a real stdin prompt.
+fn resolve_setup_token_name(profile: &Profile, name: Option<&str>, fallback: &str) -> String {
+    match &profile.email {
+        Some(email) => email.clone(),
+        None => match name {
+            Some(explicit) => explicit.to_string(),
+            None => prompt_account_name(fallback),
+        },
+    }
+}
+
+pub async fn login_with_token(
+    config_path: &Path,
+    force: bool,
+    name: Option<&str>,
+    account: Option<&str>,
+    org: Option<&str>,
+) -> anyhow::Result<String> {
+    if account.is_some() || org.is_some() {
+        bail!(
+            "--token cannot be combined with --account or --org: a `claude setup-token` \
+             credential carries only the user:inference scope, so it has no email and no \
+             account id for either flag to confirm against — an identity assertion that \
+             cannot be evaluated must fail closed rather than pass. Log in with --token alone \
+             (use --name to choose the account name), or drop --token and use the browser flow \
+             with --account instead. Nothing was written."
+        );
+    }
+
+    let port = login_target_port(config_path);
+    let incumbent = singleton::live_proxy_server(port);
+    let route = login_route(config_path, incumbent, port, force).await?;
+    if let LoginRoute::Refuse(msg) = route {
+        bail!("{}", msg);
+    }
+
+    let access_token = read_setup_token()?;
+    let tokens = Tokens {
+        access_token,
+        refresh_token: None,
+        expires_at_ms: crate::now_ms() + SETUP_TOKEN_ASSUMED_LIFETIME_MS,
+    };
+
+    let mut config = load_or_default(config_path)?;
+
+    let profile = fetch_profile(&tokens.access_token).await;
+    let fallback = format!("account-{}", config.accounts.len() + 1);
+    let resolved_name = resolve_setup_token_name(&profile, name, &fallback);
+
+    let result = finish_login(
+        config_path,
+        route,
+        &mut config,
+        &resolved_name,
+        &tokens,
+        profile,
+    )
+    .await;
+    if result.is_ok() {
+        eprintln!("[tcr] warning: {}", crate::proxy::NO_REFRESH_TOKEN_WARNING);
+    }
+    result
+}
+
 /// Whether `s` is plausibly an email address — no whitespace, and exactly one
 /// `@` with at least one character on each side. Deliberately not a full RFC
 /// 5322 validator: this only ever gates whether a value is safe to hand to
@@ -1296,7 +1434,7 @@ fn persist_via_file(
         org_uuid: profile.org_uuid,
         org_name: profile.org_name,
         access_token: tokens.access_token.clone(),
-        refresh_token: Some(tokens.refresh_token.clone()),
+        refresh_token: tokens.refresh_token.clone(),
         expires_at: Some(tokens.expires_at_ms),
         priority: None,
         switch_threshold: None,
@@ -1442,7 +1580,7 @@ async fn finish_login(
                 org_uuid: profile.org_uuid.clone(),
                 org_name: profile.org_name.clone(),
                 access_token: tokens.access_token.clone(),
-                refresh_token: Some(tokens.refresh_token.clone()),
+                refresh_token: tokens.refresh_token.clone(),
                 expires_at: Some(tokens.expires_at_ms),
                 priority: None,
                 switch_threshold: None,
@@ -1712,8 +1850,53 @@ mod tests {
         )
         .expect("a present refresh_token must return Ok");
         assert_eq!(tokens.access_token, "at");
-        assert_eq!(tokens.refresh_token, "rt");
+        assert_eq!(tokens.refresh_token.as_deref(), Some("rt"));
         assert_eq!(tokens.expires_at_ms, 1_700_000_000_000);
+    }
+
+    /// THE TRAP (bridge §"THE TRAP"): a refresh whose response omits a
+    /// rotated `refresh_token` must fall back to the token it was called
+    /// with — never `None`. `apply_refresh` (`manager/refresh.rs`) and
+    /// `persist_tokens` (`manager/mod.rs`) both write `tokens.refresh_token`
+    /// straight onto an existing account's row with no other check, so a
+    /// bare `None` here would silently make a healthy account unrefreshable
+    /// on its very next rotation, with no error and no log line.
+    ///
+    /// Watched failing: with the `unwrap_or_else` fallback in
+    /// `refresh_access_token_at` replaced by a bare `data.refresh_token`
+    /// (still type-correct — `Option<String>` on both sides, so this is a
+    /// silent behavioural regression, not a compile error), this test failed
+    /// with `left: None, right: Some("rt-original")`. Restored, it passes.
+    #[tokio::test]
+    async fn refresh_access_token_at_preserves_stored_refresh_token_when_response_omits_one() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let endpoint = format!("http://127.0.0.1:{port}/");
+        tokio::spawn(async move {
+            let app = axum::Router::new().route(
+                "/",
+                axum::routing::post(|| async {
+                    // A real rotation response that omits `refresh_token` —
+                    // exactly the shape Anthropic's endpoint sends when it
+                    // does not rotate the refresh token on this call.
+                    axum::Json(serde_json::json!({
+                        "access_token": "at-fresh",
+                        "expires_at": 1_893_456_000_000i64
+                    }))
+                }),
+            );
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let client = reqwest::Client::new();
+        let tokens = refresh_access_token_at(&client, "rt-original", &endpoint)
+            .await
+            .expect("a refresh with no rotated refresh_token must still succeed");
+        assert_eq!(
+            tokens.refresh_token.as_deref(),
+            Some("rt-original"),
+            "must fall back to the refresh token it was called with, never None"
+        );
     }
 
     #[test]
@@ -1762,7 +1945,7 @@ mod tests {
     fn tokens(access: &str, refresh: &str, expires: i64) -> Tokens {
         Tokens {
             access_token: access.to_string(),
-            refresh_token: refresh.to_string(),
+            refresh_token: Some(refresh.to_string()),
             expires_at_ms: expires,
         }
     }
@@ -3642,5 +3825,159 @@ mod tests {
         );
 
         std::fs::remove_file(&path).ok();
+    }
+
+    // --- setup-token (`tcr login --token`) ----------------------------------
+
+    /// An all-`None` [`Profile`] — the expected shape for a `claude
+    /// setup-token` credential, whose scope is inference-only and so its
+    /// `/api/oauth/profile` fetch will very likely fail.
+    fn all_none_profile() -> Profile {
+        Profile {
+            email: None,
+            account_uuid: None,
+            org_uuid: None,
+            org_name: None,
+        }
+    }
+
+    /// A setup-token-shaped write: [`finish_login`] given a [`Tokens`] with
+    /// `refresh_token: None` (what [`login_with_token`] always constructs)
+    /// must write `refreshToken` ABSENT from the JSON — not `null` — and
+    /// `expiresAt` set to the assumed one-year expiry.
+    ///
+    /// Watched failing: with `persist_via_file`'s account literal changed to
+    /// `refresh_token: Some("bogus-rt".to_string())` (a plausible slip if
+    /// someone "fixed" the E0308 that removing `Some(...)` around the new
+    /// `Option<String>` field would otherwise cause), this test failed with
+    /// `refreshToken must be ABSENT ... {"refreshToken":"bogus-rt",...}`.
+    /// Restored, it passes.
+    #[tokio::test]
+    async fn setup_token_account_writes_with_refresh_token_absent_and_expires_at_set() {
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-setup-token-write-{}-{}.json",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(&path, r#"{ "accounts": [] }"#).unwrap();
+        let mut config = load_or_default(&path).unwrap();
+
+        let setup_tokens = Tokens {
+            access_token: "at-setup".to_string(),
+            refresh_token: None,
+            expires_at_ms: 1_893_456_000_000,
+        };
+
+        let name = finish_login(
+            &path,
+            LoginRoute::File,
+            &mut config,
+            "gina",
+            &setup_tokens,
+            all_none_profile(),
+        )
+        .await
+        .expect("a setup-token credential with no refresh token must still write");
+        assert_eq!(name, "gina");
+
+        let doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let account = &doc["accounts"][0];
+        assert_eq!(account["name"], serde_json::json!("gina"));
+        assert!(
+            account.get("refreshToken").is_none(),
+            "refreshToken must be ABSENT (skip_serializing_if), not written as null or a \
+             leftover value: {account}"
+        );
+        assert_eq!(
+            account["expiresAt"],
+            serde_json::json!(1_893_456_000_000i64)
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// `--token` combined with `--account` must refuse and write nothing —
+    /// checked byte-for-byte, not just "still has 2 accounts": an inference-
+    /// only token carries no identity for `--account` to confirm against.
+    ///
+    /// Watched failing: with the `account.is_some() || org.is_some()` guard
+    /// at the top of `login_with_token` deleted, this test hung waiting on a
+    /// real stdin read (the function fell through past the refusal straight
+    /// into `read_setup_token`) instead of returning the expected `Err` —
+    /// the observable failure for a test with no stdin to feed it. Restored,
+    /// it returns immediately with the refusal and the file is untouched.
+    #[tokio::test]
+    async fn login_with_token_refuses_with_account_and_writes_nothing() {
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-setup-token-refuse-account-{}-{}.json",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(&path, two_account_seed()).unwrap();
+        let before = std::fs::read_to_string(&path).unwrap();
+
+        let err = login_with_token(&path, false, None, Some("alice@example.com"), None)
+            .await
+            .expect_err("--token combined with --account must refuse");
+        assert!(err.to_string().contains("--account"), "{}", err.to_string());
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            before, after,
+            "the file must be byte-identical — --token+--account must write nothing"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// `--token` combined with `--org` (no `--account`) must refuse too — the
+    /// same "no identity to confirm against" reasoning applies to either flag
+    /// alone.
+    #[tokio::test]
+    async fn login_with_token_refuses_with_org_and_writes_nothing() {
+        let path = std::env::temp_dir().join(format!(
+            "tcr-oauth-setup-token-refuse-org-{}-{}.json",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(&path, two_account_seed()).unwrap();
+        let before = std::fs::read_to_string(&path).unwrap();
+
+        let err = login_with_token(&path, false, None, None, Some("Corp"))
+            .await
+            .expect_err("--token combined with --org must refuse");
+        assert!(err.to_string().contains("--org"), "{}", err.to_string());
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            before, after,
+            "the file must be byte-identical — --token+--org must write nothing"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// An all-`None` profile plus `--name` must produce that exact name,
+    /// without ever reaching the stdin prompt — the profile-email branch is
+    /// skipped (no email), the `--name` branch is taken instead of falling
+    /// through to `prompt_account_name`.
+    #[test]
+    fn resolve_setup_token_name_prefers_explicit_name_over_prompt() {
+        let name = resolve_setup_token_name(&all_none_profile(), Some("bob-work"), "account-1");
+        assert_eq!(name, "bob-work");
+    }
+
+    /// The profile's email still wins over `--name` when the fetch DID come
+    /// back with one — inference-only scope makes this the unlikely case,
+    /// not the impossible one.
+    #[test]
+    fn resolve_setup_token_name_prefers_profile_email_over_name() {
+        let name = resolve_setup_token_name(
+            &profile_named("carol@example.com"),
+            Some("ignored"),
+            "account-1",
+        );
+        assert_eq!(name, "carol@example.com");
     }
 }

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -1181,6 +1181,33 @@ fn read_setup_token() -> anyhow::Result<String> {
 /// fetch happened to carry one, else `name` (`--name`), else a prompt —
 /// split out of [`login_with_token`] so the fallback chain is directly
 /// testable without a real stdin prompt.
+/// The name a setup-token account falls back to when the operator declines to
+/// type one: `unnamed`, or the first free `unnamed-N` when that is taken.
+///
+/// Deliberately NOT the browser flow's `account-{len+1}` fallback. That one is
+/// derived from the account COUNT, so removing a row and adding another hands
+/// out a name already in use — harmless for a credential that carries an email
+/// and a uuid to be resolved by, and not harmless here. A setup-token account
+/// has neither (the scope is inference-only), so
+/// [`crate::identity::resolve`] can only match it on its NAME: two accounts
+/// sharing one would resolve onto the same row, and the second login would
+/// overwrite the first one's token instead of adding an account.
+///
+/// Scanning for the first free suffix rather than counting is what makes that
+/// structurally impossible instead of merely unlikely.
+fn unnamed_fallback(accounts: &[Account]) -> String {
+    const BASE: &str = "unnamed";
+    if !accounts.iter().any(|a| a.name == BASE) {
+        return BASE.to_string();
+    }
+    // Start at 2: `unnamed` itself is the first, so the next one a human reads
+    // should be `unnamed-2`, not `unnamed-1`.
+    (2..)
+        .map(|n| format!("{BASE}-{n}"))
+        .find(|candidate| !accounts.iter().any(|a| &a.name == candidate))
+        .expect("an unbounded range always yields a free name")
+}
+
 fn resolve_setup_token_name(profile: &Profile, name: Option<&str>, fallback: &str) -> String {
     match &profile.email {
         Some(email) => email.clone(),
@@ -1226,7 +1253,7 @@ pub async fn login_with_token(
     let mut config = load_or_default(config_path)?;
 
     let profile = fetch_profile(&tokens.access_token).await;
-    let fallback = format!("account-{}", config.accounts.len() + 1);
+    let fallback = unnamed_fallback(&config.accounts);
     let resolved_name = resolve_setup_token_name(&profile, name, &fallback);
 
     let result = finish_login(
@@ -3979,5 +4006,60 @@ mod tests {
             "account-1",
         );
         assert_eq!(name, "carol@example.com");
+    }
+
+    // --- the `unnamed` fallback ---------------------------------------------
+
+    /// An `Account` carrying nothing but a name — the only field
+    /// [`unnamed_fallback`] reads.
+    fn named_account(name: &str) -> Account {
+        Account {
+            name: name.to_string(),
+            account_type: "oauth".to_string(),
+            account_uuid: None,
+            org_uuid: None,
+            org_name: None,
+            access_token: "at-placeholder".to_string(),
+            refresh_token: None,
+            expires_at: None,
+            priority: None,
+            switch_threshold: None,
+            disabled: None,
+            groups: None,
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    #[test]
+    fn unnamed_fallback_is_plain_unnamed_when_free() {
+        assert_eq!(unnamed_fallback(&[]), "unnamed");
+        assert_eq!(
+            unnamed_fallback(&[named_account("alice@example.com")]),
+            "unnamed"
+        );
+    }
+
+    /// The collision case, and the reason this function exists at all: an
+    /// inference-only account has no email and no uuid, so `identity::resolve`
+    /// can only match it by NAME. Handing out `unnamed` twice would resolve the
+    /// second login onto the first row and overwrite its token instead of
+    /// adding an account.
+    #[test]
+    fn unnamed_fallback_skips_taken_names() {
+        assert_eq!(unnamed_fallback(&[named_account("unnamed")]), "unnamed-2");
+        assert_eq!(
+            unnamed_fallback(&[named_account("unnamed"), named_account("unnamed-2")]),
+            "unnamed-3"
+        );
+    }
+
+    /// Gaps are filled rather than skipped past — the name is chosen by
+    /// scanning for the first FREE suffix, never by counting rows, so removing
+    /// `unnamed-2` and adding an account reuses that slot instead of colliding
+    /// with `unnamed-3`. A count-derived fallback gets this wrong.
+    #[test]
+    fn unnamed_fallback_fills_a_gap_left_by_a_removed_account() {
+        let accounts = [named_account("unnamed"), named_account("unnamed-3")];
+        assert_eq!(unnamed_fallback(&accounts), "unnamed-2");
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1620,8 +1620,11 @@ pub struct AddAccountResponse {
 
 /// Shown when the submitted account carries no refresh token: it will serve
 /// until its access token expires and then go dead, silently, unless the
-/// operator hears about it now.
-const NO_REFRESH_TOKEN_WARNING: &str =
+/// operator hears about it now. `pub(crate)` so [`crate::oauth::login_with_token`]
+/// can print the same hazard on the offline (file) route too — that path
+/// never goes through this module's `add_account_handler`, so nothing else
+/// would say it.
+pub(crate) const NO_REFRESH_TOKEN_WARNING: &str =
     "this account has no refresh token — it will serve until its access token expires, then go dead";
 
 /// Join whichever of the durable-persist warning and the no-refresh-token
@@ -8220,7 +8223,7 @@ mod tests {
                 Box::pin(async {
                     Ok(crate::oauth::Tokens {
                         access_token: "fresh-access".into(),
-                        refresh_token: "fresh-refresh".into(),
+                        refresh_token: Some("fresh-refresh".into()),
                         expires_at_ms: crate::now_ms() + 3_600_000,
                     })
                 })


### PR DESCRIPTION
Adds `tcr login --token`, so a credential minted by `claude setup-token` can join the pool without a browser round trip — useful on a headless box, or when the account's browser session lives on a different machine.

It reuses every correctness layer the browser flow already has (`login_route`'s live-vs-file decision, `fetch_profile`, `finish_login`) and replaces only the half that opens a browser.

## What this kind of credential actually is

Worth stating up front, because it drives every design decision below. `claude setup-token` runs the same PKCE flow with the same client id, but passes `inferenceOnly`, so the mint carries **only the `user:inference` scope** and asks for a one-year `expires_in`. The server returns a refresh token; the Claude CLI discards it before the user ever sees it. On the wire it is `Authorization: Bearer` plus `anthropic-beta: oauth-2025-04-20` — both already what this proxy sends, so there are **no wire changes here**.

Three consequences the code has to deal with:

**No refresh token, ever.** `Tokens.refresh_token` becomes `Option<String>`. The refresh loop already tolerated this (`refresh_plan` returns `None` and no-ops), so nothing there needed changing.

**No identity.** `/api/oauth/profile` needs more than `user:inference`, so the profile fetch this path still makes will usually come back empty. That is expected, not an error — the account is named from `--name`, or a prompt, or `unnamed`.

**No `--account`/`--org`.** Both flags exist to confirm a fresh login authenticated as a specific existing row. An inference-only token carries no identity to confirm against, and an assertion that cannot be evaluated must fail closed, so `--token` refuses outright rather than quietly skipping the check.

## The trap this change had to avoid

Making `Tokens.refresh_token` an `Option` is the dangerous part. **Five** sites wrote `Some(tokens.refresh_token.clone())` into an account. Two of them — `apply_refresh` and `persist_tokens` — are on the *refresh success* path, so letting a bare `None` reach them would write `None` onto a **healthy** account the first time Anthropic omits a rotated refresh token, silently making every account in the fleet unrefreshable, with no error and no log line.

The invariant that prevents it: `refresh_access_token_at` keeps its `unwrap_or_else` fallback to the current refresh token, so the refresh path always yields `Some(...)`. `None` is reachable only from the new setup-token path. Both manager sites now carry a comment saying so, and there is a test at the `refresh_access_token_at` level pinning it.

## Why `unnamed` scans instead of counting

The browser flow falls back to `account-{len+1}`, derived from the account *count*. That is safe there because such an account has an email and a UUID for `identity::resolve` to match on. A setup-token account has neither, so its **name is the only thing it can be resolved by** — and a count-derived name is handed out again as soon as a row is removed. Two accounts sharing one name resolve to the same row, and the second `--token` login would overwrite the first one's credentials instead of adding an account. So this path scans for the first free `unnamed-N`, which makes the collision structurally impossible rather than merely unlikely.

## Known limitations, stated rather than discovered later

- **The account is quota-unknown until it serves once.** The dedicated `/api/oauth/usage` probe is gated on having a refresh token, so it skips these rows. Quota still arrives from the `anthropic-ratelimit-unified-*` response headers on every served request, so the account is lazily informed rather than blind — but it has no numbers before its first request, and none while idle.
- **It is excluded from keep-warm**, by the same refresh-token filter.
- **Nothing marks it dead when the token expires or is revoked.** `AccountStatus::Error` is only ever set by a rejected *refresh*, which this account can never attempt. Follow-up work, and it needs a real token to measure against; the existing constraint that a request-level 401 must not condemn a row (rotation churn) means the rule has to be narrower than "401 means dead".
- **The one-year expiry is stamped, not read.** Nothing in the token is introspectable, so `expiresAt` records what the mint requests. It gives `tcr status` something truthful to show instead of "no expiry", but it is an assumption and is documented as one.
- **The pasted token echoes to the terminal.** Suppressing it would need a new dependency, which is a separate decision. It is read from stdin rather than argv so it stays out of `ps` and shell history, and it is never printed or logged by `tcr` itself.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo check --all-targets` and `cargo test` all exit 0 — **988 tests passed, 0 failed** across 8 binaries, re-run independently rather than taken from the implementing agent's report.

Every new test was watched failing before being trusted: the production line it guards was broken, the failure confirmed as the expected one, then restored. For the naming guard that was `left: "unnamed"` / `right: "unnamed-2"` on both collision tests.

The `0.2.30 → 0.2.31` version bump is not discretionary — `check-release-version.sh` blocks a commit while the version matches an already-tagged release.

https://claude.ai/code/session_019S6QSbz7z8GRNRSs1B6ot3
