### PR TITLE
chore: add the 0.2.31 appcast entry

### DIFF
--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.31</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.31</link>
+      <sparkle:version>465</sparkle:version>
+      <sparkle:shortVersionString>0.2.31</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Tue, 01 Sep 2026 14:30:46 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.31/TcrBar-0.2.31.dmg" type="application/octet-stream" sparkle:edSignature="mifIgBwFNl5tTikLgt9jtlVCnm/hCyqIiDa6u5C9jHSvdfssA/0FR9elKR0YwbdKiUGM/Jq21/pu1JLtxucrBg==" length="6420609" />
+    </item>
+    <item>
       <title>TcrBar 0.2.30</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.30</link>
       <sparkle:version>463</sparkle:version>


### PR DESCRIPTION
Stage 8 of `release-tcrbar.sh` writes this entry and deliberately leaves it uncommitted — the entry can only exist after the tag does, so committing it with the release would look to the version gate like code shipping under an already-released version.

Leaving it uncommitted is not harmless: the `v0.2.3` entry was written, never committed, and the published feed sat on `0.2.1` for a day with a signed `0.2.3` DMG already sitting on the release.

Verified against the surface a user actually reads, not a workflow exit code: the file here and the live response from `releases/latest/download/appcast.xml` are both 15950 bytes and compare equal under `cmp`, so the repo's copy and the served feed cannot disagree about what 0.2.31 is.

`v0.2.31` is published with 15 assets including `TcrBar-0.2.31.dmg` (6420609 bytes) and `appcast.xml`, is not marked prerelease, and `latest` resolves to it. The live feed serves `TcrBar-0.2.31.dmg` on top.

https://claude.ai/code/session_019S6QSbz7z8GRNRSs1B6ot3