### PR TITLE
feat: guard the appcast 404 window on a tag push

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2503,7 +2503,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.31"
+version = "0.2.32"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "teamclaude-rs"
-version = "0.2.31"
+version = "0.2.32"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/scripts/guard-appcast-window.sh
+++ b/scripts/guard-appcast-window.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Close the 404 window documented in docs/RELEASING.md § "Known gap".
+#
+# A tag push makes cargo-dist publish a GitHub Release with the CLI tarballs and
+# NO appcast.xml. That release becomes `latest`, and the SUFeedURL compiled into
+# every installed TcrBar — releases/latest/download/appcast.xml — 404s until the
+# DMG lands minutes later. Marking the tag prerelease keeps `latest` pointing at
+# the previous good release; release-tcrbar.sh stage 9 clears the flag once the
+# assets are up.
+#
+# The in-repo guard (quarantine_if_assetless) does not fire here: it tests for a
+# release with NO assets, and a cargo-dist release has thirteen. This tests the
+# predicate that actually matters — no appcast.xml asset.
+#
+# Watched firing, both directions, before this was trusted — a guard that has
+# only ever reported "safe" proves nothing:
+#
+#   printf '%s' '{"isPrerelease":false,"assets":[{"name":"tcr.tar.xz"},{"name":"sha256.sum"}]}' \
+#     | python3 -c 'import json,sys; d=json.load(sys.stdin); print("yes" if any(a["name"]=="appcast.xml" for a in d.get("assets",[])) else "no")'
+#   # -> no   (window open; guard marks prerelease. quarantine_if_assetless
+#   #          stands down here, because assets ARE present — that is the gap.)
+#
+#   printf '%s' '{"isPrerelease":false,"assets":[{"name":"appcast.xml"}]}' | (same)
+#   # -> yes  (safe; guard stands down)
+set -eu
+
+TAG="${1:?usage: guard-appcast-window.sh vX.Y.Z}"
+REPO=dhkts1/teamclaude-rs
+DEADLINE=$(( $(date +%s) + 1800 ))
+
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    if assets=$(gh release view "$TAG" --repo "$REPO" --json assets,isPrerelease 2>/dev/null); then
+        has_appcast=$(printf '%s' "$assets" | python3 -c 'import json,sys; d=json.load(sys.stdin); print("yes" if any(a["name"]=="appcast.xml" for a in d.get("assets",[])) else "no")')
+        is_pre=$(printf '%s' "$assets" | python3 -c 'import json,sys; print(json.load(sys.stdin)["isPrerelease"])')
+        if [ "$has_appcast" = "yes" ]; then
+            echo "SAFE: $TAG carries appcast.xml — window never opened, or stage 9 closed it"
+            exit 0
+        fi
+        if [ "$is_pre" = "True" ]; then
+            echo "HELD: $TAG is prerelease with no appcast yet — latest still points at the previous release"
+        else
+            echo "WINDOW OPEN: $TAG is latest with no appcast.xml — marking prerelease"
+            gh release edit "$TAG" --repo "$REPO" --prerelease
+            echo "MARKED: $TAG now prerelease"
+        fi
+    fi
+    sleep 15
+done
+
+echo "GAVE UP after 30m with no appcast.xml on $TAG — check the feed by hand:"
+echo "  curl -sL https://github.com/$REPO/releases/latest/download/appcast.xml | grep -oE 'TcrBar-[0-9.]+\\.dmg' | head -2"
+exit 1


### PR DESCRIPTION
A tag push makes cargo-dist publish its GitHub Release immediately, with the CLI tarballs and **no `appcast.xml`**. That release becomes `latest`, so `releases/latest/download/appcast.xml` — the `SUFeedURL` compiled into every installed TcrBar — 404s until the DMG lands minutes later. No install can check for updates during that window, and shipping a new build does not fix it, because the broken URL is already compiled into the installs that are failing.

`docs/RELEASING.md` § "Known gap" documents this, and names why the existing guard misses it: `quarantine_if_assetless` tests for a release with **no assets**, and a cargo-dist release has thirteen. It is aimed at a state this pipeline no longer produces.

This tests the predicate that actually matters — no `appcast.xml` asset — and marks the tag prerelease so `latest` falls back to the previous good release. `release-tcrbar.sh` stage 9 clears the flag once assets are up. It gives up loudly after 30 minutes with the by-hand feed check, rather than going quiet: silence is not the same as safe.

### Watched firing

A guard that has only ever reported "safe" proves nothing, so both directions were exercised before trusting it, with the fixtures recorded in the script header:

- assets present, none of them `appcast.xml` → guard **fires**. This is precisely the case `quarantine_if_assetless` stands down on, because assets *are* present.
- `appcast.xml` present → guard **stands down**.

### Run in anger

Used during the 0.2.31 release, where it reported `SAFE: v0.2.31 carries appcast.xml`. The release appeared after 420s and stage 9 uploaded immediately, so the window never opened. That is the difference between having got the timing right once and the timing not being able to hurt us.

### Version bump

`0.2.31 → 0.2.32` is not discretionary — `check-release-version.sh` classifies `scripts/` as shippable and blocks a commit while the version matches an already-tagged release.

https://claude.ai/code/session_019S6QSbz7z8GRNRSs1B6ot3