### PR TITLE
fix: make a reserved group private in both directions

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -1146,6 +1146,22 @@ struct AccountRow: View {
                 .help("Out of the rotation — `tcr` sends this account no traffic.")
         } else if account.health == .needsRelogin {
             EmptyView()
+        } else if account.servesGroupTrafficOnly {
+            // Predicate lives on the model (`Account.servesGroupTrafficOnly`) so
+            // it is testable without SwiftUI and matches the server's ANY rule.
+            //
+            // This branch exists because its absence was itself the bug: a
+            // reserved account rendered `GIL` + `ROTATING` side by side, which
+            // reads as "tagged AND in the pool" — the exact state an operator
+            // reserves a group to prevent, shown as if nothing had happened.
+            StatusPill("group only", tint: Tok.inkFaint)
+                .help(
+                    "Reserved — serves only requests that ask for one of its "
+                        + "groups by name. Pool traffic never lands here, and this "
+                        + "group's own traffic never leaves it: a `--group` request "
+                        + "with no member free waits, or fails, rather than using "
+                        + "another account."
+                )
         } else {
             StatusPill("rotating", tint: Tok.inkFaint)
                 .help(

--- a/apps/macos/Sources/TcrBar/Tokens.swift
+++ b/apps/macos/Sources/TcrBar/Tokens.swift
@@ -488,7 +488,20 @@ public struct GroupChip: View {
                 )
         )
         .fixedSize()
-        .help(tag.isReserved ? "\(tag.name) (reserved — held out of the general pool)" : tag.name)
+        .help(
+            tag.isReserved
+                // Both directions, because half the sentence is how the pool-facing
+                // half got read as the whole feature: "held out of the general pool"
+                // says nothing about whether THIS group's traffic can wander off to
+                // another account, and it can't.
+                ? "\(tag.name) (reserved — pool traffic never uses this account, "
+                    + "and --group \(tag.name) never serves from outside the group)"
+                // Named explicitly rather than left bare: a group tag with no lock is
+                // decoration, and reading it as isolation is what lets pool traffic
+                // sit on an account someone believed was private.
+                : "\(tag.name) (tagged only — not reserved, so pool traffic still "
+                    + "uses this account and --group \(tag.name) may be served by another)"
+        )
     }
 }
 

--- a/apps/macos/Sources/TcrBarCore/FleetStatus.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetStatus.swift
@@ -1380,6 +1380,25 @@ public struct Account: Decodable, Equatable, Identifiable, Sendable {
             )
         }
     }
+
+    /// Whether this account is held out of GENERAL rotation because at least one
+    /// of its groups is reserved — the panel's "group only" state, and the
+    /// reason it must not also claim to be "rotating".
+    ///
+    /// `contains`, deliberately not `allSatisfy`: the server blocks unrequested
+    /// traffic when ANY group on the account is reserved
+    /// (`Manager::reserved_blocks` — `groups.iter().any(...)`), so an account in
+    /// reserved `codereview` plus plain `dev` serves no pool traffic either.
+    /// Mirroring that with `allSatisfy` would label it "rotating" while the
+    /// server sent it nothing, which is the misreading this whole state exists
+    /// to end.
+    ///
+    /// Lives here rather than inline in the view so the rule is testable
+    /// without standing up SwiftUI, and so there is one place to correct if the
+    /// server's predicate ever changes.
+    public var servesGroupTrafficOnly: Bool {
+        groupTags.contains(where: \.isReserved)
+    }
 }
 
 /// One entry in ``Account/groupMenuActions``, the row-level context menu

--- a/apps/macos/Tests/TcrBarTests/GroupTagTests.swift
+++ b/apps/macos/Tests/TcrBarTests/GroupTagTests.swift
@@ -78,6 +78,44 @@ final class GroupTagTests: XCTestCase {
         XCTAssertEqual(account.groupTags.first?.isReserved, false)
     }
 
+    // MARK: - Account.servesGroupTrafficOnly (the "group only" row state)
+
+    /// An account whose only group is reserved serves no pool traffic, so the
+    /// row must not also claim to be "rotating" — the `GIL` + `ROTATING` pair
+    /// that read as "tagged AND pooled" and hid a real leak.
+    func testReservedGroupMakesAccountGroupOnly() {
+        let account = tagAccount(
+            "a@example.com", groups: ["codereview"], reservedGroups: ["codereview"])
+        XCTAssertTrue(account.servesGroupTrafficOnly)
+    }
+
+    /// The case an `allSatisfy` implementation gets wrong. The server holds an
+    /// account out of general rotation when ANY group is reserved, so one
+    /// reserved group plus one plain group is still group-only.
+    func testOneReservedGroupAmongPlainOnesIsStillGroupOnly() {
+        let account = tagAccount(
+            "a@example.com",
+            groups: ["dev", "codereview"],
+            reservedGroups: ["codereview"]
+        )
+        XCTAssertTrue(
+            account.servesGroupTrafficOnly,
+            "any reserved group holds the account out of the pool, not only all of them"
+        )
+    }
+
+    /// Tagged but unreserved is the silent no-op: the account still takes pool
+    /// traffic, so it genuinely is rotating and must keep saying so.
+    func testTaggedButUnreservedAccountStillRotates() {
+        let account = tagAccount("a@example.com", groups: ["dev"], reservedGroups: [])
+        XCTAssertFalse(account.servesGroupTrafficOnly)
+    }
+
+    /// An ungrouped account is plain rotation — no groups, nothing reserved.
+    func testUngroupedAccountIsNotGroupOnly() {
+        XCTAssertFalse(tagAccount("a@example.com", groups: nil).servesGroupTrafficOnly)
+    }
+
     // MARK: - GroupTagColor
 
     func testMalformedHexReturnsNilFromParse() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -585,6 +585,17 @@ pub fn reserve_group(config_path: &Path, group: &str) -> anyhow::Result<()> {
     match outcome {
         config::GroupReserveWrite::Updated => {
             println!("group '{group}' reserved. {remaining} unreserved enabled account(s) remain.");
+            // Say what reserving actually does, at the one moment an operator is
+            // guaranteed to be reading. The second half is the surprising one: it
+            // can make a `--group` request WAIT or 429 where it used to be served
+            // by someone else, and an operator who learns that from a stalled
+            // session instead of from here will read it as a hang.
+            println!(
+                "  · pool traffic will no longer use its accounts, and '{group}' traffic will no longer leave it"
+            );
+            println!(
+                "  · a --group {group} request with no member free now waits or returns 429 rather than using another account"
+            );
             if remaining < 3 {
                 eprintln!(
                     "warning: only {remaining} unreserved enabled account(s) remain — ordinary (unrequested) traffic may starve."

--- a/src/config.rs
+++ b/src/config.rs
@@ -227,10 +227,26 @@ impl Account {
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupSettings {
-    /// When `true`, an account carrying this group is off-limits to traffic
-    /// that did not ask for one of its groups — see
-    /// [`crate::manager::select::eligible`]'s doc-comment for the exact rule.
-    /// Absent/`false` (default) keeps today's prefer-only behaviour.
+    /// When `true`, this group is PRIVATE IN BOTH DIRECTIONS. This is the
+    /// canonical statement of what `reserved` means; every other mention should
+    /// point here rather than restate it.
+    ///
+    /// 1. **Nothing else comes in.** An account carrying this group is
+    ///    off-limits to traffic that did not ask for one of its groups — see
+    ///    [`crate::manager::select::eligible`] for the exact rule.
+    /// 2. **Its own traffic never leaves.** An explicit `--group` ask for this
+    ///    group is STRICT: when no member can serve, the request refuses rather
+    ///    than falling back to the pool, and the caller's exhaustion ladder
+    ///    soft-waits for a member or answers an honest 429. An UNRESERVED group
+    ///    keeps prefer-only semantics and still spills.
+    ///
+    /// Direction 2 is deliberately not a second flag. The two are one intent —
+    /// "this group is mine" — and splitting them produced a group that looked
+    /// private while still leaking: measured on the live fleet 2026-09-01, an
+    /// unreserved group's member absorbed 127 pool diverts in a day, and the
+    /// rate-limit that caused then spilled that group's own traffic 33 times.
+    ///
+    /// Absent/`false` (default) is prefer-only in both directions.
     #[serde(default)]
     pub reserved: bool,
     /// When `true`, an explicit `--group` ask for this group is allowed to

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -1439,6 +1439,59 @@ impl Manager {
         }
     }
 
+    /// [`Self::retry_after_hint`], scoped to the members of one group.
+    ///
+    /// Exists for STRICT (reserved) groups. A strict `--group g` request can only
+    /// ever be served by a member of `g`, so sizing its wait with the fleet-wide
+    /// hint above times it against accounts the request will never be allowed to
+    /// use: any unrelated account un-gating sooner wins that `min`, the caller's
+    /// one-shot soft-wait is spent waking early, and the request answers a 429
+    /// while its own member is still seconds from free. The fleet-wide hint stays
+    /// exactly as it is — ungrouped traffic genuinely can use any account, and
+    /// that promise must keep holding for it.
+    ///
+    /// `Some(group)` (not `None`) reaches [`Self::account_gate`] on purpose: an
+    /// explicit ask is never reserved-blocked by its own group
+    /// ([`Self::reserved_blocks`]), so this reports the member's REAL gate — its
+    /// rate-limit hold or quota window — rather than the reservation that is the
+    /// whole reason we are here.
+    ///
+    /// Returns the same `60` default when no member advertises a recovery instant,
+    /// so a strict group whose members are all `Error`/disabled degrades to the
+    /// same honest "try again in a minute" as an exhausted fleet.
+    pub fn retry_after_hint_for_group(
+        &self,
+        now: OffsetDateTime,
+        is_fable: bool,
+        group: &str,
+    ) -> i64 {
+        let now_ms = odt_to_ms(now);
+        let reserved_groups = self.reserved_groups();
+        let accounts = self.accounts.read().expect("accounts lock poisoned");
+        let soonest = accounts
+            .iter()
+            .filter(|account| account.groups.iter().any(|g| g == group))
+            .filter_map(|account| {
+                let threshold = account.switch_threshold.unwrap_or(self.global_threshold);
+                let (_, free_at) = Self::account_gate(
+                    account,
+                    threshold,
+                    now,
+                    now_ms,
+                    is_fable,
+                    Some(group),
+                    &reserved_groups,
+                );
+                free_at.map(odt_to_ms)
+            })
+            .filter(|&at| at > now_ms)
+            .min();
+        match soonest {
+            Some(at) => ((at - now_ms + 999) / 1000).max(1),
+            None => 60,
+        }
+    }
+
     /// Mark account `idx` as serving one more in-flight request: bump its
     /// `in_flight` count and stamp `last_served_ms`, returning an [`InFlightGuard`]
     /// that decrements the count on Drop. The proxy takes this the moment it picks
@@ -1639,6 +1692,22 @@ impl Manager {
             .read()
             .expect("reserved_groups lock poisoned")
             .clone()
+    }
+
+    /// Whether `group` is currently reserved — and therefore STRICT: its own
+    /// traffic never spills to a non-member (see
+    /// [`Self::select_with_group`]'s strict arm).
+    ///
+    /// A membership test rather than [`Self::reserved_groups`] + `contains`,
+    /// because the request path asks this per request and only ever needs the
+    /// one answer; cloning the set to look at a single key is waste on a hot
+    /// path. Reads the same hot-reloaded cache, so `tcr group unreserve` takes
+    /// effect on the next request with no restart.
+    pub fn is_group_reserved(&self, group: &str) -> bool {
+        self.reserved_groups
+            .read()
+            .expect("reserved_groups lock poisoned")
+            .contains(group)
     }
 
     /// A cloned snapshot of the currently control-account-allowed group
@@ -3462,6 +3531,103 @@ mod tests {
             ),
             Some(0),
             "--group codereview still selects its own reserved account"
+        );
+    }
+
+    /// Semantics test #2b: a RESERVED group is strict — when its members are
+    /// all gated, the ask returns `None` instead of spilling into the pool.
+    ///
+    /// This is the second half of what `reserved` means. Reservation already
+    /// keeps unrequested traffic OUT of the group
+    /// ([`reserved_group_blocks_unrequested_traffic_both_directions`]); this
+    /// keeps the group's own traffic IN. Without it, a reserved group's request
+    /// silently lands on an account the operator deliberately walled off from
+    /// it — measured on the live fleet 2026-09-01, 33 times in one day, every
+    /// one `reason="all-members-unavailable"`, after pool traffic had
+    /// rate-limited the group's only member.
+    ///
+    /// The contrast case is deliberately left to
+    /// [`group_preference_prefers_then_falls_back_to_the_pool`]: an
+    /// UNRESERVED group keeps the prefer-and-spill behaviour unchanged, so
+    /// strictness rides entirely on `reserved` and needs no second flag.
+    #[test]
+    fn a_reserved_group_never_falls_back_to_the_pool() {
+        let reserved_acct = account_in_groups("reserved-acct", 5, &["codereview"]);
+        let plain = account("plain", 0); // better priority — would win any pool pick
+        let manager = build_manager(
+            config_with_reserved(vec![reserved_acct, plain], &["codereview"]),
+            lock_refresher(),
+        );
+        let now = OffsetDateTime::now_utc();
+
+        // Gate the group's only member out entirely (disabled = hard-ineligible),
+        // exactly as `group_preference_prefers_then_falls_back_to_the_pool` does.
+        {
+            let mut accounts = manager.accounts.write().expect("accounts lock poisoned");
+            accounts[0].disabled = true;
+        }
+
+        // POSITIVE CONTROL: the pool itself is still perfectly servable. Without
+        // this, the `None` below would also be satisfied by a fleet where nothing
+        // at all could be picked — proving the assertion about strictness rather
+        // than about an empty pool.
+        assert_eq!(
+            manager.select_with_group(&HashSet::new(), now, None, None, "/v1/messages", None, None),
+            Some(1),
+            "control: the ungrouped pool is servable, so a None below is strictness, not exhaustion"
+        );
+
+        assert_eq!(
+            manager.select_with_group(
+                &HashSet::new(),
+                now,
+                None,
+                None,
+                "/v1/messages",
+                None,
+                Some("codereview"),
+            ),
+            None,
+            "a reserved group must never spill into the pool — refuse and let the \
+             caller's exhaustion ladder soft-wait or answer an honest 429"
+        );
+    }
+
+    /// A strict group's retry hint is sized by when one of ITS members frees,
+    /// not by whichever account in the fleet un-gates first.
+    ///
+    /// The fleet-wide [`Manager::retry_after_hint`] minimises over every
+    /// account, so an unrelated account recovering sooner wins. For a strict
+    /// `--group` request that number is a promise about capacity the request is
+    /// not allowed to use: the caller spends its one-shot soft-wait, wakes to
+    /// find its own member still held, and answers a 429 that was avoidable.
+    /// The member here is held 10x longer than the non-member precisely so the
+    /// two hints cannot coincide by accident.
+    #[test]
+    fn a_strict_groups_retry_hint_is_sized_by_its_own_member() {
+        let member = account_in_groups("member", 0, &["codereview"]);
+        let outsider = account("outsider", 1);
+        let manager = build_manager(
+            config_with_reserved(vec![member, outsider], &["codereview"]),
+            lock_refresher(),
+        );
+        let now = OffsetDateTime::now_utc();
+
+        manager.mark_rate_limited(0, 600); // the group's member
+        manager.mark_rate_limited(1, 60); // an unrelated account, free much sooner
+
+        let fleet = manager.retry_after_hint(now, false);
+        let scoped = manager.retry_after_hint_for_group(now, false, "codereview");
+
+        // Control: the fleet-wide hint really is won by the outsider, so the
+        // assertion below is measuring the group scoping and not a tautology.
+        assert!(
+            fleet <= 60,
+            "control: fleet-wide hint should follow the sooner outsider, got {fleet}s"
+        );
+        assert!(
+            scoped > 500,
+            "a strict group's hint must follow its own held member (~600s), got {scoped}s"
         );
     }
 

--- a/src/manager/select.rs
+++ b/src/manager/select.rs
@@ -924,6 +924,33 @@ impl Manager {
             let mut best =
                 self.pick_eligible(&accounts, pool_tried, now, now_ms, is_fable, true, group);
 
+            // A RESERVED group is STRICT, and strictness is checked BEFORE the soft
+            // fallback below can widen the pick. `reserved` means the group is
+            // private in BOTH directions: `Self::reserved_blocks` already keeps
+            // unrequested traffic OUT of its members, and this keeps the group's own
+            // traffic IN. An UNRESERVED group is unaffected and still spills.
+            //
+            // Deliberately not a second config flag. One concept — "this group is
+            // mine" — is what an operator reads off the panel's lock glyph, and two
+            // half-set booleans produce a group that looks private while still
+            // leaking. Every existing prefer-and-fall-back test uses an unreserved
+            // group and is untouched by this.
+            //
+            // Measured on the live fleet 2026-09-01: pool traffic diverted onto a
+            // reserved-group member 127 times in a day (116 requests, 43 of them
+            // Opus), rate-limiting it (`hold_seconds=17`); three seconds later that
+            // group's OWN `--group` ask found its only member gated and spilled to
+            // the pool — 33 times, every one `reason="all-members-unavailable"`.
+            // The inbound leak caused the outbound one, so closing only the first
+            // still leaves an operator's private account serving traffic it was
+            // walled off from.
+            //
+            // Returning `None` is not dropping the request: it hands the caller's
+            // exhaustion ladder (`proxy.rs`) the same `None` a truly exhausted fleet
+            // produces, which soft-waits once for a transient park (the 17s hold
+            // above) and answers an honest 429 only for real exhaustion.
+            let strict_group = group.filter(|g| reserved_groups.contains(*g));
+
             // Soft fallback (CRITICAL — pacing must never DROP a servable request,
             // and a group with no current capacity must never either): if the first
             // pass found nothing, retry ignoring BOTH pacing and the group, serving
@@ -932,7 +959,28 @@ impl Manager {
             // pass use identical eligibility, so a None first pass ⟹ None here too —
             // default-OFF stays byte-identical (no spurious fallback, no log).
             if best.is_none() {
-                if let Some(idx) =
+                if let Some(g) = strict_group {
+                    // Same classifier the fallback arm uses, so an operator counting
+                    // `reason=` tokens sees one vocabulary across both outcomes.
+                    let miss = Self::classify_group_miss(
+                        &accounts,
+                        tried,
+                        control_excluded,
+                        self.global_threshold,
+                        &self.pacing,
+                        now,
+                        now_ms,
+                        is_fable,
+                        g,
+                        &reserved_groups,
+                    );
+                    tracing::info!(
+                        group = g,
+                        reason = miss.as_str(),
+                        "group: strict (reserved) — refusing to fall back to the whole pool, returning no account — {}",
+                        miss.explain(),
+                    );
+                } else if let Some(idx) =
                     self.pick_least_loaded(&accounts, pool_tried, now, now_ms, is_fable, None)
                 {
                     if let Some(account) = accounts.get(idx) {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -2167,6 +2167,19 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
             ) {
                 Some(idx) => idx,
                 None => {
+                    // A RESERVED group is strict: this request may only ever be
+                    // served by one of its members, so every answer below — the
+                    // wait it sizes, the revalidation it might attempt, the 429 it
+                    // finally returns — has to be scoped to that group rather than
+                    // to a fleet this request is not allowed to touch.
+                    //
+                    // Recomputed here rather than hoisted alongside `request_group`
+                    // at the top of the handler: `reserved` hot-reloads, so
+                    // `tcr group unreserve <g>` releases an already-stalled request
+                    // on its next pass through this arm instead of after a restart.
+                    let strict_group = request_group
+                        .as_deref()
+                        .filter(|g| manager.is_group_reserved(g));
                     if every_attempt_transport_failed(transport_failures, upstream_responses) {
                         // Nothing reached an upstream — but WHY decides the status.
                         // If any attempt died in the resolver, the honest answer is
@@ -2202,7 +2215,17 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
                     // windows / long holds) has soonest_free >> the ceiling →
                     // soft_wait_secs returns None → fall through to the honest 429.
                     match soft_wait_secs(
-                        manager.retry_after_hint(now, request_is_fable),
+                        match strict_group {
+                            // Size the wait by when a MEMBER frees. The fleet-wide
+                            // hint would be won by any unrelated account un-gating
+                            // sooner, spending this request's one-shot soft-wait on
+                            // a recovery it cannot use and 429-ing while its own
+                            // member was still seconds away.
+                            Some(group) => {
+                                manager.retry_after_hint_for_group(now, request_is_fable, group)
+                            }
+                            None => manager.retry_after_hint(now, request_is_fable),
+                        },
                         soft_waited_exhaustion,
                     ) {
                         Some(secs) => {
@@ -2266,7 +2289,18 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
                             // refreshes stale quota; a 429 arms a real hold via the
                             // existing inline-429 handling. `None` (throttled, or
                             // nothing servable) keeps the honest exhausted 429.
-                            if manager.revalidation_serve_enabled() {
+                            // `strict_group.is_none()` guards the THIRD spill door,
+                            // and the least visible one. `select_revalidation`
+                            // passes `group: None` to its hard gate, which by
+                            // `Manager::reserved_blocks` EXCLUDES every account
+                            // carrying a reserved group — so for a strict request
+                            // it can only ever return a NON-member. Left ungated it
+                            // would hand the request to precisely the account the
+                            // reservation exists to keep it off, moments after the
+                            // strict arm in `select_with_group` refused to. A
+                            // reserved group falls straight through to the honest
+                            // 429 instead.
+                            if strict_group.is_none() && manager.revalidation_serve_enabled() {
                                 if let Some(idx) = manager.select_revalidation(
                                     &tried,
                                     now,
@@ -2280,6 +2314,7 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
                                         now,
                                         account_count,
                                         request_is_fable,
+                                        strict_group,
                                     );
                                 }
                             } else {
@@ -2288,6 +2323,7 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
                                     now,
                                     account_count,
                                     request_is_fable,
+                                    strict_group,
                                 );
                             }
                         }
@@ -3054,6 +3090,9 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
             OffsetDateTime::now_utc(),
             account_count,
             request_is_fable,
+            request_group
+                .as_deref()
+                .filter(|g| manager.is_group_reserved(g)),
         )
     }
 }
@@ -3828,22 +3867,43 @@ fn error_response(
 /// 429 with a fleet-wide `retry-after` hint when no account is currently usable.
 /// `is_fable` scopes the hint to the request's model class so a Fable request is
 /// told the true Fable-weekly recovery instant (see [`Manager::retry_after_hint`]).
+/// `strict_group` names the RESERVED group this request asked for, when it asked
+/// for one. It changes both halves of the answer, because for a strict request
+/// the fleet-wide story is a lie in both:
+///
+/// - the hint is sized by [`Manager::retry_after_hint_for_group`], since an
+///   unrelated account un-gating sooner tells this client nothing about when it
+///   can be served; and
+/// - the message names the group instead of claiming every account is spent,
+///   which would send an operator to look at a fleet that is mostly idle.
 fn exhausted_response(
     manager: &Manager,
     now: OffsetDateTime,
     account_count: usize,
     is_fable: bool,
+    strict_group: Option<&str>,
 ) -> Response {
-    let retry_after = manager.retry_after_hint(now, is_fable);
+    let retry_after = match strict_group {
+        Some(group) => manager.retry_after_hint_for_group(now, is_fable, group),
+        None => manager.retry_after_hint(now, is_fable),
+    };
+    let detail = match strict_group {
+        Some(group) => format!(
+            "No account in reserved group '{group}' is available, and a reserved \
+             group never serves from outside itself. Retry in {retry_after}s."
+        ),
+        None => format!("All {account_count} accounts exhausted. Retry in {retry_after}s."),
+    };
     tracing::warn!(
         account_count,
         retry_after,
-        "returning fleet-exhausted 429 to client"
+        group = strict_group.unwrap_or("-"),
+        "returning exhausted 429 to client"
     );
     error_response(
         StatusCode::TOO_MANY_REQUESTS,
         "rate_limit_error",
-        &format!("All {account_count} accounts exhausted. Retry in {retry_after}s."),
+        &detail,
         Some(retry_after),
     )
 }


### PR DESCRIPTION
## The bug

A group tag was never isolation on its own, and the gap ran in both directions.

`reserved` already kept unrequested traffic **out** of a group's accounts. Nothing kept a
group's own traffic **in**: `--group` was prefer-only, so `select_with_group` dropped the group
and re-picked across the whole pool whenever no member could serve.

Measured on a live fleet on 2026-09-01, the two halves turned out to be one loop:

| | count |
|---|---|
| pool traffic diverted onto a group member | **127** in a day |
| requests it served for the pool | **116** (43 Opus) |
| that group's own `--group` asks spilled to the pool | **33** |

Pool traffic rate-limited the member (`hold_seconds=17`). Three seconds after one such 429, the
group's own ask found its only member gated and was served from the pool — every one of the 33
logged `reason="all-members-unavailable"`. Closing only the inbound half leaves the outbound one
firing under exactly the load the inbound half creates.

## The rule

> **A reserved group is strict. An unreserved group stays prefer-only.**

Deliberately not a second flag. The two directions are one intent — "this group is mine" — and
splitting them is what produced a group that looked private while still leaking. It also keeps
the panel to one state to render rather than two overlapping booleans in an eight-character
badge. Every existing prefer-and-spill test uses an unreserved group and is untouched.

## Three spill doors, closed together

Any one left open makes the guarantee false under load:

1. **`select_with_group`** refuses the soft fallback for a reserved group and returns `None`,
   handing the caller's existing exhaustion ladder the same `None` a truly exhausted fleet
   produces. No new failure path is invented.
2. **`retry_after_hint_for_group`** sizes the wait by when a *member* frees. The fleet-wide hint
   is won by any unrelated account un-gating sooner, which spends the one-shot soft-wait on a
   recovery the request cannot use and 429s while its own member is still seconds away.
3. **Revalidation serve is skipped** for a strict request. It passes `group: None` to its hard
   gate, which *excludes* reserved accounts — so for a strict request it could only ever have
   returned a non-member. This was the least visible of the three.

Behaviour after: a transient hold waits and then serves **on the group's own account**; a
genuinely spent quota answers an honest 429 naming the group instead of claiming the whole fleet
is exhausted.

## The panel had stopped telling the truth

`rotationPill` never consulted `reservedGroups`, so a reserved account rendered its group tag
beside `ROTATING` — which reads as "tagged AND pooled", the exact state reserving a group
prevents. Reserved accounts now render `group only`.

The predicate matches the server's rule: **any** reserved group holds an account out of rotation
(`Manager::reserved_blocks` — `groups.iter().any(...)`), not all of them. An unreserved tag now
says in its own tooltip that it is decoration.

## Verification

- **990 Rust tests, 370 Swift tests, `clippy` exit 0 with zero warnings, `cargo fmt` clean.** All
  six pre-commit gates pass.
- **Every new test was watched failing first**, per `CLAUDE.md`:
  - the strict-select test failed with `left: Some(1), right: None` before the fix — it also
    carries a positive control asserting the ungrouped pool is servable, so its `None` proves
    strictness rather than an empty fleet;
  - the group-only predicate was temporarily flipped to `allSatisfy`, which failed **two** tests
    — the mixed reserved+plain case, and the ungrouped case (`allSatisfy` on an empty array is
    `true`, which would have rendered every ungrouped account as "group only");
  - the retry-hint test is differential by construction: fleet-wide ≤60s versus group-scoped
    >500s on identical state, which an unfiltered implementation cannot satisfy.
- **Not yet verified on the running proxy.** The Rust change needs a restart to take effect (only
  group membership and `groupSettings` hot-reload), so the live check — driving a `--group`
  session while its member is held and confirming the new `group: strict (reserved)` line appears
  with no `-> serving <other>` after it — is still outstanding and should happen in a quiet window.

## Reviewer's attention, please

`reserved` gains a second meaning. Blast radius on the fleet this was measured against is one
group; a group with `reserved: false` is unaffected. The authoritative statement now lives in
`GroupSettings::reserved`'s doc-comment, with other mentions pointing at it rather than
restating it.

Worth a second opinion: strictness means a `--group` request can now stall where it used to be
served. That is the requested behaviour, but it is a real change in failure mode, which is why
the CLI now prints what reserving does at the moment an operator runs it, and why the panel state
exists at all.

https://claude.ai/code/session_01D3TF4EqbijHrRy5C6QWNKm
