### PR TITLE
fix: tell the client why the fleet is exhausted and when it frees

### DIFF
--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -1141,6 +1141,20 @@ impl Drop for InFlightGuard {
     }
 }
 
+/// What [`Manager::exhaustion_hint`] learned about an exhausted fleet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExhaustionHint {
+    /// Whole seconds until the soonest account frees, at least 1; the `60`
+    /// sentinel when `free_at` is `None`.
+    pub retry_after: i64,
+    /// The instant that account frees, when any account advertises one.
+    pub free_at: Option<OffsetDateTime>,
+    /// The gate holding that account — what `retry_after` is timed against.
+    pub binding: Option<GateReason>,
+    /// Every account out of rotation, counted by the gate holding it.
+    pub gated: BTreeMap<GateReason, usize>,
+}
+
 fn odt_to_ms(now: OffsetDateTime) -> i64 {
     (now.unix_timestamp_nanos() / 1_000_000) as i64
 }
@@ -1395,48 +1409,9 @@ impl Manager {
     /// A `retry-after` hint (seconds) for a synthetic 429 when every account is
     /// exhausted: the soonest instant at which SOME account genuinely re-enters
     /// rotation, clamped to at least 1s, defaulting to 60s when nothing is known.
-    ///
-    /// Honest by construction: it minimises over each account's
-    /// [`Self::account_gate`] `free_at` — the instant ALL of *that* account's
-    /// active gates clear — instead of the raw min over every window's reset. The
-    /// raw-min was bug-shaped: it counted a 5-hour reset of an account that stays
-    /// gated on its weekly bucket, and the reset of an `Error`/disabled account
-    /// that never self-frees at all, so it promised a recovery that would not
-    /// happen. Accounts that contribute nothing here (`Ok`, `Login`, `Disabled`,
-    /// or a gating window with no known reset) are correctly skipped.
-    ///
-    /// `is_fable` scopes the evaluation exactly as selection does: only a Fable
-    /// request is gated by the model-scoped weekly (`7d_oi`) bucket, so an
-    /// all-Fable-exhausted fleet reports that bucket's reset while non-Fable
-    /// traffic ignores it.
+    /// The seconds half of [`Self::exhaustion_hint`]; see it for the derivation.
     pub fn retry_after_hint(&self, now: OffsetDateTime, is_fable: bool) -> i64 {
-        let now_ms = odt_to_ms(now);
-        let reserved_groups = self.reserved_groups();
-        let accounts = self.accounts.read().expect("accounts lock poisoned");
-        let soonest = accounts
-            .iter()
-            .filter_map(|account| {
-                let threshold = account.switch_threshold.unwrap_or(self.global_threshold);
-                // `group: None` — same "unrequested traffic" view `Self::snapshot`
-                // reports; a promise this hint makes must hold for the traffic
-                // that would actually hit the synthetic 429 it is sizing.
-                let (_, free_at) = Self::account_gate(
-                    account,
-                    threshold,
-                    now,
-                    now_ms,
-                    is_fable,
-                    None,
-                    &reserved_groups,
-                );
-                free_at.map(odt_to_ms)
-            })
-            .filter(|&at| at > now_ms)
-            .min();
-        match soonest {
-            Some(at) => ((at - now_ms + 999) / 1000).max(1),
-            None => 60,
-        }
+        self.exhaustion_hint(now, is_fable, None).retry_after
     }
 
     /// [`Self::retry_after_hint`], scoped to the members of one group.
@@ -1450,12 +1425,6 @@ impl Manager {
     /// exactly as it is — ungrouped traffic genuinely can use any account, and
     /// that promise must keep holding for it.
     ///
-    /// `Some(group)` (not `None`) reaches [`Self::account_gate`] on purpose: an
-    /// explicit ask is never reserved-blocked by its own group
-    /// ([`Self::reserved_blocks`]), so this reports the member's REAL gate — its
-    /// rate-limit hold or quota window — rather than the reservation that is the
-    /// whole reason we are here.
-    ///
     /// Returns the same `60` default when no member advertises a recovery instant,
     /// so a strict group whose members are all `Error`/disabled degrades to the
     /// same honest "try again in a minute" as an exhausted fleet.
@@ -1465,30 +1434,96 @@ impl Manager {
         is_fable: bool,
         group: &str,
     ) -> i64 {
+        self.exhaustion_hint(now, is_fable, Some(group)).retry_after
+    }
+
+    /// Everything a synthetic exhausted 429 can honestly tell the client, derived
+    /// once from the same per-account gate view selection uses.
+    ///
+    /// `retry_after` is the soonest instant at which SOME account genuinely
+    /// re-enters rotation, in whole seconds, clamped to at least 1. Honest by
+    /// construction: it minimises over each account's [`Self::account_gate`]
+    /// `free_at` — the instant ALL of *that* account's active gates clear —
+    /// instead of the raw min over every window's reset. The raw-min was
+    /// bug-shaped: it counted a 5-hour reset of an account that stays gated on
+    /// its weekly bucket, and the reset of an `Error`/disabled account that never
+    /// self-frees at all, so it promised a recovery that would not happen.
+    /// Accounts that contribute nothing (`Ok`, `Login`, `Disabled`, or a gating
+    /// window with no known reset) are skipped.
+    ///
+    /// When NO account advertises a recovery instant, `retry_after` is the `60`
+    /// sentinel and `free_at` is `None`. The two are reported separately on
+    /// purpose: a caller sizing a wait keeps reading the number, and a caller
+    /// writing a message can say "no reset time is known" instead of printing a
+    /// fixed 60 that a reader would take for a measurement. `proxy.rs` relies on
+    /// the sentinel staying above its soft-wait cap — see the compile-time
+    /// assertion beside `EXHAUSTION_SOFT_WAIT_MAX_SECS` there.
+    ///
+    /// `binding` is the gate that holds the soonest-freeing account — the one
+    /// whose clearing `retry_after` is timed against — so the 429 can carry the
+    /// matching `anthropic-ratelimit-unified-*` claim when that gate is a quota
+    /// window, and stay a plain 429 when it is not. `gated` counts every account
+    /// out of rotation by its gate, for the message.
+    ///
+    /// `is_fable` scopes the evaluation exactly as selection does: only a Fable
+    /// request is gated by the model-scoped weekly (`7d_oi`) bucket, so an
+    /// all-Fable-exhausted fleet reports that bucket's reset while non-Fable
+    /// traffic ignores it.
+    ///
+    /// `group` narrows the fleet to one group's members and, reaching
+    /// [`Self::account_gate`] as `Some(group)` on purpose, reports each member's
+    /// REAL gate rather than the reservation: an explicit ask is never
+    /// reserved-blocked by its own group ([`Self::reserved_blocks`]). `None` is
+    /// the "unrequested traffic" view [`Self::snapshot`] reports — a promise this
+    /// hint makes must hold for the traffic that would actually hit the 429.
+    pub fn exhaustion_hint(
+        &self,
+        now: OffsetDateTime,
+        is_fable: bool,
+        group: Option<&str>,
+    ) -> ExhaustionHint {
         let now_ms = odt_to_ms(now);
         let reserved_groups = self.reserved_groups();
         let accounts = self.accounts.read().expect("accounts lock poisoned");
-        let soonest = accounts
+        let mut gated: BTreeMap<GateReason, usize> = BTreeMap::new();
+        let mut soonest: Option<(i64, GateReason)> = None;
+        for account in accounts
             .iter()
-            .filter(|account| account.groups.iter().any(|g| g == group))
-            .filter_map(|account| {
-                let threshold = account.switch_threshold.unwrap_or(self.global_threshold);
-                let (_, free_at) = Self::account_gate(
-                    account,
-                    threshold,
-                    now,
-                    now_ms,
-                    is_fable,
-                    Some(group),
-                    &reserved_groups,
-                );
-                free_at.map(odt_to_ms)
-            })
-            .filter(|&at| at > now_ms)
-            .min();
+            .filter(|account| group.is_none_or(|g| account.groups.iter().any(|m| m == g)))
+        {
+            let threshold = account.switch_threshold.unwrap_or(self.global_threshold);
+            let (reason, free_at) = Self::account_gate(
+                account,
+                threshold,
+                now,
+                now_ms,
+                is_fable,
+                group,
+                &reserved_groups,
+            );
+            if reason != GateReason::Ok {
+                *gated.entry(reason).or_insert(0) += 1;
+            }
+            let Some(at) = free_at.map(odt_to_ms).filter(|&at| at > now_ms) else {
+                continue;
+            };
+            if soonest.is_none_or(|(best, _)| at < best) {
+                soonest = Some((at, reason));
+            }
+        }
         match soonest {
-            Some(at) => ((at - now_ms + 999) / 1000).max(1),
-            None => 60,
+            Some((at, reason)) => ExhaustionHint {
+                retry_after: ((at - now_ms + 999) / 1000).max(1),
+                free_at: ms_to_odt(at),
+                binding: Some(reason),
+                gated,
+            },
+            None => ExhaustionHint {
+                retry_after: 60,
+                free_at: None,
+                binding: None,
+                gated,
+            },
         }
     }
 
@@ -8227,6 +8262,72 @@ mod tests {
             hint > 800,
             "must not report B's 100s or A's 200s reset, got {hint}"
         );
+    }
+
+    /// The full hint: the gate that TIMES the wait, and a count of every account
+    /// out of rotation by its gate. Same fleet as the test above, so the binding
+    /// gate is C's 5-hour window, while A's weekly and B's dead credential are
+    /// counted without being allowed to drive the time.
+    #[test]
+    fn exhaustion_hint_names_the_binding_gate_and_counts_every_gated_account() {
+        let now = OffsetDateTime::now_utc();
+        let at = |secs: i64| now + Duration::seconds(secs);
+        let mut a = AccountRuntime::from_config(&account("a", 0), false);
+        a.switch_threshold = Some(0.90);
+        a.quota.five_hour = Some(window(0.99, Some(at(200))));
+        a.quota.seven_day = Some(window(0.99, Some(at(5_000))));
+        let mut b = AccountRuntime::from_config(&account("b", 0), false);
+        b.switch_threshold = Some(0.90);
+        b.status = AccountStatus::Error;
+        b.quota.five_hour = Some(window(0.99, Some(at(100))));
+        let mut c = AccountRuntime::from_config(&account("c", 0), false);
+        c.switch_threshold = Some(0.90);
+        c.quota.five_hour = Some(window(0.99, Some(at(900))));
+
+        let manager = Manager::from_runtimes(vec![a, b, c]);
+        let hint = manager.exhaustion_hint(now, false, None);
+        assert_eq!(
+            hint.binding,
+            Some(GateReason::FiveHour),
+            "C's 5h window times the wait"
+        );
+        assert_eq!(
+            hint.free_at.map(odt_to_ms),
+            Some(odt_to_ms(at(900))),
+            "free_at is C's reset instant"
+        );
+        assert_eq!(
+            hint.retry_after,
+            manager.retry_after_hint(now, false),
+            "the seconds half is byte-identical to retry_after_hint"
+        );
+        let counts: Vec<(GateReason, usize)> = hint.gated.iter().map(|(r, n)| (*r, *n)).collect();
+        assert_eq!(
+            counts,
+            vec![
+                (GateReason::FiveHour, 1),
+                (GateReason::SevenDay, 1),
+                (GateReason::Login, 1)
+            ],
+            "every gated account is counted under the gate that binds IT"
+        );
+    }
+
+    /// When no account advertises a reset, the number stays the 60 sentinel the
+    /// proxy's soft-wait relies on, but `free_at`/`binding` are `None` so a
+    /// message can say "no reset known" instead of printing 60 as a measurement.
+    #[test]
+    fn exhaustion_hint_reports_an_unknown_reset_as_unknown_not_as_sixty_seconds() {
+        let now = OffsetDateTime::now_utc();
+        let mut a = AccountRuntime::from_config(&account("a", 0), false);
+        a.switch_threshold = Some(0.90);
+        a.quota.seven_day = Some(window(0.99, None));
+        let manager = Manager::from_runtimes(vec![a]);
+        let hint = manager.exhaustion_hint(now, false, None);
+        assert_eq!(hint.retry_after, 60);
+        assert_eq!(hint.free_at, None);
+        assert_eq!(hint.binding, None);
+        assert_eq!(hint.gated.get(&GateReason::SevenDay), Some(&1));
     }
 
     /// `next_session_key` hands out strictly-increasing, unique u64s starting at 1.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -43,7 +43,7 @@ use crate::manager::{
     AccountStatus, AddAccountOutcome, AddPersist, ControlPersist, DisablePersist, InFlightGuard,
     Manager, SetControlOutcome, SetDisabledOutcome,
 };
-use crate::stats::{RequestLogEntry, SessionKind};
+use crate::stats::{GateReason, RequestLogEntry, SessionKind};
 
 /// Cap on a buffered request body (256 MiB) — a single-user localhost proxy has
 /// no legitimate payload near this, but an unbounded read is a DoS surface. The
@@ -3866,16 +3866,32 @@ fn error_response(
 
 /// 429 with a fleet-wide `retry-after` hint when no account is currently usable.
 /// `is_fable` scopes the hint to the request's model class so a Fable request is
-/// told the true Fable-weekly recovery instant (see [`Manager::retry_after_hint`]).
+/// told the true Fable-weekly recovery instant (see [`Manager::exhaustion_hint`]).
 /// `strict_group` names the RESERVED group this request asked for, when it asked
 /// for one. It changes both halves of the answer, because for a strict request
 /// the fleet-wide story is a lie in both:
 ///
-/// - the hint is sized by [`Manager::retry_after_hint_for_group`], since an
-///   unrelated account un-gating sooner tells this client nothing about when it
-///   can be served; and
+/// - the hint is sized over the group's members only, since an unrelated
+///   account un-gating sooner tells this client nothing about when it can be
+///   served; and
 /// - the message names the group instead of claiming every account is spent,
 ///   which would send an operator to look at a fleet that is mostly idle.
+///
+/// The response speaks the client's language, not only ours. Claude Code labels
+/// any 429 that carries no `anthropic-ratelimit-unified-status` header "Server
+/// is temporarily limiting requests (not your usage limit)" — the opposite of
+/// the truth when every account is inside a quota window. So when the gate that
+/// times `retry-after` IS a quota window, the 429 also carries the unified
+/// `status: rejected`, the `reset` epoch and the `representative-claim` the
+/// client maps to its own limit types, and the client renders a usage limit with
+/// the real reset instant. A hold or an unknown gate stays a plain 429: an
+/// upstream `retry-after` is not the user's usage limit, and claiming one would
+/// be the same lie in the other direction.
+///
+/// The `retry-after` figure is computed live from when an account actually
+/// frees, never a constant — the only fixed number here is the 60 the hint falls
+/// back to when NO account advertises a reset, and the message says so rather
+/// than printing it as if it had been measured.
 fn exhausted_response(
     manager: &Manager,
     now: OffsetDateTime,
@@ -3883,29 +3899,103 @@ fn exhausted_response(
     is_fable: bool,
     strict_group: Option<&str>,
 ) -> Response {
-    let retry_after = match strict_group {
-        Some(group) => manager.retry_after_hint_for_group(now, is_fable, group),
-        None => manager.retry_after_hint(now, is_fable),
+    let hint = manager.exhaustion_hint(now, is_fable, strict_group);
+    let retry_after = hint.retry_after;
+    let causes = describe_gates(&hint.gated);
+    let when = match hint.free_at {
+        Some(at) => format!(
+            "Retry in {retry_after}s (soonest account frees at {}).",
+            at_utc(at)
+        ),
+        None => format!("No account reports a reset time; retry in {retry_after}s."),
     };
     let detail = match strict_group {
         Some(group) => format!(
             "No account in reserved group '{group}' is available, and a reserved \
-             group never serves from outside itself. Retry in {retry_after}s."
+             group never serves from outside itself{causes}. {when}"
         ),
-        None => format!("All {account_count} accounts exhausted. Retry in {retry_after}s."),
+        None => format!("All {account_count} accounts exhausted{causes}. {when}"),
     };
     tracing::warn!(
         account_count,
         retry_after,
+        binding = ?hint.binding,
         group = strict_group.unwrap_or("-"),
         "returning exhausted 429 to client"
     );
-    error_response(
+    let mut response = error_response(
         StatusCode::TOO_MANY_REQUESTS,
         "rate_limit_error",
         &detail,
         Some(retry_after),
-    )
+    );
+    if let (Some(claim), Some(at)) = (hint.binding.and_then(unified_claim_for), hint.free_at) {
+        let headers = response.headers_mut();
+        headers.insert(
+            "anthropic-ratelimit-unified-status",
+            HeaderValue::from_static("rejected"),
+        );
+        headers.insert(
+            "anthropic-ratelimit-unified-representative-claim",
+            HeaderValue::from_static(claim),
+        );
+        if let Ok(value) = HeaderValue::from_str(&at.unix_timestamp().to_string()) {
+            headers.insert("anthropic-ratelimit-unified-reset", value);
+        }
+    }
+    response
+}
+
+/// The `anthropic-ratelimit-unified-representative-claim` value for a gate, or
+/// `None` for a gate that is not a quota window. The values are the ones the
+/// Claude Code client maps to its limit types (`five_hour`, `seven_day`); the
+/// Fable weekly is reported as the plain weekly claim because the client has no
+/// Fable-specific one and a weekly reset is what it is.
+fn unified_claim_for(reason: GateReason) -> Option<&'static str> {
+    match reason {
+        GateReason::FiveHour => Some("five_hour"),
+        GateReason::SevenDay | GateReason::FableWeekly => Some("seven_day"),
+        GateReason::Ok
+        | GateReason::Hold
+        | GateReason::Standard
+        | GateReason::Login
+        | GateReason::Rejected
+        | GateReason::Disabled
+        | GateReason::Reserved => None,
+    }
+}
+
+/// `: 3 in the 5-hour window, 1 on an upstream hold` — or empty when nothing is
+/// gated, so the message never ends in a dangling colon.
+fn describe_gates(gated: &std::collections::BTreeMap<GateReason, usize>) -> String {
+    let parts: Vec<String> = gated
+        .iter()
+        .map(|(reason, n)| {
+            let what = match reason {
+                GateReason::Ok => "in rotation",
+                GateReason::Hold => "on an upstream hold",
+                GateReason::FiveHour => "in the 5-hour window",
+                GateReason::SevenDay => "in the weekly window",
+                GateReason::FableWeekly => "in the Fable weekly window",
+                GateReason::Standard => "at a token limit",
+                GateReason::Login => "needing re-login",
+                GateReason::Rejected => "rejected upstream",
+                GateReason::Disabled => "disabled",
+                GateReason::Reserved => "reserved for another group",
+            };
+            format!("{n} {what}")
+        })
+        .collect();
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!(": {}", parts.join(", "))
+    }
+}
+
+/// `HH:MM:SS UTC` for a message a human reads next to a seconds count.
+fn at_utc(at: OffsetDateTime) -> String {
+    format!("{:02}:{:02}:{:02} UTC", at.hour(), at.minute(), at.second())
 }
 
 /// Whether a 502 is the honest verdict: at least one attempt failed in transport
@@ -9445,6 +9535,16 @@ mod tests {
 
     /// Boot an N-account fleet (all cloned from `dummy`) pointed at `upstream`.
     fn fleet(upstream: SocketAddr, names: &[&str]) -> Arc<Manager> {
+        fleet_configured(upstream, names, |_| {})
+    }
+
+    /// [`fleet`] with a hook to edit the config before the manager boots — for a
+    /// test that needs an unmodelled top-level key (`revalidationServe`) set.
+    fn fleet_configured(
+        upstream: SocketAddr,
+        names: &[&str],
+        configure: impl FnOnce(&mut Config),
+    ) -> Arc<Manager> {
         struct NoRefresh;
         impl crate::oauth::TokenRefresher for NoRefresh {
             fn refresh(&self, _t: String) -> crate::oauth::RefreshFuture {
@@ -9458,6 +9558,7 @@ mod tests {
             config.accounts.push(extra);
         }
         config.accounts.remove(0); // keep exactly `names`, in order
+        configure(&mut config);
         Manager::new(
             config,
             Arc::new(NoRefresh),
@@ -9486,6 +9587,28 @@ mod tests {
             .unwrap();
         let status = resp.status().as_u16();
         (status, resp.text().await.unwrap())
+    }
+
+    /// [`post_one_with_body`] plus the response HEADERS — for asserting what a
+    /// synthesized 429 tells a client that reads headers, not only its body.
+    async fn post_one_full(manager: Arc<Manager>) -> (u16, HeaderMap, String) {
+        let proxy = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = proxy.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(proxy, app(manager)).await;
+        });
+        let body = serde_json::to_vec(&serde_json::json!({ "model": "claude-x", "messages": [] }))
+            .unwrap();
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let resp = client
+            .post(format!("http://{proxy_addr}/v1/messages"))
+            .body(body)
+            .send()
+            .await
+            .unwrap();
+        let status = resp.status().as_u16();
+        let headers = resp.headers().clone();
+        (status, headers, resp.text().await.unwrap())
     }
 
     /// Serve `manager` on a fresh loopback listener and POST one `/v1/messages`,
@@ -10435,6 +10558,98 @@ mod tests {
             attempts.load(std::sync::atomic::Ordering::SeqCst),
             2,
             "both accounts were tried once each before the fleet-exhausted 429"
+        );
+    }
+
+    /// A fleet spent on its 5-hour windows answers a 429 the client can READ as a
+    /// usage limit: `anthropic-ratelimit-unified-status: rejected`, the claim the
+    /// client maps to its five-hour type, and a `reset` equal to the window's real
+    /// reset — not a constant. Without those headers the client labels the 429
+    /// "not your usage limit", which is the opposite of what happened. The body
+    /// names the cause and the instant too, for a reader without a header view.
+    #[tokio::test]
+    async fn exhausted_429_carries_the_unified_headers_when_a_quota_window_binds() {
+        let up_addr = spawn_scripted_upstream(vec![Some(raw_200())]).await;
+        // Revalidation-serve (default ON) would probe an over-threshold account
+        // with a real send instead of failing the request; this test is about the
+        // 429 the client gets once nothing is servable, so it is off here.
+        let manager = fleet_configured(up_addr, &["a", "b"], |config| {
+            config
+                .extra
+                .insert("revalidationServe".to_string(), serde_json::json!(false));
+        });
+        let reset = OffsetDateTime::now_utc().unix_timestamp() + 900;
+        let mut spent = HeaderMap::new();
+        spent.insert(
+            "anthropic-ratelimit-unified-5h-utilization",
+            HeaderValue::from_static("0.99"),
+        );
+        spent.insert(
+            "anthropic-ratelimit-unified-5h-reset",
+            HeaderValue::from_str(&reset.to_string()).unwrap(),
+        );
+        for idx in 0..2 {
+            assert!(
+                manager.update_quota(idx, &spent),
+                "fixture must land a 5h window"
+            );
+        }
+
+        let (status, headers, body) = post_one_full(manager).await;
+        assert_eq!(
+            status, 429,
+            "no eligible account → exhausted 429; body: {body}"
+        );
+        let h = |name: &str| headers.get(name).map(|v| v.to_str().unwrap().to_string());
+        assert_eq!(
+            h("anthropic-ratelimit-unified-status").as_deref(),
+            Some("rejected")
+        );
+        assert_eq!(
+            h("anthropic-ratelimit-unified-representative-claim").as_deref(),
+            Some("five_hour")
+        );
+        assert_eq!(
+            h("anthropic-ratelimit-unified-reset").as_deref(),
+            Some(reset.to_string().as_str()),
+            "the reset is the window's own instant, not a synthesized one"
+        );
+        let retry_after: i64 = h("retry-after").unwrap().parse().unwrap();
+        assert!(
+            (895..=900).contains(&retry_after),
+            "retry-after is the live distance to that reset, got {retry_after}"
+        );
+        assert!(
+            body.contains("All 2 accounts exhausted: 2 in the 5-hour window.")
+                && body.contains("soonest account frees at"),
+            "the body names the cause and the instant: {body}"
+        );
+    }
+
+    /// An upstream `retry-after` hold is NOT the user's usage limit, so a fleet
+    /// held that way stays a plain 429: no unified headers, and a body that says
+    /// "hold" rather than claiming a window. Both accounts carry the hold a
+    /// transient upstream 429 arms (`mark_rate_limited`), 600s out.
+    #[tokio::test]
+    async fn exhausted_429_stays_plain_when_an_upstream_hold_binds() {
+        let up_addr = spawn_scripted_upstream(vec![Some(raw_200())]).await;
+        let manager = fleet(up_addr, &["a", "b"]);
+        for idx in 0..2 {
+            manager.mark_rate_limited(idx, 600);
+        }
+        let (status, headers, body) = post_one_full(manager).await;
+        assert_eq!(status, 429, "body: {body}");
+        assert!(
+            headers.get("anthropic-ratelimit-unified-status").is_none(),
+            "a hold must not be dressed up as a usage limit"
+        );
+        assert!(
+            headers.get("retry-after").is_some(),
+            "the live retry-after still ships"
+        );
+        assert!(
+            body.contains("2 on an upstream hold") && body.contains("Retry in "),
+            "the body names the hold: {body}"
         );
     }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -66,7 +66,9 @@ impl QuotaState {
 /// out, so a paced account still reads [`GateReason::Ok`].
 ///
 /// Serde-derived so it crosses the status endpoint's wire ([`crate::status`]).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
 #[serde(rename_all = "kebab-case")]
 pub enum GateReason {
     /// In rotation — no hard gate is active.


### PR DESCRIPTION
🍄

## What the client saw

When the pool is spent, the proxy answers a 429 with a `retry-after` and "All N accounts exhausted. Retry in Ns." Two readers get that wrong:

- **Claude Code** labels any 429 that has no `anthropic-ratelimit-unified-status` header as "Server is temporarily limiting requests (not your usage limit)". When every account is inside a quota window that is the opposite of the truth, and it tells a script author to treat the wait as a capacity blip rather than a limit with a known reset.
- **A person** reads "Retry in 60s" as a measurement. It is the value the hint falls back to when no account advertises a reset at all. Every other figure is computed live from when an account actually frees.

## What changes

`exhausted_response` now derives everything from one `Manager::exhaustion_hint`, which reports the seconds (unchanged), the instant the soonest account frees, the gate holding that account, and a count of every gated account by gate.

- When the binding gate is a quota window, the 429 also carries `anthropic-ratelimit-unified-status: rejected`, `anthropic-ratelimit-unified-representative-claim` (`five_hour` / `seven_day`, the values the client maps to its limit types) and `anthropic-ratelimit-unified-reset` set to the window's real reset epoch. The client then renders a usage limit with the actual reset instant.
- A hold (upstream `retry-after`) or an unknown gate stays a plain 429 — an upstream hold is not the user's usage limit either.
- The body names the cause and the time: `All 4 accounts exhausted: 3 in the 5-hour window, 1 on an upstream hold. Retry in 812s (soonest account frees at 21:14:03 UTC).` When nothing is known: `No account reports a reset time; retry in 60s.`

`retry_after_hint` / `retry_after_hint_for_group` delegate to the new function, so the seconds — and the 60 sentinel the soft-wait cap asserts against at compile time — are byte-identical. `GateReason` gains `Ord`/`Hash` to serve as the map key.

## Verification

- `cargo test`: 922 lib tests pass, all integration suites green. `cargo clippy --all-targets -D warnings` clean, `cargo fmt --check` clean.
- New tests: `exhaustion_hint_names_the_binding_gate_and_counts_every_gated_account`, `exhaustion_hint_reports_an_unknown_reset_as_unknown_not_as_sixty_seconds`, `exhausted_429_carries_the_unified_headers_when_a_quota_window_binds` (end to end, asserts the reset header equals the seeded window's epoch and `retry-after` is within 5s of the live distance), `exhausted_429_stays_plain_when_an_upstream_hold_binds`.
- The header assertion was watched failing with the value flipped to `allowed` (`left: Some("allowed") right: Some("rejected")`), then restored.
- The client behaviour was read from the CLI's 429 branch: it picks the "temporarily limiting" label when the unified status header is absent, and parses `representative-claim` / `unified-reset` into its rate-limit type and reset instant. Not exercised against a live CLI session; worth one manual run before the release that carries it.

https://claude.ai/code/session_01KcLnQArb4R9HdNwdgLHkRF
