### PR TITLE
feat: install the menu-bar app from the installer and from tcr ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,16 @@ and a terminal dashboard, and `tcr` is a drop-in for the Node
 ## Install
 
 ```sh
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/dhkts1/teamclaude-rs/releases/latest/download/teamclaude-rs-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://raw.githubusercontent.com/dhkts1/teamclaude-rs/main/install.sh | sh
 ```
 
-This installs the `tcr` CLI only; TcrBar is the `.dmg` on the
-[release page](https://github.com/dhkts1/teamclaude-rs/releases/latest).
+This installs the `tcr` CLI, and on macOS also installs TcrBar from the `.dmg` on the
+[release page](https://github.com/dhkts1/teamclaude-rs/releases/latest) — set `TCR_SKIP_UI=1` to skip that
+second step. For the `tcr` CLI only, on any platform, use the cargo-dist installer directly:
+
+```sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/dhkts1/teamclaude-rs/releases/latest/download/teamclaude-rs-installer.sh | sh
+```
 
 Or from source, with a Rust toolchain. Use the script rather than `cp`, because [`cp` onto a
 running binary rewrites the same inode and macOS then kills it](CONTRIBUTING.md#installing-it-onto-your-path):

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# install.sh — the one-line installer: `tcr` CLI, then TcrBar on macOS.
+#
+# Step 1 is exactly the cargo-dist shell installer teamclaude-rs-installer.sh
+# always was — regenerated every release from dist-workspace.toml, no
+# post-install hook, not something this script edits. Step 2 is new: on
+# macOS, install TcrBar too, so the default install gets both halves of the
+# system instead of leaving the app as a manual dmg download.
+#
+# `set -e` is deliberately NOT used past the curl|sh pipe: that pipe's exit
+# status is judged explicitly (PIPESTATUS[0] is the curl leg, PIPESTATUS[1]
+# is `sh` running the installer) so a curl failure and an installer failure
+# are told apart, and one bad step 2 does not retroactively make step 1 look
+# like it failed.
+set -uo pipefail
+
+DIST_INSTALLER_URL="https://github.com/dhkts1/teamclaude-rs/releases/latest/download/teamclaude-rs-installer.sh"
+LATEST_RELEASE_API_URL="https://api.github.com/repos/dhkts1/teamclaude-rs/releases/latest"
+APP_NAME="TcrBar"
+
+usage() {
+  cat <<'USAGE'
+install.sh — install the `tcr` CLI, and on macOS TcrBar too.
+
+Env:
+  TCR_SKIP_UI=1   Skip the TcrBar install step entirely (CLI only, all
+                  platforms). Also honoured non-interactively so CI and
+                  containers never try to touch /Applications.
+  TEAMCLAUDE_RS_INSTALL_DIR, TEAMCLAUDE_RS_DOWNLOAD_URL,
+  TEAMCLAUDE_RS_INSTALLER_GHE_BASE_URL,
+  TEAMCLAUDE_RS_INSTALLER_GITHUB_BASE_URL, TEAMCLAUDE_RS_GITHUB_TOKEN
+                  Passed through to the cargo-dist shell installer
+                  unmodified (see src/update.rs for what each one does).
+USAGE
+}
+
+case "${1:-}" in
+  --help | -h)
+    usage
+    exit 0
+    ;;
+esac
+
+echo "==> Installing the tcr CLI…"
+curl --proto '=https' --tlsv1.2 -LsSf "$DIST_INSTALLER_URL" | sh
+dist_rc="${PIPESTATUS[1]:-1}"
+if [ "$dist_rc" -ne 0 ]; then
+  echo "tcr CLI install failed (exit $dist_rc)" >&2
+  exit "$dist_rc"
+fi
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  exit 0
+fi
+
+if [ "${TCR_SKIP_UI:-0}" = "1" ]; then
+  echo "==> TCR_SKIP_UI=1 — skipping the TcrBar install."
+  exit 0
+fi
+
+if [ -d "/Applications/${APP_NAME}.app" ] && pgrep -x "$APP_NAME" >/dev/null 2>&1; then
+  echo "==> ${APP_NAME} is already installed and running."
+  echo "    Updates come through the app itself (Sparkle) — nothing more to do here."
+  exit 0
+fi
+
+# validate_release_tag, mirrored from src/update.rs so this shell installer
+# and the Rust update path agree on what a safe tag looks like. The tag is
+# interpolated into a URL path below, and an unvalidated one does not stay
+# inside dhkts1/teamclaude-rs: see update.rs's own doc-comment for the
+# concrete escape it blocks.
+validate_release_tag() {
+  local t="$1"
+  [ -n "$t" ] || return 1
+  case "$t" in
+    *[!0-9A-Za-z.+_-]*) return 1 ;;
+  esac
+  case "$t" in
+    [0-9A-Za-z]*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+echo "==> Resolving the latest TcrBar release…"
+release_json="$(curl -fsSL "$LATEST_RELEASE_API_URL")" || {
+  echo "could not reach $LATEST_RELEASE_API_URL — skipping the TcrBar install" >&2
+  exit 0
+}
+tag="$(printf '%s' "$release_json" | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+
+if ! validate_release_tag "$tag"; then
+  echo "the latest-release API returned an unusable tag_name (${tag:-<empty>}) — skipping the TcrBar install" >&2
+  exit 0
+fi
+
+version="${tag#v}"
+dmg_url="https://github.com/dhkts1/teamclaude-rs/releases/download/${tag}/${APP_NAME}-${version}.dmg"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+dmg_path="$tmp_dir/${APP_NAME}.dmg"
+
+echo "==> Downloading ${APP_NAME} ${tag}…"
+if ! curl -fsSL -o "$dmg_path" "$dmg_url"; then
+  echo "could not download $dmg_url — skipping the TcrBar install" >&2
+  exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$script_dir/scripts/install-tcrbar-from-dmg.sh" "$dmg_path"
+
+echo ""
+echo "Installed: /Applications/${APP_NAME}.app"
+echo "NOTE: ${APP_NAME} bundles its own tcr and prefers it over PATH, so"
+echo "      \`tcr status --json\` run from the app may report a different"
+echo "      build than \`which tcr\`."

--- a/scripts/install-tcrbar-from-dmg.sh
+++ b/scripts/install-tcrbar-from-dmg.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# install-tcrbar-from-dmg.sh — mount a TcrBar dmg and swap it into /Applications.
+#
+# Shared by install.sh (the one-line installer, step 2) and `tcr ui` (which
+# `include_str!`s this file rather than re-implementing the mount/swap in
+# Rust) so there is exactly one copy of this logic, not two that drift.
+#
+# Usage: install-tcrbar-from-dmg.sh <path-to-dmg>
+#
+# Mirrors apps/macos/scripts/install.sh's staging discipline for the same
+# reasons documented there: ditto (not cp -R) preserves the code signature,
+# the staging dir lives beside the destination so the final move is an atomic
+# rename(2), and an EXIT trap cleans up on every catchable path so a failed
+# install never leaves an orphan bundle or a mounted dmg behind. This script
+# does not build anything and does not stop a running app itself — the
+# caller (install.sh) already refused before getting here if TcrBar is
+# running, per CLAUDE.md: you cannot replace /Applications/TcrBar.app while
+# it is running, because its bundled `tcr` is an executing image inside the
+# very bundle being swapped.
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <path-to-dmg>" >&2
+  exit 1
+fi
+
+DMG="$1"
+APP_NAME="TcrBar"
+DEST="/Applications/${APP_NAME}.app"
+
+if [ ! -f "$DMG" ]; then
+  echo "no dmg at $DMG" >&2
+  exit 1
+fi
+
+MOUNT_DIR=""
+STAGE_DIR=""
+
+cleanup() {
+  rc=$?
+  if [ -n "$STAGE_DIR" ]; then
+    rm -rf "$STAGE_DIR"
+  fi
+  if [ -n "$MOUNT_DIR" ] && [ -d "$MOUNT_DIR" ]; then
+    hdiutil detach "$MOUNT_DIR" -quiet -force >/dev/null 2>&1 || true
+  fi
+  exit "$rc"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM HUP
+
+MOUNT_DIR="$(mktemp -d)"
+echo "==> Mounting $DMG…"
+hdiutil attach -nobrowse -readonly -mountpoint "$MOUNT_DIR" "$DMG" >/dev/null
+
+SRC="$MOUNT_DIR/${APP_NAME}.app"
+if [ ! -d "$SRC" ]; then
+  echo "no ${APP_NAME}.app found inside $DMG" >&2
+  exit 1
+fi
+
+# Staging directory lives beside the destination: rename(2) is only atomic
+# within one filesystem, and /tmp is frequently a different one.
+STAGE_DIR="$(mktemp -d "$(dirname "$DEST")/.${APP_NAME}.install.XXXXXX")"
+STAGE="$STAGE_DIR/${APP_NAME}.app"
+BACKUP="$STAGE_DIR/${APP_NAME}.previous.app"
+
+echo "==> Staging the new bundle…"
+ditto "$SRC" "$STAGE"
+
+echo "==> Verifying the staged bundle…"
+if ! codesign -v --deep --strict "$STAGE"; then
+  echo "staged bundle from $DMG failed code-signature verification — refusing to install" >&2
+  exit 1
+fi
+
+echo "==> Installing to ${DEST}…"
+if [ -e "$DEST" ]; then
+  mv "$DEST" "$BACKUP"
+fi
+if ! mv "$STAGE" "$DEST"; then
+  echo "could not move the staged bundle into place — restoring the previous install" >&2
+  if [ -d "$BACKUP" ]; then
+    mv "$BACKUP" "$DEST" || true
+  fi
+  exit 1
+fi
+rm -rf "$BACKUP"
+
+/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister \
+  -f "$DEST" >/dev/null 2>&1 || true
+
+echo "==> Installed: $DEST"

--- a/src/main.rs
+++ b/src/main.rs
@@ -537,8 +537,35 @@ async fn run_status(args: StatusArgs) -> anyhow::Result<()> {
 /// LaunchServices to open a bundle id, which resolves wherever the app was
 /// installed. A `tcr` that shells into a source tree would break the moment the
 /// checkout moved.
+/// The shared mount/swap logic, embedded once so `install.sh` and this binary
+/// never carry two copies that drift. See `scripts/install-tcrbar-from-dmg.sh`
+/// for what it does and why.
+#[cfg(target_os = "macos")]
+const INSTALL_TCRBAR_FROM_DMG_SH: &str = include_str!("../scripts/install-tcrbar-from-dmg.sh");
+
+/// Is a process literally named `TcrBar` running right now?
+///
+/// Matched by exact name (`pgrep -x`), not a path pattern like
+/// `apps/macos/scripts/install.sh` uses — this runs on a machine that may
+/// have TcrBar installed from a dmg, never built from source, so there is no
+/// destination path to derive a pattern from. `pgrep -x` still cannot
+/// distinguish it from an unrelated program that happens to share the name;
+/// that gap already exists in `apps/macos/scripts/uninstall.sh`.
+#[cfg(target_os = "macos")]
+fn tcrbar_is_running() -> anyhow::Result<bool> {
+    use anyhow::Context;
+    let status = std::process::Command::new("pgrep")
+        .args(["-x", "TcrBar"])
+        .status()
+        .context("failed to run `pgrep`")?;
+    Ok(status.success())
+}
+
+/// `tcr ui` — open TcrBar, installing it first if it is missing (macOS only).
 #[cfg(target_os = "macos")]
 fn run_ui() -> anyhow::Result<()> {
+    use std::io::{IsTerminal, Write as _};
+
     use anyhow::Context;
 
     let status = std::process::Command::new("open")
@@ -550,13 +577,76 @@ fn run_ui() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    // `open -b` fails when the bundle id is not registered, which almost always
-    // means "not installed" rather than "broken". Say which, and say how to fix
-    // it, rather than surfacing LaunchServices' own opaque exit code.
-    anyhow::bail!(
-        "TcrBar is not installed. Build and install it with:\n    \
-         bash apps/macos/scripts/install.sh"
-    )
+    // `open -b` fails when the bundle id is not registered, which almost
+    // always means "not installed" rather than "broken".
+    if !std::io::stdin().is_terminal() {
+        anyhow::bail!(
+            "TcrBar is not installed. Run `tcr ui` in a terminal to install it, or \
+             download the dmg from https://github.com/dhkts1/teamclaude-rs/releases/latest"
+        );
+    }
+
+    if tcrbar_is_running()? {
+        anyhow::bail!(
+            "a process named TcrBar is already running but is not registered with \
+             LaunchServices under io.github.dhkts1.tcrbar — quit it before `tcr ui` \
+             installs a fresh copy, then run `tcr ui` again. Installing over a running \
+             copy is refused: its own bundled `tcr` may be an executing image inside \
+             the very bundle being replaced."
+        );
+    }
+
+    eprint!("TcrBar is not installed. Download and install it to /Applications? [y/N] ");
+    std::io::stderr()
+        .flush()
+        .context("failed to flush the prompt")?;
+    let mut answer = String::new();
+    std::io::stdin()
+        .read_line(&mut answer)
+        .context("failed to read the answer")?;
+    if !matches!(answer.trim(), "y" | "Y" | "yes" | "Yes") {
+        anyhow::bail!("not installing — re-run `tcr ui` when you're ready.");
+    }
+
+    let tag = update::fetch_latest_release_tag()
+        .context("could not resolve the latest TcrBar release")?;
+    println!("tcr: downloading TcrBar {tag}…");
+
+    let tmp_dir = tempfile::Builder::new()
+        .prefix("tcr-ui-install-")
+        .tempdir()
+        .context("could not create a temp directory for the download")?;
+    let dmg_path = tmp_dir.path().join("TcrBar.dmg");
+    update::download_tcrbar_dmg(&tag, &dmg_path)
+        .with_context(|| format!("could not download the TcrBar {tag} dmg"))?;
+
+    let script_path = tmp_dir.path().join("install-tcrbar-from-dmg.sh");
+    std::fs::write(&script_path, INSTALL_TCRBAR_FROM_DMG_SH)
+        .context("could not write the install script to a temp file")?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o700))
+            .context("could not make the install script executable")?;
+    }
+
+    let install_status = std::process::Command::new("bash")
+        .arg(&script_path)
+        .arg(&dmg_path)
+        .status()
+        .context("failed to run the TcrBar install script")?;
+    if !install_status.success() {
+        anyhow::bail!("installing TcrBar {tag} failed with {install_status}");
+    }
+
+    let status = std::process::Command::new("open")
+        .args(["-b", "io.github.dhkts1.tcrbar"])
+        .status()
+        .context("failed to run `open`")?;
+    if !status.success() {
+        anyhow::bail!("TcrBar {tag} was installed but `open -b` still failed with {status}");
+    }
+    Ok(())
 }
 
 /// Non-macOS builds keep the subcommand so `--help` is identical everywhere, and

--- a/src/update.rs
+++ b/src/update.rs
@@ -476,6 +476,22 @@ pub fn installer_url_for_tag(tag: &str) -> anyhow::Result<String> {
     ))
 }
 
+/// The TcrBar dmg asset URL for one specific tag.
+///
+/// Same tag-pinning and same validation as [`installer_url_for_tag`], and for
+/// the same reason: the tag is interpolated into a URL PATH. The asset name
+/// drops a leading `v` from the tag (`.github/workflows/release-app.yml`
+/// names the dmg `TcrBar-<version>.dmg`, not `TcrBar-<tag>.dmg`), so a tag of
+/// `v0.2.32` resolves to `TcrBar-0.2.32.dmg`, and a tag with no leading `v`
+/// resolves to a name equal to itself.
+pub fn dmg_url_for_tag(tag: &str) -> anyhow::Result<String> {
+    validate_release_tag(tag)?;
+    let version = tag.strip_prefix('v').unwrap_or(tag);
+    Ok(format!(
+        "https://github.com/{RELEASE_REPO}/releases/download/{tag}/TcrBar-{version}.dmg"
+    ))
+}
+
 /// Accept only a release tag shape: `^v?[0-9A-Za-z][0-9A-Za-z.+_-]*$`.
 ///
 /// Written as an explicit character test rather than a regex because the crate
@@ -582,6 +598,31 @@ fn fetch_bytes(url: &str, accept: &str) -> anyhow::Result<Vec<u8>> {
         Ok(result) => result,
         Err(_) => bail!("the download thread panicked"),
     }
+}
+
+/// Resolve the newest published release's tag.
+///
+/// Composes [`latest_release_api_url`], the shared [`fetch_bytes`] HTTP
+/// client, and [`parse_latest_tag`] into the one call a caller outside this
+/// module needs — `fetch_bytes` itself stays private so there is exactly one
+/// place that builds the `https_only` reqwest client this module relies on
+/// for chain of custody.
+pub fn fetch_latest_release_tag() -> anyhow::Result<String> {
+    let body = fetch_bytes(&latest_release_api_url(), "application/vnd.github+json")
+        .context("could not reach the GitHub releases API")?;
+    parse_latest_tag(&String::from_utf8_lossy(&body))
+}
+
+/// Download the TcrBar dmg for `tag` to `dest`, using the same HTTP client
+/// (and the same TLS-only chain-of-custody guard) `tcr update` uses for the
+/// CLI installer script.
+pub fn download_tcrbar_dmg(tag: &str, dest: &Path) -> anyhow::Result<()> {
+    let url = dmg_url_for_tag(tag)?;
+    let bytes = fetch_bytes(&url, "application/octet-stream")
+        .with_context(|| format!("could not download the TcrBar dmg from {url}"))?;
+    std::fs::write(dest, &bytes)
+        .with_context(|| format!("could not write the downloaded dmg to {}", dest.display()))?;
+    Ok(())
 }
 
 /// Write the installer into a fresh private directory and mark it executable.
@@ -1652,6 +1693,30 @@ mod tests {
         assert!(!installer_url_for_tag("v0.1.0")
             .unwrap()
             .contains("/latest/"));
+    }
+
+    /// Mirrors `asset_and_api_urls_are_built_from_one_repo_constant` for the
+    /// dmg asset: the `v` is dropped from the file name (the release workflow
+    /// names the dmg `TcrBar-<version>.dmg`) but kept in the tag-pinned path.
+    #[test]
+    fn dmg_url_drops_the_v_from_the_filename_not_the_path() {
+        assert_eq!(
+            dmg_url_for_tag("v0.2.32").unwrap(),
+            "https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.32/TcrBar-0.2.32.dmg"
+        );
+        // A tag with no leading `v` names a file equal to itself.
+        assert_eq!(
+            dmg_url_for_tag("0.2.32").unwrap(),
+            "https://github.com/dhkts1/teamclaude-rs/releases/download/0.2.32/TcrBar-0.2.32.dmg"
+        );
+    }
+
+    /// Same guard as `installer_url_for_tag`, same reason: the tag lands in a
+    /// URL path here too.
+    #[test]
+    fn dmg_url_rejects_a_path_escaping_tag() {
+        assert!(dmg_url_for_tag("../../../../attacker/evil/releases/download/v1").is_err());
+        assert!(dmg_url_for_tag("").is_err());
     }
 
     /// The tag is interpolated into a URL PATH, so the repo pin is only real if


### PR DESCRIPTION
🍄

Was meant to stack on #180, but that PR merged into `main` before this one opened and its branch was deleted — `main` now carries everything #180 added, so this targets `main` directly. Verified: `README.md` is byte-identical between this branch's base commit and current `main` (only `Cargo.lock` differs there, an unrelated dependency bump).

The one-line installer and `tcr ui` both used to leave TcrBar out: the README installer was CLI-only, and `tcr ui` failed with an instruction only a source checkout could follow.

- `install.sh` at the repo root runs the existing cargo-dist CLI installer unchanged, then on macOS resolves the latest release, downloads the dmg, and mounts/verifies/swaps it into `/Applications` — mirroring `apps/macos/scripts/install.sh`'s staging discipline (ditto, code-signature check before the swap, atomic rename, EXIT trap). `TCR_SKIP_UI=1` skips the second step.
- `tcr ui` now offers to download and install TcrBar itself when it's missing and stdin is a terminal, sharing the same mount/swap script (`scripts/install-tcrbar-from-dmg.sh`, embedded via `include_str!`) so there's one copy of that logic, not two that drift.
- Both refuse outright, with a clear message, if TcrBar is already running — you cannot replace `/Applications/TcrBar.app` while its bundled `tcr` is an executing image inside it.
- README now points the one-liner at `install.sh`, keeping the cargo-dist installer one line below as the CLI-only alternative.

Never ran the real dmg install on this machine — a live TcrBar/tcr may be running here — and never signaled TcrBar or tcr.

## Test plan
- `cargo build --release` → 0
- `cargo test -j 4` → 0 (924 lib tests + all integration tests, including the new `dmg_url_for_tag` tests)
- Watched `dmg_url_rejects_a_path_escaping_tag` fail red by temporarily removing the `validate_release_tag` call, then restored and re-ran green
- `cargo clippy --all-targets -j 4` → 0
- `shellcheck install.sh scripts/install-tcrbar-from-dmg.sh` → 0
- Dry-ran `install.sh` on this machine with `TCR_SKIP_UI=1` and a mocked `curl` → 0, no `/Applications` writes
- Pre-commit's six gates passed on all three commits (one `cargo fmt` fixup along the way)

https://claude.ai/code/session_01Egpy1WcHQSmAyAaFQcrww6