### PR TITLE
chore: add the 0.2.33 appcast entry

### DIFF
--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.33</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.33</link>
+      <sparkle:version>475</sparkle:version>
+      <sparkle:shortVersionString>0.2.33</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Sat, 05 Sep 2026 20:52:17 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.33/TcrBar-0.2.33.dmg" type="application/octet-stream" sparkle:edSignature="315pFkAp2zq96x+wJUvCW+ANNlM2cpoFDCGGqudn+9nx0T4q3P5AH/rpdya7AuPLRAUbXkZ7IO9sRBW18rX2Bg==" length="6438783" />
+    </item>
+    <item>
       <title>TcrBar 0.2.32</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.32</link>
       <sparkle:version>469</sparkle:version>


### PR DESCRIPTION
🍄 The appcast entry stage 8 of the v0.2.33 release wrote; same bytes as the appcast.xml already on the release.

https://claude.ai/code/session_01Egpy1WcHQSmAyAaFQcrww6