### PR TITLE
fix: refuse a rejected setup token at login, and mark one dead on its first 401

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "teamclaude-rs"
-version = "0.2.33"
+version = "0.2.34"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -912,6 +912,11 @@ struct AccountRow: View {
     /// Defaults to `false` so every other call site (the live panel) is
     /// unchanged.
     var snapshotMode: Bool = false
+    /// The last "Copy Access Token" that did not land — `tcr`'s own words,
+    /// drawn under the row like the other failure lines. Row-local rather
+    /// than a controller: nothing else needs to know, and a copy that did
+    /// land leaves no state at all (the pasteboard is the only evidence).
+    @State private var tokenCopyFailure: TokenCommand.Failure?
 
     /// The single tint for this row's quota evidence. The bar and the
     /// percentage run both read it, so the two can never disagree about
@@ -1376,6 +1381,11 @@ struct AccountRow: View {
         Button("Copy Account Name") {
             copyToPasteboard(account.name)
         }
+        // The token is a secret: it goes from `tcr token`'s stdout straight
+        // to the pasteboard and is never rendered, logged or kept.
+        Button("Copy Access Token") {
+            Task { await performCopyToken() }
+        }
         Divider()
         groupMenuItems
         Divider()
@@ -1593,6 +1603,18 @@ struct AccountRow: View {
     /// Shared by "Copy Account Name" and the per-group command copy — one
     /// place that clears then sets, so every copy in this menu behaves the
     /// same way.
+    /// `tcr token <name>` off the main actor, then the pasteboard. A failure
+    /// replaces any earlier one on this row; a success clears it.
+    private func performCopyToken() async {
+        switch await TokenCommand.fetch(query: account.name) {
+        case .success(let token):
+            copyToPasteboard(token)
+            tokenCopyFailure = nil
+        case .failure(let failure):
+            tokenCopyFailure = failure
+        }
+    }
+
     private func copyToPasteboard(_ text: String) {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
@@ -1895,6 +1917,12 @@ struct AccountRow: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
             if let failure = removeController.failure(for: account.name) {
+                Label(failure.summary, systemImage: Tok.unreadableGlyph)
+                    .font(Tok.detailFont)
+                    .foregroundStyle(Tok.spent)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            if let failure = tokenCopyFailure {
                 Label(failure.summary, systemImage: Tok.unreadableGlyph)
                     .font(Tok.detailFont)
                     .foregroundStyle(Tok.spent)

--- a/apps/macos/Sources/TcrBarCore/TokenCommand.swift
+++ b/apps/macos/Sources/TcrBarCore/TokenCommand.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Reading one account's access token for the row's "Copy Access Token"
+/// action — `tcr token <query> [--org <org>]` (`src/cli.rs`'s
+/// `print_access_token`). A subprocess, like every other credential touch in
+/// this app: `~/.config/teamclaude.json` holds live OAuth tokens and this app
+/// never opens it directly.
+///
+/// The token is the whole of stdout, one line. It is a secret: the caller
+/// puts it on the pasteboard and nowhere else — never in a log, a label, or
+/// a failure message. Failures carry only `tcr`'s stderr, which names the
+/// account, not the credential.
+public enum TokenCommand {
+    /// `query` is passed positionally and verbatim — no shell involved.
+    public static func arguments(query: String, org: String? = nil) -> [String] {
+        guard let org else { return ["token", query] }
+        return ["token", query, "--org", org]
+    }
+
+    /// Why no token was produced. `tcr`'s own words, unparaphrased.
+    public struct Failure: Error, Equatable, Sendable {
+        public let exitCode: Int32
+        public let message: String
+
+        public init(exitCode: Int32, message: String) {
+            self.exitCode = exitCode
+            self.message = message
+        }
+
+        /// One line, always non-empty, safe to render in the row.
+        public var summary: String {
+            let detail = message.isEmpty ? "no output" : message
+            return "copy token failed (exit \(exitCode)): \(detail)"
+        }
+    }
+
+    /// Pure classification of a finished invocation. Exit 0 with an empty
+    /// stdout is a failure, not a success: an empty pasteboard would look
+    /// exactly like a copy that landed.
+    public static func classify(exitCode: Int32, stdout: Data, stderr: String) -> Result<String, Failure> {
+        let text = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard exitCode == 0 else {
+            return .failure(Failure(exitCode: exitCode, message: text))
+        }
+        let token = (String(data: stdout, encoding: .utf8) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else {
+            return .failure(Failure(exitCode: exitCode, message: "tcr printed no token"))
+        }
+        return .success(token)
+    }
+
+    /// Blocking invocation — always called off the main actor.
+    nonisolated static func perform(query: String, org: String? = nil) -> Result<String, Failure> {
+        switch TcrTool.resolve() {
+        case .failure(let notFound):
+            return .failure(
+                Failure(
+                    exitCode: -1,
+                    message: "tcr not found (searched \(notFound.searched.count) locations)"
+                ))
+        case .success(let executable):
+            do {
+                let output = try TcrTool.run(
+                    executable: executable, arguments: arguments(query: query, org: org))
+                return classify(exitCode: output.exitCode, stdout: output.stdout, stderr: output.stderr)
+            } catch {
+                return .failure(Failure(exitCode: -1, message: error.localizedDescription))
+            }
+        }
+    }
+
+    /// Run `tcr token` off the main actor and hand back the token, or why not.
+    public static func fetch(query: String, org: String? = nil) async -> Result<String, Failure> {
+        await Task.detached(priority: .userInitiated) {
+            perform(query: query, org: org)
+        }.value
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/TokenCommandTests.swift
+++ b/apps/macos/Tests/TcrBarTests/TokenCommandTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import XCTest
+
+@testable import TcrBarCore
+
+/// "Copy Access Token" is a subprocess (`tcr token <name>`) whose stdout goes
+/// straight to the pasteboard. These pin the classification: the one case a
+/// user cannot tell apart from success is an EMPTY copy, so exit 0 with no
+/// stdout must be a failure.
+///
+/// Token values are obviously fake — this repository is public.
+final class TokenCommandTests: XCTestCase {
+
+    func testArgumentsPassQueryPositionally() {
+        XCTAssertEqual(TokenCommand.arguments(query: "alice@example.com"), ["token", "alice@example.com"])
+        XCTAssertEqual(
+            TokenCommand.arguments(query: "alice@example.com", org: "acme"),
+            ["token", "alice@example.com", "--org", "acme"])
+    }
+
+    func testExitZeroWithTokenIsSuccessTrimmed() {
+        let out = Data("at-fake-alice\n".utf8)
+        XCTAssertEqual(TokenCommand.classify(exitCode: 0, stdout: out, stderr: ""), .success("at-fake-alice"))
+    }
+
+    func testExitZeroWithEmptyStdoutIsFailure() {
+        let result = TokenCommand.classify(exitCode: 0, stdout: Data(), stderr: "")
+        guard case .failure(let failure) = result else {
+            return XCTFail("an empty token must not reach the pasteboard")
+        }
+        XCTAssertEqual(failure.exitCode, 0)
+        XCTAssertTrue(failure.summary.contains("no token"), failure.summary)
+    }
+
+    func testNonZeroExitCarriesStderrVerbatim() {
+        let result = TokenCommand.classify(
+            exitCode: 1, stdout: Data(), stderr: "Error: no account matches 'nobody'\n")
+        XCTAssertEqual(
+            result, .failure(TokenCommand.Failure(exitCode: 1, message: "Error: no account matches 'nobody'"))
+        )
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -269,6 +269,19 @@ against, so the check can never be evaluated, and an assertion that cannot be ev
 must fail closed rather than silently pass. Drop `--token` and use the browser flow with
 `--account` instead, or use `--token` alone.
 
+**The token is checked before it is written.** `tcr login --token` makes one authenticated
+call with it — the same 1-token `POST /v1/messages` the keep-warm sends — and refuses on a
+401 or 403, writing nothing: mint a fresh one and try again. A 429 or a 5xx is accepted (an
+answer that got past auth proves the credential), and an unreachable upstream stores the
+token with a warning rather than blocking an offline add. This check exists because an
+account added this way is the one kind nothing else ever validates: with no refresh
+token there is nothing to refresh and nothing to probe, so a mistyped or revoked token
+used to be stored and reported `active` while every request it served came back 401. The
+proxy now closes the other half too — a 401 on an account with no refresh token marks it
+`error` on the spot (it cannot be rotation churn, since the token never changes), so a
+credential that dies later shows as `error` in `tcr status` after its first failed request
+instead of never.
+
 ---
 
 ## `tcr accounts`
@@ -284,9 +297,9 @@ zeroes.
 
 ---
 
-## Account resolution: `remove`, `priority`, `enable`, `disable`
+## Account resolution: `remove`, `priority`, `enable`, `disable`, `token`
 
-These four take a positional `<query>` naming one account, and they all resolve it the same
+These five take a positional `<query>` naming one account, and they all resolve it the same
 way.
 
 The rule is: **exact `name`, and if nothing matched, exact email**, where "email" means the
@@ -365,6 +378,17 @@ The four outcomes:
 If you have set `proxy.apiKey`, these two commands need it; they go through the same
 loopback-plus-key gate as every other `/_tcr/` route, with no loopback exemption. See
 [configuration.md](configuration.md#proxyapikey-is-a-security-control-not-a-convenience).
+
+### `tcr token <query>`
+
+Prints the account's current access token to stdout — one line, nothing else — so it can
+be piped or copied. Flags: `--config`, `--org`. Read-only; a non-matching query exits
+non-zero with the file untouched. It reads the file rather than the running proxy, which is
+current enough: every refresh the proxy performs is written straight back to the file.
+
+The token is a credential. Pipe it (`tcr token alice@example.com | pbcopy`); do not paste
+it into a chat, a ticket, or a command line that lands in shell history. TcrBar's
+right-click **Copy Access Token** runs exactly this and puts stdout on the pasteboard.
 
 ---
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -333,6 +333,28 @@ pub fn set_priority(
     Ok(())
 }
 
+/// `tcr token <query>` — print the matched account's access token to stdout,
+/// nothing else, so a caller can pipe or copy it. Exists for TcrBar's "Copy
+/// Access Token" row action: the app never reads the config file itself
+/// (it holds live credentials), so every credential read is a subprocess.
+///
+/// Reads the FILE, not the running proxy — close enough, because every
+/// refresh the proxy performs is persisted straight back to the file
+/// (`Manager::persist_tokens`); the window where the two differ is the
+/// write itself. Read-only: a non-matching query errors with the file
+/// untouched, and nothing is logged — the token goes to stdout only.
+pub fn print_access_token(
+    config_path: &Path,
+    query: &str,
+    org: Option<&str>,
+) -> anyhow::Result<()> {
+    let config = config::load(config_path)
+        .with_context(|| format!("load config at {}", config_path.display()))?;
+    let idx = resolve_account(&config.accounts, query, org)?;
+    println!("{}", config.accounts[idx].access_token);
+    Ok(())
+}
+
 /// Printed after every group mutation that actually changed the file.
 ///
 /// Used to say "will not see this until it restarts" — true before

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,9 @@ enum Command {
     Remove(RemoveArgs),
     /// Set an account's rotation priority (lower value = preferred).
     Priority(PriorityArgs),
+    /// Print an account's current access token to stdout (a secret — pipe it, do
+    /// not paste it into a chat or a shell history).
+    Token(TokenArgs),
     /// Enable an account (clears the `disabled` flag).
     Enable(EnableArgs),
     /// Disable an account (holds it out of rotation).
@@ -81,6 +84,19 @@ struct AccountsArgs {
 
 #[derive(clap::Args)]
 struct RemoveArgs {
+    /// Path to the config file (default: ~/.config/teamclaude.json).
+    #[arg(long)]
+    config: Option<PathBuf>,
+    /// Account name, or its bare email if the name carries an org suffix. Exact
+    /// and case-sensitive — not a substring.
+    query: String,
+    /// Narrow an ambiguous match to a single org (name or uuid).
+    #[arg(long)]
+    org: Option<String>,
+}
+
+#[derive(clap::Args)]
+struct TokenArgs {
     /// Path to the config file (default: ~/.config/teamclaude.json).
     #[arg(long)]
     config: Option<PathBuf>,
@@ -409,6 +425,7 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Login(args)) => run_login(args).await,
         Some(Command::Accounts(args)) => run_accounts(args).await,
         Some(Command::Remove(args)) => run_remove(args).await,
+        Some(Command::Token(args)) => run_token(args),
         Some(Command::Priority(args)) => run_priority(args),
         Some(Command::Enable(args)) => run_enable(args).await,
         Some(Command::Disable(args)) => run_disable(args).await,
@@ -433,6 +450,12 @@ async fn run_accounts(args: AccountsArgs) -> anyhow::Result<()> {
 async fn run_remove(args: RemoveArgs) -> anyhow::Result<()> {
     let config_path = args.config.unwrap_or_else(config::default_path);
     cli::remove_account(&config_path, &args.query, args.org.as_deref()).await
+}
+
+/// `tcr token <query> [--org]` — print the account's access token.
+fn run_token(args: TokenArgs) -> anyhow::Result<()> {
+    let config_path = args.config.unwrap_or_else(config::default_path);
+    cli::print_access_token(&config_path, &args.query, args.org.as_deref())
 }
 
 /// `tcr priority <query> [N|--first|--last] [--org]` — set rotation priority.

--- a/src/manager/probing.rs
+++ b/src/manager/probing.rs
@@ -84,10 +84,12 @@ impl Manager {
     /// successful refresh would flip an `Error` row back to `Active`, silently
     /// re-inserting it into rotation". That reasoning no longer holds, and its premise
     /// has since been removed on both sides:
-    /// - `Error` now arises ONLY from a REJECTED refresh (the `AuthRejected` arm). A
-    ///   request-level 401 no longer condemns a row (that was rotation churn falsely
-    ///   sidelining healthy accounts — fixed 2026-07-17), and the port-takeover
-    ///   singleton removed token-wars, the main source of *transient* rejections.
+    /// - `Error` now arises ONLY from a REJECTED refresh (the `AuthRejected` arm), or
+    ///   from a request-level 401 on a row with NO refresh token — one that never
+    ///   reaches this filter anyway. A request-level 401 on a refreshable row no
+    ///   longer condemns it (that was rotation churn falsely sidelining healthy
+    ///   accounts — fixed 2026-07-17), and the port-takeover singleton removed
+    ///   token-wars, the main source of *transient* rejections.
     /// - Recovery requires a **successful refresh**, which a genuinely dead
     ///   credential cannot produce — so a re-probe can only ever revive a row that was
     ///   never actually dead. The feared "silently re-insert a dead account" is

--- a/src/manager/state.rs
+++ b/src/manager/state.rs
@@ -159,6 +159,18 @@ impl Manager {
             .map(|a| a.access_token.clone())
     }
 
+    /// Whether account `idx` carries a refresh token. `false` for a
+    /// `claude setup-token` credential (`tcr login --token`), whose access token
+    /// can never be renewed — so for such a row an upstream 401 is proof the
+    /// credential is dead, not rotation churn (see the proxy's 401 arm).
+    pub fn has_refresh_token(&self, idx: usize) -> bool {
+        self.accounts
+            .read()
+            .expect("accounts lock poisoned")
+            .get(idx)
+            .is_some_and(|a| a.refresh_token.is_some())
+    }
+
     /// Display name of account `idx`, for the request log.
     pub fn account_name(&self, idx: usize) -> Option<String> {
         self.accounts

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -1218,6 +1218,56 @@ fn resolve_setup_token_name(profile: &Profile, name: Option<&str>, fallback: &st
     }
 }
 
+/// What one authenticated call said about a pasted setup token, before it is
+/// written anywhere.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SetupTokenCheck {
+    /// Upstream accepted the credential (2xx, or a 429/5xx — a quota or server
+    /// answer is still one that got past auth).
+    Accepted,
+    /// Upstream refused the credential (401 or 403). Nothing may be written.
+    Rejected { status: u16 },
+    /// The call never got an upstream answer (DNS, TLS, timeout). Proves
+    /// nothing either way.
+    Unreachable { message: String },
+}
+
+/// Make ONE authenticated call with `access_token` against `upstream` — the
+/// same 1-token `POST /v1/messages` the warmer sends — and classify the answer.
+///
+/// This exists because a `claude setup-token` credential is the one kind of
+/// account nothing else ever validates: it has no refresh token, so the prober
+/// skips it, a refresh has nothing to send, and the proxy's 401 arm can only
+/// sideline it after the first real request has already failed. A bad paste
+/// therefore used to be accepted silently and reported `active` for as long
+/// as the config held it. The Messages endpoint is used rather than the
+/// profile endpoint because the profile fetch usually fails for an
+/// inference-only scope whether the token is good or not, so it cannot tell
+/// the two apart. The call is a real 1-token completion: it spends a trivial
+/// amount of quota and starts the account's 5h window, which a login is about
+/// to do anyway.
+pub async fn verify_setup_token(upstream: &str, access_token: &str) -> SetupTokenCheck {
+    use crate::warmer::AccountWarmer as _;
+    let warmer = crate::warmer::LiveWarmer::new();
+    match warmer
+        .warm(access_token.to_string(), upstream.to_string())
+        .await
+    {
+        Ok(_) => SetupTokenCheck::Accepted,
+        Err(crate::warmer::WarmError {
+            status: Some(status @ (401 | 403)),
+            ..
+        }) => SetupTokenCheck::Rejected { status },
+        Err(crate::warmer::WarmError {
+            status: Some(_), ..
+        }) => SetupTokenCheck::Accepted,
+        Err(crate::warmer::WarmError {
+            status: None,
+            message,
+        }) => SetupTokenCheck::Unreachable { message },
+    }
+}
+
 pub async fn login_with_token(
     config_path: &Path,
     force: bool,
@@ -1251,6 +1301,24 @@ pub async fn login_with_token(
     };
 
     let mut config = load_or_default(config_path)?;
+
+    // One authenticated call BEFORE anything is written: a rejected token is
+    // refused here, because nothing downstream would ever catch it (see
+    // `verify_setup_token`).
+    match verify_setup_token(&config.upstream, &tokens.access_token).await {
+        SetupTokenCheck::Accepted => {}
+        SetupTokenCheck::Rejected { status } => bail!(
+            "upstream refused this token (HTTP {status}) — it is expired, revoked or mistyped. \
+             Mint a fresh one with `claude setup-token` and try again. Nothing was written."
+        ),
+        SetupTokenCheck::Unreachable { message } => {
+            eprintln!(
+                "[tcr] warning: could not reach {} to verify the token ({message}) — \
+                 storing it unverified; a bad token will be marked `error` on its first request",
+                config.upstream
+            );
+        }
+    }
 
     let profile = fetch_profile(&tokens.access_token).await;
     let fallback = unnamed_fallback(&config.accounts);
@@ -3983,6 +4051,85 @@ mod tests {
         );
 
         std::fs::remove_file(&path).ok();
+    }
+
+    /// A canned upstream that answers every connection with `status_line` and an
+    /// empty body, for [`verify_setup_token`]. Returns its base URL.
+    async fn canned_upstream(status_line: &'static str) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 4096];
+                    let _ = sock.read(&mut buf).await;
+                    let _ = sock
+                        .write_all(
+                            format!(
+                                "HTTP/1.1 {status_line}\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+                            )
+                            .as_bytes(),
+                        )
+                        .await;
+                });
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    /// The bug this guards: a pasted token upstream refuses with 401 must be
+    /// classified `Rejected`, so `login_with_token` writes nothing. Before the
+    /// check existed the account was stored and reported `active` while every
+    /// request it served came back 401.
+    #[tokio::test]
+    async fn verify_setup_token_classifies_401_as_rejected() {
+        let upstream = canned_upstream("401 Unauthorized").await;
+        assert_eq!(
+            verify_setup_token(&upstream, "bad-token").await,
+            SetupTokenCheck::Rejected { status: 401 }
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_setup_token_classifies_403_as_rejected() {
+        let upstream = canned_upstream("403 Forbidden").await;
+        assert_eq!(
+            verify_setup_token(&upstream, "refused-token").await,
+            SetupTokenCheck::Rejected { status: 403 }
+        );
+    }
+
+    /// A 2xx is acceptance, and so is a 429: a quota answer is one that got past
+    /// auth, and refusing a valid-but-exhausted token would block the operator
+    /// from adding an account they mean to use once its window resets.
+    #[tokio::test]
+    async fn verify_setup_token_accepts_2xx_and_429() {
+        let ok = canned_upstream("200 OK").await;
+        assert_eq!(
+            verify_setup_token(&ok, "good-token").await,
+            SetupTokenCheck::Accepted
+        );
+        let exhausted = canned_upstream("429 Too Many Requests").await;
+        assert_eq!(
+            verify_setup_token(&exhausted, "exhausted-token").await,
+            SetupTokenCheck::Accepted
+        );
+    }
+
+    /// No upstream answer at all proves nothing about the token — the caller
+    /// stores it with a warning rather than refusing an offline operator.
+    #[tokio::test]
+    async fn verify_setup_token_reports_dead_upstream_as_unreachable() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        assert!(matches!(
+            verify_setup_token(&format!("http://{addr}"), "any-token").await,
+            SetupTokenCheck::Unreachable { .. }
+        ));
     }
 
     /// An all-`None` profile plus `--name` must produce that exact name,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -9,8 +9,11 @@
 //!   new token was applied it retries the SAME account; if the force was
 //!   coalesced/cooldown-suppressed or the refresh failed (no new token) it rotates
 //!   away WITHOUT sidelining — a healthy account is never marked `Error` for losing
-//!   a race to the refresh throttle. Only a second `401` on a genuinely refreshed
-//!   token sidelines it. A stale-token `401` is never passed to the client.
+//!   a race to the refresh throttle. A second `401` rotates too — it is rotation
+//!   churn, not proof of death; only a REJECTED refresh sets `Error`. The one
+//!   exception is an account with no refresh token (`tcr login --token`): its
+//!   token can neither churn nor be renewed, so a single `401` marks it `Error`.
+//!   A stale-token `401` is never passed to the client.
 //! - A `429` with a `rejected` unified status is durable quota exhaustion →
 //!   throttle + rotate; a transient `429` waits (bounded) and retries the same
 //!   account, or rotates once the wait would be too long.
@@ -2565,6 +2568,25 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
         // 401 → force-refresh once, then retry the SAME account with the fresh
         // token. Neither arm may set the terminal `Error` status — see below.
         if status == StatusCode::UNAUTHORIZED {
+            // A 401 on an account with NO refresh token is not churn — there is no
+            // refresh that could have rotated the token out from under this
+            // request, and none that could ever revive it. The credential is dead
+            // and only a re-login cures it, so `Error` (terminal, skipped by
+            // selection) is the truthful state. Without this arm a `tcr login
+            // --token` account whose token was rejected sat Active forever: never
+            // probed (`probeable_indices` wants a refresh token), never refreshed
+            // (`refresh_plan` has nothing to send), and rotated away from on every
+            // request while `tcr status` reported it healthy.
+            if !manager.has_refresh_token(idx) {
+                tracing::error!(
+                    account = account_name.as_deref().unwrap_or("?"),
+                    account_index = idx,
+                    "upstream 401 on an account with no refresh token — credential rejected, re-login needed"
+                );
+                manager.mark_error(idx);
+                tried.insert(idx);
+                continue;
+            }
             if forced_401.insert(idx) {
                 if manager.ensure_fresh_force(idx).await {
                     next_idx = Some(idx);
@@ -8474,6 +8496,75 @@ mod tests {
             manager.account_status(0),
             Some(AccountStatus::Active),
             "a forced refresh that produced no new token must rotate, not sideline the account"
+        );
+    }
+
+    /// The inverse of the two 401 tests around it: an account with NO refresh
+    /// token (`tcr login --token`) that 401s must be marked `Error` on the spot.
+    /// The churn argument that protects refreshable accounts does not apply —
+    /// nothing can have rotated its token, and nothing can ever renew it — and
+    /// before this arm existed such a row stayed `active` in `tcr status` for
+    /// as long as the config held it, 401ing every request it was handed.
+    #[tokio::test]
+    async fn single_401_on_account_without_refresh_token_marks_error() {
+        struct NeverCalled;
+        impl crate::oauth::TokenRefresher for NeverCalled {
+            fn refresh(&self, _refresh_token: String) -> crate::oauth::RefreshFuture {
+                Box::pin(async {
+                    panic!("a refresh must never be attempted for an account with no refresh token")
+                })
+            }
+        }
+
+        let upstream = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let up_addr = upstream.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = upstream.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut buf = [0u8; 1024];
+                    let _ = sock.read(&mut buf).await;
+                    let _ = sock
+                        .write_all(
+                            b"HTTP/1.1 401 Unauthorized\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+                        )
+                        .await;
+                });
+            }
+        });
+
+        let mut config = dummy_config(None, &format!("http://{up_addr}"));
+        config.accounts[0].refresh_token = None;
+        let manager = Manager::new(
+            config,
+            Arc::new(NeverCalled),
+            Arc::new(crate::probe::LiveUsageProber::new()),
+            Arc::new(crate::warmer::LiveWarmer::new()),
+            None,
+        );
+
+        let proxy = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = proxy.local_addr().unwrap();
+        let served = manager.clone();
+        tokio::spawn(async move {
+            let _ = axum::serve(proxy, app(served)).await;
+        });
+
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let _ = client
+            .post(format!("http://{proxy_addr}/v1/messages"))
+            .body("{}")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            manager.account_status(0),
+            Some(AccountStatus::Error),
+            "a 401 on an account that cannot refresh is a dead credential, not churn"
         );
     }
 


### PR DESCRIPTION
🍄

## The bug

An account added with `tcr login --token` whose token is invalid was accepted without a check, then reported `state=ok status=active` for as long as the config held it while every request it served came back 401. Nothing in the panel said it was dead except that no prompt ever ran through it.

It is the one kind of account nothing validated. It has no refresh token, so:

- the prober skips it (`probeable_indices` filters `refresh_token.is_some()`),
- a refresh has nothing to send (`refresh_plan` returns `None`),
- the proxy's 401 arm — built to protect refreshable accounts from rotation churn — rotates away and leaves it Active.

## The fix, both ends

**Login.** `login_with_token` makes one authenticated call before writing — the keep-warm's own 1-token `POST /v1/messages`, because the profile endpoint fails for an inference-only scope whether the token is good or not — and refuses on 401/403 with nothing written. 429/5xx are accepted (an answer that got past auth proves the credential); an unreachable upstream stores the token with a warning rather than blocking an offline add.

**Runtime.** The proxy's 401 arm marks an account with no refresh token `Error` on the spot. The churn argument that protects OAuth accounts does not apply: its token cannot have been rotated out from under the request and cannot be renewed, so a re-login is the only cure and `Error` is the truthful state. A credential that dies later now shows `error` in `tcr status` after its first failed request instead of never.

## Also: the token is reachable from the panel

- `tcr token <query> [--org]` — read-only, prints the access token to stdout, one line. Resolves the account like `remove`/`enable`.
- TcrBar right-click → **Copy Access Token**, next to Copy Account Name. Runs `tcr token` off the main actor and puts stdout on the pasteboard; the token is never rendered, logged or kept. Exit 0 with empty stdout is a failure there, since an empty copy looks exactly like one that landed.

## Verification

```
cargo clippy --all-targets -- -D warnings   → exit 0
cargo test                                  → 936 passed (lib) + integration suites, 0 failed
swift test --package-path apps/macos        → Executed 374 tests, with 0 failures
```

New tests: `verify_setup_token_*` against canned 401/403/200/429 and a dead port; `single_401_on_account_without_refresh_token_marks_error` beside the two existing 401 tests; `TokenCommandTests` for the Swift classifier. Both Rust guards were watched fail with the fix reverted (`if false && …` / `402 | 403`) and pass restored. `tcr token` was exercised by hand on a fake temp config: hit prints the token exit 0, miss prints `no account matches` exit 1.

Version bumped 0.2.33 → 0.2.34 (the release gate refuses a shipped tag).

https://claude.ai/code/session_01H3JPJxQW1Q1AbrNbWVJypv
