### PR TITLE
feat: show the release notes in a window after an update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.34"
+version = "0.2.35"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "teamclaude-rs"
-version = "0.2.34"
+version = "0.2.35"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -46,6 +46,9 @@ struct FleetView: View {
     /// whatever the panel happens to show. Runtime is untouched — the default is
     /// `false` and the live panel still scrolls.
     var snapshotMode: Bool = false
+    /// Opens the "What's new" window. A closure rather than the controller so
+    /// the render harness passes `{}` and can neither fetch nor open anything.
+    var onWhatsNew: () -> Void = {}
 
     /// Surfaced in place rather than swallowed: a button that silently does
     /// nothing is worse than one that says why.
@@ -562,6 +565,8 @@ struct FleetView: View {
                     "Ask the release feed whether a newer TcrBar exists. "
                         + "Also reachable as `tcrbar://check-for-updates`."
                 )
+            Button("What's New…") { onWhatsNew() }
+                .help("The release notes for the TcrBar you are running.")
             Button("Quit") { NSApplication.shared.terminate(nil) }
             Spacer(minLength: 0)
         }

--- a/apps/macos/Sources/TcrBar/MenuBarShell.swift
+++ b/apps/macos/Sources/TcrBar/MenuBarShell.swift
@@ -51,6 +51,11 @@ final class MenuBarShell {
     /// to find it, so an updater that only existed while the panel was open would
     /// make the CLI's call do nothing on an app nobody had clicked.
     let updater: Updater
+    /// The release-notes window and its state. Owned here so the notes loaded
+    /// at launch are the ones the footer button reopens, and so the
+    /// right-click menu can reach it with the panel closed.
+    let whatsNew: WhatsNewController
+    let whatsNewWindow: WhatsNewWindow
 
     let statusItem: NSStatusItem
     let popover: NSPopover
@@ -72,7 +77,8 @@ final class MenuBarShell {
         preference: LaunchPreference? = nil,
         updater: Updater? = nil,
         groupController: GroupController? = nil,
-        removeController: RemoveAccountController? = nil
+        removeController: RemoveAccountController? = nil,
+        whatsNew: WhatsNewController? = nil
     ) {
         self.poller = poller ?? StatusPoller()
         self.server = server ?? ServerController()
@@ -84,6 +90,16 @@ final class MenuBarShell {
         self.updater = updater ?? Updater()
         self.groupController = groupController ?? GroupController()
         self.removeController = removeController ?? RemoveAccountController()
+        // The controller's `init` is inert; nothing fetches until `AppDelegate`
+        // calls `checkAfterLaunch()`, which the shell probe never does.
+        self.whatsNew =
+            whatsNew
+            ?? WhatsNewController(
+                store: WhatsNewStore(),
+                fetcher: GitHubReleaseClient(version: AppBuild.shortVersion),
+                location: ReleaseFeedLocation.from(bundle: .main),
+                currentVersion: AppBuild.shortVersion)
+        self.whatsNewWindow = WhatsNewWindow(controller: self.whatsNew)
 
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         // An `NSStatusItem`'s visibility is *persisted*, and the app must never
@@ -120,7 +136,8 @@ final class MenuBarShell {
                 poller: self.poller, server: self.server, loginItem: self.loginItem,
                 accounts: self.accounts, control: self.control, awake: self.awake,
                 preference: self.preference, updater: self.updater,
-                groupController: self.groupController, removeController: self.removeController))
+                groupController: self.groupController, removeController: self.removeController,
+                onWhatsNew: { [weak self] in self?.openWhatsNew() }))
         // Without this the popover takes a default size and the panel is clipped.
         //
         // This is the specific thing `MenuBarExtra` did for free. `FleetView`
@@ -267,6 +284,11 @@ final class MenuBarShell {
         updateItem.isEnabled = updater.canCheckForUpdates
         menu.addItem(updateItem)
 
+        let notesItem = NSMenuItem(
+            title: "What's New…", action: #selector(quickWhatsNew), keyEquivalent: "")
+        notesItem.target = self
+        menu.addItem(notesItem)
+
         let quitItem = NSMenuItem(
             title: "Quit", action: #selector(quickQuit), keyEquivalent: "")
         quitItem.target = self
@@ -281,6 +303,15 @@ final class MenuBarShell {
     @objc private func quickRefresh() { Task { await poller.pollOnce() } }
     @objc private func quickToggleAwake() { awake.toggle() }
     @objc private func quickCheckForUpdates() { updater.checkForUpdates() }
+    @objc private func quickWhatsNew() { openWhatsNew() }
+
+    /// The on-demand route: footer button, right-click item. Shows the window
+    /// at once (loading state) and lets the controller fill it in.
+    func openWhatsNew() {
+        closePanel()
+        whatsNewWindow.present()
+        Task { await whatsNew.showOnDemand() }
+    }
     @objc private func quickQuit() { NSApplication.shared.terminate(nil) }
 
     func openPanel() {
@@ -334,6 +365,7 @@ struct FleetPanel: View {
     @ObservedObject var updater: Updater
     @ObservedObject var groupController: GroupController
     @ObservedObject var removeController: RemoveAccountController
+    var onWhatsNew: () -> Void = {}
 
     var body: some View {
         FleetView(
@@ -346,7 +378,8 @@ struct FleetPanel: View {
             updater: updater,
             groupController: groupController,
             removeController: removeController,
-            startServerAtLaunch: $preference.startServerAtLaunch
+            startServerAtLaunch: $preference.startServerAtLaunch,
+            onWhatsNew: onWhatsNew
         )
     }
 }

--- a/apps/macos/Sources/TcrBar/ShellProbe.swift
+++ b/apps/macos/Sources/TcrBar/ShellProbe.swift
@@ -107,7 +107,13 @@ enum ShellProbe {
             // — it must also remember nothing, or a probe run would rewrite the
             // operator's `keepThisMacAwake` preference. See `AwakeController.harness()`.
             awake: AwakeController.harness(),
-            updater: Updater(startingUpdater: false))
+            updater: Updater(startingUpdater: false),
+            // Same posture for the release notes: remembers nothing, and a
+            // fetcher that cannot reach anything — a probe run must neither
+            // write `lastSeenVersion` nor touch the network.
+            whatsNew: WhatsNewController(
+                store: WhatsNewStore(defaults: nil), fetcher: NeverFetches(),
+                location: nil, currentVersion: nil))
 
         var checks: [Check] = []
         var notes: [String] = []
@@ -551,5 +557,12 @@ enum ShellProbe {
         }
         let json = "[\(rows.joined(separator: ","))]"
         return (try? Fleet.decode(Data(json.utf8))) ?? Fleet(accounts: [])
+    }
+}
+
+/// A `ReleaseFetching` that refuses every call — for harness runs.
+struct NeverFetches: ReleaseFetching {
+    func fetchRelease(at url: URL) async throws -> ReleaseNotes {
+        throw ReleaseFetchError.network("harness run: no network")
     }
 }

--- a/apps/macos/Sources/TcrBar/TcrBarApp.swift
+++ b/apps/macos/Sources/TcrBar/TcrBarApp.swift
@@ -88,6 +88,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         let shell = MenuBarShell()
         self.shell = shell
+        // The one call that can open the release-notes window unbidden: only
+        // after an update (a version the operator has not seen notes for), and
+        // only once the notes actually loaded. Never awaited — a hung network
+        // must not hold up launch — and never reached by the render or probe
+        // harnesses, which build the shell without this delegate.
+        Task {
+            if await shell.whatsNew.checkAfterLaunch() {
+                shell.whatsNewWindow.present()
+            }
+        }
         // Was `FleetView.onAppear`, which under `MenuBarExtra` meant the fleet
         // was not polled until the panel had been opened once — the menu-bar
         // glyph sat at its `.pending` gauge until then.

--- a/apps/macos/Sources/TcrBar/WhatsNewWindow.swift
+++ b/apps/macos/Sources/TcrBar/WhatsNewWindow.swift
@@ -1,0 +1,179 @@
+import AppKit
+import SwiftUI
+import TcrBarCore
+
+/// The "What's new in TcrBar X.Y.Z" window — the first real window this app
+/// has had; everything else is the popover and a transient menu.
+///
+/// Built once, lazily, and reused, for the same reason `MenuBarShell` keeps
+/// one hosting controller for the popover: a window rebuilt per open loses
+/// its size, its scroll position and its key focus, and a window that is
+/// `isReleasedWhenClosed` (AppKit's default) is deallocated by the red button
+/// and crashes or duplicates on the next open.
+///
+/// ⌘W is handled by hand. There is no main menu in this app (it is an
+/// accessory), so nothing else dispatches the Close key equivalent; a local
+/// event monitor, installed while the window is on screen, does it.
+@MainActor
+final class WhatsNewWindow {
+    private let controller: WhatsNewController
+    private var window: NSWindow?
+    private var keyMonitor: Any?
+
+    init(controller: WhatsNewController) {
+        self.controller = controller
+    }
+
+    /// Bring the window up, frontmost. The activation call is the same one
+    /// `openPanel()` and `Updater.checkForUpdates()` make: without it the
+    /// window opens BEHIND whatever the operator is looking at.
+    func present() {
+        let window = self.window ?? makeWindow()
+        self.window = window
+        window.title = controller.title
+        if #available(macOS 14.0, *) {
+            NSApp.activate()
+        } else {
+            NSApp.activate(ignoringOtherApps: true)
+        }
+        window.makeKeyAndOrderFront(nil)
+        installKeyMonitor()
+    }
+
+    func close() {
+        window?.performClose(nil)
+    }
+
+    private func makeWindow() -> NSWindow {
+        let hosting = NSHostingController(
+            rootView: WhatsNewView(controller: controller, onClose: { [weak self] in self?.close() }))
+        let window = NSWindow(contentViewController: hosting)
+        window.styleMask = [.titled, .closable, .resizable, .miniaturizable]
+        window.isReleasedWhenClosed = false
+        window.setContentSize(NSSize(width: 480, height: 520))
+        window.minSize = NSSize(width: 360, height: 280)
+        window.center()
+        NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification, object: window, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.removeKeyMonitor() }
+        }
+        return window
+    }
+
+    private func installKeyMonitor() {
+        guard keyMonitor == nil else { return }
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self, let window = self.window, window.isKeyWindow,
+                event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
+                event.charactersIgnoringModifiers == "w"
+            else { return event }
+            window.performClose(nil)
+            return nil
+        }
+    }
+
+    private func removeKeyMonitor() {
+        if let keyMonitor {
+            NSEvent.removeMonitor(keyMonitor)
+            self.keyMonitor = nil
+        }
+    }
+}
+
+/// The window's content: title row with the GitHub link, the notes (or why
+/// there are none), a Close button. Scrolls; Esc closes.
+struct WhatsNewView: View {
+    @ObservedObject var controller: WhatsNewController
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(controller.title)
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundStyle(Tok.ink)
+                Spacer()
+                if let page {
+                    Link("Open on GitHub", destination: page)
+                        .font(Tok.secondaryFont)
+                }
+            }
+            .padding(.horizontal, Tok.space5)
+            .padding(.top, Tok.space5)
+            .padding(.bottom, Tok.space4)
+            Hairline()
+            ScrollView {
+                VStack(alignment: .leading, spacing: Tok.space3) {
+                    content
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(Tok.space5)
+            }
+            Hairline()
+            HStack {
+                Spacer()
+                Button("Close", action: onClose)
+                    .keyboardShortcut(.cancelAction)
+            }
+            .padding(Tok.space4)
+        }
+        .background(Tok.panel)
+        .frame(minWidth: 360, minHeight: 280)
+    }
+
+    private var page: URL? {
+        switch controller.state {
+        case .notes(_, _, let page), .failed(_, _, let page): return page
+        case .idle, .loading: return nil
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch controller.state {
+        case .idle, .loading:
+            HStack(spacing: Tok.space3) {
+                ProgressView().controlSize(.small)
+                Text("Loading release notes…")
+                    .font(Tok.bodyFont)
+                    .foregroundStyle(Tok.inkDim)
+            }
+        case .failed(_, let message, _):
+            Label(message, systemImage: "exclamationmark.triangle")
+                .font(Tok.bodyFont)
+                .foregroundStyle(Tok.spent)
+                .fixedSize(horizontal: false, vertical: true)
+        case .notes(_, let blocks, _):
+            ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
+                blockView(block)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func blockView(_ block: WhatsNewMarkdown.Block) -> some View {
+        switch block {
+        case .heading(let text):
+            Text(WhatsNewMarkdown.inline(text))
+                .font(Tok.titleFont)
+                .foregroundStyle(Tok.ink)
+                .padding(.top, Tok.space2)
+        case .bullet(let text):
+            HStack(alignment: .firstTextBaseline, spacing: Tok.space3) {
+                Text("•").foregroundStyle(Tok.inkDim)
+                Text(WhatsNewMarkdown.inline(text))
+                    .font(Tok.bodyFont)
+                    .foregroundStyle(Tok.ink)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+            }
+        case .paragraph(let text):
+            Text(WhatsNewMarkdown.inline(text))
+                .font(Tok.bodyFont)
+                .foregroundStyle(Tok.ink)
+                .fixedSize(horizontal: false, vertical: true)
+                .textSelection(.enabled)
+        }
+    }
+}

--- a/apps/macos/Sources/TcrBarCore/WhatsNew.swift
+++ b/apps/macos/Sources/TcrBarCore/WhatsNew.swift
@@ -1,0 +1,420 @@
+import Combine
+import Foundation
+
+// MARK: - Store
+
+/// The version whose release notes the operator has already been shown,
+/// persisted in `UserDefaults` — the one fact the "What's new" window's
+/// launch gate reads.
+///
+/// ## The key string is load-bearing
+///
+/// Same warning as ``LaunchPreference``: renaming ``lastSeenVersionKey`` fails
+/// nothing and silently forgets what the operator has seen, so the next launch
+/// re-shows notes they already closed. `WhatsNewTests` pins the literal.
+///
+/// `defaults` is optional, mirroring `AwakeController.harness()`: `nil` means
+/// "remember nothing", which is what a render or probe run must use — a
+/// harness that wrote to the operator's real preferences would change what
+/// the real app shows next launch.
+@MainActor
+public final class WhatsNewStore: ObservableObject {
+    /// The `UserDefaults` key. Do not change it. See the type's doc-comment.
+    public static let lastSeenVersionKey = "lastSeenVersion"
+
+    private let defaults: UserDefaults?
+
+    /// Written through on every change. `nil` is "never shown anything".
+    @Published public var lastSeenVersion: String? {
+        didSet { defaults?.set(lastSeenVersion, forKey: Self.lastSeenVersionKey) }
+    }
+
+    public init(defaults: UserDefaults? = .standard) {
+        self.defaults = defaults
+        // Property initialisation in `init` does not fire `didSet`.
+        self.lastSeenVersion = defaults?.string(forKey: Self.lastSeenVersionKey)
+    }
+}
+
+// MARK: - Gate
+
+/// The pure decision behind "show the notes on this launch?". Split out so the
+/// four cases are testable without a bundle, a network or a window.
+public enum WhatsNewGate {
+    public enum Decision: Equatable, Sendable {
+        /// Nothing was ever recorded — a fresh install. Record the current
+        /// version and show nothing: there is no "what changed" for a first run.
+        case recordOnly
+        /// The operator has already seen this version's notes.
+        case skip
+        /// The app is running a version the operator has not seen notes for.
+        case show(version: String)
+    }
+
+    /// - Parameters:
+    ///   - lastSeen: ``WhatsNewStore/lastSeenVersion``.
+    ///   - current: `AppBuild.shortVersion`. `nil` (an unbundled binary, a test
+    ///     host) never shows — there is no version to fetch notes for, and a
+    ///     harness must not be the thing that opens a window.
+    public static func decide(lastSeen: String?, current: String?) -> Decision {
+        guard let current, !current.isEmpty else { return .skip }
+        guard let lastSeen else { return .recordOnly }
+        return lastSeen == current ? .skip : .show(version: current)
+    }
+}
+
+// MARK: - Where the releases live
+
+/// `owner`/`repo` on GitHub, derived from the bundle's Sparkle feed URL rather
+/// than written down a second time. `build-tcrbar.sh` puts
+/// `https://github.com/<owner>/<repo>/releases/latest/download/appcast.xml`
+/// into `SUFeedURL`; the release API the notes come from is the same
+/// repository, so the feed URL is the one source and this type just reads it.
+public struct ReleaseFeedLocation: Equatable, Sendable {
+    public let owner: String
+    public let repo: String
+
+    public init(owner: String, repo: String) {
+        self.owner = owner
+        self.repo = repo
+    }
+
+    /// `nil` for anything that is not `https://github.com/<owner>/<repo>/…`.
+    public static func parse(feedURL: String) -> ReleaseFeedLocation? {
+        guard let url = URL(string: feedURL),
+            url.scheme == "https",
+            url.host?.lowercased() == "github.com"
+        else { return nil }
+        let parts = url.pathComponents.filter { $0 != "/" }
+        guard parts.count >= 2, !parts[0].isEmpty, !parts[1].isEmpty else { return nil }
+        return ReleaseFeedLocation(owner: parts[0], repo: parts[1])
+    }
+
+    /// Reads `SUFeedURL` from `bundle`. `nil` when the key is absent — an
+    /// unbundled `swift build` binary — or does not parse.
+    public static func from(bundle: Bundle) -> ReleaseFeedLocation? {
+        guard let feed = bundle.object(forInfoDictionaryKey: "SUFeedURL") as? String else {
+            return nil
+        }
+        return parse(feedURL: feed)
+    }
+
+    /// The API endpoint for one release by tag.
+    public func releaseAPIURL(tag: String) -> URL? {
+        URL(string: "https://api.github.com/repos/\(owner)/\(repo)/releases/tags/\(tag)")
+    }
+
+    /// The page a human reads for the same release.
+    public func releasePageURL(tag: String) -> URL? {
+        URL(string: "https://github.com/\(owner)/\(repo)/releases/tag/\(tag)")
+    }
+}
+
+// MARK: - Markdown, the small subset a release body uses
+
+/// A release body reduced to the three block shapes the notes use. Inline
+/// styling (backticks, bold) stays in the text and is rendered by
+/// `AttributedString(markdown:)` per block — WITH `.inlineOnlyPreservingWhitespace`,
+/// never `.full`: under `.full` a bullet remainder like `#186 fixed …` is an
+/// ATX heading and the `#186` disappears from the rendered line.
+public enum WhatsNewMarkdown {
+    public enum Block: Equatable, Sendable {
+        case heading(String)
+        case bullet(String)
+        case paragraph(String)
+    }
+
+    /// The body of the `## <heading>` section — up to the next `## ` line —
+    /// or the whole body when no such heading exists. Case-insensitive on the
+    /// heading text, since "What's new" and "What's New" have both been typed.
+    public static func section(_ heading: String, in body: String) -> String {
+        let lines = body.components(separatedBy: .newlines)
+        let wanted = heading.lowercased()
+        guard
+            let start = lines.firstIndex(where: {
+                headingText(of: $0)?.lowercased() == wanted
+            })
+        else { return body }
+        var out: [String] = []
+        for line in lines[(start + 1)...] {
+            if headingText(of: line) != nil { break }
+            out.append(line)
+        }
+        return out.joined(separator: "\n")
+    }
+
+    /// `## Title` → `Title`; anything else → `nil`. Only level-2 headings are
+    /// section boundaries in a release body (level 3 is a sub-heading inside).
+    static func headingText(of line: String) -> String? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("## ") else { return nil }
+        return String(trimmed.dropFirst(3)).trimmingCharacters(in: .whitespaces)
+    }
+
+    /// Split into blocks. Blank lines are dropped; consecutive non-blank,
+    /// non-bullet, non-heading lines join into one paragraph, as markdown
+    /// renders them.
+    public static func parse(_ markdown: String) -> [Block] {
+        var blocks: [Block] = []
+        var paragraph: [String] = []
+        func flush() {
+            if !paragraph.isEmpty {
+                blocks.append(.paragraph(paragraph.joined(separator: " ")))
+                paragraph.removeAll()
+            }
+        }
+        for raw in markdown.components(separatedBy: .newlines) {
+            let line = raw.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty {
+                flush()
+            } else if let heading = anyHeadingText(of: line) {
+                flush()
+                blocks.append(.heading(heading))
+            } else if let bullet = bulletText(of: line) {
+                flush()
+                blocks.append(.bullet(bullet))
+            } else {
+                paragraph.append(line)
+            }
+        }
+        flush()
+        return blocks
+    }
+
+    /// `#`…`######` followed by a space. `#186` has no space, so it is text.
+    static func anyHeadingText(of line: String) -> String? {
+        let hashes = line.prefix { $0 == "#" }
+        guard (1...6).contains(hashes.count) else { return nil }
+        let rest = line.dropFirst(hashes.count)
+        guard rest.first == " " else { return nil }
+        return rest.trimmingCharacters(in: .whitespaces)
+    }
+
+    static func bulletText(of line: String) -> String? {
+        for marker in ["- ", "* ", "+ "] where line.hasPrefix(marker) {
+            return String(line.dropFirst(marker.count)).trimmingCharacters(in: .whitespaces)
+        }
+        return nil
+    }
+
+    /// Inline markdown for ONE block's text, whitespace preserved, or the raw
+    /// text when the parser rejects it (an unmatched backtick must not blank
+    /// the whole window).
+    public static func inline(_ text: String) -> AttributedString {
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        return (try? AttributedString(markdown: text, options: options)) ?? AttributedString(text)
+    }
+}
+
+// MARK: - GitHub
+
+/// The fields of a GitHub release this feature reads.
+public struct ReleaseNotes: Decodable, Equatable, Sendable {
+    public let tagName: String
+    public let body: String?
+    public let htmlURL: URL?
+
+    enum CodingKeys: String, CodingKey {
+        case tagName = "tag_name"
+        case body
+        case htmlURL = "html_url"
+    }
+
+    public init(tagName: String, body: String?, htmlURL: URL?) {
+        self.tagName = tagName
+        self.body = body
+        self.htmlURL = htmlURL
+    }
+}
+
+public enum ReleaseFetchError: Error, Equatable, Sendable {
+    /// No release for that tag — the notes are not written yet, or this is a
+    /// build nobody released. Expected right after a tag push, not a fault.
+    case notFound
+    /// GitHub's unauthenticated limit (60/hour per address) is spent.
+    case rateLimited
+    /// No answer at all: offline, DNS, timeout.
+    case network(String)
+    case unexpectedStatus(Int)
+}
+
+/// Abstracts the one network call so the controller is testable with a fake.
+public protocol ReleaseFetching: Sendable {
+    func fetchRelease(at url: URL) async throws -> ReleaseNotes
+}
+
+/// The real thing: one `GET` to the releases API with the headers GitHub asks
+/// for. `no_proxy` is not needed — this is a GUI process with no proxy env,
+/// and api.github.com is not a host `tcr` intercepts.
+public struct GitHubReleaseClient: ReleaseFetching {
+    private let session: URLSession
+    private let userAgent: String
+
+    /// - Parameter version: goes into `User-Agent: TcrBar/<version>` so GitHub
+    ///   can tell this client apart from an anonymous script.
+    public init(session: URLSession = .shared, version: String?) {
+        self.session = session
+        self.userAgent = "TcrBar/\(version ?? "unknown")"
+    }
+
+    public func fetchRelease(at url: URL) async throws -> ReleaseNotes {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 15
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw ReleaseFetchError.network(error.localizedDescription)
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw ReleaseFetchError.network("no HTTP response")
+        }
+        switch http.statusCode {
+        case 200:
+            do {
+                return try JSONDecoder().decode(ReleaseNotes.self, from: data)
+            } catch {
+                throw ReleaseFetchError.unexpectedStatus(200)
+            }
+        case 404:
+            throw ReleaseFetchError.notFound
+        case 403, 429:
+            if http.value(forHTTPHeaderField: "X-RateLimit-Remaining") == "0" || http.statusCode == 429 {
+                throw ReleaseFetchError.rateLimited
+            }
+            throw ReleaseFetchError.unexpectedStatus(http.statusCode)
+        default:
+            throw ReleaseFetchError.unexpectedStatus(http.statusCode)
+        }
+    }
+}
+
+// MARK: - Controller
+
+/// What the window shows, and the two ways it gets opened.
+///
+/// `init` does nothing — no fetch, no timer. The launch gate is
+/// ``checkAfterLaunch()``, called exactly once from
+/// `applicationDidFinishLaunching`, which neither the render harness nor the
+/// shell probe ever reaches. That, not a flag, is what keeps a probe run from
+/// touching the network or opening a window; `WhatsNewTests` pins the
+/// zero-side-effect `init`.
+@MainActor
+public final class WhatsNewController: ObservableObject {
+    public enum State: Equatable, Sendable {
+        case idle
+        case loading(version: String)
+        case notes(version: String, blocks: [WhatsNewMarkdown.Block], page: URL?)
+        case failed(version: String, message: String, page: URL?)
+    }
+
+    /// The section of the release body the window shows.
+    public static let sectionHeading = "What's new"
+
+    @Published public private(set) var state: State = .idle
+
+    private let store: WhatsNewStore
+    private let fetcher: ReleaseFetching
+    private let location: ReleaseFeedLocation?
+    private let currentVersion: String?
+    /// How many fetches this controller has made — read by tests to prove the
+    /// cache and the inert `init`.
+    public private(set) var fetchCount = 0
+
+    public init(
+        store: WhatsNewStore,
+        fetcher: ReleaseFetching,
+        location: ReleaseFeedLocation?,
+        currentVersion: String?
+    ) {
+        self.store = store
+        self.fetcher = fetcher
+        self.location = location
+        self.currentVersion = currentVersion
+    }
+
+    /// The window's title.
+    public var title: String {
+        "What's new in TcrBar \(currentVersion ?? "")".trimmingCharacters(in: .whitespaces)
+    }
+
+    /// The launch gate. Returns `true` when the caller should present the
+    /// window. Records the version only once notes were actually loaded: a
+    /// launch that could not reach GitHub stays unrecorded and tries again
+    /// next launch, rather than marking notes as seen that nobody saw.
+    public func checkAfterLaunch() async -> Bool {
+        switch WhatsNewGate.decide(lastSeen: store.lastSeenVersion, current: currentVersion) {
+        case .skip:
+            return false
+        case .recordOnly:
+            store.lastSeenVersion = currentVersion
+            return false
+        case .show(let version):
+            await load(version: version)
+            guard case .notes = state else { return false }
+            store.lastSeenVersion = version
+            return true
+        }
+    }
+
+    /// The footer button and the right-click item. Reuses notes already
+    /// loaded for this version; otherwise fetches, and a failure is shown in
+    /// the window rather than swallowed. Records the version either way — the
+    /// operator asked, so nothing needs to pop up unbidden later.
+    public func showOnDemand() async {
+        guard let version = currentVersion, !version.isEmpty else {
+            state = .failed(version: "", message: "This build has no version to look up.", page: nil)
+            return
+        }
+        if case .notes(let loaded, _, _) = state, loaded == version {
+            store.lastSeenVersion = version
+            return
+        }
+        await load(version: version)
+        store.lastSeenVersion = version
+    }
+
+    private func load(version: String) async {
+        let tag = "v\(version)"
+        let page = location?.releasePageURL(tag: tag)
+        guard let location, let api = location.releaseAPIURL(tag: tag) else {
+            state = .failed(
+                version: version,
+                message: "This build does not say where its releases live (no feed URL).",
+                page: nil)
+            return
+        }
+        state = .loading(version: version)
+        fetchCount += 1
+        do {
+            let release = try await fetcher.fetchRelease(at: api)
+            let body = release.body ?? ""
+            let blocks = WhatsNewMarkdown.parse(
+                WhatsNewMarkdown.section(Self.sectionHeading, in: body))
+            if blocks.isEmpty {
+                state = .failed(
+                    version: version, message: "The \(tag) release has no notes yet.",
+                    page: release.htmlURL ?? page)
+            } else {
+                state = .notes(version: version, blocks: blocks, page: release.htmlURL ?? page)
+            }
+        } catch let error as ReleaseFetchError {
+            state = .failed(version: version, message: Self.message(for: error, tag: tag), page: page)
+        } catch {
+            state = .failed(version: version, message: error.localizedDescription, page: page)
+        }
+    }
+
+    static func message(for error: ReleaseFetchError, tag: String) -> String {
+        switch error {
+        case .notFound: return "No release notes for \(tag) yet."
+        case .rateLimited: return "GitHub is rate-limiting this address — try again in an hour."
+        case .network(let detail): return "Couldn't reach GitHub: \(detail)"
+        case .unexpectedStatus(let code): return "GitHub answered HTTP \(code)."
+        }
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/WhatsNewTests.swift
+++ b/apps/macos/Tests/TcrBarTests/WhatsNewTests.swift
@@ -1,0 +1,352 @@
+import Foundation
+import XCTest
+
+@testable import TcrBarCore
+
+/// The "What's new" window: the launch gate, the persisted marker, where the
+/// notes come from, the markdown subset, and the controller that ties them.
+///
+/// No network here: `FakeFetcher` stands in for GitHub. Versions and bodies
+/// are made up — this repository is public.
+final class WhatsNewTests: XCTestCase {
+
+    // MARK: gate
+
+    func testGateFreshInstallRecordsWithoutShowing() {
+        XCTAssertEqual(WhatsNewGate.decide(lastSeen: nil, current: "0.2.34"), .recordOnly)
+    }
+
+    func testGateSameVersionSkips() {
+        XCTAssertEqual(WhatsNewGate.decide(lastSeen: "0.2.34", current: "0.2.34"), .skip)
+    }
+
+    func testGateNewVersionShows() {
+        XCTAssertEqual(
+            WhatsNewGate.decide(lastSeen: "0.2.33", current: "0.2.34"), .show(version: "0.2.34"))
+    }
+
+    /// An unbundled binary or a test host has no version; that must never be
+    /// the thing that opens a window.
+    func testGateNilCurrentNeverShows() {
+        XCTAssertEqual(WhatsNewGate.decide(lastSeen: "0.2.33", current: nil), .skip)
+        XCTAssertEqual(WhatsNewGate.decide(lastSeen: nil, current: ""), .skip)
+    }
+
+    // MARK: store
+
+    func testStoreKeyLiteralIsPinned() {
+        XCTAssertEqual(WhatsNewStore.lastSeenVersionKey, "lastSeenVersion")
+    }
+
+    @MainActor
+    func testStoreRoundTripsThroughDefaults() {
+        let suite = "WhatsNewTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        XCTAssertNil(WhatsNewStore(defaults: defaults).lastSeenVersion)
+        WhatsNewStore(defaults: defaults).lastSeenVersion = "0.2.34"
+        XCTAssertEqual(WhatsNewStore(defaults: defaults).lastSeenVersion, "0.2.34")
+    }
+
+    @MainActor
+    func testStoreWithNilDefaultsRemembersNothing() {
+        let store = WhatsNewStore(defaults: nil)
+        store.lastSeenVersion = "0.2.34"
+        XCTAssertEqual(store.lastSeenVersion, "0.2.34", "in-memory value still moves")
+        XCTAssertNil(WhatsNewStore(defaults: nil).lastSeenVersion)
+    }
+
+    // MARK: feed location
+
+    /// The literal `build-tcrbar.sh` writes into `SUFeedURL`.
+    func testFeedLocationParsesTheShippedFeedURL() {
+        let loc = ReleaseFeedLocation.parse(
+            feedURL: "https://github.com/dhkts1/teamclaude-rs/releases/latest/download/appcast.xml")
+        XCTAssertEqual(loc, ReleaseFeedLocation(owner: "dhkts1", repo: "teamclaude-rs"))
+        XCTAssertEqual(
+            loc?.releaseAPIURL(tag: "v0.2.34")?.absoluteString,
+            "https://api.github.com/repos/dhkts1/teamclaude-rs/releases/tags/v0.2.34")
+        XCTAssertEqual(
+            loc?.releasePageURL(tag: "v0.2.34")?.absoluteString,
+            "https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.34")
+    }
+
+    func testFeedLocationRejectsOtherHostsAndJunk() {
+        XCTAssertNil(ReleaseFeedLocation.parse(feedURL: "https://example.com/a/b/appcast.xml"))
+        XCTAssertNil(ReleaseFeedLocation.parse(feedURL: "http://github.com/a/b/appcast.xml"))
+        XCTAssertNil(ReleaseFeedLocation.parse(feedURL: "https://github.com/onlyowner"))
+        XCTAssertNil(ReleaseFeedLocation.parse(feedURL: "not a url"))
+    }
+
+    // MARK: markdown
+
+    private let body = """
+        ## What's new
+
+        - `tcr login --token` checks the token first (#186).
+        - Right-click → **Copy Access Token** (#186).
+
+        A closing line.
+
+        ## Install teamclaude-rs 0.2.34
+
+        curl something
+        """
+
+    func testSectionExtractsUpToTheNextLevelTwoHeading() {
+        let section = WhatsNewMarkdown.section("What's new", in: body)
+        XCTAssertTrue(section.contains("Copy Access Token"))
+        XCTAssertTrue(section.contains("A closing line."))
+        XCTAssertFalse(section.contains("Install teamclaude-rs"))
+        XCTAssertFalse(section.contains("curl something"))
+    }
+
+    func testSectionIsCaseInsensitiveAndFallsBackToWholeBody() {
+        XCTAssertTrue(WhatsNewMarkdown.section("what's NEW", in: body).contains("Copy Access Token"))
+        let plain = "just a line\n\n- and a bullet"
+        XCTAssertEqual(WhatsNewMarkdown.section("What's new", in: plain), plain)
+    }
+
+    func testParseSplitsHeadingsBulletsAndParagraphs() {
+        let blocks = WhatsNewMarkdown.parse(body)
+        XCTAssertEqual(
+            blocks,
+            [
+                .heading("What's new"),
+                .bullet("`tcr login --token` checks the token first (#186)."),
+                .bullet("Right-click → **Copy Access Token** (#186)."),
+                .paragraph("A closing line."),
+                .heading("Install teamclaude-rs 0.2.34"),
+                .paragraph("curl something"),
+            ])
+    }
+
+    func testParseJoinsWrappedParagraphLinesAndKeepsHashNumbersAsText() {
+        let blocks = WhatsNewMarkdown.parse("first line\nsecond line\n\n#186 is not a heading")
+        XCTAssertEqual(
+            blocks, [.paragraph("first line second line"), .paragraph("#186 is not a heading")])
+    }
+
+    /// The bug the inline-only option exists for: with `.full`, a line that
+    /// starts `#186` is an ATX heading and the `#186` is gone.
+    func testInlineKeepsIssueNumbersBackticksAndArrows() {
+        let rendered = String(WhatsNewMarkdown.inline("#186 fixed `tcr token` → done — really").characters)
+        XCTAssertEqual(rendered, "#186 fixed tcr token → done — really")
+    }
+
+    func testInlineNeverThrowsOnUnbalancedMarkup() {
+        let rendered = String(WhatsNewMarkdown.inline("one `unclosed **bold").characters)
+        XCTAssertFalse(rendered.isEmpty)
+        XCTAssertTrue(rendered.contains("unclosed"))
+    }
+
+    // MARK: controller
+
+    private final class FakeFetcher: ReleaseFetching, @unchecked Sendable {
+        var result: Result<ReleaseNotes, ReleaseFetchError>
+        init(_ result: Result<ReleaseNotes, ReleaseFetchError>) { self.result = result }
+        func fetchRelease(at url: URL) async throws -> ReleaseNotes { try result.get() }
+    }
+
+    private let location = ReleaseFeedLocation(owner: "alice", repo: "example")
+
+    private func notes(_ body: String?) -> ReleaseNotes {
+        ReleaseNotes(
+            tagName: "v0.2.34", body: body,
+            htmlURL: URL(string: "https://github.com/alice/example/releases/tag/v0.2.34"))
+    }
+
+    @MainActor
+    func testInitIsInert() {
+        let fetcher = FakeFetcher(.success(notes(body)))
+        let c = WhatsNewController(
+            store: WhatsNewStore(defaults: nil), fetcher: fetcher, location: location,
+            currentVersion: "0.2.34")
+        XCTAssertEqual(c.state, .idle)
+        XCTAssertEqual(c.fetchCount, 0)
+    }
+
+    @MainActor
+    func testFreshInstallRecordsAndDoesNotFetch() async {
+        let store = WhatsNewStore(defaults: nil)
+        let c = WhatsNewController(
+            store: store, fetcher: FakeFetcher(.success(notes(body))), location: location,
+            currentVersion: "0.2.34")
+        let show = await c.checkAfterLaunch()
+        XCTAssertFalse(show)
+        XCTAssertEqual(store.lastSeenVersion, "0.2.34")
+        XCTAssertEqual(c.fetchCount, 0)
+    }
+
+    @MainActor
+    func testNewVersionLoadsNotesAndRecords() async {
+        let store = WhatsNewStore(defaults: nil)
+        store.lastSeenVersion = "0.2.33"
+        let c = WhatsNewController(
+            store: store, fetcher: FakeFetcher(.success(notes(body))), location: location,
+            currentVersion: "0.2.34")
+        let show = await c.checkAfterLaunch()
+        XCTAssertTrue(show)
+        XCTAssertEqual(store.lastSeenVersion, "0.2.34")
+        guard case .notes(let version, let blocks, let page) = c.state else {
+            return XCTFail("expected notes, got \(c.state)")
+        }
+        XCTAssertEqual(version, "0.2.34")
+        XCTAssertEqual(blocks.first, .bullet("`tcr login --token` checks the token first (#186)."))
+        XCTAssertEqual(page?.absoluteString, "https://github.com/alice/example/releases/tag/v0.2.34")
+    }
+
+    /// Offline at the one launch that would have shown the notes must NOT mark
+    /// them seen — the next launch tries again.
+    @MainActor
+    func testFailedLaunchFetchLeavesVersionUnrecorded() async {
+        let store = WhatsNewStore(defaults: nil)
+        store.lastSeenVersion = "0.2.33"
+        let c = WhatsNewController(
+            store: store, fetcher: FakeFetcher(.failure(.network("offline"))), location: location,
+            currentVersion: "0.2.34")
+        let show = await c.checkAfterLaunch()
+        XCTAssertFalse(show)
+        XCTAssertEqual(store.lastSeenVersion, "0.2.33")
+        guard case .failed(_, let message, _) = c.state else {
+            return XCTFail("expected failed, got \(c.state)")
+        }
+        XCTAssertTrue(message.contains("offline"), message)
+    }
+
+    @MainActor
+    func testNotFoundIsWordedAsNotYet() async {
+        let c = WhatsNewController(
+            store: WhatsNewStore(defaults: nil), fetcher: FakeFetcher(.failure(.notFound)),
+            location: location, currentVersion: "0.2.34")
+        await c.showOnDemand()
+        guard case .failed(_, let message, let page) = c.state else {
+            return XCTFail("expected failed, got \(c.state)")
+        }
+        XCTAssertEqual(message, "No release notes for v0.2.34 yet.")
+        XCTAssertNotNil(page, "the human page link still shows, so they can look themselves")
+    }
+
+    @MainActor
+    func testOnDemandReusesLoadedNotes() async {
+        let fetcher = FakeFetcher(.success(notes(body)))
+        let c = WhatsNewController(
+            store: WhatsNewStore(defaults: nil), fetcher: fetcher, location: location,
+            currentVersion: "0.2.34")
+        await c.showOnDemand()
+        await c.showOnDemand()
+        XCTAssertEqual(c.fetchCount, 1)
+    }
+
+    @MainActor
+    func testOnDemandRetriesAfterAFailure() async {
+        let fetcher = FakeFetcher(.failure(.network("offline")))
+        let c = WhatsNewController(
+            store: WhatsNewStore(defaults: nil), fetcher: fetcher, location: location,
+            currentVersion: "0.2.34")
+        await c.showOnDemand()
+        fetcher.result = .success(notes(body))
+        await c.showOnDemand()
+        XCTAssertEqual(c.fetchCount, 2)
+        guard case .notes = c.state else { return XCTFail("expected notes, got \(c.state)") }
+    }
+
+    @MainActor
+    func testEmptySectionIsReportedNotShownBlank() async {
+        let c = WhatsNewController(
+            store: WhatsNewStore(defaults: nil),
+            fetcher: FakeFetcher(.success(notes("## Install\n\ncurl"))), location: location,
+            currentVersion: "0.2.34")
+        await c.showOnDemand()
+        // No "What's new" heading → whole body → blocks exist, so notes show.
+        guard case .notes = c.state else { return XCTFail("expected notes, got \(c.state)") }
+        let empty = WhatsNewController(
+            store: WhatsNewStore(defaults: nil), fetcher: FakeFetcher(.success(notes(""))),
+            location: location, currentVersion: "0.2.34")
+        await empty.showOnDemand()
+        guard case .failed(_, let message, _) = empty.state else {
+            return XCTFail("expected failed, got \(empty.state)")
+        }
+        XCTAssertTrue(message.contains("no notes yet"), message)
+    }
+
+    @MainActor
+    func testMissingFeedLocationFailsWithoutFetching() async {
+        let fetcher = FakeFetcher(.success(notes(body)))
+        let c = WhatsNewController(
+            store: WhatsNewStore(defaults: nil), fetcher: fetcher, location: nil,
+            currentVersion: "0.2.34")
+        await c.showOnDemand()
+        XCTAssertEqual(fetcher === fetcher, true)
+        XCTAssertEqual(c.fetchCount, 0)
+        guard case .failed = c.state else { return XCTFail("expected failed, got \(c.state)") }
+    }
+
+    // MARK: GitHub client, via a stubbed URLProtocol
+
+    final class StubProtocol: URLProtocol {
+        nonisolated(unsafe) static var handler: ((URLRequest) -> (Int, [String: String], Data))?
+        nonisolated(unsafe) static var lastRequest: URLRequest?
+
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+        override func startLoading() {
+            Self.lastRequest = request
+            guard let handler = Self.handler else { return }
+            let (status, headers, body) = handler(request)
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: status, httpVersion: "HTTP/1.1",
+                headerFields: headers)!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: body)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {}
+    }
+
+    private func stubbedClient() -> GitHubReleaseClient {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubProtocol.self]
+        return GitHubReleaseClient(session: URLSession(configuration: config), version: "0.2.34")
+    }
+
+    private let api = URL(string: "https://api.github.com/repos/alice/example/releases/tags/v0.2.34")!
+
+    func testClientDecodesAReleaseAndSendsTheHeaders() async throws {
+        StubProtocol.handler = { _ in
+            (
+                200, ["Content-Type": "application/json"],
+                Data(
+                    "{\"tag_name\":\"v0.2.34\",\"body\":\"## What's new\\n\\n- x\",\"html_url\":\"https://github.com/alice/example/releases/tag/v0.2.34\"}"
+                        .utf8)
+            )
+        }
+        let release = try await stubbedClient().fetchRelease(at: api)
+        XCTAssertEqual(release.tagName, "v0.2.34")
+        XCTAssertEqual(release.body, "## What's new\n\n- x")
+        XCTAssertEqual(
+            StubProtocol.lastRequest?.value(forHTTPHeaderField: "Accept"), "application/vnd.github+json")
+        XCTAssertEqual(StubProtocol.lastRequest?.value(forHTTPHeaderField: "User-Agent"), "TcrBar/0.2.34")
+    }
+
+    func testClientMaps404AndRateLimit() async {
+        StubProtocol.handler = { _ in (404, [:], Data()) }
+        do {
+            _ = try await stubbedClient().fetchRelease(at: api)
+            XCTFail("404 must throw")
+        } catch let error as ReleaseFetchError {
+            XCTAssertEqual(error, .notFound)
+        } catch {
+            XCTFail("wrong error type: \(error)")
+        }
+        StubProtocol.handler = { _ in (403, ["X-RateLimit-Remaining": "0"], Data()) }
+        do {
+            _ = try await stubbedClient().fetchRelease(at: api)
+            XCTFail("rate limit must throw")
+        } catch let error as ReleaseFetchError {
+            XCTAssertEqual(error, .rateLimited)
+        } catch {
+            XCTFail("wrong error type: \(error)")
+        }
+    }
+}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -99,6 +99,18 @@ Flags:
 - `--tag vX.Y.Z` — must equal `v<Cargo.toml version>`. Mismatch aborts.
 - `--verify-only <path/to/TcrBar.app>` — run the signature asserts against an existing bundle.
 
+## The app shows the release notes after an update
+
+On the first launch of a version the operator has not seen, TcrBar fetches the GitHub Release
+for its own tag (`releases/tags/v<version>`, unauthenticated) and shows the `## What's new`
+section of the release body in a window — the whole body when that heading is absent. The
+window can be reopened any time from the panel footer or the right-click menu (**What's New…**).
+
+So the `## What's new` section IS the changelog; write it into the release body when the tag is
+cut (`gh release edit vX.Y.Z --notes-file …`). Until the Release object exists for the tag the
+app gets a 404, says nothing, and tries again on the next launch — it records a version as seen
+only once notes were actually shown. A fresh install records the current version silently.
+
 ## What the pipeline does
 
 1. `build-tcrbar.sh` — Swift build, bundle assembly, `tcr` bundled alongside, local signature.


### PR DESCRIPTION
🍄

## What it does

After an update, on the first launch of a version you have not seen notes for, TcrBar opens a **What's new in TcrBar X.Y.Z** window with the `## What's new` section of the GitHub release for its own tag. Scrollable; closes with Close, Esc, the red button or ⌘W (hand-rolled — an accessory app has no main menu to dispatch it). Reopen any time: panel footer **What's New…** or the right-click menu.

## How it decides

`lastSeenVersion` in UserDefaults vs `AppBuild.shortVersion`: fresh install → record silently, no window; same → nothing; new → fetch, show, and record **only once notes loaded**. Offline or a 404 (the tag has no release yet) stays quiet and retries next launch. owner/repo is derived from the bundle's `SUFeedURL`, so the release location is written down once.

The controller's `init` is inert and the gate fires only from `applicationDidFinishLaunching`, which neither the render harness nor the shell probe reaches; the probe also injects a nil-defaults store and a refusing fetcher.

## Markdown

A small block splitter (heading / bullet / paragraph) with `AttributedString(markdown:)` per block under `.inlineOnlyPreservingWhitespace`. Under `.full`, a bullet whose text starts `#186` is an ATX heading and the issue number vanishes — a test pins it.

## Verification

- `swift test`: 400 passed, 26 new (`WhatsNewTests`: gate, store key literal, feed-URL parsing, section extraction, block parsing, inline rendering, controller record/no-record, cache, GitHub client via a stubbed `URLProtocol` for 200/404/403-rate-limit + headers). Gate and markdown-option guards watched fail with the fix reverted.
- `swift-format lint --strict` clean on the new files; `cargo clippy -D warnings` exit 0.
- `TcrBar --shell-probe`: 9/9 PASS on this build.
- Live: `lastSeenVersion=0.2.33` + a 0.2.34 build → the v0.2.34 notes fetched from GitHub, the window opened frontmost (480×552), marker moved to 0.2.34. The unbundled binary (no `CFBundleShortVersionString`) opens nothing, as designed.

Version 0.2.34 → 0.2.35 for the release gate. `docs/RELEASING.md` says the `## What's new` section is now the changelog the app reads.

https://claude.ai/code/session_01H3JPJxQW1Q1AbrNbWVJypv
