### PR TITLE
chore: add the 0.2.35 appcast entry

### DIFF
--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.35</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.35</link>
+      <sparkle:version>479</sparkle:version>
+      <sparkle:shortVersionString>0.2.35</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Sun, 06 Sep 2026 13:45:10 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.35/TcrBar-0.2.35.dmg" type="application/octet-stream" sparkle:edSignature="WkEauQjdj6xfGC11bUJCXmFfrUkRibJhEuWC4o2ggSslFZXhC4yO4Oypy7meHpPT12Jh94B64GuZGJo1OmEFBQ==" length="7184317" />
+    </item>
+    <item>
       <title>TcrBar 0.2.34</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.34</link>
       <sparkle:version>477</sparkle:version>


### PR DESCRIPTION
🍄 The appcast entry stage 8 of the v0.2.35 release wrote; same bytes as the appcast.xml already on the release.

https://claude.ai/code/session_01H3JPJxQW1Q1AbrNbWVJypv
