### PR TITLE
fix: take the port and come to the front on the first launch after an update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.35"
+version = "0.2.36"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "teamclaude-rs"
-version = "0.2.35"
+version = "0.2.36"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/apps/macos/Sources/TcrBar/TcrBarApp.swift
+++ b/apps/macos/Sources/TcrBar/TcrBarApp.swift
@@ -118,7 +118,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // `--headless` is the flag that matters here — without it the child dies
         // on startup trying to put a TUI on a pipe.
         if shell.preference.startServerAtLaunch {
-            shell.server.start()
+            // The first launch after an UPDATE takes the port; every other
+            // launch stands down to an incumbent. When TcrBar quits for an
+            // update it stops its own child, so normally nothing holds the port
+            // and the two are the same spawn. The case this exists for is a
+            // proxy that outlived the old app — one it never supervised, or
+            // one it failed to stop — which the old `--no-replace` start
+            // quietly yielded to, leaving the just-updated app showing
+            // "Take over port…" for the operator to press by hand (0.2.35).
+            // The operator chose the update; the proxy it replaces is by
+            // definition the pre-update one.
+            if LaunchVersionMarker().noteLaunch(current: AppBuild.shortVersion) {
+                NSLog("TcrBar: first launch of \(AppBuild.shortVersion ?? "?") — taking the port")
+                shell.server.startTakingOverPort()
+            } else {
+                shell.server.start()
+            }
         }
         // Same shape, same place, same once-per-process guarantee: re-take the
         // power assertions if that is how the operator left them. A reboot is

--- a/apps/macos/Sources/TcrBar/WhatsNewWindow.swift
+++ b/apps/macos/Sources/TcrBar/WhatsNewWindow.swift
@@ -31,12 +31,16 @@ final class WhatsNewWindow {
         let window = self.window ?? makeWindow()
         self.window = window
         window.title = controller.title
-        if #available(macOS 14.0, *) {
-            NSApp.activate()
-        } else {
-            NSApp.activate(ignoringOtherApps: true)
-        }
+        // `ignoringOtherApps: true` on purpose, and `orderFrontRegardless()` on
+        // top of `makeKeyAndOrderFront`. On macOS 14 a bare `NSApp.activate()`
+        // is cooperative — it only takes focus when the user just interacted
+        // with this app, which is true for the popover (a click opened it)
+        // and false here: this fires from a launch, seconds after a Sparkle
+        // relaunch, with the operator looking at something else. Shipped that
+        // way in 0.2.35 the window came up BEHIND the frontmost window.
+        NSApp.activate(ignoringOtherApps: true)
         window.makeKeyAndOrderFront(nil)
+        window.orderFrontRegardless()
         installKeyMonitor()
     }
 

--- a/apps/macos/Sources/TcrBarCore/WhatsNew.swift
+++ b/apps/macos/Sources/TcrBarCore/WhatsNew.swift
@@ -36,6 +36,38 @@ public final class WhatsNewStore: ObservableObject {
     }
 }
 
+// MARK: - Which version launched last
+
+/// Remembers the version that last LAUNCHED — distinct from
+/// ``WhatsNewStore/lastSeenVersion``, which moves only once notes were shown.
+/// This one moves on every launch, unconditionally, so "is this the first
+/// launch after an update?" is answered exactly once per update, whether or
+/// not GitHub was reachable. It gates the port takeover on that launch: an
+/// update that could not fetch its notes must not re-take the port on every
+/// launch until it can.
+@MainActor
+public final class LaunchVersionMarker {
+    /// The `UserDefaults` key. Do not change it.
+    public static let lastLaunchedVersionKey = "lastLaunchedVersion"
+
+    private let defaults: UserDefaults?
+
+    public init(defaults: UserDefaults? = .standard) {
+        self.defaults = defaults
+    }
+
+    /// Record `current` as launched and say whether it differs from the
+    /// version that launched before it. `false` on a fresh install (nothing
+    /// recorded) and when `current` is unknown — neither is an update.
+    public func noteLaunch(current: String?) -> Bool {
+        guard let current, !current.isEmpty else { return false }
+        let previous = defaults?.string(forKey: Self.lastLaunchedVersionKey)
+        defaults?.set(current, forKey: Self.lastLaunchedVersionKey)
+        guard let previous, !previous.isEmpty else { return false }
+        return previous != current
+    }
+}
+
 // MARK: - Gate
 
 /// The pure decision behind "show the notes on this launch?". Split out so the

--- a/apps/macos/Tests/TcrBarTests/WhatsNewTests.swift
+++ b/apps/macos/Tests/TcrBarTests/WhatsNewTests.swift
@@ -56,6 +56,33 @@ final class WhatsNewTests: XCTestCase {
         XCTAssertNil(WhatsNewStore(defaults: nil).lastSeenVersion)
     }
 
+    // MARK: launch marker
+
+    func testLaunchMarkerKeyIsPinned() {
+        XCTAssertEqual(LaunchVersionMarker.lastLaunchedVersionKey, "lastLaunchedVersion")
+    }
+
+    /// Fresh install → not an update; same version again → not an update; a
+    /// changed version → an update exactly once, then not again.
+    @MainActor
+    func testLaunchMarkerFlagsOnlyTheFirstLaunchOfAChangedVersion() {
+        let suite = "WhatsNewTests.marker.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        XCTAssertFalse(LaunchVersionMarker(defaults: defaults).noteLaunch(current: "0.2.35"))
+        XCTAssertFalse(LaunchVersionMarker(defaults: defaults).noteLaunch(current: "0.2.35"))
+        XCTAssertTrue(LaunchVersionMarker(defaults: defaults).noteLaunch(current: "0.2.36"))
+        XCTAssertFalse(LaunchVersionMarker(defaults: defaults).noteLaunch(current: "0.2.36"))
+        XCTAssertFalse(LaunchVersionMarker(defaults: defaults).noteLaunch(current: nil))
+    }
+
+    @MainActor
+    func testLaunchMarkerWithNilDefaultsNeverFlags() {
+        let marker = LaunchVersionMarker(defaults: nil)
+        XCTAssertFalse(marker.noteLaunch(current: "0.2.35"))
+        XCTAssertFalse(marker.noteLaunch(current: "0.2.36"))
+    }
+
     // MARK: feed location
 
     /// The literal `build-tcrbar.sh` writes into `SUFeedURL`.

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -3669,10 +3669,13 @@ mod tests {
             config_with_reserved(vec![member, outsider], &["codereview"]),
             lock_refresher(),
         );
-        let now = OffsetDateTime::now_utc();
-
         manager.mark_rate_limited(0, 600); // the group's member
         manager.mark_rate_limited(1, 60); // an unrelated account, free much sooner
+                                          // AFTER the marks: each `mark_rate_limited` reads its own clock, so a
+                                          // `now` taken before them is a few microseconds earlier than the
+                                          // holds' anchor and the 60 s hint rounds up to 61 — which failed the
+                                          // `<= 60` control on CI (#189) with nothing wrong in the code.
+        let now = OffsetDateTime::now_utc();
 
         let fleet = manager.retry_after_hint(now, false);
         let scoped = manager.retry_after_hint_for_group(now, false, "codereview");


### PR DESCRIPTION
🍄

Two things broke on the 0.2.34 → 0.2.35 update, seen live, plus the flaky test that reddened #189.

## Port did not transfer after the update

The relaunched app spawned `tcr server --no-replace`, stood down to a proxy that had outlived the old app, and sat showing **Take over port…** for the operator to press. Now the **first launch of a changed version** takes the port (`startTakingOverPort`); every other launch stands down as before. When TcrBar quits for an update it stops its own child, so normally nothing holds the port and the two are the same spawn — this exists for the proxy the old app never supervised or failed to stop.

The decision is a new `LaunchVersionMarker` (`lastLaunchedVersion`), moved on **every** launch, deliberately separate from `lastSeenVersion` (moved only once notes were shown): an update that could not fetch its notes must not re-take the port on every launch until it can.

## Notes window came up behind the frontmost window

On macOS 14 a bare `NSApp.activate()` is cooperative — it takes focus only after the user interacted with this app; true for the popover (a click opened it), false for a window opened seconds after a Sparkle relaunch. It now activates ignoring other apps and `orderFrontRegardless()`.

## Flaky test

`a_strict_groups_retry_hint_is_sized_by_its_own_member` took `now` before the marks, whose own clock is a hair later, so the 60 s hint rounded to 61 and failed the `<= 60` control. `now` is taken after the marks; 5/5 green locally.

## Verification

- `WhatsNewTests`: 29 green, 3 new for the marker (key literal; flags exactly the first launch of a changed version, then never again; nil defaults never flags). Watched fail with the comparison stubbed.
- `TcrBar --shell-probe`: 9/9 PASS. Rust test ×5 green. `cargo fmt` clean.
- Version 0.2.35 → 0.2.36 for the release gate. The real proof is the 0.2.35 → 0.2.36 Sparkle update on a Mac with a surviving proxy: port taken, window frontmost.

https://claude.ai/code/session_01H3JPJxQW1Q1AbrNbWVJypv
