### PR TITLE
feat: show each account's plan in the panel, and tell two same-email rows apart

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -348,7 +348,7 @@ struct FleetView: View {
             accounts: accounts,
             control: control,
             onChanged: { await poller.pollOnce() },
-            onRelogin: { reloginAccount(account.name) },
+            onRelogin: { reloginAccount(account.ref) },
             groupController: groupController,
             removeController: removeController,
             allAccounts: fleet.accounts,
@@ -696,8 +696,10 @@ struct FleetView: View {
     /// through so the Terminal script can name it. Surfaces a failure the same
     /// way — a button that silently does nothing is worse than one that says
     /// why.
-    private func reloginAccount(_ name: String) {
-        if case .failure(let why) = LoginLauncher.launch(reloggingIn: name) {
+    private func reloginAccount(_ account: AccountRef) {
+        if case .failure(let why) = LoginLauncher.launch(
+            reloggingIn: account.name, org: account.orgUuid)
+        {
             switch why {
             case .toolMissing(let searched):
                 loginError = "tcr not found (searched \(searched.count) locations)."
@@ -1141,6 +1143,40 @@ struct AccountRow: View {
     /// a phantom checkmark on an older `tcr` build (which cannot even confirm
     /// the concept exists) would be worse than the feature simply not
     /// appearing yet.
+    /// The account's plan, beside the name — `MAX 20X`, `TEAM 5X`,
+    /// `TEAM STANDARD`.
+    ///
+    /// It sits next to the NAME rather than out with the rotation pills because
+    /// it is a fact about which account this is, not about how it is behaving
+    /// right now. On this fleet the same email appears twice, and before this
+    /// tag existed the two rows were visually identical — the panel simply had
+    /// no way to say which was the personal Max org and which the company Team.
+    ///
+    /// Silent when the server reports no plan (never profiled, or a build that
+    /// predates the field). A guessed label here would defeat the one thing the
+    /// tag is for. `Tok.inkFaint` — the neutral hue, not one of the quota or
+    /// rotation status colours: a plan is a designation, not a measured state,
+    /// and tinting it like one would make an ordinary account look alarming.
+    ///
+    /// Dim TEXT rather than a ``StatusPill``, and that is a width decision, not
+    /// a taste one. As a pill this read `TEAM STANDARD` — uppercased, tracked,
+    /// padded and bordered — and the row is `Tok.panelWidth` (380pt) wide: the
+    /// pill's chrome pushed the name past its budget and rendered it as `h…m`.
+    /// A tag whose whole job is telling two same-named rows apart must not be
+    /// the thing that erases the name. Plain text at the same font, with no
+    /// chrome and no uppercasing, is narrow enough for the worst row (unmeasured
+    /// + rotating + the longest label) and still reads as secondary.
+    @ViewBuilder
+    private var planIndicator: some View {
+        if let plan = account.plan, !plan.isEmpty {
+            Text(plan)
+                .font(Tok.pillFont)
+                .foregroundStyle(Tok.inkFaint)
+                .fixedSize()
+                .help("This account's plan, as Anthropic reports it for its organization.")
+        }
+    }
+
     @ViewBuilder
     private var controlIndicator: some View {
         if control.isControl(account.name) {
@@ -1192,6 +1228,14 @@ struct AccountRow: View {
     /// actionable.
     private var rowAccessibilityLabel: String {
         var parts = [account.name]
+        // Spoken right after the name, for the same reason the tag is drawn
+        // there: on a fleet holding one email twice, the plan is what tells a
+        // listener WHICH of two identically-named rows they are on. Without it
+        // a VoiceOver user hears the same name announced twice with no way to
+        // tell the personal Max org from the company Team one.
+        if let plan = account.plan, !plan.isEmpty {
+            parts.append(plan)
+        }
         // Spoken beside the name for the same reason `controlIndicator` is
         // drawn beside it: this is an identity fact, not a rotation/quota one,
         // and a VoiceOver user reaching the row should not have to open the
@@ -1259,22 +1303,22 @@ struct AccountRow: View {
         // spoken when it did, because a gate that decides whether Fable
         // requests can land here is not a sighted-user-only fact.
         if let fable = account.fableWeeklySpokenLabel(now: Date()) { parts.append(fable) }
-        if let failure = accounts.failure(for: account.name) {
+        if let failure = accounts.failure(for: account.ref) {
             parts.append("last action failed: \(failure.summary)")
         }
-        if let failure = removeController.failure(for: account.name) {
+        if let failure = removeController.failure(for: account.ref) {
             parts.append("last action failed: \(failure.summary)")
         }
         // Spoken for the same reason the pill is: a confirmation only a sighted
         // user gets is half built, and the `✓` in `rowLabel` is punctuation to a
         // screen reader.
-        if let verdict = accounts.verdict(for: account.name, reportedDisabled: account.disabled) {
+        if let verdict = accounts.verdict(for: account.ref, reportedDisabled: account.disabled) {
             parts.append(verdict.spokenLabel)
         }
         // Same reason `removalNoticeLine` is drawn at all: a VoiceOver user
         // gets no other signal that the delete landed but the row did not
         // change, since nothing here re-derives the fleet from the config.
-        if removeController.needsRestart(account.name) {
+        if removeController.needsRestart(account.ref) {
             parts.append("removed from config and stopped, stays listed as disabled until the proxy restarts")
         }
         return parts.joined(separator: ", ")
@@ -1359,7 +1403,7 @@ struct AccountRow: View {
         Button(enabling ? "Enable" : "Disable") {
             Task { await performToggle(enabling: enabling) }
         }
-        .disabled(accounts.isPending(account.name))
+        .disabled(accounts.isPending(account.ref))
         if account.health == .needsRelogin {
             Button("Re-login…") { onRelogin() }
         }
@@ -1372,14 +1416,18 @@ struct AccountRow: View {
         if !control.unavailable {
             if control.isControl(account.name) {
                 Button("Clear Control Account") {
-                    Task { await performSetControl(name: nil, key: account.name) }
+                    Task { await performSetControl(name: nil, key: account.id) }
                 }
-                .disabled(control.isPending(account.name))
+                .disabled(control.isPending(account.id))
             } else {
                 Button("Use as Control Account") {
-                    Task { await performSetControl(name: account.name, key: account.name) }
+                    // `name` is what `tcr control` stores (a bare string — see
+                    // `ControlAccountController.isControl`), while `key` is
+                    // this row's own identity, so the spinner lands on the row
+                    // that was clicked even when two rows share a name.
+                    Task { await performSetControl(name: account.name, key: account.id) }
                 }
-                .disabled(control.isPending(account.name))
+                .disabled(control.isPending(account.id))
             }
         }
         Divider()
@@ -1401,7 +1449,7 @@ struct AccountRow: View {
         Button("Delete Account…") {
             confirmDeleteAccount()
         }
-        .disabled(removeController.isPending(account.name))
+        .disabled(removeController.isPending(account.ref))
     }
 
     /// One entry per ``Account/groupMenuActions``, wired directly to
@@ -1602,16 +1650,21 @@ struct AccountRow: View {
         delete.keyEquivalent = ""
 
         guard alert.runModal() == .alertFirstButtonReturn else { return }
-        Task { await removeController.remove(account: account.name) }
+        Task { await removeController.remove(account: account.ref) }
     }
 
     /// Shared by "Copy Account Name" and the per-group command copy — one
     /// place that clears then sets, so every copy in this menu behaves the
     /// same way.
-    /// `tcr token <name>` off the main actor, then the pasteboard. A failure
-    /// replaces any earlier one on this row; a success clears it.
+    /// `tcr token <name> [--org <uuid>]` off the main actor, then the
+    /// pasteboard. A failure replaces any earlier one on this row; a success
+    /// clears it.
+    ///
+    /// The `--org` is what makes this work at all on a fleet holding one email
+    /// twice: without it `tcr` refused with `'…' is ambiguous — matches 2
+    /// accounts … Narrow with --org`, so neither row's token could be copied.
     private func performCopyToken() async {
-        switch await TokenCommand.fetch(query: account.name) {
+        switch await TokenCommand.fetch(query: account.name, org: account.orgUuid) {
         case .success(let token):
             copyToPasteboard(token)
             tokenCopyFailure = nil
@@ -1707,13 +1760,13 @@ struct AccountRow: View {
         // cannot see it — `disabled` flipped, so the comparison confirms.
         // Losing it here is what let the row stamp `parked ✓` on a change
         // that would not survive a restart.
-        let attempt = await accounts.setEnabled(enabling, account: account.name)
+        let attempt = await accounts.setEnabled(enabling, account: account.ref)
         guard case .accepted(let notice) = attempt else { return }
         let readback = await onChanged()
         accounts.record(
             readback: readback,
             requestedEnabled: enabling,
-            account: account.name,
+            account: account.ref,
             notice: notice
         )
     }
@@ -1732,6 +1785,15 @@ struct AccountRow: View {
                     .truncationMode(.middle)
                     .help(account.name)
                     .textSelection(.enabled)
+                    // The name outranks everything beside it for width. Without
+                    // this the plan tag — `TEAM STANDARD` is the long one —
+                    // took its space from the name, and a row rendered as
+                    // `h…m TEAM STANDARD`: the tag exists to tell two rows
+                    // apart, so a tag that erases the name it is qualifying is
+                    // worse than no tag. Pills are `fixedSize()` and small; the
+                    // name is the row's identity and shrinks last.
+                    .layoutPriority(1)
+                planIndicator
                 controlIndicator
                 Spacer(minLength: Tok.tightSpacing)
                 rotationPill
@@ -1913,7 +1975,7 @@ struct AccountRow: View {
                     .foregroundStyle(Tok.spent)
                     .lineLimit(2)
             }
-            if let failure = accounts.failure(for: account.name) {
+            if let failure = accounts.failure(for: account.ref) {
                 // `tcr`'s own words, verbatim. A toggle that did not happen must
                 // never be indistinguishable from one that did.
                 Label(failure.summary, systemImage: Tok.unreadableGlyph)
@@ -1921,7 +1983,7 @@ struct AccountRow: View {
                     .foregroundStyle(Tok.spent)
                     .fixedSize(horizontal: false, vertical: true)
             }
-            if let failure = removeController.failure(for: account.name) {
+            if let failure = removeController.failure(for: account.ref) {
                 Label(failure.summary, systemImage: Tok.unreadableGlyph)
                     .font(Tok.detailFont)
                     .foregroundStyle(Tok.spent)
@@ -2012,7 +2074,7 @@ struct AccountRow: View {
     /// colour the line above reserves for a `tcr` failure.
     @ViewBuilder
     private var removalNoticeLine: some View {
-        if removeController.needsRestart(account.name) {
+        if removeController.needsRestart(account.ref) {
             Label(
                 "Removed from config and stopped. Stays listed as disabled until the proxy restarts.",
                 systemImage: "arrow.triangle.2.circlepath"
@@ -2033,7 +2095,7 @@ struct AccountRow: View {
     /// tellable apart.
     @ViewBuilder
     private var verdictLine: some View {
-        if let verdict = accounts.verdict(for: account.name, reportedDisabled: account.disabled) {
+        if let verdict = accounts.verdict(for: account.ref, reportedDisabled: account.disabled) {
             Label(verdict.rowLabel, systemImage: Self.verdictGlyph(verdict))
                 .font(Tok.detailFont)
                 .foregroundStyle(Self.verdictTint(verdict))
@@ -2095,7 +2157,7 @@ struct AccountRow: View {
     /// `disabled` field so the label always names what the click will do.
     private var toggleButton: some View {
         let enabling = account.disabled
-        let pending = accounts.isPending(account.name)
+        let pending = accounts.isPending(account.ref)
         // A bare "…" names neither the action nor its progress, and a screen
         // reader announces it as punctuation. The button is already disabled
         // while in flight, so its label is the only signal anything is happening.

--- a/apps/macos/Sources/TcrBar/RenderStates.swift
+++ b/apps/macos/Sources/TcrBar/RenderStates.swift
@@ -65,6 +65,8 @@ enum RenderStates {
             ("01-healthy", .loaded(fleet(healthyJSON)), false, nil),
             ("01c-divergent-windows", .loaded(fleet(divergentWindowsJSON)), false, nil),
             ("01d-unmeasured-window-proof", .loaded(fleet(unmeasuredWindowJSON)), false, nil),
+            ("01e-plan-labels", .loaded(fleet(planLabelsJSON)), false, nil),
+            ("01f-duplicate-email", .loaded(fleet(duplicateEmailJSON)), false, nil),
             ("02-mixed-thirteen", .loaded(fleet(mixedJSON)), false, nil),
             ("03-zero-capacity", .loaded(fleet(exhaustedJSON)), false, nil),
             ("04-unmeasured-row", .loaded(fleet(unmeasuredJSON)), false, nil),
@@ -299,7 +301,19 @@ enum RenderStates {
         // `Account.groups`'s own doc-comment on why a missing key and an
         // empty array are kept distinct rather than collapsed.
         groups: [String]? = nil,
-        reservedGroups: [String]? = nil
+        reservedGroups: [String]? = nil,
+        // The plan label the SERVER derived, wire field `"plan"`. `nil` omits
+        // the key entirely — the never-profiled row and the older-server row
+        // alike, both of which must draw NO tag rather than a guessed one, so
+        // every scene that does not opt in is also the negative case.
+        plan: String? = nil,
+        // The org this row belongs to, wire field `"orgUuid"`. It is what makes
+        // two rows sharing a name distinct: `Account.id` is org-qualified, so a
+        // fixture pair with one email and two orgs renders as TWO rows here and
+        // collapsed to one before that fix. `nil` omits the key, which is the
+        // older-server shape.
+        orgUuid: String? = nil,
+        gate: String? = nil
     ) -> String {
         func resetAtMs(_ minutes: Int?) -> String {
             guard let minutes else { return "null" }
@@ -328,8 +342,12 @@ enum RenderStates {
         func quote(_ raw: String) -> String {
             raw == "null" ? "null" : "\"\(raw)\""
         }
+        let planFragment = plan.map { "\"plan\":\"\($0)\"," } ?? ""
+        let orgFragment = orgUuid.map { "\"orgUuid\":\"\($0)\"," } ?? ""
+        let gateFragment = gate.map { "\"gate\":\"\($0)\"," } ?? ""
         return """
             {"name":"\(name)","priority":0,"status":"\(status)","disabled":\(disabled),
+             \(planFragment)\(orgFragment)\(gateFragment)
              "quota":\(quota),"quotaState":"\(state)","fiveHour":\(fh),
              "fiveHourState":\(quote(fhState)),"sevenDay":\(sd),"sevenDayState":\(quote(sdState)),
              "sevenDayOi":\(sevenDayOi),"sevenDayOiState":\(quote(sevenDayOiState)),
@@ -499,8 +517,54 @@ enum RenderStates {
     /// `near` or `spent`: this is the healthy scene, and the two tinted shapes
     /// are scene 14's job.
     private static var healthyJSON: String {
-        "[\(account("alice@example.com", quota: "0.12", state: "ok", fiveHourResetInMinutes: 130, sevenDayResetInMinutes: 4_320, sevenDayOi: "0.21", sevenDayOiState: "ok", sevenDayOiResetInMinutes: 6_498)),"
-            + "\(account("bob@example.com", quota: "0.31", state: "ok", sevenDayOi: "0.44", sevenDayOiState: "ok", groups: ["research"], reservedGroups: ["research"]))]"
+        "[\(account("alice@example.com", quota: "0.12", state: "ok", fiveHourResetInMinutes: 130, sevenDayResetInMinutes: 4_320, sevenDayOi: "0.21", sevenDayOiState: "ok", sevenDayOiResetInMinutes: 6_498, plan: "Max 20x", orgUuid: "11111111-1111-1111-1111-111111111111")),"
+            + "\(account("bob@example.com", quota: "0.31", state: "ok", sevenDayOi: "0.44", sevenDayOiState: "ok", groups: ["research"], reservedGroups: ["research"], plan: "Team 5x", orgUuid: "22222222-2222-2222-2222-222222222222"))]"
+    }
+
+    /// The three plan labels a real fleet produces, side by side — `Max 20x`,
+    /// `Team 5x`, `Team Standard` — plus one row with NO plan at all.
+    ///
+    /// The fourth row is the point as much as the first three: an account that
+    /// has never been profiled must draw no tag, not a guessed one, and a
+    /// screenshot is the only place that negative is actually visible.
+    private static var planLabelsJSON: String {
+        let rows = [
+            account(
+                "alice@example.com", quota: "0.12", state: "ok",
+                plan: "Max 20x", orgUuid: "11111111-1111-1111-1111-111111111111"),
+            account(
+                "bob@example.com", quota: "0.31", state: "ok",
+                plan: "Team 5x", orgUuid: "22222222-2222-2222-2222-222222222222"),
+            account(
+                "carol@example.com", quota: "0.44", state: "ok",
+                plan: "Team Standard", orgUuid: "22222222-2222-2222-2222-222222222222"),
+            account("dave@example.com", quota: "0.08", state: "ok"),
+        ]
+        return "[\(rows.joined(separator: ","))]"
+    }
+
+    /// THE SAME EMAIL, TWICE — the shape that broke the panel.
+    ///
+    /// Both rows carry `henry@example.com`; only the org differs. Before
+    /// ``AccountRef`` they collapsed to one SwiftUI identity, so the panel drew
+    /// the FIRST row's numbers on both and neither wore its own gate pill,
+    /// while `tcr status --json` reported the two correctly and differently.
+    ///
+    /// The two rows are deliberately as unlike each other as a pair can be —
+    /// one spent and rejected, one fresh and never probed, and different plans
+    /// — because that is what makes the failure legible in a PNG: if the render
+    /// shows two identical rows, the collapse is back.
+    private static var duplicateEmailJSON: String {
+        let old = account(
+            "henry@example.com", quota: "1.0", state: "spent", probe: "ok", held: hold,
+            plan: "Max 20x", orgUuid: "11111111-1111-1111-1111-111111111111",
+            gate: "rejected")
+        let fresh = account(
+            "henry@example.com", quota: "null", state: "ok", probe: "never",
+            usage: unmeasuredUsage,
+            plan: "Team Standard", orgUuid: "22222222-2222-2222-2222-222222222222",
+            gate: "ok")
+        return "[\(old),\(fresh)]"
     }
 
     /// The bug this scene exists to catch: a 7d-red account must not paint

--- a/apps/macos/Sources/TcrBar/ShellProbe.swift
+++ b/apps/macos/Sources/TcrBar/ShellProbe.swift
@@ -164,7 +164,8 @@ enum ShellProbe {
                     + "bounds=\(Int(bounds.width))x\(Int(bounds.height)))"))
 
         guard let button else {
-            report(checks, environment: environment(shell, occlusionAtOpen: occlusionAtOpen),
+            report(
+                checks, environment: environment(shell, occlusionAtOpen: occlusionAtOpen),
                 notes: notes)
             exit(1)
         }
@@ -306,7 +307,8 @@ enum ShellProbe {
         //     so the gauge is right in both while the cup stays cyan in both.
         checks.append(appearanceCheck())
 
-        report(checks, environment: environment(shell, occlusionAtOpen: occlusionAtOpen),
+        report(
+            checks, environment: environment(shell, occlusionAtOpen: occlusionAtOpen),
             notes: notes)
         exit(checks.allSatisfy(\.passed) ? 0 : 1)
     }
@@ -429,7 +431,9 @@ enum ShellProbe {
                     colour.alphaComponent > 0.35
                 else { continue }
                 out.opaque += 1
-                let r = colour.redComponent, g = colour.greenComponent, b = colour.blueComponent
+                let r = colour.redComponent
+                let g = colour.greenComponent
+                let b = colour.blueComponent
                 if g - r > 0.15 && b - r > 0.15 {
                     out.cyan += 1
                 } else {
@@ -501,8 +505,9 @@ enum ShellProbe {
     /// One line per assertion, and the verdict grep-able on its own line.
     private static func report(_ checks: [Check], environment: String, notes: [String]) {
         for check in checks.sorted(by: { $0.number < $1.number }) {
-            print("shell-probe: \(check.passed ? "PASS" : "FAIL") \(check.number). "
-                + "\(check.name) — \(check.detail)")
+            print(
+                "shell-probe: \(check.passed ? "PASS" : "FAIL") \(check.number). "
+                    + "\(check.name) — \(check.detail)")
         }
         for note in notes {
             print("shell-probe: NOTE \(note)")
@@ -532,6 +537,8 @@ enum ShellProbe {
         let rows = (1...13).map { index in
             """
             {"name":"probe-\(index)@example.com","priority":0,"status":"active",
+             "plan":"\(index % 2 == 0 ? "Team Standard" : "Max 20x")",
+             "orgUuid":"\(index % 2 == 0 ? "22222222-2222-2222-2222-222222222222" : "11111111-1111-1111-1111-111111111111")",
              "disabled":false,"quota":0.\(index % 9 + 1),"quotaState":"ok",
              "fiveHour":0.1,"sevenDay":0.1,
              "sevenDayOi":0.1,"sevenDayOiState":"ok","sevenDayOiResetAtMs":\(fableReset),

--- a/apps/macos/Sources/TcrBarCore/AccountControl.swift
+++ b/apps/macos/Sources/TcrBarCore/AccountControl.swift
@@ -39,12 +39,25 @@ import Foundation
 /// ``ToggleVerdict``. The panel still only ever asserts what `tcr status`
 /// reports; it just no longer treats exit 0 as evidence that anything happened.
 public enum AccountCommand {
-    /// The complete argument vector. `name` is passed positionally and verbatim —
-    /// no `--org`, no flags, nothing that could name a process.
+    /// The complete argument vector. `name` is passed positionally and
+    /// verbatim; nothing here is shell-interpreted.
+    ///
+    /// `org` narrows an ambiguous name, exactly as it does for
+    /// ``TokenCommand/arguments(query:org:)`` and
+    /// ``RemoveAccountCommand/arguments(query:org:)``. It is not optional
+    /// decoration: point 2 above says a name resolves "to that row or to
+    /// nothing, except where two accounts share an email across orgs, which
+    /// `match_one` returns as ambiguous rather than picking one" — and that
+    /// exception is the fleet's ordinary state, not a corner. Without the flag
+    /// the toggle simply refuses on those rows.
+    ///
+    /// Omitted entirely when `org` is `nil`, so a row from a server that
+    /// reports no org builds precisely the command it built before.
     ///
     /// `enabled: true` means "put this account back in rotation".
-    public static func arguments(enabled: Bool, name: String) -> [String] {
-        [enabled ? "enable" : "disable", name]
+    public static func arguments(enabled: Bool, name: String, org: String? = nil) -> [String] {
+        guard let org else { return [enabled ? "enable" : "disable", name] }
+        return [enabled ? "enable" : "disable", name, "--org", org]
     }
 
     /// Why a toggle did not happen. Carries the CLI's own words; this app does not
@@ -92,7 +105,8 @@ public enum AccountCommand {
     }
 
     /// Blocking invocation — always called off the main actor.
-    nonisolated static func perform(enabled: Bool, name: String) -> Outcome {
+    nonisolated static func perform(enabled: Bool, account: AccountRef) -> Outcome {
+        let name = account.name
         switch TcrTool.resolve() {
         case .failure(let notFound):
             return .failed(
@@ -105,7 +119,7 @@ public enum AccountCommand {
             do {
                 let output = try TcrTool.run(
                     executable: executable,
-                    arguments: arguments(enabled: enabled, name: name)
+                    arguments: arguments(enabled: enabled, name: name, org: account.orgUuid)
                 )
                 return classify(enabling: enabled, exitCode: output.exitCode, stderr: output.stderr)
             } catch {
@@ -119,7 +133,11 @@ public enum AccountCommand {
 /// Per-account toggle state for the panel: which rows have a call in flight, and
 /// which rows have a failure that has not been superseded by a later attempt.
 ///
-/// Keyed by account name, which is `Account.id`.
+/// Keyed by ``AccountRef/id`` — the ORG-QUALIFIED identity, not the bare name.
+/// Keying by name collapsed the fleet's two same-email rows into one entry, so a
+/// failure or an in-flight spinner belonging to one row rendered on both. That
+/// key must stay identical to the one `ForEach` uses, which is why both come
+/// from ``AccountRef`` rather than being spelled out twice.
 @MainActor
 public final class AccountController: ObservableObject {
     @Published public private(set) var pending: Set<String> = []
@@ -130,8 +148,10 @@ public final class AccountController: ObservableObject {
 
     public init() {}
 
-    public func isPending(_ name: String) -> Bool { pending.contains(name) }
-    public func failure(for name: String) -> AccountCommand.Failure? { failures[name] }
+    public func isPending(_ account: AccountRef) -> Bool { pending.contains(account.id) }
+    public func failure(for account: AccountRef) -> AccountCommand.Failure? {
+        failures[account.id]
+    }
 
     /// Record what the poll that followed a successful toggle reported. Called by
     /// the row immediately after its refresh, so the verdict describes the same
@@ -142,17 +162,18 @@ public final class AccountController: ObservableObject {
     public func record(
         readback: PollState,
         requestedEnabled: Bool,
-        account name: String,
+        account: AccountRef,
         notice: String? = nil,
         now: Date = Date()
     ) {
+        let key = account.id
         let verdict = ToggleReadback.verdict(
             requestedEnabled: requestedEnabled,
-            account: name,
+            account: account,
             readback: readback,
             notice: notice
         )
-        verdicts[name] = RecordedVerdict(verdict: verdict, at: now)
+        verdicts[key] = RecordedVerdict(verdict: verdict, at: now)
         // Every verdict ages out (see ``ToggleReadback/visible(_:reportedDisabled:now:)``),
         // and `visible` is the authority on how long. This timer exists only so the
         // expiry is actually DRAWN: nothing else republishes when the deadline
@@ -164,12 +185,12 @@ public final class AccountController: ObservableObject {
         // normally clear on agreement long before their deadline, but the case the
         // deadline exists for — an account that left the fleet, where agreement can
         // never come — is exactly the case where nothing else would ever clear it.
-        let recorded = verdicts[name]
+        let recorded = verdicts[key]
         let lifetime = ToggleReadback.lifetime(of: verdict)
         Task { [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(lifetime * 1_000_000_000))
-            guard let self, self.verdicts[name] == recorded else { return }
-            self.verdicts[name] = nil
+            guard let self, self.verdicts[key] == recorded else { return }
+            self.verdicts[key] = nil
         }
     }
 
@@ -177,11 +198,11 @@ public final class AccountController: ObservableObject {
     /// what the *current* fleet read says about the account, which is what stops a
     /// confirmation from outliving its truth.
     public func verdict(
-        for name: String,
+        for account: AccountRef,
         reportedDisabled: Bool?,
         now: Date = Date()
     ) -> ToggleVerdict? {
-        ToggleReadback.visible(verdicts[name], reportedDisabled: reportedDisabled, now: now)
+        ToggleReadback.visible(verdicts[account.id], reportedDisabled: reportedDisabled, now: now)
     }
 
     /// What a click did, as far as the subprocess can say.
@@ -201,19 +222,20 @@ public final class AccountController: ObservableObject {
     /// to decide whether a status refresh is worth doing, never to update a local
     /// copy of `disabled`.
     @discardableResult
-    public func setEnabled(_ enabled: Bool, account name: String) async -> Attempt {
-        guard !pending.contains(name) else { return .skipped }
-        pending.insert(name)
+    public func setEnabled(_ enabled: Bool, account: AccountRef) async -> Attempt {
+        let key = account.id
+        guard !pending.contains(key) else { return .skipped }
+        pending.insert(key)
         // A new attempt clears the previous verdict; a stale error beside a
         // now-succeeding row would be its own lie. The read-back verdict goes for
         // the same reason: a `parked ✓` left over from the last click must not sit
         // beside a call that is still in flight and might not be honoured.
-        failures[name] = nil
-        verdicts[name] = nil
-        defer { pending.remove(name) }
+        failures[key] = nil
+        verdicts[key] = nil
+        defer { pending.remove(key) }
 
         let outcome = await Task.detached(priority: .userInitiated) {
-            AccountCommand.perform(enabled: enabled, name: name)
+            AccountCommand.perform(enabled: enabled, account: account)
         }.value
 
         switch outcome {
@@ -222,7 +244,7 @@ public final class AccountController: ObservableObject {
         case .spoke(let notice):
             return .accepted(notice: notice)
         case .failed(let failure):
-            failures[name] = failure
+            failures[key] = failure
             return .refused
         }
     }

--- a/apps/macos/Sources/TcrBarCore/AccountRef.swift
+++ b/apps/macos/Sources/TcrBarCore/AccountRef.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// How this app names ONE account, everywhere: the display name plus the org it
+/// belongs to.
+///
+/// It exists because a name is not an identity. The fleet holds the same email
+/// twice — once in a personal Max org, once in the company Team org — and until
+/// this type existed the panel had no way to tell those two rows apart. The
+/// consequences were not subtle:
+///
+///  * `ForEach(…, id: \.element.id)` collapsed the pair into ONE SwiftUI
+///    identity, so both rows drew the first row's quota bars and neither wore
+///    its own gate pill, while `tcr status --json` reported the two correctly
+///    and differently. A screenshot of the panel disagreed with the CLI.
+///  * Every per-account dictionary — in-flight toggles, failures, read-back
+///    verdicts, removed-needs-restart — was keyed by name, so a failure on one
+///    row rendered on both.
+///  * Every command the panel issued carried a bare name, and `tcr` refuses an
+///    ambiguous one rather than guessing: "Copy Access Token" on either row
+///    failed with `'…' is ambiguous — matches 2 accounts … Narrow with --org`.
+///
+/// The two halves are deliberately kept separate rather than pre-joined into a
+/// string, because they are used for different things and must not be confused:
+/// ``id`` is what the UI keys on, and ``name``/``orgUuid`` are what the CLI is
+/// handed (`tcr token <name> --org <uuid>`). `tcr` has never taken the joined
+/// form and must never be passed it.
+public struct AccountRef: Hashable, Sendable {
+    /// The account's display name — an email on this fleet. What `tcr` matches
+    /// positionally.
+    public let name: String
+    /// The org UUID, when the server reported one. Passed as `--org` to narrow
+    /// an ambiguous `name`; `nil` from a server built before the org keys
+    /// existed, in which case no flag is passed and behaviour is exactly what it
+    /// was.
+    public let orgUuid: String?
+
+    public init(name: String, orgUuid: String? = nil) {
+        self.name = name
+        // An empty string is not an org. Normalizing here rather than at each
+        // call site is what keeps `--org ""` — which `tcr` would match nothing
+        // for — from ever being built.
+        self.orgUuid = (orgUuid?.isEmpty == false) ? orgUuid : nil
+    }
+
+    /// The single definition of this app's per-account identity. `Account.id`
+    /// and every by-account dictionary key resolve to this, so a row's SwiftUI
+    /// identity and its verdict's dictionary key cannot disagree.
+    ///
+    /// Falls back to the bare `name` when there is no org, which keeps an older
+    /// server's rows rendering exactly as they do today — and is the honest
+    /// answer there: with no org on the wire, the name is all the identity this
+    /// build can see.
+    ///
+    /// The `|` separator cannot collide with a real value: an org UUID contains
+    /// no `|`, so `a|uuid` is reachable only from `AccountRef(name: "a",
+    /// orgUuid: "uuid")`.
+    public var id: String {
+        guard let orgUuid else { return name }
+        return "\(name)|\(orgUuid)"
+    }
+}
+
+extension Account {
+    /// This row, as the identity every controller and command should take.
+    public var ref: AccountRef { AccountRef(name: name, orgUuid: orgUuid) }
+}

--- a/apps/macos/Sources/TcrBarCore/ControlAccountController.swift
+++ b/apps/macos/Sources/TcrBarCore/ControlAccountController.swift
@@ -169,6 +169,24 @@ public final class ControlAccountController: ObservableObject {
 
     public func isPending(_ name: String) -> Bool { pending.contains(name) }
     public func failure(for name: String) -> ControlAccountCommand.Failure? { failures[name] }
+    /// Deliberately keyed on the bare NAME, unlike every other per-account
+    /// lookup in this app, which moved to ``AccountRef/id`` when the fleet's
+    /// two same-email rows were found colliding.
+    ///
+    /// This one cannot follow, and pretending otherwise would be the worse
+    /// choice. The stored `controlAccount` (`src/config.rs`, `Config::control_account`)
+    /// is a bare string, and the server resolves it by name to the FIRST
+    /// matching row (`Manager::assemble`'s `accounts.iter().position`), then
+    /// stamps `control: true` on the wire for every row whose name equals it
+    /// (`src/cli.rs`, `render_accounts_json`). So on a duplicated email the
+    /// SERVER already reports both rows as control, and an org-qualified check
+    /// here would show one row as control and the other not — disagreeing with
+    /// the process that actually routes the traffic, which is a worse lie than
+    /// agreeing with it.
+    ///
+    /// Making this correct is a SERVER change: `controlAccount` has to carry an
+    /// org, or the wire has to name the resolved index. Reported separately
+    /// rather than half-fixed here.
     public func isControl(_ name: String) -> Bool { !unavailable && current == name }
 
     /// Re-read `tcr control --show`. Safe to call any time — on panel open,

--- a/apps/macos/Sources/TcrBarCore/FleetStatus.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetStatus.swift
@@ -976,6 +976,40 @@ public struct Account: Decodable, Equatable, Identifiable, Sendable {
     /// group's ``GroupTag/background`` `nil`.
     public let groupColors: [String: String]?
 
+    /// The customer-facing plan label the SERVER derived (`Max 20x`, `Team 5x`,
+    /// `Team Standard`, …). Derived once, in Rust
+    /// (`tcr_status_wire::plan_label`), and never re-derived here: a second
+    /// implementation of the mapping is a second thing to get wrong, and the
+    /// one guarantee this field exists to give is that every surface names a
+    /// row's plan identically.
+    ///
+    /// `nil` for an account that has never been profiled, and for any server
+    /// built before this key existed. Both render as no tag at all — never a
+    /// guessed label, because the whole job of this field is telling two rows
+    /// with the SAME NAME apart, and a fabricated one defeats it.
+    public let plan: String?
+
+    /// The three raw profile strings the label was derived FROM, kept for a
+    /// reader that wants the provider's own vocabulary rather than English.
+    /// Optional for the same forward-compat reason ``groups`` is.
+    public let organizationType: String?
+    public let rateLimitTier: String?
+    public let seatTier: String?
+
+    /// The org this account is scoped to. Load-bearing, not informational:
+    /// every `tcr` account verb takes `--org <name-or-uuid-prefix>`, and this
+    /// is the ONLY thing that lets the panel address one of two rows sharing an
+    /// email. Without it "Copy Access Token" failed with `'…' is ambiguous —
+    /// matches 2 accounts`, because the command it built carried a name and
+    /// nothing to narrow it by.
+    ///
+    /// ``orgUuid`` is what the panel passes: it is exact, where ``orgName`` is
+    /// a display string two orgs can share. `nil` from a server built before
+    /// these keys existed, which is why every call site treats the flag as
+    /// optional rather than required.
+    public let orgUuid: String?
+    public let orgName: String?
+
     /// Explicit memberwise init, needed only because adding `fiveHourState`/
     /// `sevenDayState` after the struct already had test fixtures constructing
     /// it directly would otherwise force every one of them to grow two new
@@ -1016,7 +1050,13 @@ public struct Account: Decodable, Equatable, Identifiable, Sendable {
         reservedGroups: [String]? = nil,
         controlAllowedGroups: [String]? = nil,
         groupColors: [String: String]? = nil,
-        usage: UsageRow? = nil
+        usage: UsageRow? = nil,
+        plan: String? = nil,
+        organizationType: String? = nil,
+        rateLimitTier: String? = nil,
+        seatTier: String? = nil,
+        orgUuid: String? = nil,
+        orgName: String? = nil
     ) {
         self.name = name
         self.priority = priority
@@ -1051,9 +1091,28 @@ public struct Account: Decodable, Equatable, Identifiable, Sendable {
         self.controlAllowedGroups = controlAllowedGroups
         self.groupColors = groupColors
         self.usage = usage
+        self.plan = plan
+        self.organizationType = organizationType
+        self.rateLimitTier = rateLimitTier
+        self.seatTier = seatTier
+        self.orgUuid = orgUuid
+        self.orgName = orgName
     }
 
-    public var id: String { name }
+    /// This row's identity, ORG-QUALIFIED — `name` alone is not unique.
+    ///
+    /// This was a live defect, not a theoretical one. Two rows sharing an email
+    /// in different orgs collapsed to one SwiftUI identity in
+    /// `ForEach(…, id: \.element.id)`, so the panel painted the FIRST row's
+    /// numbers on both and neither wore its own pill — while `tcr status
+    /// --json` reported them correctly and differently. Every by-name
+    /// dictionary in the panel (pending verdicts, failures, restart-needed)
+    /// collided the same way, for the same reason.
+    ///
+    /// Delegates to ``AccountRef/id`` rather than restating the rule, so this
+    /// row's SwiftUI identity and the key its verdict is stored under cannot
+    /// drift apart — the drift being the bug itself.
+    public var id: String { ref.id }
 
     /// Worst-first ordering key. A disabled account is not an alarm — it is an
     /// operator decision — so it sorts below a spent one. This does *not* drive

--- a/apps/macos/Sources/TcrBarCore/LoginLauncher.swift
+++ b/apps/macos/Sources/TcrBarCore/LoginLauncher.swift
@@ -71,7 +71,18 @@ public enum LoginLauncher {
     /// into an `echo`: an account name is attacker-adjacent input in
     /// principle, and unquoted interpolation into a `.command` file is
     /// injection.
-    public static func script(forExecutableAt path: String, reloggingIn name: String? = nil) -> String {
+    /// `org` narrows an ambiguous `--account`, exactly as it does for every
+    /// other account verb. It is not optional polish on this fleet: `tcr
+    /// login --account` resolves through the same `resolve_account` that
+    /// refuses rather than guessing (`src/oauth.rs`,
+    /// `assert_requested_identity`), so a re-login on either of two rows
+    /// sharing an email failed outright. Quoted the same POSIX way as the
+    /// path and the name, for the same reason.
+    public static func script(
+        forExecutableAt path: String,
+        reloggingIn name: String? = nil,
+        org: String? = nil
+    ) -> String {
         // Single-quote the path and escape any embedded single quote the POSIX
         // way ('\'') so the shell receives exactly one argument whatever the path
         // contains.
@@ -94,7 +105,14 @@ public enum LoginLauncher {
 
                 """
             let quotedName = "'" + name.replacingOccurrences(of: "'", with: "'\\''") + "'"
-            accountArgument = " --account \(quotedName)"
+            let orgArgument: String
+            if let org, !org.isEmpty {
+                let quotedOrg = "'" + org.replacingOccurrences(of: "'", with: "'\\''") + "'"
+                orgArgument = " --org \(quotedOrg)"
+            } else {
+                orgArgument = ""
+            }
+            accountArgument = " --account \(quotedName)\(orgArgument)"
         } else {
             hint = ""
             accountArgument = ""
@@ -129,6 +147,7 @@ public enum LoginLauncher {
     @discardableResult
     public static func launch(
         reloggingIn name: String? = nil,
+        org: String? = nil,
         uuid: () -> UUID = UUID.init,
         resolve: () -> Result<URL, TcrTool.NotFound> = { TcrTool.resolve() },
         open: (URL) -> Void = { NSWorkspace.shared.open($0) }
@@ -139,7 +158,7 @@ public enum LoginLauncher {
         case .failure(let missing): return .failure(.toolMissing(searched: missing.searched))
         }
 
-        let script = script(forExecutableAt: executable.path, reloggingIn: name)
+        let script = script(forExecutableAt: executable.path, reloggingIn: name, org: org)
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("tcr-login-\(uuid().uuidString).command")
 

--- a/apps/macos/Sources/TcrBarCore/RemoveAccountControl.swift
+++ b/apps/macos/Sources/TcrBarCore/RemoveAccountControl.swift
@@ -94,7 +94,7 @@ public enum RemoveAccountCommand {
 /// listed until restart" notice, since the row itself has no way to reflect
 /// a boot-time config change on its own.
 ///
-/// Keyed by account name, same as ``AccountController``. Never cleared: like
+/// Keyed by ``AccountRef/id``, same as ``AccountController``. Never cleared: like
 /// ``GroupController/appliedPendingRestart``, there is no live config reload
 /// for this field, so once a delete lands it stays pending-restart until the
 /// app relaunches (which matches reality) — the panel is expected to keep
@@ -107,11 +107,13 @@ public final class RemoveAccountController: ObservableObject {
 
     public init() {}
 
-    public func isPending(_ name: String) -> Bool { pending.contains(name) }
-    public func failure(for name: String) -> RemoveAccountCommand.Failure? { failures[name] }
-    /// Whether `name` was successfully deleted from the config this session —
-    /// the fact the "restart to apply" notice is drawn from.
-    public func needsRestart(_ name: String) -> Bool { removed.contains(name) }
+    public func isPending(_ account: AccountRef) -> Bool { pending.contains(account.id) }
+    public func failure(for account: AccountRef) -> RemoveAccountCommand.Failure? {
+        failures[account.id]
+    }
+    /// Whether this account was successfully deleted from the config this
+    /// session — the fact the "restart to apply" notice is drawn from.
+    public func needsRestart(_ account: AccountRef) -> Bool { removed.contains(account.id) }
 
     /// What a call did, as far as the subprocess can say — mirrors
     /// ``AccountController/Attempt``/``GroupController/Attempt``.
@@ -121,30 +123,31 @@ public final class RemoveAccountController: ObservableObject {
         case accepted(notice: String?)
     }
 
-    /// `tcr remove <name>`. `org` narrows an ambiguous match, mirroring the
-    /// CLI's own `--org` flag; the panel does not currently offer a way to
-    /// set it, so callers pass `nil` until that becomes a real ambiguity to
-    /// solve.
+    /// `tcr remove <name> [--org <uuid>]`. The org comes from the row itself
+    /// (``AccountRef/orgUuid``) rather than being left `nil`: on this fleet a
+    /// bare name matches two accounts and `tcr` refuses rather than guessing,
+    /// so a delete of either row failed as ambiguous.
     @discardableResult
-    public func remove(account name: String, org: String? = nil) async -> Attempt {
-        guard !pending.contains(name) else { return .skipped }
-        pending.insert(name)
-        failures[name] = nil
-        defer { pending.remove(name) }
+    public func remove(account: AccountRef) async -> Attempt {
+        let key = account.id
+        guard !pending.contains(key) else { return .skipped }
+        pending.insert(key)
+        failures[key] = nil
+        defer { pending.remove(key) }
 
         let outcome = await Task.detached(priority: .userInitiated) {
-            RemoveAccountCommand.perform(query: name, org: org)
+            RemoveAccountCommand.perform(query: account.name, org: account.orgUuid)
         }.value
 
         switch outcome {
         case .clean:
-            removed.insert(name)
+            removed.insert(key)
             return .accepted(notice: nil)
         case .spoke(let notice):
-            removed.insert(name)
+            removed.insert(key)
             return .accepted(notice: notice)
         case .failed(let failure):
-            failures[name] = failure
+            failures[key] = failure
             return .refused
         }
     }

--- a/apps/macos/Sources/TcrBarCore/ToggleVerdict.swift
+++ b/apps/macos/Sources/TcrBarCore/ToggleVerdict.swift
@@ -225,25 +225,31 @@ public enum ToggleReadback {
     /// prose to decide how bad it is.
     public static func verdict(
         requestedEnabled: Bool,
-        account name: String,
+        account ref: AccountRef,
         readback: PollState,
         notice: String? = nil
     ) -> ToggleVerdict {
         let plain = plainVerdict(
-            requestedEnabled: requestedEnabled, account: name, readback: readback)
+            requestedEnabled: requestedEnabled, account: ref, readback: readback)
         guard let notice, !notice.isEmpty else { return plain }
         return .spokeUp(notice: notice, about: plain)
     }
 
     /// The read-back comparison alone, with no knowledge of what `tcr` printed.
+    ///
+    /// The row is found by ORG-QUALIFIED id, not by name. Matching on name alone
+    /// picked whichever of the fleet's two same-email rows came first, so a
+    /// toggle of one could be "confirmed" against the OTHER row's `disabled` —
+    /// a confirmation of something that never happened, which is precisely the
+    /// class of lie this type exists to prevent.
     private static func plainVerdict(
         requestedEnabled: Bool,
-        account name: String,
+        account ref: AccountRef,
         readback: PollState
     ) -> ToggleVerdict {
         switch readback {
         case .loaded(let fleet):
-            guard let account = fleet.accounts.first(where: { $0.name == name }) else {
+            guard let account = fleet.accounts.first(where: { $0.id == ref.id }) else {
                 return .unverified(
                     requestedEnabled: requestedEnabled,
                     reason: "the fleet no longer lists this account"

--- a/apps/macos/Tests/TcrBarTests/AccountIdentityTests.swift
+++ b/apps/macos/Tests/TcrBarTests/AccountIdentityTests.swift
@@ -1,0 +1,212 @@
+import XCTest
+
+@testable import TcrBarCore
+
+/// The fleet holds one email twice — a personal Max org and a company Team org.
+/// Everything here guards the consequences of that, which were all real:
+/// two rows collapsing into one in the panel, and every per-account command
+/// refusing as ambiguous.
+final class AccountIdentityTests: XCTestCase {
+
+    private let personal = "11111111-1111-1111-1111-111111111111"
+    private let team = "22222222-2222-2222-2222-222222222222"
+
+    // MARK: - identity
+
+    /// The defect itself: `ForEach(…, id: \.element.id)` treated the pair as one
+    /// row, so the panel drew the first row's numbers on both and neither wore
+    /// its own gate pill, while `tcr status --json` reported them correctly and
+    /// differently.
+    func testTwoRowsSharingAnEmailInDifferentOrgsHaveDistinctIds() throws {
+        let fleet = try Fleet.decode(Data(duplicateEmailJSON.utf8))
+        XCTAssertEqual(fleet.accounts.count, 2)
+
+        let ids = Set(fleet.accounts.map(\.id))
+        XCTAssertEqual(
+            ids.count, 2,
+            "two rows sharing a name must be two identities — one id means the panel "
+                + "renders one row's numbers twice"
+        )
+        XCTAssertEqual(
+            Set(fleet.accounts.map(\.name)).count, 1,
+            "the control: the two rows really do share a name, so this test is not "
+                + "passing because the fixture made them different"
+        )
+    }
+
+    /// A server that reports no org — an older build — must render exactly as it
+    /// does today, and with no org there genuinely is no more identity to have.
+    func testIdFallsBackToTheBareNameWithoutAnOrg() {
+        XCTAssertEqual(AccountRef(name: "alice@example.com").id, "alice@example.com")
+        XCTAssertEqual(
+            AccountRef(name: "alice@example.com", orgUuid: "").id, "alice@example.com",
+            "an empty string is not an org — it must not produce a trailing separator"
+        )
+    }
+
+    /// The row's `id` and the key its verdict is filed under must be the same
+    /// string, because the drift between them IS the bug.
+    func testAccountIdMatchesItsRefsId() throws {
+        let fleet = try Fleet.decode(Data(duplicateEmailJSON.utf8))
+        for account in fleet.accounts {
+            XCTAssertEqual(account.id, account.ref.id)
+        }
+    }
+
+    /// A verdict recorded against one row must not appear on the other. Keyed by
+    /// name, both rows showed it.
+    @MainActor
+    func testAVerdictOnOneRowDoesNotSurfaceOnItsTwin() async throws {
+        let fleet = try Fleet.decode(Data(duplicateEmailJSON.utf8))
+        let first = fleet.accounts[0].ref
+        let second = fleet.accounts[1].ref
+
+        let controller = AccountController()
+        controller.record(
+            readback: .loaded(fleet),
+            requestedEnabled: true,
+            account: first,
+            now: Date()
+        )
+
+        XCTAssertNotNil(
+            controller.verdict(for: first, reportedDisabled: false),
+            "the row that was toggled shows its own verdict"
+        )
+        XCTAssertNil(
+            controller.verdict(for: second, reportedDisabled: false),
+            "its same-email twin in another org must show nothing"
+        )
+    }
+
+    // MARK: - decoding
+
+    func testPlanAndOrgKeysDecode() throws {
+        let fleet = try Fleet.decode(Data(duplicateEmailJSON.utf8))
+        XCTAssertEqual(fleet.accounts[0].plan, "Max 20x")
+        XCTAssertEqual(fleet.accounts[0].organizationType, "claude_max")
+        XCTAssertEqual(fleet.accounts[0].rateLimitTier, "default_claude_max_20x")
+        XCTAssertNil(fleet.accounts[0].seatTier, "a Max org has no seat")
+        XCTAssertEqual(fleet.accounts[0].orgUuid, personal)
+        XCTAssertEqual(fleet.accounts[0].orgName, "Example Personal")
+
+        XCTAssertEqual(fleet.accounts[1].plan, "Team Standard")
+        XCTAssertEqual(fleet.accounts[1].seatTier, "team_standard")
+        XCTAssertEqual(fleet.accounts[1].orgUuid, team)
+    }
+
+    /// The forward-compat contract every optional field on this row carries: a
+    /// server built before these keys existed omits them entirely, and its rows
+    /// must still decode rather than throwing the panel back to a fabricated
+    /// offline snapshot.
+    func testARowWithNoPlanOrOrgKeysStillDecodes() throws {
+        let fleet = try Fleet.decode(Data(planlessJSON.utf8))
+        let account = try XCTUnwrap(fleet.accounts.first)
+        XCTAssertNil(account.plan)
+        XCTAssertNil(account.organizationType)
+        XCTAssertNil(account.orgUuid)
+        XCTAssertEqual(account.id, "solo@example.com")
+    }
+
+    // MARK: - the commands each row issues
+
+    /// Every per-account verb passes `--org` when the row has one. Without it
+    /// `tcr` refuses: `'…' is ambiguous — matches 2 accounts … Narrow with
+    /// --org`, which is what "Copy Access Token" failed with on this fleet.
+    func testEveryPerAccountCommandCarriesTheOrgWhenThereIsOne() {
+        XCTAssertEqual(
+            TokenCommand.arguments(query: "henry@example.com", org: personal),
+            ["token", "henry@example.com", "--org", personal]
+        )
+        XCTAssertEqual(
+            RemoveAccountCommand.arguments(query: "henry@example.com", org: personal),
+            ["remove", "henry@example.com", "--org", personal]
+        )
+        XCTAssertEqual(
+            AccountCommand.arguments(enabled: false, name: "henry@example.com", org: personal),
+            ["disable", "henry@example.com", "--org", personal]
+        )
+        XCTAssertEqual(
+            AccountCommand.arguments(enabled: true, name: "henry@example.com", org: personal),
+            ["enable", "henry@example.com", "--org", personal]
+        )
+        XCTAssertTrue(
+            LoginLauncher.script(
+                forExecutableAt: "/usr/local/bin/tcr",
+                reloggingIn: "henry@example.com",
+                org: personal
+            ).contains("--account 'henry@example.com' --org '\(personal)'"),
+            "a re-login resolves through the same refuse-on-ambiguity path"
+        )
+    }
+
+    /// And the negative: a row with no org builds precisely the command it built
+    /// before, with no empty flag appended. A stray `--org ''` would match
+    /// nothing and break every single-org fleet.
+    func testNoOrgMeansNoFlagAtAll() {
+        XCTAssertEqual(
+            TokenCommand.arguments(query: "solo@example.com"),
+            ["token", "solo@example.com"]
+        )
+        XCTAssertEqual(
+            RemoveAccountCommand.arguments(query: "solo@example.com"),
+            ["remove", "solo@example.com"]
+        )
+        XCTAssertEqual(
+            AccountCommand.arguments(enabled: true, name: "solo@example.com"),
+            ["enable", "solo@example.com"]
+        )
+        let script = LoginLauncher.script(
+            forExecutableAt: "/usr/local/bin/tcr", reloggingIn: "solo@example.com")
+        XCTAssertTrue(script.contains("--account 'solo@example.com'"))
+        XCTAssertFalse(script.contains("--org"), "no org means no flag, never an empty one")
+    }
+
+    /// An org value is quoted the same POSIX way the path and the name already
+    /// are — it goes onto a command line in a `.command` file, so unquoted
+    /// interpolation is injection.
+    func testTheOrgArgumentIsShellQuoted() {
+        let script = LoginLauncher.script(
+            forExecutableAt: "/usr/local/bin/tcr",
+            reloggingIn: "solo@example.com",
+            org: "it's; rm -rf /"
+        )
+        XCTAssertTrue(script.contains("--org 'it'\\''s; rm -rf /'"))
+    }
+
+    // MARK: - fixtures
+
+    private var duplicateEmailJSON: String {
+        """
+        [{"name":"henry@example.com","priority":0,"status":"active","disabled":false,
+          "plan":"Max 20x","organizationType":"claude_max",
+          "rateLimitTier":"default_claude_max_20x","seatTier":null,
+          "orgUuid":"\(personal)","orgName":"Example Personal",
+          "quota":1.0,"quotaState":"spent","fiveHour":1.0,"sevenDay":1.0,
+          "sevenDayOi":null,"held":[],"requests":13011,"inputTokens":1,"outputTokens":1,
+          "cacheReadTokens":1,"cacheHitRatio":0.5,"probeStatus":"ok","probeError":null,
+          "lastStreamError":null,"streamErrorCount":0,"source":"live",
+          "serverSha":"abc1234","serverDirty":false},
+         {"name":"henry@example.com","priority":1,"status":"active","disabled":false,
+          "plan":"Team Standard","organizationType":"claude_team",
+          "rateLimitTier":"default_raven","seatTier":"team_standard",
+          "orgUuid":"\(team)","orgName":"Example Team",
+          "quota":null,"quotaState":"ok","fiveHour":null,"sevenDay":null,
+          "sevenDayOi":null,"held":[],"requests":0,"inputTokens":0,"outputTokens":0,
+          "cacheReadTokens":0,"cacheHitRatio":null,"probeStatus":"never","probeError":null,
+          "lastStreamError":null,"streamErrorCount":0,"source":"live",
+          "serverSha":"abc1234","serverDirty":false}]
+        """
+    }
+
+    private var planlessJSON: String {
+        """
+        [{"name":"solo@example.com","priority":0,"status":"active","disabled":false,
+          "quota":0.1,"quotaState":"ok","fiveHour":0.1,"sevenDay":0.1,
+          "sevenDayOi":null,"held":[],"requests":1,"inputTokens":1,"outputTokens":1,
+          "cacheReadTokens":1,"cacheHitRatio":0.5,"probeStatus":"ok","probeError":null,
+          "lastStreamError":null,"streamErrorCount":0,"source":"live",
+          "serverSha":"abc1234","serverDirty":false}]
+        """
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/RemoveAccountControlTests.swift
+++ b/apps/macos/Tests/TcrBarTests/RemoveAccountControlTests.swift
@@ -75,7 +75,7 @@ final class RemoveAccountCommandTests: XCTestCase {
 @MainActor
 final class RemoveAccountControllerTests: XCTestCase {
 
-    private let alice = "alice@example.com"
+    private let alice = AccountRef(name: "alice@example.com")
 
     func testNeverRemovedByDefault() {
         let controller = RemoveAccountController()

--- a/apps/macos/Tests/TcrBarTests/ToggleVerdictTests.swift
+++ b/apps/macos/Tests/TcrBarTests/ToggleVerdictTests.swift
@@ -17,7 +17,7 @@ import XCTest
 /// Account names are obviously fake — this repository is public.
 final class ToggleVerdictTests: XCTestCase {
 
-    private let alice = "alice@example.com"
+    private let alice = AccountRef(name: "alice@example.com")
 
     /// `tcr`'s own words on the success path, from the live reproduction: the park
     /// applied to the running rotation, no config entry matched it, so it comes
@@ -381,7 +381,9 @@ final class ToggleVerdictTests: XCTestCase {
             .notHonoured(requestedEnabled: false)
         )
         // A verdict for one account must not surface on another row.
-        XCTAssertNil(controller.verdict(for: "bob@example.com", reportedDisabled: false, now: now))
+        XCTAssertNil(
+            controller.verdict(
+                for: AccountRef(name: "bob@example.com"), reportedDisabled: false, now: now))
     }
 
     /// The whole path the row takes, with the durability warning in it: what the
@@ -417,7 +419,19 @@ final class ToggleVerdictTests: XCTestCase {
 /// Inert account with only the fields this comparison reads. `status` is
 /// deliberately "active" even when parked — that is what live output does, and it
 /// is why `disabled` is the only field compared.
+///
+/// Takes the ``AccountRef`` rather than a bare name so a fixture row and the
+/// verdict looking it up carry the SAME identity — including its org, which is
+/// what the lookup now matches on.
+private func account(_ ref: AccountRef, disabled: Bool) -> Account {
+    account(name: ref.name, orgUuid: ref.orgUuid, disabled: disabled)
+}
+
 private func account(_ name: String, disabled: Bool) -> Account {
+    account(name: name, orgUuid: nil, disabled: disabled)
+}
+
+private func account(name: String, orgUuid: String?, disabled: Bool) -> Account {
     Account(
         name: name,
         priority: 1,
@@ -440,6 +454,7 @@ private func account(_ name: String, disabled: Bool) -> Account {
         streamErrorCount: 0,
         source: .live,
         serverSha: "abc1234",
-        serverDirty: false
+        serverDirty: false,
+        orgUuid: orgUuid
     )
 }


### PR DESCRIPTION
🍄 The panel half of #192. Each row now shows its plan beside the name (`Max 20x`, `Team 5x`, `Team Standard`, …), and two rows that share an email are two rows.

## What changes

- **Plan label** — dim text after the account name, from the wire's `plan`. Rendered as a status pill first; that pushed a long name out to `h…m` at 380pt, so it is plain text with no pill chrome. Worst case (`henry-long-name@example.com` + `Team Standard`) truncates the name, ordinary rows show it whole.
- **Row identity is email + org.** `Account.id` was the bare email, and `ForEach(…, id:)` plus every per-row lookup (`verdict(for:)`, `failure(for:)`, `needsRestart`) keyed on it, so a personal Max row and a Team seat for the same email rendered as ONE identity — the second row showed the first's numbers and lost its own verdict. Now keyed on `AccountRef` (name + `orgUuid`); rows from a server that predates `orgUuid` keep `id == name`.
- **Every per-row action narrows with `--org <orgUuid>`** — copy token, remove, enable/disable, priority — so "Copy Access Token" no longer fails as ambiguous on a duplicated email.
- New `--render-states` fixtures `01e-plan-labels` and `01f-duplicate-email`, checked by eye, not by exit code.

## Two defects seen and deliberately not half-fixed

1. **`tcr control` on a duplicated email marks BOTH rows control.** `controlAccount` is a bare name; `Manager::assemble` resolves it to the first matching row and `render_accounts_json` stamps `control: true` on every row with that name. The panel keeps `isControl` keyed on name so it agrees with the process that routes. Fix is server-side: `controlAccount` carries an org, or the wire names the resolved index.
2. **The panel never decodes `gate`.** A `gate: rejected` row shows `SPENT`, not `REJECTED`; `FleetView`'s comment that the wire has no gate field is stale (`AccountStatusRow.gate` exists). Separate change.

## Gates

`cargo fmt --all --check` 0 · `cargo clippy --all-targets --locked -- -D warnings` 0 · `cargo test --all --locked` 0 · `swift-format lint --strict` 0 · `swift build` 0 · `swift test` 0 (412 tests). Rebased onto `644e923`; the rebased tree is byte-identical to the gated one (`git diff` empty).

https://claude.ai/code/session_0154byNxtvz4fUkQPKkwAGBZ
