### PR TITLE
fix: persist the control account by identity, not a bare name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "teamclaude-rs"
-version = "0.2.37"
+version = "0.2.38"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -398,7 +398,7 @@ fn find_account_by_name(accounts: &[Account], name: &str) -> anyhow::Result<usiz
 ///
 /// `None` when there is nothing to say, which is every ordinary add.
 fn control_account_group_notice(config: &Config, account: &str, group: &str) -> Option<String> {
-    if config.control_account.as_deref() != Some(account) {
+    if config.control_account.as_ref().map(|c| c.name()) != Some(account) {
         return None;
     }
     Some(format!(
@@ -865,7 +865,7 @@ fn group_membership(config: &Config) -> (std::collections::BTreeMap<&str, Vec<&s
 const ROUTE_BLOCK_CONTROL_ONLY: &str = "control-account-only";
 
 fn group_routes(config: &Config, group: &str, members: &[&str]) -> bool {
-    match config.control_account.as_deref() {
+    match config.control_account.as_ref().map(|c| c.name()) {
         Some(control) => {
             members.iter().any(|member| *member != control) || config.group_allows_control(group)
         }
@@ -1362,16 +1362,18 @@ fn write_control_account(
     org: Option<&str>,
 ) -> anyhow::Result<Option<String>> {
     let config = load_for_edit(config_path)?;
-    let name = match query {
+    let target = match query {
         None => None,
-        Some(q) => Some(
-            config.accounts[resolve_account(&config.accounts, q, org)?]
-                .name
-                .clone(),
-        ),
+        Some(q) => Some(config.accounts[resolve_account(&config.accounts, q, org)?].clone()),
     };
-    config::save_control_account(config_path, name.as_deref())
+    let name = target.as_ref().map(|a| a.name.clone());
+    let outcome = config::save_control_account(config_path, target.as_ref())
         .with_context(|| format!("save config at {}", config_path.display()))?;
+    if let config::ControlWrite::Ambiguous = outcome {
+        bail!(
+            "more than one config entry shares this account's identity — give each its own orgUuid, then retry"
+        );
+    }
     Ok(name)
 }
 
@@ -1465,7 +1467,10 @@ pub async fn show_control(config_path: &Path) -> anyhow::Result<()> {
         .with_context(|| format!("load config at {}", config_path.display()))?;
     let control = match fetch_live_status(&config).await {
         Ok(payload) => payload.control,
-        Err(_) => config.control_account.clone(),
+        Err(_) => config
+            .control_account
+            .as_ref()
+            .map(|c| c.name().to_string()),
     };
     match control {
         Some(name) => println!("{name}"),
@@ -2469,7 +2474,10 @@ pub async fn status(config_path: &Path, json: bool) -> anyhow::Result<()> {
                 // way, so this is the same reading a live server would derive
                 // at boot.
                 let http1_only = config.http1_only;
-                let control = config.control_account.clone();
+                let control = config
+                    .control_account
+                    .as_ref()
+                    .map(|c| c.name().to_string());
                 let group_colors = config.group_colors();
                 let snapshot = snapshot_offline(
                     config,

--- a/src/config.rs
+++ b/src/config.rs
@@ -691,6 +691,86 @@ impl ThrottleConfig {
     }
 }
 
+/// The `controlAccount` key on disk: either the legacy bare account name every
+/// config written before this change carries, or an identity object — the same
+/// `name`/`accountUuid`/`orgUuid`/`orgName` fields `accounts[]` entries store —
+/// that survives a restart when an email is duplicated across two rows.
+/// `#[serde(untagged)]` is unambiguous here because the two shapes are
+/// structurally disjoint: a JSON string can never parse as the object variant
+/// and vice versa.
+///
+/// [`save_control_account`] always WRITES the identity shape once a real
+/// [`Account`] is known — it never re-emits the legacy string — but every
+/// reader (this type's own `Deserialize`, and boot resolution in
+/// `crate::manager::Manager::assemble`) keeps accepting the legacy shape
+/// unchanged, so a config nobody has re-saved since this change still loads
+/// and resolves exactly as before.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged, rename_all = "camelCase")]
+pub enum ControlAccountRef {
+    /// Written by every `tcr` build before this change: just the account's
+    /// `name`. Resolved by name/email alone (no org filter) — see
+    /// [`Self::org_filter`] — which is byte-identical to the old
+    /// `position(|a| a.name == *name)` lookup for the common case, a unique
+    /// name, and only starts refusing (rather than guessing) once that name is
+    /// duplicated.
+    Legacy(String),
+    /// The shape a `set` writes going forward: the same identity fields
+    /// `accounts[]` entries carry, so a duplicated email round-trips onto the
+    /// specific row it was set on.
+    ///
+    /// `rename_all = "camelCase"` is repeated here, not just at the enum
+    /// level, because serde's container `rename_all` renames VARIANT names for
+    /// an enum, not the FIELDS of a struct variant — the two are separate
+    /// attribute targets and only the variant-level one reaches these fields.
+    #[serde(rename_all = "camelCase")]
+    Identity {
+        name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        account_uuid: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        org_uuid: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        org_name: Option<String>,
+    },
+}
+
+impl ControlAccountRef {
+    /// The account name/email, present in both shapes.
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Legacy(name) => name,
+            Self::Identity { name, .. } => name,
+        }
+    }
+
+    /// The org discriminator to narrow a name/email match by, for boot
+    /// resolution — `None` for the legacy shape (it never carried one) and for
+    /// an identity object that itself has neither field. Prefers the uuid over
+    /// the name, matching [`crate::identity::org_key_of`]'s own preference.
+    pub fn org_filter(&self) -> Option<&str> {
+        match self {
+            Self::Legacy(_) => None,
+            Self::Identity {
+                org_uuid, org_name, ..
+            } => crate::identity::org_key_of(org_uuid.as_deref(), org_name.as_deref()),
+        }
+    }
+}
+
+impl From<&Account> for ControlAccountRef {
+    /// Always builds the IDENTITY shape — see this type's doc-comment for why
+    /// a set always upgrades the key rather than re-writing the legacy string.
+    fn from(account: &Account) -> Self {
+        Self::Identity {
+            name: account.name.clone(),
+            account_uuid: account.account_uuid.clone(),
+            org_uuid: account.org_uuid.clone(),
+            org_name: account.org_name.clone(),
+        }
+    }
+}
+
 /// Top-level config document.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -733,15 +813,21 @@ pub struct Config {
     /// fail rather than rotating. Set to the exact `accounts[].name`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lock_account: Option<String>,
-    /// The identity-bound control account: the one name that `_tcr/accounts/control`
-    /// resolves to and that stays PROBEABLE (usage tracked) even while `disabled`.
-    /// Unlike [`Self::lock_account`] this does NOT change selection by itself —
-    /// see the manager's `control_idx` doc for the resolution and the routing this
-    /// key only sets up for (part 2). Absent → no control account (default).
-    /// `skip_serializing_if` so clearing it REMOVES the key rather than writing
-    /// `null` — same contract as `lock_account` would want if it grew a setter.
+    /// The identity-bound control account: the one account that
+    /// `_tcr/accounts/control` resolves to and that stays PROBEABLE (usage
+    /// tracked) even while `disabled`. Unlike [`Self::lock_account`] this does
+    /// NOT change selection by itself — see the manager's `control_idx` doc for
+    /// the resolution and the routing this key only sets up for (part 2).
+    /// Absent → no control account (default). `skip_serializing_if` so clearing
+    /// it REMOVES the key rather than writing `null` — same contract as
+    /// `lock_account` would want if it grew a setter.
+    ///
+    /// [`ControlAccountRef`] accepts a legacy bare name (every config on disk
+    /// before this change) or an identity object; boot resolution refuses to
+    /// guess when a bare name is duplicated rather than silently binding to
+    /// whichever row sorts first — see `crate::manager::Manager::assemble`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub control_account: Option<String>,
+    pub control_account: Option<ControlAccountRef>,
     /// Quota headroom reserved for the control account against GENERAL
     /// (non-control-preferred) picks — part of the routing half (part 2) of the
     /// control-account feature. `threshold - control_reserve` is the effective
@@ -2022,18 +2108,32 @@ fn merge_plan(
     }
 }
 
-/// What a targeted [`save_control_account`] did to the on-disk document.
-/// Simpler than [`DisabledWrite`]: `controlAccount` is a single top-level
-/// string, not a per-entry flag located by identity, so there is no
-/// `NoEntry`/`Ambiguous` — the key is either already what was asked, or it
-/// isn't, and the caller is free to name an account nothing on disk carries
-/// yet (resolution to a live rotation slot happens in the manager, not here).
+/// What a targeted [`save_control_account`] did to the on-disk document. Same
+/// shape as [`DisabledWrite`] now, and for the same reason: writing the
+/// identity object requires resolving `target` against the on-disk
+/// `accounts[]` first, and an identity matching more than one entry cannot be
+/// written without guessing which row "is" the control account.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ControlWrite {
     /// The key was set (or removed) and the file rewritten.
     Updated,
     /// The document already said exactly this; nothing was written.
     Unchanged,
+    /// More than one on-disk entry carries `target`'s identity; nothing was
+    /// written. Same refusal as [`DisabledWrite::Ambiguous`], for the same
+    /// reason: guessing which entry the new control account "is" risks
+    /// silently binding control to the wrong row.
+    Ambiguous,
+}
+
+impl std::fmt::Display for ControlWrite {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Updated => "updated",
+            Self::Unchanged => "unchanged",
+            Self::Ambiguous => "more than one entry on disk carries this identity",
+        })
+    }
 }
 
 /// Persist ONLY the top-level `controlAccount` key into the file at `path`,
@@ -2045,13 +2145,26 @@ pub enum ControlWrite {
 /// file's RAW JSON document via [`read_document`] + [`write_atomic`], never on
 /// a `Config` round-trip through [`save`].
 ///
-/// `name == None` REMOVES the key (matches `#[serde(skip_serializing_if =
+/// `target == None` REMOVES the key (matches `#[serde(skip_serializing_if =
 /// "Option::is_none")]` on [`Config::control_account`]) rather than writing
 /// `null` — the same "clear removes, never sets to a null-ish literal"
 /// contract [`save_disabled`] uses for `disabled == false`.
-pub fn save_control_account(path: &Path, name: Option<&str>) -> Result<ControlWrite, ConfigError> {
+///
+/// `target == Some(account)` writes the [`ControlAccountRef::Identity`] shape
+/// built from `account`'s own identity fields — never the legacy bare-string
+/// shape, even when the document currently has one — after checking, via
+/// [`locate_account_entry`] (the same resolver [`find_account_entry`] is built
+/// on, reused rather than re-implemented), that `account`'s identity does not
+/// match more than one on-disk entry. It is deliberately NOT an error for
+/// `account` to match NO on-disk entry: the caller is free to name a rotation
+/// slot that has not been written to disk yet, exactly as the legacy `&str`
+/// signature always allowed.
+pub fn save_control_account(
+    path: &Path,
+    target: Option<&Account>,
+) -> Result<ControlWrite, ConfigError> {
     let mut doc = read_document(path)?;
-    let outcome = merge_control_account(&mut doc, name);
+    let outcome = merge_control_account(&mut doc, target);
     if outcome == ControlWrite::Updated {
         write_atomic(path, &serde_json::to_string_pretty(&doc)?)?;
     }
@@ -2452,9 +2565,17 @@ fn merge_group_color(
 
 /// Set or remove the top-level `controlAccount` key in `doc`. Reports whether
 /// the document actually changed, so the caller can skip a pointless rewrite
-/// of a credential file.
-fn merge_control_account(doc: &mut Map<String, Value>, name: Option<&str>) -> ControlWrite {
-    let desired = name.map(|n| Value::String(n.to_string()));
+/// of a credential file. See [`save_control_account`].
+fn merge_control_account(doc: &mut Map<String, Value>, target: Option<&Account>) -> ControlWrite {
+    if let Some(account) = target {
+        if let EntryMatch::Many = locate_account_entry(doc, account) {
+            return ControlWrite::Ambiguous;
+        }
+    }
+    let desired = target.map(|account| {
+        serde_json::to_value(ControlAccountRef::from(account))
+            .expect("ControlAccountRef always serializes")
+    });
     if doc.get("controlAccount").cloned() == desired {
         return ControlWrite::Unchanged;
     }
@@ -3615,7 +3736,29 @@ mod tests {
                 .unwrap();
         assert_eq!(
             config.control_account,
-            Some("alice@example.com".to_string())
+            Some(ControlAccountRef::Legacy("alice@example.com".to_string()))
+        );
+    }
+
+    /// The identity-object shape — what a `set` writes going forward — parses
+    /// back to the exact fields it carries, `orgUuid` included.
+    #[test]
+    fn control_account_parses_identity_object() {
+        let config: Config = serde_json::from_str(
+            r#"{ "accounts": [], "controlAccount": {
+                "name": "alice@example.com",
+                "orgUuid": "11111111-1111-1111-1111-111111111111"
+            } }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            config.control_account,
+            Some(ControlAccountRef::Identity {
+                name: "alice@example.com".to_string(),
+                account_uuid: None,
+                org_uuid: Some("11111111-1111-1111-1111-111111111111".to_string()),
+                org_name: None,
+            })
         );
     }
 
@@ -4432,22 +4575,23 @@ mod tests {
 
     // --- save_control_account -----------------------------------------------
 
-    /// Setting `controlAccount` writes the top-level key and changes nothing
-    /// else — same "raw document, not a `Config` round trip" contract as
-    /// `save_disabled`. This is also `control_persist_preserves_unmodelled_top_level_keys`
-    /// from the bridge: a key nothing here models (`routes`) survives the write.
+    /// Setting `controlAccount` writes the top-level key — as the identity
+    /// object, not the legacy string — and changes nothing else — same "raw
+    /// document, not a `Config` round trip" contract as `save_disabled`. This is
+    /// also `control_persist_preserves_unmodelled_top_level_keys` from the
+    /// bridge: a key nothing here models (`routes`) survives the write.
     #[test]
     fn set_control_writes_the_key_and_changes_nothing_else() {
         let path = tmp_path("control-write");
         fs::write(&path, DISABLE_SAMPLE).unwrap();
 
         assert_eq!(
-            save_control_account(&path, Some("acct-a")).unwrap(),
+            save_control_account(&path, Some(&by_name("acct-a"))).unwrap(),
             ControlWrite::Updated
         );
 
         let mut after = read_json(&path);
-        assert_eq!(after["controlAccount"], json!("acct-a"));
+        assert_eq!(after["controlAccount"], json!({"name": "acct-a"}));
         after
             .as_object_mut()
             .expect("document is an object")
@@ -4460,7 +4604,7 @@ mod tests {
         fs::remove_file(&path).ok();
     }
 
-    /// Clearing (`name: None`) REMOVES the key rather than writing `null` —
+    /// Clearing (`target: None`) REMOVES the key rather than writing `null` —
     /// matching `#[serde(skip_serializing_if = "Option::is_none")]` on
     /// `Config::control_account`, and a set→clear round trip leaves the file
     /// exactly as it started.
@@ -4469,7 +4613,7 @@ mod tests {
         let path = tmp_path("control-roundtrip");
         fs::write(&path, DISABLE_SAMPLE).unwrap();
 
-        save_control_account(&path, Some("acct-a")).unwrap();
+        save_control_account(&path, Some(&by_name("acct-a"))).unwrap();
         assert_eq!(
             save_control_account(&path, None).unwrap(),
             ControlWrite::Updated
@@ -4502,13 +4646,86 @@ mod tests {
         );
         assert_eq!(fs::read_to_string(&path).unwrap(), DISABLE_SAMPLE);
 
-        save_control_account(&path, Some("acct-a")).unwrap();
+        save_control_account(&path, Some(&by_name("acct-a"))).unwrap();
         let with_control = fs::read_to_string(&path).unwrap();
         assert_eq!(
-            save_control_account(&path, Some("acct-a")).unwrap(),
+            save_control_account(&path, Some(&by_name("acct-a"))).unwrap(),
             ControlWrite::Unchanged
         );
         assert_eq!(fs::read_to_string(&path).unwrap(), with_control);
+        fs::remove_file(&path).ok();
+    }
+
+    /// Two on-disk entries share `target`'s identity (both share a name and
+    /// carry no uuid, so [`crate::identity::same_identity`] cannot tell them
+    /// apart): the write is refused, `ControlWrite::Ambiguous`, and the file is
+    /// untouched — mirroring [`DisabledWrite::Ambiguous`] for the same reason.
+    #[test]
+    fn control_write_on_duplicated_identity_is_refused() {
+        let path = tmp_path("control-ambiguous");
+        fs::write(
+            &path,
+            r#"{ "accounts": [
+                { "name": "dup@example.com", "accessToken": "at-1" },
+                { "name": "dup@example.com", "accessToken": "at-2" }
+            ] }"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            save_control_account(&path, Some(&by_name("dup@example.com"))).unwrap(),
+            ControlWrite::Ambiguous
+        );
+        assert!(
+            read_json(&path).get("controlAccount").is_none(),
+            "an ambiguous write must not land on disk"
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    /// An identity object carrying an `accountUuid` shared by both on-disk rows
+    /// PLUS `orgUuid` resolves the write to the RIGHT one of the two —
+    /// the "legacy two-org shape" `locate_account_entry`'s doc-comment
+    /// describes: one person, two orgs, one uuid. (Without a shared
+    /// `accountUuid` on both sides, `same_identity` cannot use the org at all —
+    /// see `control_write_on_duplicated_identity_is_refused` — so this is the
+    /// realistic disambiguating shape, not an arbitrary one.)
+    #[test]
+    fn control_write_with_org_uuid_disambiguates_duplicated_email() {
+        let path = tmp_path("control-org-disambiguates");
+        fs::write(
+            &path,
+            r#"{ "accounts": [
+                { "name": "dup@example.com", "accessToken": "at-1",
+                  "accountUuid": "33333333-3333-3333-3333-333333333333",
+                  "orgUuid": "11111111-1111-1111-1111-111111111111" },
+                { "name": "dup@example.com", "accessToken": "at-2",
+                  "accountUuid": "33333333-3333-3333-3333-333333333333",
+                  "orgUuid": "22222222-2222-2222-2222-222222222222" }
+            ] }"#,
+        )
+        .unwrap();
+        let target = crate::identity::probe(
+            "dup@example.com",
+            Some("33333333-3333-3333-3333-333333333333".to_string()),
+            Some("22222222-2222-2222-2222-222222222222".to_string()),
+            None,
+        );
+
+        assert_eq!(
+            save_control_account(&path, Some(&target)).unwrap(),
+            ControlWrite::Updated
+        );
+
+        let after = read_json(&path);
+        assert_eq!(
+            after["controlAccount"],
+            json!({
+                "name": "dup@example.com",
+                "accountUuid": "33333333-3333-3333-3333-333333333333",
+                "orgUuid": "22222222-2222-2222-2222-222222222222"
+            })
+        );
         fs::remove_file(&path).ok();
     }
 

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -731,11 +731,9 @@ pub enum SetControlOutcome {
 }
 
 /// What [`Manager::set_control`] achieved about DURABILITY — whether the
-/// control account will still be set (or cleared) after a restart. Simpler
-/// than [`DisablePersist`]: `controlAccount` is a single top-level key
-/// resolved by NAME, not a per-account flag located by identity, so there is
-/// no `NoEntry`/`Ambiguous` arm on the durable side — see
-/// [`config::ControlWrite`].
+/// control account will still be set (or cleared) after a restart. Same shape
+/// as [`DisablePersist`] now that `controlAccount` is resolved by IDENTITY, not
+/// by a bare name — see [`config::ControlWrite`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ControlPersist {
     /// The config file carries the control account (or its absence) — written
@@ -744,6 +742,10 @@ pub enum ControlPersist {
     /// No config file behind this manager (`tcr demo`, `tcr status --probe`,
     /// tests). Memory-only BY DESIGN.
     NoConfigFile,
+    /// More than one on-disk entry carries this identity; the write was
+    /// refused rather than landed on a guess. See
+    /// [`config::ControlWrite::Ambiguous`].
+    Ambiguous,
     /// The write itself failed (unreadable, malformed, or unwritable file).
     WriteFailed,
 }
@@ -756,6 +758,9 @@ impl ControlPersist {
     pub fn warning(self) -> Option<&'static str> {
         match self {
             Self::Persisted | Self::NoConfigFile => None,
+            Self::Ambiguous => Some(
+                "NOT SAVED: two config entries share this account's identity — give each its own orgUuid",
+            ),
             Self::WriteFailed => {
                 Some("NOT SAVED: writing the config failed — this will not survive a restart")
             }
@@ -1298,16 +1303,31 @@ impl Manager {
         let reset_urgency_tier_ms =
             i64::from(config.reset_urgency_tier_hours).saturating_mul(3_600_000);
 
-        let control_idx = config.control_account.as_ref().and_then(|name| {
-            let idx = accounts.iter().position(|a| a.name == *name);
-            if idx.is_none() {
-                let names: Vec<&str> = accounts.iter().map(|a| a.name.as_str()).collect();
-                tracing::error!(
-                    control_account = %name, available = ?names,
-                    "controlAccount name did not match any account — running with NO control account"
-                );
+        let control_idx = config.control_account.as_ref().and_then(|identity| {
+            match crate::identity::match_one(&accounts[..], identity.name(), identity.org_filter())
+            {
+                crate::identity::Match::One(idx) => Some(idx),
+                crate::identity::Match::None => {
+                    let names: Vec<&str> = accounts.iter().map(|a| a.name.as_str()).collect();
+                    tracing::error!(
+                        control_account = %identity.name(), available = ?names,
+                        "controlAccount did not match any account — running with NO control account"
+                    );
+                    None
+                }
+                // Two or more accounts share this identity (the reason
+                // `save_control_account` now stores org alongside the name):
+                // picking the first one silently, as the old `position(...)`
+                // scan did, risks binding control to a disabled Team-seat row
+                // while the account that resolved it live stays unpinned.
+                crate::identity::Match::Ambiguous(candidates) => {
+                    tracing::error!(
+                        control_account = %identity.name(), candidates = ?candidates,
+                        "controlAccount matches more than one account — refusing to guess, running with NO control account"
+                    );
+                    None
+                }
             }
-            idx
         });
 
         let usage = crate::usage::UsageTracker::new(
@@ -2232,7 +2252,7 @@ impl Manager {
     ///
     /// A missing `config_path` (tests, `tcr demo`, `tcr status --probe`) is a
     /// SILENT no-op — those managers must never touch a real config file.
-    fn persist_control(&self, name: Option<String>) -> ControlPersist {
+    fn persist_control(&self, target: Option<config::Account>) -> ControlPersist {
         let Some(path) = &self.config_path else {
             return ControlPersist::NoConfigFile;
         };
@@ -2243,7 +2263,7 @@ impl Manager {
             .lock()
             .expect("config write lock poisoned");
         // INV2 — no `self.config` guard is alive on this line.
-        let outcome = config::save_control_account(path, name.as_deref());
+        let outcome = config::save_control_account(path, target.as_ref());
         // INV3 — memory is touched only on the arms where the FILE now carries
         // the desired state.
         if matches!(
@@ -2251,8 +2271,9 @@ impl Manager {
             Ok(config::ControlWrite::Updated) | Ok(config::ControlWrite::Unchanged)
         ) {
             let mut config = self.config.lock().expect("config lock poisoned");
-            config.control_account = name.clone();
+            config.control_account = target.as_ref().map(config::ControlAccountRef::from);
         }
+        let name = target.as_ref().map(|a| a.name.as_str());
         match outcome {
             Ok(config::ControlWrite::Updated) => {
                 tracing::info!(
@@ -2268,6 +2289,14 @@ impl Manager {
                 );
                 ControlPersist::Persisted
             }
+            Ok(config::ControlWrite::Ambiguous) => {
+                tracing::error!(
+                    control_account = ?name,
+                    path = %path.display(),
+                    "more than one config entry carries this account's identity; refusing to guess, so the control account will NOT survive a restart"
+                );
+                ControlPersist::Ambiguous
+            }
             Err(err) => {
                 tracing::error!(
                     error = %err,
@@ -2282,22 +2311,30 @@ impl Manager {
 
     /// Set (`idx = Some(_)`) or clear (`idx = None`) the control account by
     /// rotation index, and persist it. Mirrors [`Self::set_disabled`]'s
-    /// resolve-name-then-persist shape: the name is read out under a released
-    /// `accounts` READ lock before `control_idx` is taken, so the two never
-    /// nest (same discipline `set_disabled` documents for `accounts`/`config`).
+    /// resolve-identity-then-persist shape: the identity is read out under a
+    /// released `accounts` READ lock before `control_idx` is taken, so the two
+    /// never nest (same discipline `set_disabled` documents for
+    /// `accounts`/`config`).
     fn set_control(&self, idx: Option<usize>) -> ControlPersist {
-        let name = idx.and_then(|i| {
+        let target = idx.and_then(|i| {
             self.accounts
                 .read()
                 .expect("accounts lock poisoned")
                 .get(i)
-                .map(|a| a.name.clone())
+                .map(|a| {
+                    crate::identity::probe(
+                        &a.name,
+                        a.account_uuid.clone(),
+                        a.org_uuid.clone(),
+                        a.org_name.clone(),
+                    )
+                })
         });
         {
             let mut control = self.control_idx.write().expect("control lock poisoned");
             *control = idx;
         }
-        self.persist_control(name)
+        self.persist_control(target)
     }
 
     /// Resolve a user-supplied `(query, org)` against the LIVE rotation and set
@@ -4362,7 +4399,9 @@ mod tests {
 
     fn config_with_control(accounts: Vec<Account>, control: &str) -> Config {
         let mut config = config_with(accounts);
-        config.control_account = Some(control.to_string());
+        config.control_account = Some(crate::config::ControlAccountRef::Legacy(
+            control.to_string(),
+        ));
         config
     }
 
@@ -4461,6 +4500,119 @@ mod tests {
             lock_refresher(),
         );
         assert_eq!(unmatched.control(), None);
+    }
+
+    /// The exact bug this unit fixes: a legacy bare-string `controlAccount`
+    /// that names a DUPLICATED email must not silently bind to whichever row
+    /// sorts first (the old `position(...)` behaviour) — it must refuse and run
+    /// with no control account, same as an unmatched name.
+    #[test]
+    fn assemble_refuses_legacy_control_name_on_duplicated_email() {
+        let dup_a = Account {
+            org_uuid: Some("11111111-1111-1111-1111-111111111111".to_string()),
+            ..account("dup@example.com", 0)
+        };
+        let dup_b = Account {
+            org_uuid: Some("22222222-2222-2222-2222-222222222222".to_string()),
+            disabled: Some(true),
+            ..account("dup@example.com", 0)
+        };
+        let config = config_with_control(vec![dup_a, dup_b], "dup@example.com");
+        let manager = build_manager(config, lock_refresher());
+        assert_eq!(
+            manager.control(),
+            None,
+            "an ambiguous legacy name must run with NO control account, never a guess"
+        );
+    }
+
+    /// An identity object carrying `orgUuid` resolves boot control to the RIGHT
+    /// one of two same-email rows — the fix's other half: a `controlAccount`
+    /// written with org information survives a restart instead of collapsing
+    /// back to the ambiguous legacy behaviour.
+    #[test]
+    fn assemble_resolves_identity_control_account_by_org_uuid() {
+        let dup_a = Account {
+            org_uuid: Some("11111111-1111-1111-1111-111111111111".to_string()),
+            ..account("dup@example.com", 0)
+        };
+        let dup_b = Account {
+            org_uuid: Some("22222222-2222-2222-2222-222222222222".to_string()),
+            ..account("dup@example.com", 0)
+        };
+        let mut config = config_with(vec![dup_a, dup_b]);
+        config.control_account = Some(crate::config::ControlAccountRef::Identity {
+            name: "dup@example.com".to_string(),
+            account_uuid: None,
+            org_uuid: Some("22222222-2222-2222-2222-222222222222".to_string()),
+            org_name: None,
+        });
+        let manager = build_manager(config, lock_refresher());
+        assert_eq!(
+            manager.control(),
+            Some(1),
+            "orgUuid must pick the second row, not the first"
+        );
+    }
+
+    /// Full round trip through the durable half: setting control on a
+    /// duplicated email via [`Manager::set_control_by_query`] persists the
+    /// IDENTITY shape (not the bare name), and a fresh `Manager` built from the
+    /// reloaded file resolves to the SAME row — not just "a" row. Both rows
+    /// share an `accountUuid` (one person, two orgs — the realistic shape a
+    /// duplicated email takes) so the durable write can disambiguate them at
+    /// all; see `control_write_with_org_uuid_disambiguates_duplicated_email` in
+    /// `config.rs` for why an org alone, with no shared uuid, cannot.
+    #[test]
+    fn set_control_on_duplicated_email_survives_a_reload() {
+        let path = tmp_config_path("control-survives-reload");
+        let dup_a = Account {
+            account_uuid: Some("33333333-3333-3333-3333-333333333333".to_string()),
+            org_uuid: Some("11111111-1111-1111-1111-111111111111".to_string()),
+            refresh_token: Some("rt-first".to_string()),
+            ..account("dup@example.com", 0)
+        };
+        let dup_b = Account {
+            account_uuid: Some("33333333-3333-3333-3333-333333333333".to_string()),
+            org_uuid: Some("22222222-2222-2222-2222-222222222222".to_string()),
+            refresh_token: Some("rt-second".to_string()),
+            ..account("dup@example.com", 0)
+        };
+        let config = config_with(vec![dup_a, dup_b]);
+        config::save(&path, &config).expect("write test config");
+        let manager = build_manager_with_path(config, path.clone());
+
+        let outcome = manager.set_control_by_query(
+            Some("dup@example.com"),
+            Some("22222222-2222-2222-2222-222222222222"),
+        );
+        assert_eq!(
+            outcome,
+            SetControlOutcome::Applied {
+                name: Some("dup@example.com".to_string()),
+                persist: ControlPersist::Persisted,
+            }
+        );
+        assert_eq!(manager.control(), Some(1), "resolved the SECOND row live");
+
+        // The identity object, not the bare name, must be what landed on disk.
+        let on_disk = config::load(&path).expect("reload persisted config");
+        assert_eq!(
+            on_disk.control_account,
+            Some(crate::config::ControlAccountRef::Identity {
+                name: "dup@example.com".to_string(),
+                account_uuid: Some("33333333-3333-3333-3333-333333333333".to_string()),
+                org_uuid: Some("22222222-2222-2222-2222-222222222222".to_string()),
+                org_name: None,
+            })
+        );
+
+        // A brand-new Manager built from the reloaded file resolves to the
+        // SAME row (index 1, `rt-second`) — not just "a" row.
+        let reloaded_manager = build_manager_with_path(on_disk, path.clone());
+        assert_eq!(reloaded_manager.control(), Some(1));
+
+        std::fs::remove_file(&path).ok();
     }
 
     /// Absent `controlAccount` → `control() == None`.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -6355,10 +6355,17 @@ mod tests {
             "the live manager must resolve the new control account"
         );
 
-        // 2. …and the file's top-level key carries it too.
+        // 2. …and the file's top-level key carries it too — as the identity
+        // object [`crate::config::save_control_account`] now writes (never the
+        // legacy bare string), so a duplicated email can survive a restart.
         assert_eq!(
             control_account_in_file(&path),
-            Some(serde_json::json!("alice@example.com"))
+            Some(serde_json::json!({
+                "name": "alice@example.com",
+                "accountUuid": "22222222-a",
+                "orgUuid": "11111111-1111-1111-1111-aaaaaaaaaaaa",
+                "orgName": "Org aaaaaaaaaaaa",
+            }))
         );
 
         // Clearing (`query: null`) removes it from both halves.


### PR DESCRIPTION
🍄 Setting the control account on a duplicated email works until the next restart, then
silently binds to whichever row happens to sort first.

## What was happening

The runtime setter was already careful. `set_control_by_query` resolves through
`identity::match_one` and returns `Ambiguous` rather than guessing, so `tcr control` makes
you disambiguate with `--org` when two accounts share an email.

Then it threw that work away. `set_control` resolved the index back to `a.name.clone()` — a
bare `String` — and `save_control_account` took a `&str` and wrote it. At boot,
`Manager::assemble` read it back with:

```rust
accounts.iter().position(|a| a.name == *name)
```

First match wins. No org, no ambiguity check, no warning. On a fleet where the same address
appears twice — one personal row and one Team-seat row — control binds to whichever comes
first in the array, and if that row is disabled, control silently does nothing at all.

This is the one identity-bound writer that never got the treatment the others have.
`save_disabled` and `save_group_membership` both take a `&Account`, resolve through
`locate_account_entry`, and refuse with `Ambiguous` rather than edit the wrong row.
`save_control_account` took a name.

## The change

`controlAccount` now stores identity, not a name:

```json
"controlAccount": {
  "name": "alice@example.com",
  "accountUuid": "22222222-a",
  "orgUuid": "11111111-1111-1111-1111-aaaaaaaaaaaa",
  "orgName": "Org aaaaaaaaaaaa"
}
```

The bare string stays readable — `ControlAccountRef` is `#[serde(untagged)]` over
`Legacy(String)` and the identity object, so every config already on disk keeps working.

- `save_control_account` takes `Option<&Account>`, writes the identity shape, and reuses
  `locate_account_entry`/`EntryMatch` — not a second resolver — to refuse with the new
  `ControlWrite::Ambiguous` when the target matches more than one on-disk entry.
- Boot resolution goes through `identity::match_one` with the stored org as a filter. On two
  or more matches it logs every candidate and runs with **no** control account rather than
  picking one.

Refusing loudly is the point. A missing control account is visible in `tcr status` and in the
panel; a control account bound to the wrong row looks exactly like a working one.

## Why no existing config breaks

`match_accounts` tries exact name equality first and only falls back to email matching when
that pass finds nothing — the same comparison the old `position(...)` scan did. So a legacy
bare string that resolved to exactly one account still resolves to exactly one. The only
behaviour that changes is the ambiguous case, which went from silently-wrong to loudly-none.

## Scope

`src/cli.rs` and `src/proxy.rs` are touched only because the `save_control_account` signature
change forces its call sites; the crate does not compile otherwise. The one altered proxy
assertion got stricter, not looser — it previously checked the file held the bare string
`"alice@example.com"` and now pins the full identity object.

## Verification

`cargo test` 1030 passed / 0 failed, `cargo clippy --all-targets -- -D warnings` clean.

Every new test was watched to fail against a deliberate break first: reverting boot
resolution to a first-match guess fails `assemble_refuses_legacy_control_name_on_duplicated_email`;
skipping the write-side guard fails `control_write_on_duplicated_identity_is_refused`; forcing
`org_filter` to `None` fails `assemble_resolves_identity_control_account_by_org_uuid`.

## Note on the version bump

`Cargo.toml` goes to 0.2.38 because the pre-commit release-version gate blocks any commit
touching shippable `.rs` while the version still matches a published tag.
