### PR TITLE
fix: keep every row inside the panel, narrow group edits by org, and show REJECTED

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "teamclaude-rs"
-version = "0.2.37"
+version = "0.2.38"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -1100,22 +1100,23 @@ struct AccountRow: View {
     ///
     /// This pill answers ONE question — can this account be picked for
     /// traffic — and there are at least THREE independent ways for the
-    /// answer to be no, only two of which this build can currently see:
+    /// answer to be no, and this build can now see all three:
     /// `disabled` (an operator's own choice), `account.health ==
     /// .needsRelogin` (`src/manager/select.rs:931` hard-excludes an
     /// `AccountStatus::Error` account from selection exactly like a disabled
-    /// one, even though `disabled` itself reads false), and a THIRD gate this
-    /// pill cannot yet name: `select.rs:809-822` also excludes an account
-    /// whose `quota.status == Some("rejected")` — Anthropic's own verdict —
-    /// while the snapshot `status` this app decodes stays `"active"`
-    /// (`snapshot.rs:142-153` only ever rewrites `Throttled`). Drawing
-    /// "rotating" on THAT row is the same "misread as its own opposite"
-    /// defect the first two gates were fixed for, and TcrBar currently has no
-    /// way to catch it: `tcr status --json` emits no gate field at all. A
-    /// server-side `GateReason` in the status payload is the fix, tracked
-    /// through the lead rather than added here — decode it as an OPTIONAL
-    /// field when it lands, so an older server (absent field) degrades to
-    /// today's behaviour and never to a false claim in either direction.
+    /// one, even though `disabled` itself reads false), and the third —
+    /// `select.rs:809-822` also excludes an account whose `quota.status ==
+    /// Some("rejected")`, Anthropic's own verdict — while the snapshot
+    /// `status` this app decodes stays `"active"` (`snapshot.rs:142-153` only
+    /// ever rewrites `Throttled`).
+    ///
+    /// That third gate is read from the wire's `gate` field
+    /// (``Account/isRejected``), which the server has emitted since the status
+    /// wire crate landed. An earlier version of this comment said `tcr status
+    /// --json` emitted no gate field at all and deferred the fix; the field was
+    /// already there. It is decoded as an OPTIONAL, so an older server (absent
+    /// field) degrades to the previous behaviour rather than to a false claim
+    /// in either direction.
     ///
     /// A row broken by the SECOND gate draws NEITHER "rotating" nor "parked":
     /// "parked" claims an operator decision that never happened, and
@@ -1166,6 +1167,49 @@ struct AccountRow: View {
     /// the thing that erases the name. Plain text at the same font, with no
     /// chrome and no uppercasing, is narrow enough for the worst row (unmeasured
     /// + rotating + the longest label) and still reads as secondary.
+    /// The row's DESIGNATIONS — what this account IS — on their own line under
+    /// the name: its plan, and the groups it belongs to.
+    ///
+    /// This line exists because the row overflowed the panel. Every pill is
+    /// `fixedSize()`, so a single `HStack` carrying `CONTROL` + `GROUP ONLY` +
+    /// a quota pill + two group tags + the plan has a MINIMUM width past
+    /// `Tok.panelWidth` (380pt) before the name gets a single point — and the
+    /// enclosing `.frame(width:)` centres content it cannot fit rather than
+    /// containing it, so both card edges were clipped and the header truncated.
+    /// No amount of layout priority on the name fixes that: the name can shrink
+    /// to nothing and the pills alone still overflow.
+    ///
+    /// The split is by MEANING, not just to save width, which is why it reads
+    /// as a design rather than a workaround: the first line is identity and
+    /// LIVE STATE (who this is, whether traffic lands here right now), and this
+    /// one is standing facts that change on a plan upgrade or an operator's
+    /// group edit. The group tags moved here with the plan because two long
+    /// group names are the single biggest contributor to the width — the live
+    /// fleet's `HENRY-TEAM-PARKED` alone is wider than three status pills.
+    ///
+    /// Drawn only when there is something to say; an account with no plan and
+    /// no groups reserves no space at all.
+    @ViewBuilder
+    private var designationsLine: some View {
+        if account.plan != nil || !account.groupTags.isEmpty {
+            HStack(spacing: Tok.tightSpacing) {
+                planIndicator
+                // At most two tags, the rest collapsed into a `+N` chip whose
+                // tooltip names them all. The cap stays even with a line to
+                // itself: an account can be in many groups, and this line has a
+                // budget too — it is just a far larger one.
+                ForEach(Array(account.groupTags.prefix(2))) { tag in
+                    GroupChip(tag: tag)
+                }
+                if account.groupTags.count > 2 {
+                    StatusPill("+\(account.groupTags.count - 2)", tint: Tok.inkFaint)
+                        .help(account.groupTags.map(\.name).joined(separator: ", "))
+                }
+                Spacer(minLength: 0)
+            }
+        }
+    }
+
     @ViewBuilder
     private var planIndicator: some View {
         if let plan = account.plan, !plan.isEmpty {
@@ -1191,6 +1235,14 @@ struct AccountRow: View {
             StatusPill("parked", tint: Tok.disabled)
                 .help("Out of the rotation — `tcr` sends this account no traffic.")
         } else if account.health == .needsRelogin {
+            EmptyView()
+        } else if account.isRejected {
+            // Anthropic's own verdict, and the third exclusion named above.
+            // Drawn INSTEAD of "rotating": the router will never select this
+            // account, so claiming it is in rotation is the exact
+            // "misread as its own opposite" defect the other two gates were
+            // fixed for. Nothing else on the row says it — `disabled` is false,
+            // `status` reads "active", and the quota bars can look healthy.
             EmptyView()
         } else if account.servesGroupTrafficOnly {
             // Predicate lives on the model (`Account.servesGroupTrafficOnly`) so
@@ -1256,6 +1308,8 @@ struct AccountRow: View {
             parts.append("parked, out of rotation")
         } else if account.health == .needsRelogin {
             parts.append("not in rotation")
+        } else if account.isRejected {
+            parts.append("rejected by Anthropic, not in rotation")
         } else {
             parts.append("rotating")
         }
@@ -1308,6 +1362,9 @@ struct AccountRow: View {
         }
         if let failure = removeController.failure(for: account.ref) {
             parts.append("last action failed: \(failure.summary)")
+        }
+        if let refused = groupController.failure(forAccount: account.ref) {
+            parts.append("group '\(refused.group)' failed: \(refused.failure.summary)")
         }
         // Spoken for the same reason the pill is: a confirmation only a sighted
         // user gets is half built, and the `✓` in `rowLabel` is punctuation to a
@@ -1498,7 +1555,7 @@ struct AccountRow: View {
                     copyToPasteboard(copyRun.copiedText)
                 }
                 Button("Remove from \(group)") {
-                    Task { await groupController.remove(account: account.name, from: group) }
+                    Task { await groupController.remove(account: account.ref, from: group) }
                 }
                 Button("Delete group “\(group)” for everyone…") {
                     confirmDeleteGroup(group)
@@ -1507,7 +1564,7 @@ struct AccountRow: View {
                 Button("Remove from all groups") {
                     Task {
                         for group in (account.groups ?? []) {
-                            await groupController.remove(account: account.name, from: group)
+                            await groupController.remove(account: account.ref, from: group)
                         }
                     }
                 }
@@ -1539,7 +1596,7 @@ struct AccountRow: View {
                 Divider()
                 ForEach(candidateGroupsToAdd, id: \.self) { group in
                     Button(group) {
-                        Task { await groupController.add(account: account.name, to: group) }
+                        Task { await groupController.add(account: account.ref, to: group) }
                     }
                     let copyAdd = GroupCommand.CopyCommandMenuEntry(
                         arguments: GroupCommand.addArguments(group: group, account: account.name))
@@ -1583,7 +1640,7 @@ struct AccountRow: View {
         let outcome = NewGroupName.evaluate(typed, existingGroups: everyGroupFleetWide)
         switch outcome {
         case .valid(let name):
-            Task { await groupController.add(account: account.name, to: name) }
+            Task { await groupController.add(account: account.ref, to: name) }
         case .rejected, .duplicate:
             let failureAlert = NSAlert()
             failureAlert.alertStyle = .warning
@@ -1785,15 +1842,6 @@ struct AccountRow: View {
                     .truncationMode(.middle)
                     .help(account.name)
                     .textSelection(.enabled)
-                    // The name outranks everything beside it for width. Without
-                    // this the plan tag — `TEAM STANDARD` is the long one —
-                    // took its space from the name, and a row rendered as
-                    // `h…m TEAM STANDARD`: the tag exists to tell two rows
-                    // apart, so a tag that erases the name it is qualifying is
-                    // worse than no tag. Pills are `fixedSize()` and small; the
-                    // name is the row's identity and shrinks last.
-                    .layoutPriority(1)
-                planIndicator
                 controlIndicator
                 Spacer(minLength: Tok.tightSpacing)
                 rotationPill
@@ -1819,6 +1867,19 @@ struct AccountRow: View {
                             "The refresh token was rejected — this account is out "
                                 + "of rotation and serves no traffic until you re-login."
                         )
+                } else if account.isRejected {
+                    // Ahead of the quota cases deliberately. A rejected account
+                    // can carry a perfectly ordinary reading — the gate is
+                    // Anthropic's, not a quota fact — so `spent`/`ok` would be
+                    // a true number attached to a false conclusion about
+                    // whether traffic can land here. The cause outranks the
+                    // measurement, the same way `needs re-login` above does.
+                    StatusPill("rejected", tint: Tok.spent)
+                        .help(
+                            "Anthropic has rejected this account, so `tcr` sends it no "
+                                + "traffic whatever its quota reads. It returns on their "
+                                + "verdict, not on a reset."
+                        )
                 } else if account.hasQuotaEvidence {
                     StatusPill(account.quotaState.token, tint: quotaTint)
                 } else if account.probeStatus.isFailure {
@@ -1838,22 +1899,8 @@ struct AccountRow: View {
                     StatusPill("unmeasured", tint: quotaTint)
                         .help("Never probed — this account's quota is unknown, not zero.")
                 }
-                // The entire group UI now that the dedicated group views are
-                // gone (bridge: `docs/plans/group-tags-bridge.md`) — one
-                // small colored tag per membership, right on the pills line
-                // beside CONTROL/ROTATING/quota so it reads as one more fact
-                // about the account. At most two, with the rest collapsed to
-                // a `+N` chip: the panel is `Tok.panelWidth` (380pt) wide and
-                // an account can be in many groups. An ungrouped account
-                // draws nothing here — no chip, no reserved space.
-                ForEach(Array(account.groupTags.prefix(2))) { tag in
-                    GroupChip(tag: tag)
-                }
-                if account.groupTags.count > 2 {
-                    StatusPill("+\(account.groupTags.count - 2)", tint: Tok.inkFaint)
-                        .help(account.groupTags.map(\.name).joined(separator: ", "))
-                }
             }
+            designationsLine
             // Two window lines, 5-hour on top and 7-day directly under it —
             // Gil's explicit call (bridge, 2026-08-18) — each tinted by its OWN
             // window's state (`fiveHourTint`/`sevenDayTint`) rather than the
@@ -1994,6 +2041,22 @@ struct AccountRow: View {
                     .font(Tok.detailFont)
                     .foregroundStyle(Tok.spent)
                     .fixedSize(horizontal: false, vertical: true)
+            }
+            // A refused group edit, drawn like every other refusal on this row.
+            // It was recorded and never read: `GroupController` has stored these
+            // all along and nothing displayed them, so a `tcr group add` that
+            // exited non-zero — which is what an ambiguous name does on a fleet
+            // holding one email twice — was indistinguishable from one that
+            // worked. The group is named because the menu that started it has
+            // closed by the time this appears.
+            if let refused = groupController.failure(forAccount: account.ref) {
+                Label(
+                    "group '\(refused.group)': \(refused.failure.summary)",
+                    systemImage: Tok.unreadableGlyph
+                )
+                .font(Tok.detailFont)
+                .foregroundStyle(Tok.spent)
+                .fixedSize(horizontal: false, vertical: true)
             }
             verdictLine
             removalNoticeLine

--- a/apps/macos/Sources/TcrBar/RenderStates.swift
+++ b/apps/macos/Sources/TcrBar/RenderStates.swift
@@ -67,6 +67,14 @@ enum RenderStates {
             ("01d-unmeasured-window-proof", .loaded(fleet(unmeasuredWindowJSON)), false, nil),
             ("01e-plan-labels", .loaded(fleet(planLabelsJSON)), false, nil),
             ("01f-duplicate-email", .loaded(fleet(duplicateEmailJSON)), false, nil),
+            // The control account is pinned to the worst row deliberately: the
+            // CONTROL pill is one of the six things competing for its width,
+            // and a fixture that left it off would not be the row that
+            // overflowed.
+            (
+                "01g-widest-row", .loaded(fleet(widestRowJSON)), false,
+                "henry.fitzgerald@example.com"
+            ),
             ("02-mixed-thirteen", .loaded(fleet(mixedJSON)), false, nil),
             ("03-zero-capacity", .loaded(fleet(exhaustedJSON)), false, nil),
             ("04-unmeasured-row", .loaded(fleet(unmeasuredJSON)), false, nil),
@@ -541,6 +549,33 @@ enum RenderStates {
             account("dave@example.com", quota: "0.08", state: "ok"),
         ]
         return "[\(rows.joined(separator: ","))]"
+    }
+
+    /// THE WIDEST ROW THE FLEET CAN PRODUCE — the shape that overflowed the
+    /// panel, reproduced so a PNG can prove it does not any more.
+    ///
+    /// Everything that competes for width at once: the control marker, a
+    /// reserved group (`GROUP ONLY`), a quota pill, TWO group tags one of which
+    /// is long, the longest plan label, and a 30-character email. On the live
+    /// fleet this row rendered wider than `Tok.panelWidth`, so both card edges
+    /// were clipped and the header truncated to "…eady · 15 ok".
+    ///
+    /// The pass condition is not "it looks tidy" — it is that NOTHING is
+    /// clipped and the name is still readable. A second, ordinary row is
+    /// included as the control: if the panel is over-wide for a structural
+    /// reason, both rows show it, and the bug is not the one this scene names.
+    private static var widestRowJSON: String {
+        let worst = account(
+            "henry.fitzgerald@example.com", quota: "0.62", state: "ok",
+            groups: ["gil", "henry-team-parked"],
+            reservedGroups: ["gil"],
+            plan: "Team Standard",
+            orgUuid: "22222222-2222-2222-2222-222222222222")
+        let ordinary = account(
+            "bob@example.com", quota: "0.31", state: "ok",
+            plan: "Max 20x",
+            orgUuid: "11111111-1111-1111-1111-111111111111")
+        return "[\(worst),\(ordinary)]"
     }
 
     /// THE SAME EMAIL, TWICE — the shape that broke the panel.

--- a/apps/macos/Sources/TcrBarCore/FleetStatus.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetStatus.swift
@@ -106,6 +106,55 @@ extension QuotaState: Decodable {
     }
 }
 
+/// Why the server is holding an account out of rotation right now — its own
+/// verdict, not one this app re-derives.
+///
+/// Rust spells these kebab-case (`src/stats.rs`'s `GateReason`, serialized by
+/// `gate_reason_token`): `ok`, `hold`, `five-hour`, `seven-day`,
+/// `fable-weekly`, `standard`, `login`, `rejected`, `disabled`, `reserved`.
+///
+/// [`Self/rejected`] is the one the panel could not see before this existed,
+/// and it is the reason the type does. Anthropic's own
+/// `anthropic-ratelimit-unified-status: rejected` takes an account out of
+/// selection (`src/manager/select.rs`) while `snapshot.rs` rewrites `status`
+/// only for `Throttled` — so a rejected row still reported `status: "active"`
+/// and the panel drew it as eligible for traffic the router will never send it.
+/// An earlier comment in `FleetView` claimed `tcr status --json` emitted no gate
+/// field at all; it has emitted one since the wire crate landed, and this
+/// decodes it.
+///
+/// `unknown` keeps a future variant readable rather than asserting a meaning
+/// this build cannot support, exactly like ``QuotaState/unknown(_:)``.
+public enum GateReason: Equatable, Sendable {
+    case ok
+    case rejected
+    case unknown(String)
+
+    public init(token: String) {
+        switch token {
+        case "ok": self = .ok
+        case "rejected": self = .rejected
+        default: self = .unknown(token)
+        }
+    }
+
+    /// The raw wire token, round-tripped so an unknown variant is displayable.
+    public var token: String {
+        switch self {
+        case .ok: return "ok"
+        case .rejected: return "rejected"
+        case .unknown(let raw): return raw
+        }
+    }
+}
+
+extension GateReason: Decodable {
+    public init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self.init(token: raw)
+    }
+}
+
 /// Where the numbers came from.
 ///
 /// `offline` means no server answered, so every *counter* (requests, tokens,
@@ -1010,6 +1059,21 @@ public struct Account: Decodable, Equatable, Identifiable, Sendable {
     public let orgUuid: String?
     public let orgName: String?
 
+    /// The SERVER's own reason this account is out of rotation, decoded from
+    /// the wire's `gate` — see ``GateReason``. Optional for the same
+    /// forward-compat reason every field above it is: a server built before the
+    /// key existed omits it, and its rows must keep decoding.
+    ///
+    /// `nil` is not "in rotation" — it is "this server does not report a gate",
+    /// which is why the row falls back to its old behaviour rather than
+    /// claiming anything when this is absent.
+    public let gate: GateReason?
+
+    /// Whether Anthropic itself has rejected this account, so the router will
+    /// never select it however healthy its quota looks. The one gate the panel
+    /// had no way to see, and the reason ``gate`` is decoded at all.
+    public var isRejected: Bool { gate == .rejected }
+
     /// Explicit memberwise init, needed only because adding `fiveHourState`/
     /// `sevenDayState` after the struct already had test fixtures constructing
     /// it directly would otherwise force every one of them to grow two new
@@ -1056,7 +1120,8 @@ public struct Account: Decodable, Equatable, Identifiable, Sendable {
         rateLimitTier: String? = nil,
         seatTier: String? = nil,
         orgUuid: String? = nil,
-        orgName: String? = nil
+        orgName: String? = nil,
+        gate: GateReason? = nil
     ) {
         self.name = name
         self.priority = priority
@@ -1097,6 +1162,7 @@ public struct Account: Decodable, Equatable, Identifiable, Sendable {
         self.seatTier = seatTier
         self.orgUuid = orgUuid
         self.orgName = orgName
+        self.gate = gate
     }
 
     /// This row's identity, ORG-QUALIFIED — `name` alone is not unique.

--- a/apps/macos/Sources/TcrBarCore/GroupControl.swift
+++ b/apps/macos/Sources/TcrBarCore/GroupControl.swift
@@ -59,15 +59,27 @@ public enum GroupRouting {
 ///     can apply a change to the file only and warn that a running proxy was
 ///     too old for the control route.
 public enum GroupCommand {
-    /// `tcr group add <group> <account>`. Both arguments positional and
-    /// verbatim — no flags, nothing that could be mistaken for one.
-    public static func addArguments(group: String, account: String) -> [String] {
-        ["group", "add", group, account]
+    /// `tcr group add <group> <account> [--org <uuid>]`. `group` and `account`
+    /// are positional and verbatim.
+    ///
+    /// `org` narrows a name two accounts share, the same way every other
+    /// per-account verb takes it. On this fleet it is what makes the command
+    /// work at all: the same email is logged into two orgs, and `tcr` refuses an
+    /// ambiguous name rather than guessing which row to label. Omitted entirely
+    /// when `nil`, so a single-org row builds the argument vector it always did.
+    public static func addArguments(group: String, account: String, org: String? = nil)
+        -> [String]
+    {
+        guard let org, !org.isEmpty else { return ["group", "add", group, account] }
+        return ["group", "add", group, account, "--org", org]
     }
 
-    /// `tcr group rm <group> <account>`.
-    public static func removeArguments(group: String, account: String) -> [String] {
-        ["group", "rm", group, account]
+    /// `tcr group rm <group> <account> [--org <uuid>]`.
+    public static func removeArguments(group: String, account: String, org: String? = nil)
+        -> [String]
+    {
+        guard let org, !org.isEmpty else { return ["group", "rm", group, account] }
+        return ["group", "rm", group, account, "--org", org]
     }
 
     /// `tcr group rm <group> --all` — removes the whole group.
@@ -281,6 +293,27 @@ public final class GroupController: ObservableObject {
 
     public func isPending(_ key: String) -> Bool { pending.contains(key) }
     public func failure(for key: String) -> GroupCommand.Failure? { failures[key] }
+
+    /// The most recent group failure belonging to one account ROW, whatever
+    /// group it was about, so the row can draw it without knowing which group
+    /// the operator last picked from its menu.
+    ///
+    /// This lookup is why the failure was invisible: `GroupController` recorded
+    /// every one of them and nothing in the panel ever read them back, so a
+    /// refused `tcr group add` — which is what an ambiguous, un-narrowed name
+    /// produces on this fleet — looked exactly like a success. Gil reported it
+    /// as "adding to group doesn't work", with no error anywhere to act on.
+    ///
+    /// Returns the group name alongside the failure: "adding to X failed" is
+    /// actionable where a bare `tcr` error is not, because the menu that
+    /// triggered it has already closed by the time this is drawn.
+    public func failure(forAccount account: AccountRef) -> (group: String, failure: GroupCommand.Failure)? {
+        let suffix = "/\(account.id)"
+        return
+            failures
+            .first { $0.key.hasSuffix(suffix) }
+            .map { (String($0.key.dropLast(suffix.count)), $0.value) }
+    }
     public func needsRestart(_ group: String) -> Bool { appliedPendingRestart.contains(group) }
 
     /// What a call did, as far as the subprocess can say — mirrors
@@ -315,20 +348,32 @@ public final class GroupController: ObservableObject {
         }
     }
 
-    /// `tcr group add <group> <account>`.
-    @discardableResult
-    public func add(account: String, to group: String) async -> Attempt {
-        await run(
-            key: "\(group)/\(account)", group: group,
-            arguments: GroupCommand.addArguments(group: group, account: account))
+    /// The failure key for one member's add/remove: the group and the ROW's
+    /// org-qualified identity, so two same-email rows in different orgs cannot
+    /// share an in-flight spinner or an error line — the same reason every other
+    /// per-account dictionary keys on ``AccountRef/id``.
+    /// `nonisolated` because it is a pure string join with no state to touch —
+    /// callers need it to build a key without hopping to the main actor.
+    public nonisolated static func memberKey(group: String, account: AccountRef) -> String {
+        "\(group)/\(account.id)"
     }
 
-    /// `tcr group rm <group> <account>`.
+    /// `tcr group add <group> <account> [--org <uuid>]`.
     @discardableResult
-    public func remove(account: String, from group: String) async -> Attempt {
+    public func add(account: AccountRef, to group: String) async -> Attempt {
         await run(
-            key: "\(group)/\(account)", group: group,
-            arguments: GroupCommand.removeArguments(group: group, account: account))
+            key: Self.memberKey(group: group, account: account), group: group,
+            arguments: GroupCommand.addArguments(
+                group: group, account: account.name, org: account.orgUuid))
+    }
+
+    /// `tcr group rm <group> <account> [--org <uuid>]`.
+    @discardableResult
+    public func remove(account: AccountRef, from group: String) async -> Attempt {
+        await run(
+            key: Self.memberKey(group: group, account: account), group: group,
+            arguments: GroupCommand.removeArguments(
+                group: group, account: account.name, org: account.orgUuid))
     }
 
     /// `tcr group rm <group> --all`.

--- a/apps/macos/Tests/TcrBarTests/AccountIdentityTests.swift
+++ b/apps/macos/Tests/TcrBarTests/AccountIdentityTests.swift
@@ -95,6 +95,31 @@ final class AccountIdentityTests: XCTestCase {
         XCTAssertEqual(fleet.accounts[1].orgUuid, team)
     }
 
+    /// The gate the panel had no way to see. Anthropic's own rejection takes an
+    /// account out of selection while `status` stays `"active"` and the quota
+    /// bars can look ordinary, so before this decoded the row was drawn as
+    /// eligible for traffic the router will never send it.
+    func testTheRejectedGateDecodes() throws {
+        let fleet = try Fleet.decode(Data(duplicateEmailJSON.utf8))
+        XCTAssertEqual(fleet.accounts[0].gate, .rejected)
+        XCTAssertTrue(fleet.accounts[0].isRejected)
+        XCTAssertFalse(
+            fleet.accounts[1].isRejected,
+            "the control: the sibling row carries no gate and must not inherit one"
+        )
+    }
+
+    /// A gate token this build does not know must stay readable rather than
+    /// throwing the row away — the same tolerance `QuotaState` has.
+    func testAnUnknownGateTokenIsKeptVerbatim() {
+        XCTAssertEqual(GateReason(token: "fable-weekly"), .unknown("fable-weekly"))
+        XCTAssertEqual(GateReason(token: "fable-weekly").token, "fable-weekly")
+        XCTAssertFalse(
+            GateReason(token: "five-hour") == .rejected,
+            "only `rejected` is rejected — a quota gate is not Anthropic's verdict"
+        )
+    }
+
     /// The forward-compat contract every optional field on this row carries: a
     /// server built before these keys existed omits them entirely, and its rows
     /// must still decode rather than throwing the panel back to a fabricated
@@ -105,6 +130,12 @@ final class AccountIdentityTests: XCTestCase {
         XCTAssertNil(account.plan)
         XCTAssertNil(account.organizationType)
         XCTAssertNil(account.orgUuid)
+        XCTAssertNil(
+            account.gate,
+            "absent is `nil`, not `.ok` — this server does not report a gate, which "
+                + "is not the same as reporting that there is none"
+        )
+        XCTAssertFalse(account.isRejected)
         XCTAssertEqual(account.id, "solo@example.com")
     }
 
@@ -137,6 +168,41 @@ final class AccountIdentityTests: XCTestCase {
                 org: personal
             ).contains("--account 'henry@example.com' --org '\(personal)'"),
             "a re-login resolves through the same refuse-on-ambiguity path"
+        )
+    }
+
+    /// The group verbs are the ones Gil hit: `tcr group add` took no `--org` at
+    /// all, so the panel could not name which of two same-email rows to label,
+    /// and the CLI refused.
+    func testGroupCommandsCarryTheOrgWhenThereIsOne() {
+        XCTAssertEqual(
+            GroupCommand.addArguments(group: "gil", account: "henry@example.com", org: team),
+            ["group", "add", "gil", "henry@example.com", "--org", team]
+        )
+        XCTAssertEqual(
+            GroupCommand.removeArguments(group: "gil", account: "henry@example.com", org: team),
+            ["group", "rm", "gil", "henry@example.com", "--org", team]
+        )
+        XCTAssertEqual(
+            GroupCommand.addArguments(group: "gil", account: "solo@example.com"),
+            ["group", "add", "gil", "solo@example.com"],
+            "no org means the argument vector it always built"
+        )
+        XCTAssertEqual(
+            GroupCommand.removeArguments(group: "gil", account: "solo@example.com", org: ""),
+            ["group", "rm", "gil", "solo@example.com"],
+            "an empty org is not an org — never `--org ''`, which matches nothing"
+        )
+    }
+
+    /// Two same-email rows must not share a group failure or an in-flight
+    /// spinner, for the same reason they must not share a toggle verdict.
+    func testGroupFailuresAreKeyedPerRowNotPerName() {
+        let personalRef = AccountRef(name: "henry@example.com", orgUuid: personal)
+        let teamRef = AccountRef(name: "henry@example.com", orgUuid: team)
+        XCTAssertNotEqual(
+            GroupController.memberKey(group: "gil", account: personalRef),
+            GroupController.memberKey(group: "gil", account: teamRef)
         )
     }
 
@@ -182,6 +248,7 @@ final class AccountIdentityTests: XCTestCase {
           "plan":"Max 20x","organizationType":"claude_max",
           "rateLimitTier":"default_claude_max_20x","seatTier":null,
           "orgUuid":"\(personal)","orgName":"Example Personal",
+          "gate":"rejected",
           "quota":1.0,"quotaState":"spent","fiveHour":1.0,"sevenDay":1.0,
           "sevenDayOi":null,"held":[],"requests":13011,"inputTokens":1,"outputTokens":1,
           "cacheReadTokens":1,"cacheHitRatio":0.5,"probeStatus":"ok","probeError":null,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -373,18 +373,32 @@ const GROUP_LIVE_RELOAD_NOTE: &str =
 /// Resolve `name` to exactly one configured account by EXACT match on
 /// `Account.name` (which IS the email — see [`resolve_account`]'s doc-comment).
 ///
-/// Deliberately not [`resolve_account`]: `tcr group add`/`rm`'s contract with
-/// the TcrBar panel (its argument shape is pinned, not ours to change) has no
-/// `--org` disambiguator, and an unknown name must list every configured
-/// account rather than [`resolve_account`]'s "no account matches" — the panel
-/// shells out blind and needs the full roster in the error to act on it.
-fn find_account_by_name(accounts: &[Account], name: &str) -> anyhow::Result<usize> {
-    match accounts.iter().position(|a| a.name == name) {
-        Some(idx) => Ok(idx),
-        None => {
+/// [`resolve_account`]'s rule, with the group verbs' own not-found message.
+///
+/// The resolution is [`identity::match_one`] — identical to `tcr enable`/
+/// `disable`/`token`/`remove`/`priority` — so `--org` narrows a name two
+/// accounts share and an unbreakable tie is REFUSED. This replaced an exact
+/// `position()` scan that took the first match and reported success, which on
+/// the fleet's duplicated email labelled a row nobody asked for.
+///
+/// The one thing it does not borrow from `resolve_account` is the not-found
+/// text. The panel shells out blind, so an unknown name has to come back with
+/// the full roster to act on rather than a bare "no account matches".
+fn find_account_by_name(
+    accounts: &[Account],
+    name: &str,
+    org: Option<&str>,
+) -> anyhow::Result<usize> {
+    match identity::match_one(accounts, name, org) {
+        identity::Match::One(idx) => Ok(idx),
+        identity::Match::Ambiguous(names) => bail!("{}", ambiguous_query_message(name, &names)),
+        identity::Match::None => {
             let configured: Vec<&str> = accounts.iter().map(|a| a.name.as_str()).collect();
+            let org_note = org
+                .map(|o| format!(" (with org matching '{o}')"))
+                .unwrap_or_default();
             bail!(
-                "no account named '{name}' in the config. Configured accounts: {}",
+                "no account named '{name}'{org_note} in the config. Configured accounts: {}",
                 configured.join(", ")
             );
         }
@@ -408,7 +422,19 @@ fn control_account_group_notice(config: &Config, account: &str, group: &str) -> 
     ))
 }
 
-/// `tcr group add <group> <account>` — label `account` with `group`.
+/// `tcr group add <group> <account> [--org <name-or-uuid>]` — label `account`
+/// with `group`.
+///
+/// Resolves through [`find_account_by_name`], which applies exactly the rule
+/// `tcr enable`/`disable`/`token`/`remove`/`priority` use — not a bare name
+/// lookup. Two
+/// changes come with that, and the second is the one that matters: `--org` can
+/// now narrow a name two accounts share, and an ambiguous name is REFUSED
+/// rather than silently resolved to whichever row happens to come first. The
+/// old `find_account_by_name` was an exact-name `position()` scan, so on the
+/// fleet's duplicated email it labelled the first row and reported success,
+/// which is worse than the failure it looks like: the panel's group menu had no
+/// way to say which row it meant, and no way to tell it had hit the wrong one.
 ///
 /// Idempotent: adding a label an account already carries succeeds and says so,
 /// so the panel can call it without first checking state. The group label
@@ -416,7 +442,12 @@ fn control_account_group_notice(config: &Config, account: &str, group: &str) -> 
 /// validator `tcr run --group` uses — because `add` is the one path that can
 /// put a fresh, attacker- or typo-controlled string into the config; `rm` must
 /// NOT run this check (see [`remove_from_group`]'s doc-comment).
-pub fn add_to_group(config_path: &Path, group: &str, account: &str) -> anyhow::Result<()> {
+pub fn add_to_group(
+    config_path: &Path,
+    group: &str,
+    account: &str,
+    org: Option<&str>,
+) -> anyhow::Result<()> {
     if let Err(reason) = validate_group_label_chars(group) {
         bail!("group {group:?}: invalid group label — {reason}");
     }
@@ -433,7 +464,7 @@ pub fn add_to_group(config_path: &Path, group: &str, account: &str) -> anyhow::R
     // a false-but-constant warning turn into wallpaper.
     let config = config::load(config_path)
         .with_context(|| format!("load config at {}", config_path.display()))?;
-    let idx = find_account_by_name(&config.accounts, account)?;
+    let idx = find_account_by_name(&config.accounts, account, org)?;
     let target = &config.accounts[idx];
     // The label itself is real and the write below is correct — but on the
     // CONTROL account it buys nothing, because `Manager::select_with_group`
@@ -475,8 +506,14 @@ pub fn add_to_group(config_path: &Path, group: &str, account: &str) -> anyhow::R
     Ok(())
 }
 
-/// `tcr group rm <group> <account>` / `tcr group rm <group> --all` — remove
-/// `account`'s (or every member's, with `--all`) `group` label.
+/// `tcr group rm <group> <account> [--org <name-or-uuid>]` / `tcr group rm
+/// <group> --all` — remove `account`'s (or every member's, with `--all`)
+/// `group` label.
+///
+/// The single-account path resolves through [`find_account_by_name`], same as
+/// [`add_to_group`] and for the same reasons. `--all` deliberately does not
+/// take an org: it walks every member of the group by identity already, so
+/// there is no name to disambiguate.
 ///
 /// `account == None` iff `all` — clap's `ArgGroup` on `GroupRmArgs` refuses
 /// "both" and "neither" at parse time before this ever runs, so the `expect`
@@ -490,6 +527,7 @@ pub fn remove_from_group(
     config_path: &Path,
     group: &str,
     account: Option<&str>,
+    org: Option<&str>,
     all: bool,
 ) -> anyhow::Result<()> {
     // Same reasoning as `add_to_group`: no `load_for_edit` warning here either
@@ -541,7 +579,7 @@ pub fn remove_from_group(
     // clap's ArgGroup on `GroupRmArgs` guarantees exactly one of
     // `account`/`--all` — see this function's doc-comment.
     let account = account.expect("clap guarantees `account` is Some when `all` is false");
-    let idx = find_account_by_name(&config.accounts, account)?;
+    let idx = find_account_by_name(&config.accounts, account, org)?;
     let target = &config.accounts[idx];
     let outcome = config::save_group_membership(config_path, target, group, false)
         .with_context(|| format!("save config at {}", config_path.display()))?;
@@ -2908,10 +2946,105 @@ mod tests {
       ]
     }"#;
 
+    /// The fleet's real shape: one email logged into two orgs. `tcr group add`
+    /// used to take the FIRST match and report success, so the panel labelled a
+    /// row nobody asked for and had no way to notice.
+    const DUPLICATED_EMAIL: &str = r#"{
+      "accounts": [
+        { "name": "henry@example.com", "type": "oauth", "orgName": "Personal",
+          "orgUuid": "11111111-1111-1111-1111-111111111111",
+          "accountUuid": "uuid-person", "accessToken": "at-p",
+          "refreshToken": "rt-p", "expiresAt": 1893456000000, "priority": 0 },
+        { "name": "henry@example.com", "type": "oauth", "orgName": "Example Team",
+          "orgUuid": "22222222-2222-2222-2222-222222222222",
+          "accountUuid": "uuid-person", "accessToken": "at-t",
+          "refreshToken": "rt-t", "expiresAt": 1893456000000, "priority": 1 }
+      ]
+    }"#;
+
+    /// `--org` picks the Team row out of two rows sharing an email — the whole
+    /// reason the flag exists. The assertion is on the OTHER row too: labelling
+    /// the right account is only half of it, and a resolver that labelled both
+    /// would pass a check that only looked at the one it was asked for.
+    #[test]
+    fn group_add_with_an_org_labels_that_org_and_only_that_org() {
+        let path = write_config("group-add-org", DUPLICATED_EMAIL);
+        add_to_group(
+            &path,
+            "codereview",
+            "henry@example.com",
+            Some("22222222-2222-2222-2222-222222222222"),
+        )
+        .unwrap();
+
+        let config = load(&path);
+        assert_eq!(
+            config.accounts[0].groups, None,
+            "the Personal row was not asked for and must not be labelled"
+        );
+        assert_eq!(
+            config.accounts[1].groups,
+            Some(vec!["codereview".to_string()]),
+            "the Team row is the one --org named"
+        );
+    }
+
+    /// And without `--org` it REFUSES rather than guessing. This is the
+    /// regression: the old exact-name scan silently took `accounts[0]`, so the
+    /// operator saw "Added ... to group" about the wrong account.
+    #[test]
+    fn group_add_refuses_a_duplicated_email_with_no_org() {
+        let path = write_config("group-add-ambiguous", DUPLICATED_EMAIL);
+        let err = add_to_group(&path, "codereview", "henry@example.com", None)
+            .expect_err("an unbreakable tie must refuse rather than pick the first row");
+        assert!(err.to_string().contains("ambiguous"), "{err}");
+
+        let config = load(&path);
+        assert_eq!(config.accounts[0].groups, None);
+        assert_eq!(config.accounts[1].groups, None);
+    }
+
+    /// `rm` resolves the same way — the panel's "remove from group" is the same
+    /// menu as "add to group" and must not be able to strip the wrong row.
+    #[test]
+    fn group_rm_narrows_by_org_and_refuses_without_one() {
+        let path = write_config("group-rm-org", DUPLICATED_EMAIL);
+        let team = Some("22222222-2222-2222-2222-222222222222");
+        add_to_group(&path, "codereview", "henry@example.com", team).unwrap();
+
+        let err = remove_from_group(&path, "codereview", Some("henry@example.com"), None, false)
+            .expect_err("no org means an unbreakable tie");
+        assert!(err.to_string().contains("ambiguous"), "{err}");
+        assert_eq!(
+            load(&path).accounts[1].groups,
+            Some(vec!["codereview".to_string()]),
+            "a refused removal changes nothing"
+        );
+
+        remove_from_group(&path, "codereview", Some("henry@example.com"), team, false).unwrap();
+        // Removing the last label DROPS the `groups` key rather than leaving an
+        // empty array — `save_group_membership`'s contract, same shape as
+        // `disabled == false` removing its key.
+        assert_eq!(load(&path).accounts[1].groups, None);
+    }
+
+    /// An unknown name still comes back with the whole roster, which is what
+    /// the panel needs to act on — it shells out blind. A plain "no account
+    /// matches" would be a worse error in exactly the place it is read.
+    #[test]
+    fn group_add_names_every_configured_account_when_the_name_is_unknown() {
+        let path = write_config("group-add-unknown", TWO_ACCOUNTS);
+        let err = add_to_group(&path, "codereview", "nobody@example.com", None)
+            .expect_err("an unknown account is an error");
+        let text = err.to_string();
+        assert!(text.contains("alice@example.com"), "{text}");
+        assert!(text.contains("bob@example.com"), "{text}");
+    }
+
     #[test]
     fn group_add_labels_named_account_and_leaves_siblings_byte_identical() {
         let path = write_config("group-add", TWO_ACCOUNTS);
-        add_to_group(&path, "codereview", "alice@example.com").unwrap();
+        add_to_group(&path, "codereview", "alice@example.com", None).unwrap();
         let config = load(&path);
         assert_eq!(
             config.accounts[0].groups,
@@ -2932,8 +3065,8 @@ mod tests {
     #[test]
     fn group_add_twice_is_idempotent() {
         let path = write_config("group-add-twice", TWO_ACCOUNTS);
-        add_to_group(&path, "codereview", "alice@example.com").unwrap();
-        add_to_group(&path, "codereview", "alice@example.com").unwrap();
+        add_to_group(&path, "codereview", "alice@example.com", None).unwrap();
+        add_to_group(&path, "codereview", "alice@example.com", None).unwrap();
         let config = load(&path);
         assert_eq!(
             config.accounts[0].groups,
@@ -2946,7 +3079,7 @@ mod tests {
     #[test]
     fn group_rm_removes_only_named_label_leaving_others_intact() {
         let path = write_config("group-rm-one", GROUPED_ACCOUNTS);
-        remove_from_group(&path, "codereview", Some("alice@example.com"), false).unwrap();
+        remove_from_group(&path, "codereview", Some("alice@example.com"), None, false).unwrap();
         let config = load(&path);
         assert_eq!(config.accounts[0].groups, Some(vec!["dev".to_string()]));
         // bob still carries codereview — only alice's membership changed.
@@ -2960,7 +3093,7 @@ mod tests {
     #[test]
     fn group_rm_all_clears_label_from_every_member_and_nothing_else() {
         let path = write_config("group-rm-all", GROUPED_ACCOUNTS);
-        remove_from_group(&path, "codereview", None, true).unwrap();
+        remove_from_group(&path, "codereview", None, None, true).unwrap();
         let config = load(&path);
         // alice keeps `dev`, loses `codereview`.
         assert_eq!(config.accounts[0].groups, Some(vec!["dev".to_string()]));
@@ -2979,7 +3112,7 @@ mod tests {
     fn group_rm_all_on_a_group_with_no_members_is_a_success_no_op() {
         let path = write_config("group-rm-all-empty", GROUPED_ACCOUNTS);
         let before = fs::read_to_string(&path).unwrap();
-        remove_from_group(&path, "nonexistent-group", None, true).unwrap();
+        remove_from_group(&path, "nonexistent-group", None, None, true).unwrap();
         let after = fs::read_to_string(&path).unwrap();
         assert_eq!(
             before, after,
@@ -2991,7 +3124,7 @@ mod tests {
     #[test]
     fn group_add_unknown_account_errors_and_names_the_configured_accounts() {
         let path = write_config("group-add-unknown", GROUPED_ACCOUNTS);
-        let err = add_to_group(&path, "codereview", "nobody@example.com").unwrap_err();
+        let err = add_to_group(&path, "codereview", "nobody@example.com", None).unwrap_err();
         let message = err.to_string();
         for name in ["alice@example.com", "bob@example.com", "carol@example.com"] {
             assert!(
@@ -3005,8 +3138,8 @@ mod tests {
     #[test]
     fn group_rm_unknown_account_errors_and_names_the_configured_accounts() {
         let path = write_config("group-rm-unknown", GROUPED_ACCOUNTS);
-        let err =
-            remove_from_group(&path, "codereview", Some("nobody@example.com"), false).unwrap_err();
+        let err = remove_from_group(&path, "codereview", Some("nobody@example.com"), None, false)
+            .unwrap_err();
         let message = err.to_string();
         for name in ["alice@example.com", "bob@example.com", "carol@example.com"] {
             assert!(message.contains(name), "missing {name}: {message}");
@@ -3029,7 +3162,7 @@ mod tests {
         let bad_label = "bad\u{0}label";
 
         let path = write_config("group-add-bad-label", with_bad_label);
-        let err = add_to_group(&path, bad_label, "alice@example.com").unwrap_err();
+        let err = add_to_group(&path, bad_label, "alice@example.com", None).unwrap_err();
         assert!(
             err.to_string().contains("control character"),
             "add must name the character class at fault: {err}"
@@ -3042,7 +3175,7 @@ mod tests {
         );
 
         // `rm` does NOT run the validator — it must still remove the bad label.
-        remove_from_group(&path, bad_label, Some("alice@example.com"), false).unwrap();
+        remove_from_group(&path, bad_label, Some("alice@example.com"), None, false).unwrap();
         let config = load(&path);
         assert_eq!(config.accounts[0].groups, Some(vec!["good".to_string()]));
         fs::remove_file(&path).ok();
@@ -3051,7 +3184,7 @@ mod tests {
     #[test]
     fn group_mutation_preserves_unmodelled_extra_keys() {
         let path = write_config("group-extra", GROUPED_ACCOUNTS);
-        add_to_group(&path, "burst", "carol@example.com").unwrap();
+        add_to_group(&path, "burst", "carol@example.com", None).unwrap();
         let raw = fs::read_to_string(&path).unwrap();
         let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
         // Top-level unmodelled key.
@@ -3306,7 +3439,7 @@ mod tests {
     #[test]
     fn a_second_member_makes_the_group_route_again() {
         let path = write_config("routes-second-member", CONTROL_ONLY_GROUP);
-        add_to_group(&path, "research", "worker@example.com").unwrap();
+        add_to_group(&path, "research", "worker@example.com", None).unwrap();
         let config = load(&path);
         let research = group_line(&render_groups_text(&config), "research");
         assert!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,6 +229,9 @@ struct GroupAddArgs {
     /// Account name (its bare email — `Account.name` IS the email). Exact,
     /// case-sensitive.
     account: String,
+    /// Narrow an ambiguous match to a single org (name or uuid).
+    #[arg(long)]
+    org: Option<String>,
 }
 
 #[derive(clap::Args)]
@@ -243,6 +246,11 @@ struct GroupRmArgs {
     /// "both" and "neither".
     #[arg(required_unless_present = "all", conflicts_with = "all")]
     account: Option<String>,
+    /// Narrow an ambiguous match to a single org (name or uuid). Meaningless
+    /// with `--all`, which walks every member by identity and has no name to
+    /// disambiguate.
+    #[arg(long, conflicts_with = "all")]
+    org: Option<String>,
     /// Remove the group from every member instead of one account — deletes
     /// the group, since groups exist only while some account carries the
     /// label.
@@ -513,11 +521,17 @@ fn run_group(args: GroupArgs) -> anyhow::Result<()> {
         }
         GroupAction::Add(a) => {
             let config_path = a.config.unwrap_or_else(config::default_path);
-            cli::add_to_group(&config_path, &a.group, &a.account)
+            cli::add_to_group(&config_path, &a.group, &a.account, a.org.as_deref())
         }
         GroupAction::Rm(a) => {
             let config_path = a.config.unwrap_or_else(config::default_path);
-            cli::remove_from_group(&config_path, &a.group, a.account.as_deref(), a.all)
+            cli::remove_from_group(
+                &config_path,
+                &a.group,
+                a.account.as_deref(),
+                a.org.as_deref(),
+                a.all,
+            )
         }
         GroupAction::Reserve(a) => {
             let config_path = a.config.unwrap_or_else(config::default_path);


### PR DESCRIPTION
🍄 Three things the 0.2.37 panel got wrong on the live fleet, one PR, version 0.2.38.

## Rows overflowed the popover

Every pill is `fixedSize()`, so a row carrying CONTROL + GROUP ONLY + a quota pill + two group tags + the plan label had a minimum width past 380pt before the name got a single point — and the outer fixed-width frame CENTERS content it cannot fit, so both card edges clipped and nothing in a test or a pixel-width check could see it. The row now splits by meaning: line 1 is identity and live state, line 2 is designations (plan, group tags). Ordinary names stop truncating as a side effect. New `--render-states` scene `01g-widest-row` reproduces the worst row; read the PNG, not the exit code.

## `tcr group add` labelled the wrong account

Two halves. The CLI's `group add` / `group rm` had no `--org` and resolved by an exact-name `position()` scan, so on a duplicated email it labelled whichever row came first and reported success — worse than the failure it looked like. Both now resolve through `identity::match_one`, refuse an ambiguous name, and take `--org`; the panel passes `--org <orgUuid>`. Separately, `GroupController` recorded every failure and nothing in the panel ever read one back, which is why the action looked like a no-op — it is now drawn on the row like every other refusal.

## REJECTED

The wire has carried `gate` all along; the Swift side never decoded it and a FleetView comment claimed the field did not exist. Decoded now; `gate == "rejected"` draws REJECTED instead of SPENT.

## Gates

`cargo fmt --all --check` 0 · `cargo clippy --all-targets --locked -- -D warnings` 0 · `cargo test --all --locked` 0 · `swift-format lint --strict` 0 · `swift build` 0 · `swift test` 0 · pre-commit 0. Mutation-tested: dropping `org` in `add_to_group` reds both `--org` tests; forcing the rejected decode false reds the gate test.

https://claude.ai/code/session_0154byNxtvz4fUkQPKkwAGBZ
