### PR TITLE
refactor: one account, one name — the name is unique and the only way to address an account

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Format
         run: cargo fmt --all --check
 
+      # An `--org` flag on an account verb narrows nothing now that account
+      # names are unique, so one would be a lie in `--help`. It came back once
+      # already, one verb at a time — see the script's own header.
+      - name: No --org flag
+        run: scripts/check-no-org-flag.sh
+
       # --locked: fail if CI would silently rewrite Cargo.lock. Pins the exact
       # dependency set that was reviewed — important for an auth-handling proxy.
       - name: Clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.38"
+version = "0.2.39"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "teamclaude-rs"
-version = "0.2.38"
+version = "0.2.39"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -1185,12 +1185,20 @@ struct AccountRow: View {
     /// group names are the single biggest contributor to the width — the live
     /// fleet's `HENRY-TEAM-PARKED` alone is wider than three status pills.
     ///
-    /// Drawn only when there is something to say; an account with no plan and
-    /// no groups reserves no space at all.
+    /// Drawn only when there is something to say; an account with no plan, no
+    /// groups and a bare-email name reserves no space at all.
+    ///
+    /// The org half of the name leads this line — before the plan — because it
+    /// is part of the row's IDENTITY rather than a fact about it. It is here at
+    /// all only because line one has no room for it; putting it first keeps the
+    /// two halves as close to each other as two lines allow.
     @ViewBuilder
     private var designationsLine: some View {
-        if account.plan != nil || !account.groupTags.isEmpty {
+        if account.ref.displayHalves.orgTag != nil || account.plan != nil
+            || !account.groupTags.isEmpty
+        {
             HStack(spacing: Tok.tightSpacing) {
+                orgIndicator
                 planIndicator
                 // At most two tags, the rest collapsed into a `+N` chip whose
                 // tooltip names them all. The cap stays even with a line to
@@ -1205,6 +1213,32 @@ struct AccountRow: View {
                 }
                 Spacer(minLength: 0)
             }
+        }
+    }
+
+    /// The `/<org-slug>` half of the name, verbatim and never truncated —
+    /// `fixedSize()`, like every other tag on this line.
+    ///
+    /// Rendered dim, at the tag font, because it is a continuation of the name
+    /// above rather than a separate label: it reads as part of an identity that
+    /// wrapped, which is what it is. The text is EXACTLY what the operator would
+    /// type, separator included, so a name can be reassembled by reading the two
+    /// lines left to right.
+    ///
+    /// Absent on a bare-email name, which is every row on a fleet where nobody
+    /// holds two orgs — those rows look exactly as they always have.
+    @ViewBuilder
+    private var orgIndicator: some View {
+        if let orgTag = account.ref.displayHalves.orgTag {
+            Text(orgTag)
+                .font(Tok.pillFont)
+                .foregroundStyle(Tok.inkFaint)
+                .fixedSize()
+                .textSelection(.enabled)
+                .help(
+                    "The organization half of this account's name — the full name is "
+                        + "\(account.name), which is what every `tcr` command takes."
+                )
         }
     }
 
@@ -1828,20 +1862,35 @@ struct AccountRow: View {
     private var information: some View {
         VStack(alignment: .leading, spacing: Tok.rowLineSpacing) {
             HStack(spacing: Tok.tightSpacing) {
-                Text(account.name)
+                // The EMAIL HALF only. The `/<org-slug>` half is a tag on the
+                // designations line below — see `orgIndicator`.
+                //
+                // This line used to carry the whole name and middle-truncate
+                // it, which on a qualified name rendered `henry@ex…ample-team`:
+                // not readable, not typable, and truncating the one thing that
+                // says which of a person's orgs the row is. Splitting the two
+                // halves across two lines is what lets BOTH be shown whole,
+                // rather than choosing which end to sacrifice.
+                //
+                // `.help` deliberately stays the FULL name, not this half: the
+                // tooltip is the "what do I type" answer, and the answer is the
+                // whole thing.
+                // WRAPS rather than truncates. Splitting the org half off is
+                // not on its own enough: line one also carries the live-state
+                // pills, every one of them `fixedSize()`, so on a row wearing
+                // two of them a perfectly ordinary address still ran out of
+                // room — `henry.mitchell@examp…` with ROTATING + UNMEASURED
+                // beside it. The pills cannot yield, so the name has to be
+                // allowed a second line instead of losing its tail.
+                //
+                // `fixedSize(horizontal:vertical:)` is what makes the wrap
+                // real: without it the `Text` reports the one-line height it
+                // was offered and clips, rather than growing.
+                Text(account.ref.displayHalves.email)
                     .font(Tok.bodyFont)
                     .foregroundStyle(account.disabled ? Tok.disabled : Tok.ink)
-                    .lineLimit(1)
-                    // Middle truncation, because the distinguishing part of a
-                    // name is at its ENDS: the local part at the front, and the
-                    // `/<org-slug>` suffix at the back on a row belonging to one
-                    // of a person's several orgs. Tail truncation would eat that
-                    // suffix, which is the one thing telling those rows apart —
-                    // and the thing the operator types to address one.
-                    //
-                    // It still hides the middle, so the full value stays
-                    // reachable: `.help` on hover and `.textSelection` to copy.
-                    .truncationMode(.middle)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
                     .help(account.name)
                     .textSelection(.enabled)
                 controlIndicator

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -697,9 +697,7 @@ struct FleetView: View {
     /// way — a button that silently does nothing is worse than one that says
     /// why.
     private func reloginAccount(_ account: AccountRef) {
-        if case .failure(let why) = LoginLauncher.launch(
-            reloggingIn: account.name, org: account.orgUuid)
-        {
+        if case .failure(let why) = LoginLauncher.launch(reloggingIn: account.name) {
             switch why {
             case .toolMissing(let searched):
                 loginError = "tcr not found (searched \(searched.count) locations)."
@@ -1713,15 +1711,14 @@ struct AccountRow: View {
     /// Shared by "Copy Account Name" and the per-group command copy — one
     /// place that clears then sets, so every copy in this menu behaves the
     /// same way.
-    /// `tcr token <name> [--org <uuid>]` off the main actor, then the
-    /// pasteboard. A failure replaces any earlier one on this row; a success
-    /// clears it.
+    /// `tcr token <name>` off the main actor, then the pasteboard. A failure
+    /// replaces any earlier one on this row; a success clears it.
     ///
-    /// The `--org` is what makes this work at all on a fleet holding one email
-    /// twice: without it `tcr` refused with `'…' is ambiguous — matches 2
-    /// accounts … Narrow with --org`, so neither row's token could be copied.
+    /// The name is enough because `tcr` guarantees it is unique. On a fleet
+    /// holding one email twice it was not, and this refused with `'…' is
+    /// ambiguous — matches 2 accounts`, so neither row's token could be copied.
     private func performCopyToken() async {
-        switch await TokenCommand.fetch(query: account.name, org: account.orgUuid) {
+        switch await TokenCommand.fetch(query: account.name) {
         case .success(let token):
             copyToPasteboard(token)
             tokenCopyFailure = nil
@@ -1835,10 +1832,15 @@ struct AccountRow: View {
                     .font(Tok.bodyFont)
                     .foregroundStyle(account.disabled ? Tok.disabled : Tok.ink)
                     .lineLimit(1)
-                    // Middle truncation eats the middle of an address, which is
-                    // exactly the part that distinguishes two accounts on the
-                    // same domain. Truncation hides content, so the full value
-                    // has to stay reachable somewhere.
+                    // Middle truncation, because the distinguishing part of a
+                    // name is at its ENDS: the local part at the front, and the
+                    // `/<org-slug>` suffix at the back on a row belonging to one
+                    // of a person's several orgs. Tail truncation would eat that
+                    // suffix, which is the one thing telling those rows apart —
+                    // and the thing the operator types to address one.
+                    //
+                    // It still hides the middle, so the full value stays
+                    // reachable: `.help` on hover and `.textSelection` to copy.
                     .truncationMode(.middle)
                     .help(account.name)
                     .textSelection(.enabled)

--- a/apps/macos/Sources/TcrBar/RenderStates.swift
+++ b/apps/macos/Sources/TcrBar/RenderStates.swift
@@ -586,9 +586,15 @@ enum RenderStates {
     /// numbers on both and neither wore its own gate pill, while `tcr status
     /// --json` reported the two correctly and differently. `tcr` now gives the
     /// second row its own name (`src/config.rs`, `migrate_duplicate_names`), so
-    /// the PNG must show the personal row as `henry@example.com` and the Team
-    /// row as `henry@example.com/example-team` — the full name, suffix visible,
-    /// because that is what a person types to address it.
+    /// the PNG must show BOTH halves of the Team row's name and truncate
+    /// neither: the email on line one, the `/example-team` half as the first tag
+    /// on the designations line. Read left to right across the two lines, that
+    /// is exactly what a person types to address the row.
+    ///
+    /// The email is deliberately a realistic length rather than a short one.
+    /// A short address leaves slack that hides the very overflow this scene
+    /// exists to make visible — the previous fixture's `henry@example.com`
+    /// rendered as `henry@ex…ample-team` the moment the suffix shared its line.
     ///
     /// The two rows are deliberately as unlike each other as a pair can be —
     /// one spent and rejected, one fresh and never probed, and different plans
@@ -596,11 +602,11 @@ enum RenderStates {
     /// shows two identical rows, the collapse is back.
     private static var duplicateEmailJSON: String {
         let old = account(
-            "henry@example.com", quota: "1.0", state: "spent", probe: "ok", held: hold,
+            "henry.mitchell@example.com", quota: "1.0", state: "spent", probe: "ok", held: hold,
             plan: "Max 20x", orgUuid: "11111111-1111-1111-1111-111111111111",
             gate: "rejected")
         let fresh = account(
-            "henry@example.com/example-team", quota: "null", state: "ok", probe: "never",
+            "henry.mitchell@example.com/example-team", quota: "null", state: "ok", probe: "never",
             usage: unmeasuredUsage,
             plan: "Team Standard", orgUuid: "22222222-2222-2222-2222-222222222222",
             gate: "ok")

--- a/apps/macos/Sources/TcrBar/RenderStates.swift
+++ b/apps/macos/Sources/TcrBar/RenderStates.swift
@@ -578,12 +578,17 @@ enum RenderStates {
         return "[\(worst),\(ordinary)]"
     }
 
-    /// THE SAME EMAIL, TWICE — the shape that broke the panel.
+    /// ONE PERSON, TWO ORGS — the shape that broke the panel, and the names it
+    /// wears now that `tcr` has fixed it.
     ///
-    /// Both rows carry `henry@example.com`; only the org differs. Before
-    /// ``AccountRef`` they collapsed to one SwiftUI identity, so the panel drew
-    /// the FIRST row's numbers on both and neither wore its own gate pill,
-    /// while `tcr status --json` reported the two correctly and differently.
+    /// Both rows used to carry `henry@example.com`; only the org differed. They
+    /// collapsed to one SwiftUI identity, so the panel drew the FIRST row's
+    /// numbers on both and neither wore its own gate pill, while `tcr status
+    /// --json` reported the two correctly and differently. `tcr` now gives the
+    /// second row its own name (`src/config.rs`, `migrate_duplicate_names`), so
+    /// the PNG must show the personal row as `henry@example.com` and the Team
+    /// row as `henry@example.com/example-team` — the full name, suffix visible,
+    /// because that is what a person types to address it.
     ///
     /// The two rows are deliberately as unlike each other as a pair can be —
     /// one spent and rejected, one fresh and never probed, and different plans
@@ -595,7 +600,7 @@ enum RenderStates {
             plan: "Max 20x", orgUuid: "11111111-1111-1111-1111-111111111111",
             gate: "rejected")
         let fresh = account(
-            "henry@example.com", quota: "null", state: "ok", probe: "never",
+            "henry@example.com/example-team", quota: "null", state: "ok", probe: "never",
             usage: unmeasuredUsage,
             plan: "Team Standard", orgUuid: "22222222-2222-2222-2222-222222222222",
             gate: "ok")

--- a/apps/macos/Sources/TcrBarCore/AccountControl.swift
+++ b/apps/macos/Sources/TcrBarCore/AccountControl.swift
@@ -11,14 +11,13 @@ import Foundation
 ///     `tcr disable <name>` — exactly like the server control, and this process
 ///     stays credential-free.
 ///  2. **A failed call must never look like a success.** `query` on the Rust side
-///     (`src/identity.rs`, `match_accounts`) is an EXACT match on the account name,
-///     falling back to an exact match on the email part — case-sensitive `==` both
-///     times, no substring anywhere. Passing the row's own `name` therefore resolves
-///     to that row or to nothing, except where two accounts share an email across
-///     orgs, which `match_one` returns as ambiguous rather than picking one. The
-///     exit code and stderr are still captured and surfaced in the row, and the UI
-///     never optimistically flips its own copy of `disabled` — it re-polls and
-///     shows whatever `tcr status` then reports.
+///     (`src/identity.rs`, `match_accounts`) is an EXACT match on the account
+///     name — case-sensitive `==`, no substring, no email-part fallback. Names
+///     are unique across a config by construction, so passing the row's own
+///     `name` resolves to that row or to nothing. The exit code and stderr are
+///     still captured and surfaced in the row, and the UI never optimistically
+///     flips its own copy of `disabled` — it re-polls and shows whatever
+///     `tcr status` then reports.
 ///  3. **Exit 0 with anything on stderr is not a clean success.** `tcr` reports
 ///     durability on the success path: it exits 0 having parked the live rotation
 ///     and warns on stderr that no config entry matched, so the account returns to
@@ -42,22 +41,9 @@ public enum AccountCommand {
     /// The complete argument vector. `name` is passed positionally and
     /// verbatim; nothing here is shell-interpreted.
     ///
-    /// `org` narrows an ambiguous name, exactly as it does for
-    /// ``TokenCommand/arguments(query:org:)`` and
-    /// ``RemoveAccountCommand/arguments(query:org:)``. It is not optional
-    /// decoration: point 2 above says a name resolves "to that row or to
-    /// nothing, except where two accounts share an email across orgs, which
-    /// `match_one` returns as ambiguous rather than picking one" — and that
-    /// exception is the fleet's ordinary state, not a corner. Without the flag
-    /// the toggle simply refuses on those rows.
-    ///
-    /// Omitted entirely when `org` is `nil`, so a row from a server that
-    /// reports no org builds precisely the command it built before.
-    ///
     /// `enabled: true` means "put this account back in rotation".
-    public static func arguments(enabled: Bool, name: String, org: String? = nil) -> [String] {
-        guard let org else { return [enabled ? "enable" : "disable", name] }
-        return [enabled ? "enable" : "disable", name, "--org", org]
+    public static func arguments(enabled: Bool, name: String) -> [String] {
+        [enabled ? "enable" : "disable", name]
     }
 
     /// Why a toggle did not happen. Carries the CLI's own words; this app does not
@@ -119,7 +105,7 @@ public enum AccountCommand {
             do {
                 let output = try TcrTool.run(
                     executable: executable,
-                    arguments: arguments(enabled: enabled, name: name, org: account.orgUuid)
+                    arguments: arguments(enabled: enabled, name: name)
                 )
                 return classify(enabling: enabled, exitCode: output.exitCode, stderr: output.stderr)
             } catch {
@@ -133,8 +119,8 @@ public enum AccountCommand {
 /// Per-account toggle state for the panel: which rows have a call in flight, and
 /// which rows have a failure that has not been superseded by a later attempt.
 ///
-/// Keyed by ``AccountRef/id`` — the ORG-QUALIFIED identity, not the bare name.
-/// Keying by name collapsed the fleet's two same-email rows into one entry, so a
+/// Keyed by ``AccountRef/id``, the one definition of a row's identity. When two
+/// rows could share an email this key collapsed them into one entry, so a
 /// failure or an in-flight spinner belonging to one row rendered on both. That
 /// key must stay identical to the one `ForEach` uses, which is why both come
 /// from ``AccountRef`` rather than being spelled out twice.

--- a/apps/macos/Sources/TcrBarCore/AccountRef.swift
+++ b/apps/macos/Sources/TcrBarCore/AccountRef.swift
@@ -37,6 +37,26 @@ public struct AccountRef: Hashable, Sendable {
     /// and every by-account dictionary key resolve to this, so a row's SwiftUI
     /// identity and its verdict's dictionary key cannot disagree.
     public var id: String { name }
+
+    /// The name split for DISPLAY into the email half and the org half, so the
+    /// row can put them on two different lines and truncate neither.
+    ///
+    /// The row used to draw the whole name on one line and middle-truncate it,
+    /// which on a qualified name produced `henry@ex…ample-team` — a string that
+    /// is neither readable nor typable, and the suffix is exactly the part that
+    /// says which of a person's orgs this row is. Splitting means line one holds
+    /// an ordinary email and the suffix rides the designations line as its own
+    /// tag, whole.
+    ///
+    /// The split is at the FIRST separator and the remainder is kept intact,
+    /// separator included: `a@b/x/y` yields `("a@b", "/x/y")`, never `("a@b",
+    /// "/x")` with `/y` dropped on the floor. A name is an identity — this may
+    /// re-present it, never lose a byte of it. `orgTag` is `nil` for a bare
+    /// email, which renders exactly as it always has.
+    public var displayHalves: (email: String, orgTag: String?) {
+        guard let slash = name.firstIndex(of: "/") else { return (name, nil) }
+        return (String(name[name.startIndex..<slash]), String(name[slash...]))
+    }
 }
 
 extension Account {

--- a/apps/macos/Sources/TcrBarCore/AccountRef.swift
+++ b/apps/macos/Sources/TcrBarCore/AccountRef.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-/// How this app names ONE account, everywhere: the display name plus the org it
-/// belongs to.
+/// How this app names ONE account, everywhere: its name, which is unique across
+/// the fleet.
 ///
-/// It exists because a name is not an identity. The fleet holds the same email
-/// twice — once in a personal Max org, once in the company Team org — and until
-/// this type existed the panel had no way to tell those two rows apart. The
+/// It carried an org UUID alongside the name until account names became unique.
+/// The fleet held the same email twice — once in a personal Max org, once in the
+/// company Team org — and the panel had no way to tell those two rows apart. The
 /// consequences were not subtle:
 ///
 ///  * `ForEach(…, id: \.element.id)` collapsed the pair into ONE SwiftUI
@@ -17,50 +17,29 @@ import Foundation
 ///    row rendered on both.
 ///  * Every command the panel issued carried a bare name, and `tcr` refuses an
 ///    ambiguous one rather than guessing: "Copy Access Token" on either row
-///    failed with `'…' is ambiguous — matches 2 accounts … Narrow with --org`.
+///    failed with `'…' is ambiguous — matches 2 accounts`.
 ///
-/// The two halves are deliberately kept separate rather than pre-joined into a
-/// string, because they are used for different things and must not be confused:
-/// ``id`` is what the UI keys on, and ``name``/``orgUuid`` are what the CLI is
-/// handed (`tcr token <name> --org <uuid>`). `tcr` has never taken the joined
-/// form and must never be passed it.
+/// `tcr` fixed that below this app: two rows can no longer share a name, so the
+/// name IS the identity and there is nothing left to pair it with. The type
+/// survives the collapse because it is the one place that statement lives — a
+/// row's SwiftUI identity, its dictionary key and the argument handed to `tcr`
+/// all resolve here, so they cannot drift apart again.
 public struct AccountRef: Hashable, Sendable {
-    /// The account's display name — an email on this fleet. What `tcr` matches
-    /// positionally.
+    /// The account's name — an email, or `email/<org-slug>` on a fleet where one
+    /// person holds two orgs. Unique, and what `tcr` matches exactly.
     public let name: String
-    /// The org UUID, when the server reported one. Passed as `--org` to narrow
-    /// an ambiguous `name`; `nil` from a server built before the org keys
-    /// existed, in which case no flag is passed and behaviour is exactly what it
-    /// was.
-    public let orgUuid: String?
 
-    public init(name: String, orgUuid: String? = nil) {
+    public init(name: String) {
         self.name = name
-        // An empty string is not an org. Normalizing here rather than at each
-        // call site is what keeps `--org ""` — which `tcr` would match nothing
-        // for — from ever being built.
-        self.orgUuid = (orgUuid?.isEmpty == false) ? orgUuid : nil
     }
 
     /// The single definition of this app's per-account identity. `Account.id`
     /// and every by-account dictionary key resolve to this, so a row's SwiftUI
     /// identity and its verdict's dictionary key cannot disagree.
-    ///
-    /// Falls back to the bare `name` when there is no org, which keeps an older
-    /// server's rows rendering exactly as they do today — and is the honest
-    /// answer there: with no org on the wire, the name is all the identity this
-    /// build can see.
-    ///
-    /// The `|` separator cannot collide with a real value: an org UUID contains
-    /// no `|`, so `a|uuid` is reachable only from `AccountRef(name: "a",
-    /// orgUuid: "uuid")`.
-    public var id: String {
-        guard let orgUuid else { return name }
-        return "\(name)|\(orgUuid)"
-    }
+    public var id: String { name }
 }
 
 extension Account {
     /// This row, as the identity every controller and command should take.
-    public var ref: AccountRef { AccountRef(name: name, orgUuid: orgUuid) }
+    public var ref: AccountRef { AccountRef(name: name) }
 }

--- a/apps/macos/Sources/TcrBarCore/ControlAccountController.swift
+++ b/apps/macos/Sources/TcrBarCore/ControlAccountController.swift
@@ -31,8 +31,8 @@ public enum ControlAccountCommand {
 
     /// `tcr control <name>` to set it, or `tcr control --clear` to clear it.
     /// `name` is passed positionally and verbatim, exactly like
-    /// ``AccountCommand/arguments(enabled:name:)`` — no `--org`, nothing that
-    /// could be mistaken for a flag.
+    /// ``AccountCommand/arguments(enabled:name:)`` — nothing here could be
+    /// mistaken for a flag.
     public static func setArguments(name: String?) -> [String] {
         guard let name else { return ["control", "--clear"] }
         return ["control", name]
@@ -169,24 +169,16 @@ public final class ControlAccountController: ObservableObject {
 
     public func isPending(_ name: String) -> Bool { pending.contains(name) }
     public func failure(for name: String) -> ControlAccountCommand.Failure? { failures[name] }
-    /// Deliberately keyed on the bare NAME, unlike every other per-account
-    /// lookup in this app, which moved to ``AccountRef/id`` when the fleet's
-    /// two same-email rows were found colliding.
+    /// Keyed on the NAME, which is now the same thing as ``AccountRef/id`` —
+    /// they agree by construction rather than by coincidence.
     ///
-    /// This one cannot follow, and pretending otherwise would be the worse
-    /// choice. The stored `controlAccount` (`src/config.rs`, `Config::control_account`)
-    /// is a bare string, and the server resolves it by name to the FIRST
-    /// matching row (`Manager::assemble`'s `accounts.iter().position`), then
-    /// stamps `control: true` on the wire for every row whose name equals it
-    /// (`src/cli.rs`, `render_accounts_json`). So on a duplicated email the
-    /// SERVER already reports both rows as control, and an org-qualified check
-    /// here would show one row as control and the other not — disagreeing with
-    /// the process that actually routes the traffic, which is a worse lie than
-    /// agreeing with it.
-    ///
-    /// Making this correct is a SERVER change: `controlAccount` has to carry an
-    /// org, or the wire has to name the resolved index. Reported separately
-    /// rather than half-fixed here.
+    /// That was a real defect while an email could name two rows. The stored
+    /// `controlAccount` was resolved to the FIRST matching row, and the wire
+    /// then stamped `control: true` on EVERY row whose name equalled it, so the
+    /// panel showed both rows as control and matched a server that was itself
+    /// confused. `tcr` fixed it below this app by making the name unique
+    /// (`src/config.rs`, `migrate_duplicate_names`), which is why this check can
+    /// be the plain equality it looks like.
     public func isControl(_ name: String) -> Bool { !unavailable && current == name }
 
     /// Re-read `tcr control --show`. Safe to call any time — on panel open,

--- a/apps/macos/Sources/TcrBarCore/FleetStatus.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetStatus.swift
@@ -1045,17 +1045,14 @@ public struct Account: Decodable, Equatable, Identifiable, Sendable {
     public let rateLimitTier: String?
     public let seatTier: String?
 
-    /// The org this account is scoped to. Load-bearing, not informational:
-    /// every `tcr` account verb takes `--org <name-or-uuid-prefix>`, and this
-    /// is the ONLY thing that lets the panel address one of two rows sharing an
-    /// email. Without it "Copy Access Token" failed with `'…' is ambiguous —
-    /// matches 2 accounts`, because the command it built carried a name and
-    /// nothing to narrow it by.
+    /// The org this account is scoped to — a fact to SHOW, not an address.
     ///
-    /// ``orgUuid`` is what the panel passes: it is exact, where ``orgName`` is
-    /// a display string two orgs can share. `nil` from a server built before
-    /// these keys existed, which is why every call site treats the flag as
-    /// optional rather than required.
+    /// It was briefly the only thing that let the panel address one of two rows
+    /// sharing an email: without it, "Copy Access Token" failed with `'…' is
+    /// ambiguous — matches 2 accounts`, because the command it built carried a
+    /// name and nothing to narrow it by. Account names are unique now, so the
+    /// name is the address and these are back to being ordinary facts about the
+    /// row. `nil` from a server built before these keys existed.
     public let orgUuid: String?
     public let orgName: String?
 
@@ -1165,10 +1162,11 @@ public struct Account: Decodable, Equatable, Identifiable, Sendable {
         self.gate = gate
     }
 
-    /// This row's identity, ORG-QUALIFIED — `name` alone is not unique.
+    /// This row's identity — its name, which `tcr` guarantees is unique.
     ///
-    /// This was a live defect, not a theoretical one. Two rows sharing an email
-    /// in different orgs collapsed to one SwiftUI identity in
+    /// The guarantee is the point. This was a live defect, not a theoretical
+    /// one: two rows sharing an email in different orgs collapsed to one
+    /// SwiftUI identity in
     /// `ForEach(…, id: \.element.id)`, so the panel painted the FIRST row's
     /// numbers on both and neither wore its own pill — while `tcr status
     /// --json` reported them correctly and differently. Every by-name

--- a/apps/macos/Sources/TcrBarCore/GroupControl.swift
+++ b/apps/macos/Sources/TcrBarCore/GroupControl.swift
@@ -59,27 +59,17 @@ public enum GroupRouting {
 ///     can apply a change to the file only and warn that a running proxy was
 ///     too old for the control route.
 public enum GroupCommand {
-    /// `tcr group add <group> <account> [--org <uuid>]`. `group` and `account`
-    /// are positional and verbatim.
-    ///
-    /// `org` narrows a name two accounts share, the same way every other
-    /// per-account verb takes it. On this fleet it is what makes the command
-    /// work at all: the same email is logged into two orgs, and `tcr` refuses an
-    /// ambiguous name rather than guessing which row to label. Omitted entirely
-    /// when `nil`, so a single-org row builds the argument vector it always did.
-    public static func addArguments(group: String, account: String, org: String? = nil)
-        -> [String]
-    {
-        guard let org, !org.isEmpty else { return ["group", "add", group, account] }
-        return ["group", "add", group, account, "--org", org]
+    /// `tcr group add <group> <account>`. `group` and `account` are positional
+    /// and verbatim. The account name is unique, so it labels that row or
+    /// nothing — this is the command that used to label the wrong row and report
+    /// success, back when one email named two of them.
+    public static func addArguments(group: String, account: String) -> [String] {
+        ["group", "add", group, account]
     }
 
-    /// `tcr group rm <group> <account> [--org <uuid>]`.
-    public static func removeArguments(group: String, account: String, org: String? = nil)
-        -> [String]
-    {
-        guard let org, !org.isEmpty else { return ["group", "rm", group, account] }
-        return ["group", "rm", group, account, "--org", org]
+    /// `tcr group rm <group> <account>`.
+    public static func removeArguments(group: String, account: String) -> [String] {
+        ["group", "rm", group, account]
     }
 
     /// `tcr group rm <group> --all` — removes the whole group.
@@ -348,32 +338,30 @@ public final class GroupController: ObservableObject {
         }
     }
 
-    /// The failure key for one member's add/remove: the group and the ROW's
-    /// org-qualified identity, so two same-email rows in different orgs cannot
-    /// share an in-flight spinner or an error line — the same reason every other
-    /// per-account dictionary keys on ``AccountRef/id``.
+    /// The failure key for one member's add/remove: the group and the ROW's own
+    /// identity, so two rows cannot share an in-flight spinner or an error line
+    /// — the same reason every other per-account dictionary keys on
+    /// ``AccountRef/id``.
     /// `nonisolated` because it is a pure string join with no state to touch —
     /// callers need it to build a key without hopping to the main actor.
     public nonisolated static func memberKey(group: String, account: AccountRef) -> String {
         "\(group)/\(account.id)"
     }
 
-    /// `tcr group add <group> <account> [--org <uuid>]`.
+    /// `tcr group add <group> <account>`.
     @discardableResult
     public func add(account: AccountRef, to group: String) async -> Attempt {
         await run(
             key: Self.memberKey(group: group, account: account), group: group,
-            arguments: GroupCommand.addArguments(
-                group: group, account: account.name, org: account.orgUuid))
+            arguments: GroupCommand.addArguments(group: group, account: account.name))
     }
 
-    /// `tcr group rm <group> <account> [--org <uuid>]`.
+    /// `tcr group rm <group> <account>`.
     @discardableResult
     public func remove(account: AccountRef, from group: String) async -> Attempt {
         await run(
             key: Self.memberKey(group: group, account: account), group: group,
-            arguments: GroupCommand.removeArguments(
-                group: group, account: account.name, org: account.orgUuid))
+            arguments: GroupCommand.removeArguments(group: group, account: account.name))
     }
 
     /// `tcr group rm <group> --all`.

--- a/apps/macos/Sources/TcrBarCore/LoginLauncher.swift
+++ b/apps/macos/Sources/TcrBarCore/LoginLauncher.swift
@@ -71,17 +71,14 @@ public enum LoginLauncher {
     /// into an `echo`: an account name is attacker-adjacent input in
     /// principle, and unquoted interpolation into a `.command` file is
     /// injection.
-    /// `org` narrows an ambiguous `--account`, exactly as it does for every
-    /// other account verb. It is not optional polish on this fleet: `tcr
-    /// login --account` resolves through the same `resolve_account` that
-    /// refuses rather than guessing (`src/oauth.rs`,
-    /// `assert_requested_identity`), so a re-login on either of two rows
-    /// sharing an email failed outright. Quoted the same POSIX way as the
-    /// path and the name, for the same reason.
+    /// The name is the whole address `tcr login --account` needs: it resolves
+    /// through the same `resolve_account` every other verb uses, which refuses
+    /// rather than guessing (`src/oauth.rs`, `assert_requested_identity`). That
+    /// refusal used to be reachable — a re-login on either of two rows sharing
+    /// an email failed outright — and unique names removed the tie itself.
     public static func script(
         forExecutableAt path: String,
-        reloggingIn name: String? = nil,
-        org: String? = nil
+        reloggingIn name: String? = nil
     ) -> String {
         // Single-quote the path and escape any embedded single quote the POSIX
         // way ('\'') so the shell receives exactly one argument whatever the path
@@ -105,14 +102,7 @@ public enum LoginLauncher {
 
                 """
             let quotedName = "'" + name.replacingOccurrences(of: "'", with: "'\\''") + "'"
-            let orgArgument: String
-            if let org, !org.isEmpty {
-                let quotedOrg = "'" + org.replacingOccurrences(of: "'", with: "'\\''") + "'"
-                orgArgument = " --org \(quotedOrg)"
-            } else {
-                orgArgument = ""
-            }
-            accountArgument = " --account \(quotedName)\(orgArgument)"
+            accountArgument = " --account \(quotedName)"
         } else {
             hint = ""
             accountArgument = ""
@@ -147,7 +137,6 @@ public enum LoginLauncher {
     @discardableResult
     public static func launch(
         reloggingIn name: String? = nil,
-        org: String? = nil,
         uuid: () -> UUID = UUID.init,
         resolve: () -> Result<URL, TcrTool.NotFound> = { TcrTool.resolve() },
         open: (URL) -> Void = { NSWorkspace.shared.open($0) }
@@ -158,7 +147,7 @@ public enum LoginLauncher {
         case .failure(let missing): return .failure(.toolMissing(searched: missing.searched))
         }
 
-        let script = script(forExecutableAt: executable.path, reloggingIn: name, org: org)
+        let script = script(forExecutableAt: executable.path, reloggingIn: name)
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("tcr-login-\(uuid().uuidString).command")
 

--- a/apps/macos/Sources/TcrBarCore/RemoveAccountControl.swift
+++ b/apps/macos/Sources/TcrBarCore/RemoveAccountControl.swift
@@ -1,8 +1,8 @@
 import Combine
 import Foundation
 
-/// Deleting a single account from the config — `tcr remove <query> [--org
-/// <org>]` (`src/cli.rs`'s `remove_account`, dispatched from `src/main.rs`'s
+/// Deleting a single account from the config — `tcr remove <query>`
+/// (`src/cli.rs`'s `remove_account`, dispatched from `src/main.rs`'s
 /// `run_remove`). Same shape as ``AccountCommand``/``GroupCommand``, and for
 /// the same reasons:
 ///
@@ -25,12 +25,10 @@ import Foundation
 ///  4. **Exit 0 with anything on stderr is not a clean success.** Same
 ///     three-arm ``Outcome`` as ``AccountCommand``/``GroupCommand``.
 public enum RemoveAccountCommand {
-    /// `tcr remove <query>`, or `tcr remove <query> --org <org>` to narrow an
-    /// ambiguous match. `query` is passed positionally and verbatim — no
+    /// `tcr remove <query>`. `query` is passed positionally and verbatim — no
     /// shell involved, so nothing here needs to escape it.
-    public static func arguments(query: String, org: String? = nil) -> [String] {
-        guard let org else { return ["remove", query] }
-        return ["remove", query, "--org", org]
+    public static func arguments(query: String) -> [String] {
+        ["remove", query]
     }
 
     /// Why a delete did not happen. `tcr`'s own words, unparaphrased.
@@ -68,7 +66,7 @@ public enum RemoveAccountCommand {
     }
 
     /// Blocking invocation — always called off the main actor.
-    nonisolated static func perform(query: String, org: String? = nil) -> Outcome {
+    nonisolated static func perform(query: String) -> Outcome {
         switch TcrTool.resolve() {
         case .failure(let notFound):
             return .failed(
@@ -79,7 +77,7 @@ public enum RemoveAccountCommand {
         case .success(let executable):
             do {
                 let output = try TcrTool.run(
-                    executable: executable, arguments: arguments(query: query, org: org))
+                    executable: executable, arguments: arguments(query: query))
                 return classify(exitCode: output.exitCode, stderr: output.stderr)
             } catch {
                 return .failed(Failure(exitCode: -1, message: error.localizedDescription))
@@ -123,10 +121,10 @@ public final class RemoveAccountController: ObservableObject {
         case accepted(notice: String?)
     }
 
-    /// `tcr remove <name> [--org <uuid>]`. The org comes from the row itself
-    /// (``AccountRef/orgUuid``) rather than being left `nil`: on this fleet a
-    /// bare name matches two accounts and `tcr` refuses rather than guessing,
-    /// so a delete of either row failed as ambiguous.
+    /// `tcr remove <name>`. The name is the whole address: it is unique across
+    /// the config, so it names this row or nothing. It used to name two rows on
+    /// this fleet, and `tcr` refused rather than guessing — so a delete of
+    /// either one failed as ambiguous.
     @discardableResult
     public func remove(account: AccountRef) async -> Attempt {
         let key = account.id
@@ -136,7 +134,7 @@ public final class RemoveAccountController: ObservableObject {
         defer { pending.remove(key) }
 
         let outcome = await Task.detached(priority: .userInitiated) {
-            RemoveAccountCommand.perform(query: account.name, org: account.orgUuid)
+            RemoveAccountCommand.perform(query: account.name)
         }.value
 
         switch outcome {

--- a/apps/macos/Sources/TcrBarCore/TokenCommand.swift
+++ b/apps/macos/Sources/TcrBarCore/TokenCommand.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Reading one account's access token for the row's "Copy Access Token"
-/// action — `tcr token <query> [--org <org>]` (`src/cli.rs`'s
+/// action — `tcr token <query>` (`src/cli.rs`'s
 /// `print_access_token`). A subprocess, like every other credential touch in
 /// this app: `~/.config/teamclaude.json` holds live OAuth tokens and this app
 /// never opens it directly.
@@ -12,9 +12,8 @@ import Foundation
 /// account, not the credential.
 public enum TokenCommand {
     /// `query` is passed positionally and verbatim — no shell involved.
-    public static func arguments(query: String, org: String? = nil) -> [String] {
-        guard let org else { return ["token", query] }
-        return ["token", query, "--org", org]
+    public static func arguments(query: String) -> [String] {
+        ["token", query]
     }
 
     /// Why no token was produced. `tcr`'s own words, unparaphrased.
@@ -51,7 +50,7 @@ public enum TokenCommand {
     }
 
     /// Blocking invocation — always called off the main actor.
-    nonisolated static func perform(query: String, org: String? = nil) -> Result<String, Failure> {
+    nonisolated static func perform(query: String) -> Result<String, Failure> {
         switch TcrTool.resolve() {
         case .failure(let notFound):
             return .failure(
@@ -62,7 +61,7 @@ public enum TokenCommand {
         case .success(let executable):
             do {
                 let output = try TcrTool.run(
-                    executable: executable, arguments: arguments(query: query, org: org))
+                    executable: executable, arguments: arguments(query: query))
                 return classify(exitCode: output.exitCode, stdout: output.stdout, stderr: output.stderr)
             } catch {
                 return .failure(Failure(exitCode: -1, message: error.localizedDescription))
@@ -71,9 +70,9 @@ public enum TokenCommand {
     }
 
     /// Run `tcr token` off the main actor and hand back the token, or why not.
-    public static func fetch(query: String, org: String? = nil) async -> Result<String, Failure> {
+    public static func fetch(query: String) async -> Result<String, Failure> {
         await Task.detached(priority: .userInitiated) {
-            perform(query: query, org: org)
+            perform(query: query)
         }.value
     }
 }

--- a/apps/macos/Tests/TcrBarTests/AccountIdentityTests.swift
+++ b/apps/macos/Tests/TcrBarTests/AccountIdentityTests.swift
@@ -39,6 +39,48 @@ final class AccountIdentityTests: XCTestCase {
         )
     }
 
+    /// The row draws a name on two lines — the email, then the `/org` half as
+    /// its own tag — so that neither has to be truncated. The split must lose
+    /// nothing: reading the two halves left to right has to reproduce the name
+    /// byte-for-byte, because that string is what the operator types back.
+    ///
+    /// The third case is the one worth having: a name with a SECOND separator
+    /// keeps the whole remainder in the tag. Splitting on every `/` would drop
+    /// `/y` on the floor and quietly display a name that addresses nothing.
+    func testDisplayHalvesSplitAtTheFirstSeparatorAndLoseNothing() {
+        let bare = AccountRef(name: "alice@example.com").displayHalves
+        XCTAssertEqual(bare.email, "alice@example.com")
+        XCTAssertNil(bare.orgTag, "a bare email has no tag — that row renders as it always has")
+
+        let qualified = AccountRef(name: "alice@example.com/acme").displayHalves
+        XCTAssertEqual(qualified.email, "alice@example.com")
+        XCTAssertEqual(
+            qualified.orgTag, "/acme",
+            "the tag carries the separator, so the two halves concatenate back to the name"
+        )
+
+        let pathological = AccountRef(name: "alice@example.com/x/y").displayHalves
+        XCTAssertEqual(pathological.email, "alice@example.com")
+        XCTAssertEqual(
+            pathological.orgTag, "/x/y",
+            "a second separator stays INSIDE the tag — splitting on it would drop /y"
+        )
+
+        // The property behind all three, stated once: nothing is lost.
+        for name in [
+            "alice@example.com",
+            "alice@example.com/acme",
+            "alice@example.com/x/y",
+            "alice@example.com/",
+        ] {
+            let halves = AccountRef(name: name).displayHalves
+            XCTAssertEqual(
+                halves.email + (halves.orgTag ?? ""), name,
+                "the two halves must reassemble into exactly the name"
+            )
+        }
+    }
+
     /// A row's identity is its name, with nothing appended: the `id` a
     /// dictionary is keyed by and the string handed to `tcr` are the same bytes,
     /// so a key can never be built that `tcr` would not accept.

--- a/apps/macos/Tests/TcrBarTests/AccountIdentityTests.swift
+++ b/apps/macos/Tests/TcrBarTests/AccountIdentityTests.swift
@@ -2,10 +2,14 @@ import XCTest
 
 @testable import TcrBarCore
 
-/// The fleet holds one email twice — a personal Max org and a company Team org.
-/// Everything here guards the consequences of that, which were all real:
-/// two rows collapsing into one in the panel, and every per-account command
-/// refusing as ambiguous.
+/// One person holding two orgs — a personal Max org and a company Team org.
+/// Everything here guards the consequences of that, which were all real: two
+/// rows collapsing into one in the panel, and every per-account command refusing
+/// as ambiguous.
+///
+/// The fixture carries the names `tcr` gives that fleet: the personal row keeps
+/// the bare email, the Team row is `email/<org-slug>`. That IS the fix — the
+/// panel's job is now to key on those names and not undo it.
 final class AccountIdentityTests: XCTestCase {
 
     private let personal = "11111111-1111-1111-1111-111111111111"
@@ -17,30 +21,32 @@ final class AccountIdentityTests: XCTestCase {
     /// row, so the panel drew the first row's numbers on both and neither wore
     /// its own gate pill, while `tcr status --json` reported them correctly and
     /// differently.
-    func testTwoRowsSharingAnEmailInDifferentOrgsHaveDistinctIds() throws {
+    func testTheTwoRowsOfOnePersonsTwoOrgsHaveDistinctIds() throws {
         let fleet = try Fleet.decode(Data(duplicateEmailJSON.utf8))
         XCTAssertEqual(fleet.accounts.count, 2)
 
         let ids = Set(fleet.accounts.map(\.id))
         XCTAssertEqual(
             ids.count, 2,
-            "two rows sharing a name must be two identities — one id means the panel "
-                + "renders one row's numbers twice"
+            "two rows must be two identities — one id means the panel renders one "
+                + "row's numbers twice"
         )
         XCTAssertEqual(
-            Set(fleet.accounts.map(\.name)).count, 1,
-            "the control: the two rows really do share a name, so this test is not "
-                + "passing because the fixture made them different"
+            fleet.accounts.map(\.name),
+            ["henry@example.com", "henry@example.com/example-team"],
+            "the control: the ids differ because the NAMES differ, which is what "
+                + "tcr guarantees — not because this app added something to them"
         )
     }
 
-    /// A server that reports no org — an older build — must render exactly as it
-    /// does today, and with no org there genuinely is no more identity to have.
-    func testIdFallsBackToTheBareNameWithoutAnOrg() {
+    /// A row's identity is its name, with nothing appended: the `id` a
+    /// dictionary is keyed by and the string handed to `tcr` are the same bytes,
+    /// so a key can never be built that `tcr` would not accept.
+    func testIdIsExactlyTheName() {
         XCTAssertEqual(AccountRef(name: "alice@example.com").id, "alice@example.com")
         XCTAssertEqual(
-            AccountRef(name: "alice@example.com", orgUuid: "").id, "alice@example.com",
-            "an empty string is not an org — it must not produce a trailing separator"
+            AccountRef(name: "alice@example.com/acme").id, "alice@example.com/acme",
+            "a qualified name is passed through untouched — no separator of our own"
         )
     }
 
@@ -141,103 +147,103 @@ final class AccountIdentityTests: XCTestCase {
 
     // MARK: - the commands each row issues
 
-    /// Every per-account verb passes `--org` when the row has one. Without it
-    /// `tcr` refuses: `'…' is ambiguous — matches 2 accounts … Narrow with
-    /// --org`, which is what "Copy Access Token" failed with on this fleet.
-    func testEveryPerAccountCommandCarriesTheOrgWhenThereIsOne() {
+    /// Every per-account verb carries the row's NAME and nothing else. The
+    /// qualified name is what addresses the Team row, and it must reach `tcr`
+    /// byte-for-byte — a panel that stripped the `/example-team` half would
+    /// silently act on the personal row instead.
+    func testEveryPerAccountCommandCarriesTheRowsFullName() {
+        let teamRow = "henry@example.com/example-team"
         XCTAssertEqual(
-            TokenCommand.arguments(query: "henry@example.com", org: personal),
-            ["token", "henry@example.com", "--org", personal]
+            TokenCommand.arguments(query: teamRow),
+            ["token", teamRow]
         )
         XCTAssertEqual(
-            RemoveAccountCommand.arguments(query: "henry@example.com", org: personal),
-            ["remove", "henry@example.com", "--org", personal]
+            RemoveAccountCommand.arguments(query: teamRow),
+            ["remove", teamRow]
         )
         XCTAssertEqual(
-            AccountCommand.arguments(enabled: false, name: "henry@example.com", org: personal),
-            ["disable", "henry@example.com", "--org", personal]
+            AccountCommand.arguments(enabled: false, name: teamRow),
+            ["disable", teamRow]
         )
         XCTAssertEqual(
-            AccountCommand.arguments(enabled: true, name: "henry@example.com", org: personal),
-            ["enable", "henry@example.com", "--org", personal]
+            AccountCommand.arguments(enabled: true, name: teamRow),
+            ["enable", teamRow]
+        )
+        XCTAssertEqual(
+            ControlAccountCommand.setArguments(name: teamRow),
+            ["control", teamRow]
         )
         XCTAssertTrue(
             LoginLauncher.script(
                 forExecutableAt: "/usr/local/bin/tcr",
-                reloggingIn: "henry@example.com",
-                org: personal
-            ).contains("--account 'henry@example.com' --org '\(personal)'"),
-            "a re-login resolves through the same refuse-on-ambiguity path"
+                reloggingIn: teamRow
+            ).contains("--account '\(teamRow)'"),
+            "a re-login names the same row every other verb does"
         )
     }
 
-    /// The group verbs are the ones Gil hit: `tcr group add` took no `--org` at
-    /// all, so the panel could not name which of two same-email rows to label,
-    /// and the CLI refused.
-    func testGroupCommandsCarryTheOrgWhenThereIsOne() {
+    /// No verb may build an `--org` flag any more: `tcr` does not take one, so
+    /// one here would abort the command outright. This is the panel's half of
+    /// the same gate the Rust side keeps.
+    func testNoCommandBuildsAnOrgFlag() {
+        let built: [[String]] = [
+            TokenCommand.arguments(query: "henry@example.com"),
+            RemoveAccountCommand.arguments(query: "henry@example.com"),
+            AccountCommand.arguments(enabled: true, name: "henry@example.com"),
+            AccountCommand.arguments(enabled: false, name: "henry@example.com"),
+            ControlAccountCommand.setArguments(name: "henry@example.com"),
+            ControlAccountCommand.setArguments(name: nil),
+            GroupCommand.addArguments(group: "gil", account: "henry@example.com"),
+            GroupCommand.removeArguments(group: "gil", account: "henry@example.com"),
+        ]
+        for arguments in built {
+            XCTAssertFalse(arguments.contains("--org"), "\(arguments) must not narrow by org")
+        }
+        let script = LoginLauncher.script(
+            forExecutableAt: "/usr/local/bin/tcr", reloggingIn: "henry@example.com")
+        XCTAssertFalse(script.contains("--org"), script)
+    }
+
+    /// The group verbs are the ones Gil hit: `tcr group add` labelled whichever
+    /// same-email row came first and reported success. The name it takes now
+    /// resolves to one row or to none.
+    func testGroupCommandsCarryTheRowsFullName() {
+        let teamRow = "henry@example.com/example-team"
         XCTAssertEqual(
-            GroupCommand.addArguments(group: "gil", account: "henry@example.com", org: team),
-            ["group", "add", "gil", "henry@example.com", "--org", team]
+            GroupCommand.addArguments(group: "gil", account: teamRow),
+            ["group", "add", "gil", teamRow]
         )
         XCTAssertEqual(
-            GroupCommand.removeArguments(group: "gil", account: "henry@example.com", org: team),
-            ["group", "rm", "gil", "henry@example.com", "--org", team]
+            GroupCommand.removeArguments(group: "gil", account: teamRow),
+            ["group", "rm", "gil", teamRow]
         )
         XCTAssertEqual(
             GroupCommand.addArguments(group: "gil", account: "solo@example.com"),
-            ["group", "add", "gil", "solo@example.com"],
-            "no org means the argument vector it always built"
-        )
-        XCTAssertEqual(
-            GroupCommand.removeArguments(group: "gil", account: "solo@example.com", org: ""),
-            ["group", "rm", "gil", "solo@example.com"],
-            "an empty org is not an org — never `--org ''`, which matches nothing"
+            ["group", "add", "gil", "solo@example.com"]
         )
     }
 
-    /// Two same-email rows must not share a group failure or an in-flight
-    /// spinner, for the same reason they must not share a toggle verdict.
-    func testGroupFailuresAreKeyedPerRowNotPerName() {
-        let personalRef = AccountRef(name: "henry@example.com", orgUuid: personal)
-        let teamRef = AccountRef(name: "henry@example.com", orgUuid: team)
+    /// The two rows must not share a group failure or an in-flight spinner, for
+    /// the same reason they must not share a toggle verdict.
+    func testGroupFailuresAreKeyedPerRow() {
+        let personalRef = AccountRef(name: "henry@example.com")
+        let teamRef = AccountRef(name: "henry@example.com/example-team")
         XCTAssertNotEqual(
             GroupController.memberKey(group: "gil", account: personalRef),
             GroupController.memberKey(group: "gil", account: teamRef)
         )
     }
 
-    /// And the negative: a row with no org builds precisely the command it built
-    /// before, with no empty flag appended. A stray `--org ''` would match
-    /// nothing and break every single-org fleet.
-    func testNoOrgMeansNoFlagAtAll() {
-        XCTAssertEqual(
-            TokenCommand.arguments(query: "solo@example.com"),
-            ["token", "solo@example.com"]
-        )
-        XCTAssertEqual(
-            RemoveAccountCommand.arguments(query: "solo@example.com"),
-            ["remove", "solo@example.com"]
-        )
-        XCTAssertEqual(
-            AccountCommand.arguments(enabled: true, name: "solo@example.com"),
-            ["enable", "solo@example.com"]
-        )
-        let script = LoginLauncher.script(
-            forExecutableAt: "/usr/local/bin/tcr", reloggingIn: "solo@example.com")
-        XCTAssertTrue(script.contains("--account 'solo@example.com'"))
-        XCTAssertFalse(script.contains("--org"), "no org means no flag, never an empty one")
-    }
-
-    /// An org value is quoted the same POSIX way the path and the name already
-    /// are — it goes onto a command line in a `.command` file, so unquoted
-    /// interpolation is injection.
-    func testTheOrgArgumentIsShellQuoted() {
+    /// A name is shell-quoted the same POSIX way the path already is — it goes
+    /// onto a command line in a `.command` file, so unquoted interpolation is
+    /// injection. An account name is attacker-adjacent input in principle, and
+    /// it now has a slash in it as a matter of course.
+    func testTheAccountArgumentIsShellQuoted() {
         let script = LoginLauncher.script(
             forExecutableAt: "/usr/local/bin/tcr",
-            reloggingIn: "solo@example.com",
-            org: "it's; rm -rf /"
+            reloggingIn: "it's; rm -rf /"
         )
-        XCTAssertTrue(script.contains("--org 'it'\\''s; rm -rf /'"))
+        XCTAssertTrue(script.contains("--account 'it'\\''s; rm -rf /'"), script)
     }
 
     // MARK: - fixtures
@@ -254,7 +260,7 @@ final class AccountIdentityTests: XCTestCase {
           "cacheReadTokens":1,"cacheHitRatio":0.5,"probeStatus":"ok","probeError":null,
           "lastStreamError":null,"streamErrorCount":0,"source":"live",
           "serverSha":"abc1234","serverDirty":false},
-         {"name":"henry@example.com","priority":1,"status":"active","disabled":false,
+         {"name":"henry@example.com/example-team","priority":1,"status":"active","disabled":false,
           "plan":"Team Standard","organizationType":"claude_team",
           "rateLimitTier":"default_raven","seatTier":"team_standard",
           "orgUuid":"\(team)","orgName":"Example Team",

--- a/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
@@ -1353,12 +1353,12 @@ final class AccountCommandTests: XCTestCase {
     }
 
     func testTheNameIsNeverTruncatedOrFlagged() {
-        // `query` resolves by exact name, then exact email (`src/identity.rs`,
-        // `match_accounts`) — an abbreviated name matches nothing at all. Pass it
-        // whole; the row already knows the exact value.
+        // `query` resolves by exact name (`src/identity.rs`, `match_accounts`) —
+        // an abbreviated name matches nothing at all. Pass it whole; the row
+        // already knows the exact value.
         let name = "alice+tag@example.com"
         let arguments = AccountCommand.arguments(enabled: false, name: name)
-        XCTAssertEqual(arguments.count, 2, "no flags, no --org, nothing else")
+        XCTAssertEqual(arguments.count, 2, "the verb and the name, nothing else")
         XCTAssertEqual(arguments[1], name)
         XCTAssertFalse(arguments.contains { $0.hasPrefix("--") })
     }

--- a/apps/macos/Tests/TcrBarTests/RemoveAccountControlTests.swift
+++ b/apps/macos/Tests/TcrBarTests/RemoveAccountControlTests.swift
@@ -13,8 +13,8 @@ final class RemoveAccountCommandTests: XCTestCase {
 
     private let alice = "alice@example.com"
 
-    // MARK: - argument shape (bridge: normal name, a name needing shell
-    // quoting, and the `--org` form)
+    // MARK: - argument shape (a normal name, a name needing shell quoting, and
+    // an org-qualified name)
 
     /// A normal query, passed positionally and verbatim.
     func testArgumentsWithAnOrdinaryName() {
@@ -33,11 +33,12 @@ final class RemoveAccountCommandTests: XCTestCase {
         )
     }
 
-    /// `--org` narrows an ambiguous match, mirroring the CLI's own flag.
-    func testArgumentsWithOrgAppendsTheFlag() {
+    /// A qualified name — the shape `tcr` gives the second of one person's two
+    /// orgs — is one argument, passed through whole.
+    func testArgumentsPassAQualifiedNameWhole() {
         XCTAssertEqual(
-            RemoveAccountCommand.arguments(query: alice, org: "acme"),
-            ["remove", alice, "--org", "acme"]
+            RemoveAccountCommand.arguments(query: "\(alice)/acme"),
+            ["remove", "\(alice)/acme"]
         )
     }
 

--- a/apps/macos/Tests/TcrBarTests/ToggleVerdictTests.swift
+++ b/apps/macos/Tests/TcrBarTests/ToggleVerdictTests.swift
@@ -421,17 +421,16 @@ final class ToggleVerdictTests: XCTestCase {
 /// is why `disabled` is the only field compared.
 ///
 /// Takes the ``AccountRef`` rather than a bare name so a fixture row and the
-/// verdict looking it up carry the SAME identity — including its org, which is
-/// what the lookup now matches on.
+/// verdict looking it up carry the SAME identity.
 private func account(_ ref: AccountRef, disabled: Bool) -> Account {
-    account(name: ref.name, orgUuid: ref.orgUuid, disabled: disabled)
+    account(name: ref.name, disabled: disabled)
 }
 
 private func account(_ name: String, disabled: Bool) -> Account {
-    account(name: name, orgUuid: nil, disabled: disabled)
+    account(name: name, disabled: disabled)
 }
 
-private func account(name: String, orgUuid: String?, disabled: Bool) -> Account {
+private func account(name: String, disabled: Bool) -> Account {
     Account(
         name: name,
         priority: 1,
@@ -454,7 +453,6 @@ private func account(name: String, orgUuid: String?, disabled: Bool) -> Account 
         streamErrorCount: 0,
         source: .live,
         serverSha: "abc1234",
-        serverDirty: false,
-        orgUuid: orgUuid
+        serverDirty: false
     )
 }

--- a/apps/macos/Tests/TcrBarTests/TokenCommandTests.swift
+++ b/apps/macos/Tests/TcrBarTests/TokenCommandTests.swift
@@ -14,8 +14,9 @@ final class TokenCommandTests: XCTestCase {
     func testArgumentsPassQueryPositionally() {
         XCTAssertEqual(TokenCommand.arguments(query: "alice@example.com"), ["token", "alice@example.com"])
         XCTAssertEqual(
-            TokenCommand.arguments(query: "alice@example.com", org: "acme"),
-            ["token", "alice@example.com", "--org", "acme"])
+            TokenCommand.arguments(query: "alice@example.com/acme"),
+            ["token", "alice@example.com/acme"],
+            "a qualified name is one argument, passed through whole")
     }
 
     func testExitZeroWithTokenIsSuccessTrimmed() {

--- a/crates/tcr-status-wire/src/lib.rs
+++ b/crates/tcr-status-wire/src/lib.rs
@@ -231,15 +231,14 @@ pub struct AccountStatusRow {
     /// telling two rows with the SAME NAME apart.
     #[serde(default)]
     pub plan: Option<String>,
-    /// The org this account is scoped to. On the wire so a CLIENT can address
-    /// this row unambiguously: every `tcr` account verb takes `--org
-    /// <name-or-uuid-prefix>`, and a client holding only `name` cannot narrow a
-    /// duplicated email — the panel's "Copy Access Token" failed with "matches 2
-    /// accounts" for exactly this reason.
+    /// The org this account is scoped to. A FACT about the row, for a client to
+    /// show — not an address: `name` is unique and is the whole address every
+    /// `tcr` verb takes.
     ///
-    /// `orgUuid` is what a client should pass: it is exact, whereas `orgName` is
-    /// a display string that two orgs can share. `orgName` rides along because a
-    /// row that has one and no uuid can still narrow by it.
+    /// It used to be how a client narrowed a duplicated email, back when two
+    /// rows could share a name and the panel's "Copy Access Token" failed with
+    /// "matches 2 accounts". Naming the org is still worth doing on a row whose
+    /// name does not already carry it.
     #[serde(default)]
     pub org_uuid: Option<String>,
     #[serde(default)]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -128,18 +128,27 @@ Runs the browser OAuth flow and adds the resulting account to the pool.
 | `--config <path>` | path | `~/.config/teamclaude.json` | config to write into |
 | `--force` | bool | `false` | override a refusal and write the config file anyway — never overrides a confirmed live route or a rejected api-key |
 | `--account <name>` | string | none | re-login a specific existing account, and refuse to write anything unless the identity that comes back resolves to it |
-| `--org <name-or-uuid>` | string | none | narrow an ambiguous `--account` match to a single org — same flag `tcr enable`/`tcr disable`/`tcr remove`/`tcr priority` take |
 | `--token` | bool | `false` | add an account from a `claude setup-token` credential instead of the browser flow — see below |
-| `--name <name>` | string | none | name the account added by `--token`, when its profile fetch comes back with no email |
+| `--name <name>` | string | none | name this account explicitly instead of letting `login` mint a name for it; refused when another account already has that name |
 
-**`--account <name> [--org <org>]` targets one existing account and refuses to fix the
+**A login names the account itself, and never asks on the happy path.** The name is the
+profile's email when no other account carries it, and `email/<org-slug>` when one does —
+so signing into a second organization of the same person lands beside the first row
+instead of on top of it. `<org-slug>` is the organization's name lower-cased with every
+run of non-alphanumerics collapsed to `-` (`Henry Token` → `henry-token`), falling back
+to the first eight characters of the org uuid when the organization reports no name.
+`--name` overrides all of that, and is refused if the name is already in use: taking a
+name off an existing row is how a login overwrites the wrong credential.
+
+**`--account <name>` targets one existing account and refuses to fix the
 wrong one.** Without it, `login` upserts by whatever identity the browser hands back — a
 default-browser OAuth flow carries whatever claude.ai session is already signed in, so
 re-logging in a dead account can silently refresh a *different*, already-healthy one and
-report success while the broken account stays broken. `--account`/`--org` resolve
+report success while the broken account stays broken. `--account` resolves
 `<name>` against the config with the same rule `tcr enable`/`tcr disable` use
-(case-sensitive, no substrings; `--org` narrows an otherwise-ambiguous email match by org
-name or org uuid). It also passes the resolved account's email as OAuth's `login_hint`,
+(exact, case-sensitive, no substrings). A re-login keeps the row's existing name rather
+than minting a new one — that name is what its pins, group labels and `controlAccount`
+key already point at. It also passes the resolved account's email as OAuth's `login_hint`,
 which pre-selects that address on a clean login page — this part is ergonomics only, not
 a guarantee: it is unverified whether the hint overrides a browser that is *already*
 signed in as someone else, which is exactly the case the default-browser flow produces.
@@ -261,8 +270,8 @@ fallback is derived from the account *count*, which hands out a name already in 
 soon as a row is removed; that is harmless for a credential carrying an identity to be
 resolved by, and is exactly the bug here, which is why this path does not share it.
 
-**`--token` refuses outright when combined with `--account` or `--org`, and writes
-nothing.** Both flags exist to confirm that the identity a fresh login authenticates as
+**`--token` refuses outright when combined with `--account`, and writes
+nothing.** That flag exists to confirm that the identity a fresh login authenticates as
 matches a specific existing row — see `--account`'s own section above. An
 inference-only token carries no email and no account id for that confirmation to run
 against, so the check can never be evaluated, and an assertion that cannot be evaluated
@@ -302,29 +311,57 @@ zeroes.
 These five take a positional `<query>` naming one account, and they all resolve it the same
 way.
 
-The rule is: **exact `name`, and if nothing matched, exact email**, where "email" means the
-name with a trailing ` (Org)` suffix stripped. Both comparisons are `==` on the raw string.
-That means resolution is **case-sensitive and never a substring**. Given an account named
-`alice@example.com (Acme)`:
+The rule is: **the account's exact `name`**, compared with `==` on the raw string. That
+means resolution is **case-sensitive and never a substring**. A name is unique across the
+config (see "Account names are unique" below), so an exact name is a complete answer and
+there is nothing to narrow it by. Given an account named `alice@example.com/acme`:
 
 ```
-tcr disable "alice@example.com (Acme)"   # matches: exact name
-tcr disable alice@example.com            # matches: exact email, org suffix stripped
+tcr disable alice@example.com/acme       # matches: exact name
+tcr disable alice@example.com            # NO MATCH unless a row is named exactly that
+tcr disable acme                         # NO MATCH: the suffix is not a name
 tcr disable alice                        # NO MATCH: not a substring
 tcr disable alice@                       # NO MATCH: not a prefix
-tcr disable ALICE@EXAMPLE.COM            # NO MATCH: case-sensitive
+tcr disable ALICE@EXAMPLE.COM/ACME       # NO MATCH: case-sensitive
 ```
 
 A query matching nothing is an error and the config is left byte-identical: resolution runs
-before any mutation, so there is no partial write. A query matching two or more accounts is
-also an error, and it lists the candidates and tells you to narrow with `--org`.
+before any mutation, so there is no partial write.
 
-`--org <name-or-uuid>` filters the candidates to one organization. It matches an org name
-exactly, or an org uuid exactly or by prefix.
+### Account names are unique
+
+`tcr` will not let two accounts share a name, so a name is the whole address every account
+verb takes. There used to be an `--org` flag on each of these verbs; it is gone, because a
+flag that no longer narrows anything is a lie in `--help`.
+
+It existed because the name was the email, and one person's two organizations — a personal
+Max org and a company Team seat — produced two rows carrying the same one. Every by-name
+path was a latent bug: `tcr token` refused as ambiguous, `tcr group add` labelled whichever
+row came first and reported success, and the menu-bar panel drew one row's numbers on both.
+
+**A config holding duplicates migrates itself, once.** On the next load, one row per
+duplicated name keeps the bare email — the row on a personal plan (`claude_max` /
+`claude_pro`), else the lowest priority number — and every other row becomes
+`email/<org-slug>` from its stored `orgName`, falling back to the first eight characters of
+its `orgUuid`. It prints one line per rename:
+
+```
+[tcr] renamed account: henry@example.com -> henry@example.com/henry-token (org Henry Token)
+```
+
+The loader never refuses a duplicated config — that would take a fleet down on upgrade —
+and it writes the result straight back, so the rename happens once rather than on every
+boot. `controlAccount` follows if it named a renamed row, group labels ride along
+untouched (they are per-entry), and the session-affinity pin file is rewritten in the same
+pass so warm sessions keep their prompt cache. If the write itself fails, the server still
+boots and says so, and a CLI verb that would edit the config refuses rather than writing
+under names that exist nowhere else.
+
+A config edited by hand back into a duplicate is simply migrated again on the next load.
 
 ### `tcr remove <query>`
 
-Deletes the account from the config. Flags: `--config`, `--org`.
+Deletes the account from the config. Flags: `--config`.
 
 This is destructive and there is no confirmation prompt. The entry is removed and the file
 is rewritten in place; the access and refresh tokens go with it, so recovering the account
@@ -334,8 +371,7 @@ so removing an account is not a way to stop traffic going to it. Use `tcr disabl
 
 ### `tcr priority <query> [N]`
 
-Sets rotation priority. **Lower value is preferred.** Flags: `--first`, `--last`, `--config`,
-`--org`.
+Sets rotation priority. **Lower value is preferred.** Flags: `--first`, `--last`, `--config`.
 
 | form | effect |
 |---|---|
@@ -353,8 +389,7 @@ not reach a running proxy.
 
 ### `tcr enable <query>` and `tcr disable <query>`
 
-`disable` holds an account out of rotation; `enable` clears the flag. Flags: `--config`,
-`--org`.
+`disable` holds an account out of rotation; `enable` clears the flag. Flags: `--config`.
 
 **These act on the running proxy first, not on the file.** A file-only write was the
 original bug: the proxy reads `disabled` from the config once, at startup, and never again,
@@ -382,7 +417,7 @@ loopback-plus-key gate as every other `/_tcr/` route, with no loopback exemption
 ### `tcr token <query>`
 
 Prints the account's current access token to stdout — one line, nothing else — so it can
-be piped or copied. Flags: `--config`, `--org`. Read-only; a non-matching query exits
+be piped or copied. Flags: `--config`. Read-only; a non-matching query exits
 non-zero with the file untouched. It reads the file rather than the running proxy, which is
 current enough: every refresh the proxy performs is written straight back to the file.
 
@@ -424,9 +459,10 @@ the wire so a Fable-scoped caption and tint have something to read.
 
 ### The plan and org keys on `--json`
 
-Every row carries which plan the account is on, and which org it belongs to. Together these answer
-the question a fleet holding the same email twice cannot otherwise answer — *which* of these two
-rows is this? — and give a script something to pass to `--org`.
+Every row carries which plan the account is on, and which org it belongs to — facts to SHOW
+beside a row, not a way to address it. The `name` is the address, and it is unique. These
+answer the question a reader looking at two rows of one person's two organizations still
+has: *which* of these is the company seat?
 
 | key | shape | what it is |
 |---|---|---|
@@ -434,8 +470,8 @@ rows is this? — and give a script something to pass to `--org`.
 | `organizationType` | string or `null` | the provider's own word, verbatim: `claude_max`, `claude_team`, `claude_pro`, `claude_enterprise` |
 | `rateLimitTier` | string or `null` | verbatim, e.g. `default_claude_max_20x` — the rate-limit multiplier, when it names one |
 | `seatTier` | string or `null` | verbatim, e.g. `team_standard` / `team_tier_1` — which seat this row holds. `null` on Max and Pro, which have no seats |
-| `orgUuid` | string or `null` | the org this account is scoped to. Pass it to `--org` to address this row unambiguously when two rows share a name |
-| `orgName` | string or `null` | the org's display name. Two orgs can share one, so prefer `orgUuid` when narrowing |
+| `orgUuid` | string or `null` | the org this account is scoped to |
+| `orgName` | string or `null` | the org's display name. Two orgs can share one, which is why `orgUuid` is the exact fact and this is the readable one |
 
 `plan` is DERIVED from the three raw keys, in one place, so the JSON, the plain text (`plan=`), the
 TUI and the macOS panel cannot disagree. The plan word comes from `organizationType`; the suffix

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,11 +144,11 @@ gate above; it is not a credential anything downstream of the proxy needs.
 
 | json key | type | default | required | what it does |
 |---|---|---|---|---|
-| `name` | string | n/a | **yes** | display name; `tcr login` writes the account email here |
+| `name` | string | n/a | **yes** | the account's name, and the only way any command addresses it. **Unique across the file** — `tcr` renames duplicates on load; see `docs/cli.md` § "Account names are unique". `tcr login` writes the account email here, or `email/<org-slug>` when another row already carries that email |
 | `type` | string | `"oauth"` | no | `"oauth"` accounts are refreshed, probed and kept warm; anything else is a static-key account |
 | `accountUuid` | string | absent | no | spliced into the outbound body's `metadata.user_id.account_uuid` so it agrees with the injected token |
 | `orgUuid` | string | absent | no | organization identity, used to match an in-memory account back to its on-disk entry |
-| `orgName` | string | absent | no | organization display name; also what `--org` matches against |
+| `orgName` | string | absent | no | organization display name; also what a duplicated `name` is renamed from (`Henry Token` → `henry-token`) |
 | `accessToken` | string | n/a | **yes** | the OAuth access token |
 | `refreshToken` | string | absent | no | used to mint a new access token before expiry — absent means the account cannot refresh itself, see below |
 | `expiresAt` | i64 | absent | no | access-token expiry as **epoch milliseconds** |

--- a/scripts/check-no-org-flag.sh
+++ b/scripts/check-no-org-flag.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# check-no-org-flag.sh — refuse any code that builds or declares an `--org`
+# flag on a `tcr` account verb.
+#
+# `--org` existed to pick one of two rows sharing a name, back when
+# `Account.name` was an email and one email could name two accounts. Names are
+# unique now (`src/config.rs`, `migrate_duplicate_names`), so the flag narrows
+# nothing — and a flag in `--help` that narrows nothing is a lie the next reader
+# has to disprove. It came back once already, one verb at a time, which is why
+# this is a gate and not a note.
+#
+# It looks for the two ways the flag can exist, and nothing else:
+#
+#   1. The literal `"--org"` in an argument vector the panel hands to `tcr`.
+#   2. A clap `org` argument on a CLI verb — the `#[arg(long)] org:` pair in
+#      `src/main.rs`, which is what would put it back in `--help`.
+#
+# Test files are exempt from (1) BY NAME, because the panel's own gate
+# (`AccountIdentityTests.testNoCommandBuildsAnOrgFlag`) has to write the literal
+# down in order to assert nothing builds it. The exemption is a fixed list, not
+# a pattern: a new test file does not silently inherit it.
+#
+# Usage: scripts/check-no-org-flag.sh [root]   (default: the repo root)
+
+set -euo pipefail
+
+root="${1:-$(git rev-parse --show-toplevel)}"
+
+# The one file allowed to write the literal: it is the assertion that nothing
+# builds it.
+exempt="apps/macos/Tests/TcrBarTests/AccountIdentityTests.swift"
+
+status=0
+
+# (1) The flag as a built argument.
+literals=$(
+    grep -rn -- '"--org"' "$root/src" "$root/apps" "$root/crates" 2>/dev/null |
+        grep -v "/$exempt:" || true
+)
+if [ -n "$literals" ]; then
+    echo "error: an --org flag is built here, and tcr no longer takes one:" >&2
+    echo "$literals" >&2
+    status=1
+fi
+
+# (2) The flag as a clap argument. Matches the `#[arg(long)]` line and the `org:`
+# field on the line after it, which is the shape every account verb used.
+declarations=$(
+    grep -rn -A1 -- '#\[arg(long' "$root/src" 2>/dev/null |
+        grep -E '^\S+[-:][0-9]+[-:]\s*org: Option<String>,' || true
+)
+if [ -n "$declarations" ]; then
+    echo "error: an --org clap argument is declared here, and would show in --help:" >&2
+    echo "$declarations" >&2
+    status=1
+fi
+
+if [ "$status" -eq 0 ]; then
+    echo "check-no-org-flag: clean (no --org flag is built or declared)"
+fi
+exit "$status"

--- a/src/affinity.rs
+++ b/src/affinity.rs
@@ -216,6 +216,51 @@ pub fn save(path: &Path, pins: &[StoredPin], now_ms: i64) -> Result<usize, Confi
     Ok(count)
 }
 
+/// Carry the pin file's [`StoredPin::name`]s across an account rename, so warm
+/// sessions survive `config::load`'s duplicate-name migration.
+///
+/// Returns how many pins were rewritten. A pin whose name matches no rename is
+/// left exactly as it was, and a file that cannot be read or parsed is left
+/// alone entirely — it is a cache, so the worst case is the cold prompt prefix
+/// those sessions would have paid anyway. That is also why the whole thing is
+/// infallible: a rename is not worth failing a boot over.
+///
+/// Only pins with no `account_uuid` actually NEED this — [`load`] resolves the
+/// rest through [`identity::resolve`], which compares uuid and org and never
+/// looks at the name. Rewriting all of them keeps the file honest about what it
+/// points at, which is what the next person to read it will assume.
+pub fn rename_pins(path: &Path, renames: &[(String, String)]) -> usize {
+    if renames.is_empty() {
+        return 0;
+    }
+    let Ok(data) = std::fs::read_to_string(path) else {
+        return 0;
+    };
+    let Ok(mut file) = serde_json::from_str::<PinFile>(&data) else {
+        return 0;
+    };
+    if file.version != FORMAT_VERSION {
+        return 0;
+    }
+    let mut rewritten = 0;
+    for pin in &mut file.pins {
+        if let Some((_, to)) = renames.iter().find(|(from, _)| *from == pin.name) {
+            pin.name.clone_from(to);
+            rewritten += 1;
+        }
+    }
+    if rewritten > 0 {
+        if let Err(err) = crate::config::write_atomic(
+            path,
+            &serde_json::to_string_pretty(&file).unwrap_or_default(),
+        ) {
+            tracing::warn!(error = %err, "could not carry session-affinity pins across the account rename");
+            return 0;
+        }
+    }
+    rewritten
+}
+
 /// Read `path` and resolve each pin against `accounts`, dropping anything stale
 /// or not resolvable to exactly one account.
 ///

--- a/src/affinity.rs
+++ b/src/affinity.rs
@@ -693,4 +693,85 @@ mod tests {
             "the oldest pin is the one dropped"
         );
     }
+
+    // ---- carrying pins across the account rename ---------------------------
+
+    /// A pin on a renamed account keeps pointing at it, and one on an untouched
+    /// account is not disturbed. Without this, every session pinned to a renamed
+    /// row resolves to nothing on the next boot and pays a full cold prefix —
+    /// the most expensive event in this system.
+    #[test]
+    fn rename_pins_rewrites_only_the_renamed_names() {
+        let path = tmp("rename");
+        save(
+            &path,
+            &[
+                pin(1, "henry@example.com", None, None, 100),
+                pin(2, "alice@example.com", None, None, 100),
+                pin(3, "henry@example.com", None, None, 200),
+            ],
+            0,
+        )
+        .expect("write pins");
+
+        let renamed = rename_pins(
+            &path,
+            &[(
+                "henry@example.com".to_string(),
+                "henry@example.com/token".to_string(),
+            )],
+        );
+        assert_eq!(renamed, 2, "both pins on that account follow it");
+
+        // The rewritten pins resolve against the RENAMED fleet — the property
+        // that actually matters, rather than the file's bytes.
+        let accounts = [
+            acct("henry@example.com/token", None, None),
+            acct("alice@example.com", None, None),
+        ];
+        let report = load(&path, &accounts, 200, i64::MAX);
+        assert_eq!(report.pins.len(), 3);
+        assert_eq!(report.pins.get(&1).map(|(idx, _)| *idx), Some(0));
+        assert_eq!(report.pins.get(&3).map(|(idx, _)| *idx), Some(0));
+        assert_eq!(
+            report.pins.get(&2).map(|(idx, _)| *idx),
+            Some(1),
+            "the untouched account's pin is untouched"
+        );
+        assert_eq!(report.unresolved, 0);
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// Nothing to do is not a failure, and neither is a missing file: this runs
+    /// at boot on a cache, so every unhappy path must return quietly rather than
+    /// hold up a server start.
+    #[test]
+    fn rename_pins_is_quiet_on_nothing_to_do() {
+        let path = tmp("rename-quiet");
+        assert_eq!(rename_pins(&path, &[]), 0, "no renames, no read");
+
+        let missing = path.with_file_name("does-not-exist.json");
+        assert_eq!(
+            rename_pins(&missing, &[("a".to_string(), "b".to_string())]),
+            0,
+            "no pin file yet — the ordinary first-boot case"
+        );
+
+        std::fs::write(&path, "{ not json").expect("write junk");
+        assert_eq!(
+            rename_pins(&path, &[("a".to_string(), "b".to_string())]),
+            0,
+            "a corrupt cache is dropped, never a boot failure"
+        );
+
+        save(&path, &[pin(1, "solo@example.com", None, None, 100)], 0).expect("write pins");
+        assert_eq!(
+            rename_pins(&path, &[("a".to_string(), "b".to_string())]),
+            0,
+            "a rename matching no pin rewrites nothing"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -116,9 +116,24 @@ fn warn_if_server_running(config: &Config) {
 /// here, before any edit happens, keeps that erasure from ever becoming
 /// reachable; the operator fixes or removes the entry by hand, then the CLI
 /// works on it same as always.
+///
+/// Refuses on [`Config::rename_write_error`] for the analogous reason. `load`
+/// renames duplicated account names in memory and persists the result; when only
+/// the memory half happened, the names this process is about to edit exist
+/// nowhere else, and the next process re-derives its own. An edit verb writing
+/// under those names would attach the change to a row no one else can find.
+/// The server has no such choice — it must boot — so it logs and continues.
 fn load_for_edit(config_path: &Path) -> anyhow::Result<Config> {
     let config = config::load(config_path)
         .with_context(|| format!("load config at {}", config_path.display()))?;
+    if let Some(why) = &config.rename_write_error {
+        bail!(
+            "config at {} holds accounts sharing a name, and the rename that would fix it could \
+             not be written back ({why}) — so nothing was changed. Fix the file's permissions, or \
+             give each row its own name by hand, and retry.",
+            config_path.display()
+        );
+    }
     if !config.quarantined_accounts.is_empty() {
         bail!(
             "config at {} has {} account(s) with no usable credential, so the CLI cannot safely \
@@ -142,26 +157,22 @@ fn save_after_edit(config_path: &Path, config: &Config) -> anyhow::Result<()> {
 
 /// Resolve a user-supplied account `query` to exactly one index in `accounts`.
 ///
-/// Delegates to [`identity::match_accounts`]: an exact `name` match wins;
-/// otherwise the email portion is matched, and `--org` (exact org name, or org
-/// uuid exact/prefix) narrows — **even when the name matched**, so a duplicate
-/// email across two orgs is disambiguated by `--org` (finding #8) rather than
-/// silently resolving to the first entry. Zero or more-than-one surviving
-/// candidate is an error — the ambiguous error lists the candidate names so the
-/// caller can disambiguate. (`Account.name` IS the email.)
+/// Delegates to [`identity::match_accounts`]: an EXACT match on the account's
+/// name, and nothing else. Names are unique across a config by construction
+/// (`config::load` renames duplicates; a login mints a free name), so an exact
+/// name is a complete answer and there is nothing left to narrow. What a
+/// duplicated name used to need — matching the email portion, then narrowing by
+/// org — is gone with the duplicates.
+///
+/// A query matching more than one row therefore means the file was hand-edited
+/// behind the loader's back. That is still an error, never a first-match guess.
 pub fn resolve_account<T: identity::Queryable>(
     accounts: &[T],
     query: &str,
-    org: Option<&str>,
 ) -> anyhow::Result<usize> {
-    match identity::match_one(accounts, query, org) {
+    match identity::match_one(accounts, query) {
         identity::Match::One(only) => Ok(only),
-        identity::Match::None => {
-            let org_note = org
-                .map(|o| format!(" (with org matching '{o}')"))
-                .unwrap_or_default();
-            bail!("no account matches '{query}'{org_note}");
-        }
+        identity::Match::None => bail!("no account matches '{query}'"),
         identity::Match::Ambiguous(names) => {
             bail!("{}", ambiguous_query_message(query, &names));
         }
@@ -173,13 +184,14 @@ pub fn resolve_account<T: identity::Queryable>(
 /// same actionable sentence — and the same candidate list — whichever answered.
 pub fn ambiguous_query_message(query: &str, names: &[String]) -> String {
     format!(
-        "'{query}' is ambiguous — matches {} accounts: {}. Narrow with --org or use an exact name.",
+        "'{query}' is ambiguous — {} accounts share that name: {}. Account names are unique by \
+         construction, so this config was edited by hand; fix the duplicate and retry.",
         names.len(),
         names.join(", ")
     )
 }
 
-/// Load → resolve `(query, org)` to one account → hand it to `mutate` → save.
+/// Load → resolve `query` to one account → hand it to `mutate` → save.
 ///
 /// Centralizes the load→resolve→save chain (incl. the nonexistent-account error
 /// path) shared by every mutating verb. Resolution happens BEFORE `mutate`, so a
@@ -190,11 +202,10 @@ pub fn ambiguous_query_message(query: &str, names: &[String]) -> String {
 fn edit_account<T>(
     config_path: &Path,
     query: &str,
-    org: Option<&str>,
     mutate: impl FnOnce(&mut Config, usize) -> T,
 ) -> anyhow::Result<T> {
     let mut config = load_for_edit(config_path)?;
-    let idx = resolve_account(&config.accounts, query, org)?;
+    let idx = resolve_account(&config.accounts, query)?;
     let out = mutate(&mut config, idx);
     save_after_edit(config_path, &config)?;
     Ok(out)
@@ -215,15 +226,11 @@ fn edit_account<T>(
 /// reasons as `set_enabled` — see its doc-comment — sharpened: a removal
 /// applied on top of a live disagreement cannot be undone by re-adding, since
 /// the account's credentials are gone from the file being edited.
-pub async fn remove_account(
-    config_path: &Path,
-    query: &str,
-    org: Option<&str>,
-) -> anyhow::Result<()> {
+pub async fn remove_account(config_path: &Path, query: &str) -> anyhow::Result<()> {
     if let Ok(config) = config::load(config_path) {
-        match post_set_disabled(&config, query, org, true).await {
+        match post_set_disabled(&config, query, true).await {
             Ok(_) => {
-                let removed = edit_account(config_path, query, org, |config, idx| {
+                let removed = edit_account(config_path, query, |config, idx| {
                     config.accounts.remove(idx).name
                 })?;
                 println!("Removed account '{removed}'.");
@@ -256,7 +263,7 @@ pub async fn remove_account(
             // we can do; say loudly that the proxy keeps using the account
             // until it restarts.
             Err(LiveControlError::NoRoute) => {
-                let removed = edit_account(config_path, query, org, |config, idx| {
+                let removed = edit_account(config_path, query, |config, idx| {
                     config.accounts.remove(idx).name
                 })?;
                 eprintln!(
@@ -269,7 +276,7 @@ pub async fn remove_account(
             }
             // It answered something we cannot use, or did not answer at all.
             Err(other) => {
-                let removed = edit_account(config_path, query, org, |config, idx| {
+                let removed = edit_account(config_path, query, |config, idx| {
                     config.accounts.remove(idx).name
                 })?;
                 eprintln!(
@@ -283,7 +290,7 @@ pub async fn remove_account(
         }
     }
 
-    let removed = edit_account(config_path, query, org, |config, idx| {
+    let removed = edit_account(config_path, query, |config, idx| {
         config.accounts.remove(idx).name
     })?;
     println!("Removed account '{removed}'.");
@@ -296,13 +303,8 @@ pub async fn remove_account(
 /// `max(0, existing priorities) + 1`; an explicit `N` is written verbatim. The
 /// `0` seed guarantees a relative move always crosses the default tier even when
 /// every existing priority sits on the same side of it.
-pub fn set_priority(
-    config_path: &Path,
-    query: &str,
-    priority: PriorityArg,
-    org: Option<&str>,
-) -> anyhow::Result<()> {
-    let (name, value) = edit_account(config_path, query, org, |config, idx| {
+pub fn set_priority(config_path: &Path, query: &str, priority: PriorityArg) -> anyhow::Result<()> {
+    let (name, value) = edit_account(config_path, query, |config, idx| {
         let value = match priority {
             PriorityArg::N(n) => n,
             PriorityArg::First => {
@@ -343,14 +345,10 @@ pub fn set_priority(
 /// (`Manager::persist_tokens`); the window where the two differ is the
 /// write itself. Read-only: a non-matching query errors with the file
 /// untouched, and nothing is logged — the token goes to stdout only.
-pub fn print_access_token(
-    config_path: &Path,
-    query: &str,
-    org: Option<&str>,
-) -> anyhow::Result<()> {
+pub fn print_access_token(config_path: &Path, query: &str) -> anyhow::Result<()> {
     let config = config::load(config_path)
         .with_context(|| format!("load config at {}", config_path.display()))?;
-    let idx = resolve_account(&config.accounts, query, org)?;
+    let idx = resolve_account(&config.accounts, query)?;
     println!("{}", config.accounts[idx].access_token);
     Ok(())
 }
@@ -371,34 +369,21 @@ const GROUP_LIVE_RELOAD_NOTE: &str =
     "note: the running proxy picks this up automatically (next request or status check) — no restart needed";
 
 /// Resolve `name` to exactly one configured account by EXACT match on
-/// `Account.name` (which IS the email — see [`resolve_account`]'s doc-comment).
+/// `Account.name`.
 ///
 /// [`resolve_account`]'s rule, with the group verbs' own not-found message.
-///
-/// The resolution is [`identity::match_one`] — identical to `tcr enable`/
-/// `disable`/`token`/`remove`/`priority` — so `--org` narrows a name two
-/// accounts share and an unbreakable tie is REFUSED. This replaced an exact
-/// `position()` scan that took the first match and reported success, which on
-/// the fleet's duplicated email labelled a row nobody asked for.
 ///
 /// The one thing it does not borrow from `resolve_account` is the not-found
 /// text. The panel shells out blind, so an unknown name has to come back with
 /// the full roster to act on rather than a bare "no account matches".
-fn find_account_by_name(
-    accounts: &[Account],
-    name: &str,
-    org: Option<&str>,
-) -> anyhow::Result<usize> {
-    match identity::match_one(accounts, name, org) {
+fn find_account_by_name(accounts: &[Account], name: &str) -> anyhow::Result<usize> {
+    match identity::match_one(accounts, name) {
         identity::Match::One(idx) => Ok(idx),
         identity::Match::Ambiguous(names) => bail!("{}", ambiguous_query_message(name, &names)),
         identity::Match::None => {
             let configured: Vec<&str> = accounts.iter().map(|a| a.name.as_str()).collect();
-            let org_note = org
-                .map(|o| format!(" (with org matching '{o}')"))
-                .unwrap_or_default();
             bail!(
-                "no account named '{name}'{org_note} in the config. Configured accounts: {}",
+                "no account named '{name}' in the config. Configured accounts: {}",
                 configured.join(", ")
             );
         }
@@ -422,19 +407,14 @@ fn control_account_group_notice(config: &Config, account: &str, group: &str) -> 
     ))
 }
 
-/// `tcr group add <group> <account> [--org <name-or-uuid>]` — label `account`
-/// with `group`.
+/// `tcr group add <group> <account>` — label `account` with `group`.
 ///
 /// Resolves through [`find_account_by_name`], which applies exactly the rule
-/// `tcr enable`/`disable`/`token`/`remove`/`priority` use — not a bare name
-/// lookup. Two
-/// changes come with that, and the second is the one that matters: `--org` can
-/// now narrow a name two accounts share, and an ambiguous name is REFUSED
-/// rather than silently resolved to whichever row happens to come first. The
-/// old `find_account_by_name` was an exact-name `position()` scan, so on the
-/// fleet's duplicated email it labelled the first row and reported success,
-/// which is worse than the failure it looks like: the panel's group menu had no
-/// way to say which row it meant, and no way to tell it had hit the wrong one.
+/// `tcr enable`/`disable`/`token`/`remove`/`priority` use, and refuses an
+/// ambiguous name rather than resolving it to whichever row comes first. That
+/// refusal used to be reachable: on a fleet holding one email twice, this
+/// labelled the first row and reported success, and the panel's group menu had
+/// no way to say which row it meant. Unique names removed the ambiguity itself.
 ///
 /// Idempotent: adding a label an account already carries succeeds and says so,
 /// so the panel can call it without first checking state. The group label
@@ -442,12 +422,7 @@ fn control_account_group_notice(config: &Config, account: &str, group: &str) -> 
 /// validator `tcr run --group` uses — because `add` is the one path that can
 /// put a fresh, attacker- or typo-controlled string into the config; `rm` must
 /// NOT run this check (see [`remove_from_group`]'s doc-comment).
-pub fn add_to_group(
-    config_path: &Path,
-    group: &str,
-    account: &str,
-    org: Option<&str>,
-) -> anyhow::Result<()> {
+pub fn add_to_group(config_path: &Path, group: &str, account: &str) -> anyhow::Result<()> {
     if let Err(reason) = validate_group_label_chars(group) {
         bail!("group {group:?}: invalid group label — {reason}");
     }
@@ -464,7 +439,7 @@ pub fn add_to_group(
     // a false-but-constant warning turn into wallpaper.
     let config = config::load(config_path)
         .with_context(|| format!("load config at {}", config_path.display()))?;
-    let idx = find_account_by_name(&config.accounts, account, org)?;
+    let idx = find_account_by_name(&config.accounts, account)?;
     let target = &config.accounts[idx];
     // The label itself is real and the write below is correct — but on the
     // CONTROL account it buys nothing, because `Manager::select_with_group`
@@ -506,14 +481,11 @@ pub fn add_to_group(
     Ok(())
 }
 
-/// `tcr group rm <group> <account> [--org <name-or-uuid>]` / `tcr group rm
-/// <group> --all` — remove `account`'s (or every member's, with `--all`)
-/// `group` label.
+/// `tcr group rm <group> <account>` / `tcr group rm <group> --all` — remove
+/// `account`'s (or every member's, with `--all`) `group` label.
 ///
 /// The single-account path resolves through [`find_account_by_name`], same as
-/// [`add_to_group`] and for the same reasons. `--all` deliberately does not
-/// take an org: it walks every member of the group by identity already, so
-/// there is no name to disambiguate.
+/// [`add_to_group`] and for the same reasons.
 ///
 /// `account == None` iff `all` — clap's `ArgGroup` on `GroupRmArgs` refuses
 /// "both" and "neither" at parse time before this ever runs, so the `expect`
@@ -527,7 +499,6 @@ pub fn remove_from_group(
     config_path: &Path,
     group: &str,
     account: Option<&str>,
-    org: Option<&str>,
     all: bool,
 ) -> anyhow::Result<()> {
     // Same reasoning as `add_to_group`: no `load_for_edit` warning here either
@@ -579,7 +550,7 @@ pub fn remove_from_group(
     // clap's ArgGroup on `GroupRmArgs` guarantees exactly one of
     // `account`/`--all` — see this function's doc-comment.
     let account = account.expect("clap guarantees `account` is Some when `all` is false");
-    let idx = find_account_by_name(&config.accounts, account, org)?;
+    let idx = find_account_by_name(&config.accounts, account)?;
     let target = &config.accounts[idx];
     let outcome = config::save_group_membership(config_path, target, group, false)
         .with_context(|| format!("save config at {}", config_path.display()))?;
@@ -995,17 +966,12 @@ fn render_groups_json(config: &Config) -> anyhow::Result<String> {
 /// `skip_serializing_if = Option::is_none` DROPS the key entirely — matching the
 /// JS `delete account.disabled`, not a `false` literal. `Manager::set_disabled`'s
 /// persist does the same, so both paths leave the same document.
-pub async fn set_enabled(
-    config_path: &Path,
-    query: &str,
-    org: Option<&str>,
-    disabled: bool,
-) -> anyhow::Result<()> {
+pub async fn set_enabled(config_path: &Path, query: &str, disabled: bool) -> anyhow::Result<()> {
     // A config we cannot read has no port and no api-key to reach a server with;
     // fall through to the file path, which reports the load failure as it always
     // has. Never a silent skip of the live attempt for any other reason.
     if let Ok(config) = config::load(config_path) {
-        match post_set_disabled(&config, query, org, disabled).await {
+        match post_set_disabled(&config, query, disabled).await {
             Ok(applied) => {
                 println!(
                     "{} account '{}'.",
@@ -1034,7 +1000,7 @@ pub async fn set_enabled(
             // we can do, and it is HALF a disable — say so loudly. This arm is the
             // one that used to be the whole function, silently.
             Err(LiveControlError::NoRoute) => {
-                let name = write_disabled_flag(config_path, query, org, disabled)?;
+                let name = write_disabled_flag(config_path, query, disabled)?;
                 eprintln!(
                     "[tcr] WARNING: the proxy running on :{} is too old to accept live account control (no {} route), so only the config file was changed. It will KEEP {} '{name}' until it restarts. Run `tcr restart` when a cold prompt cache is acceptable.",
                     config.proxy.port,
@@ -1057,7 +1023,7 @@ pub async fn set_enabled(
             // shape of consequence as the arm above, different cause, and equally
             // never silent.
             Err(other) => {
-                let name = write_disabled_flag(config_path, query, org, disabled)?;
+                let name = write_disabled_flag(config_path, query, disabled)?;
                 eprintln!(
                     "[tcr] WARNING: could not apply this to the proxy running on :{} ({}), so only the config file was changed. It may KEEP {} '{name}' until it restarts.",
                     config.proxy.port,
@@ -1069,7 +1035,7 @@ pub async fn set_enabled(
         }
     }
 
-    let name = write_disabled_flag(config_path, query, org, disabled)?;
+    let name = write_disabled_flag(config_path, query, disabled)?;
     println!(
         "{} account '{name}'.",
         if disabled { "Disabled" } else { "Enabled" }
@@ -1080,13 +1046,8 @@ pub async fn set_enabled(
 /// The file half of enable/disable: resolve, set the flag, save, return the
 /// resolved name. Exactly what `set_enabled` did before it learned to ask the
 /// server.
-fn write_disabled_flag(
-    config_path: &Path,
-    query: &str,
-    org: Option<&str>,
-    disabled: bool,
-) -> anyhow::Result<String> {
-    edit_account(config_path, query, org, |config, idx| {
+fn write_disabled_flag(config_path: &Path, query: &str, disabled: bool) -> anyhow::Result<String> {
+    edit_account(config_path, query, |config, idx| {
         config.accounts[idx].disabled = if disabled { Some(true) } else { None };
         config.accounts[idx].name.clone()
     })
@@ -1145,7 +1106,6 @@ impl LiveControlError {
 async fn post_set_disabled(
     config: &Config,
     query: &str,
-    org: Option<&str>,
     disabled: bool,
 ) -> Result<crate::proxy::SetDisabledResponse, LiveControlError> {
     let client = reqwest::Client::builder()
@@ -1162,7 +1122,6 @@ async fn post_set_disabled(
     );
     let mut request = client.post(&url).json(&serde_json::json!({
         "query": query,
-        "org": org,
         "disabled": disabled,
     }));
     if let Some(key) = config.proxy.api_key.as_deref() {
@@ -1323,7 +1282,6 @@ pub(crate) async fn post_add_account(
 async fn post_set_control(
     config: &Config,
     query: Option<&str>,
-    org: Option<&str>,
 ) -> Result<crate::proxy::SetControlResponse, LiveControlError> {
     let client = reqwest::Client::builder()
         .no_proxy()
@@ -1337,10 +1295,9 @@ async fn post_set_control(
         config.proxy.port,
         crate::proxy::CONTROL_PATH
     );
-    let mut request = client.post(&url).json(&serde_json::json!({
-        "query": query,
-        "org": org,
-    }));
+    let mut request = client
+        .post(&url)
+        .json(&serde_json::json!({ "query": query }));
     if let Some(key) = config.proxy.api_key.as_deref() {
         request = request.header("x-api-key", key);
     }
@@ -1397,19 +1354,19 @@ async fn post_set_control(
 fn write_control_account(
     config_path: &Path,
     query: Option<&str>,
-    org: Option<&str>,
 ) -> anyhow::Result<Option<String>> {
     let config = load_for_edit(config_path)?;
     let target = match query {
         None => None,
-        Some(q) => Some(config.accounts[resolve_account(&config.accounts, q, org)?].clone()),
+        Some(q) => Some(config.accounts[resolve_account(&config.accounts, q)?].clone()),
     };
     let name = target.as_ref().map(|a| a.name.clone());
     let outcome = config::save_control_account(config_path, target.as_ref())
         .with_context(|| format!("save config at {}", config_path.display()))?;
     if let config::ControlWrite::Ambiguous = outcome {
         bail!(
-            "more than one config entry shares this account's identity — give each its own orgUuid, then retry"
+            "more than one config entry shares this account's identity — nothing was changed. \
+             Give each its own accountUuid/orgUuid and retry."
         );
     }
     Ok(name)
@@ -1419,17 +1376,13 @@ fn write_control_account(
 /// first** — same posture as [`set_enabled`], and for the same reason: a
 /// file-only write would leave the running process still resolving identity
 /// traffic to its OLD control account (or none) until it restarts.
-pub async fn set_control(
-    config_path: &Path,
-    query: Option<&str>,
-    org: Option<&str>,
-) -> anyhow::Result<()> {
+pub async fn set_control(config_path: &Path, query: Option<&str>) -> anyhow::Result<()> {
     // A config we cannot read has no port and no api-key to reach a server
     // with; fall through to the file path, which reports the load failure as
     // it always has. Never a silent skip of the live attempt for any other
     // reason.
     if let Ok(config) = config::load(config_path) {
-        match post_set_control(&config, query, org).await {
+        match post_set_control(&config, query).await {
             Ok(applied) => {
                 match &applied.name {
                     Some(name) => println!("Set control account to '{name}'."),
@@ -1458,7 +1411,7 @@ pub async fn set_control(
             // is all we can do, and it is HALF a control-account change — say
             // so loudly.
             Err(LiveControlError::NoRoute) => {
-                write_control_account(config_path, query, org)?;
+                write_control_account(config_path, query)?;
                 eprintln!(
                     "[tcr] WARNING: the proxy running on :{} is too old to accept live account control (no {} route), so only the config file was changed. It will KEEP its OLD control account until it restarts. Run `tcr restart` when a cold prompt cache is acceptable.",
                     config.proxy.port,
@@ -1478,7 +1431,7 @@ pub async fn set_control(
             }
             // It answered something we cannot use, or did not answer at all.
             Err(other) => {
-                write_control_account(config_path, query, org)?;
+                write_control_account(config_path, query)?;
                 eprintln!(
                     "[tcr] WARNING: could not apply this to the proxy running on :{} ({}), so only the config file was changed. It may KEEP its OLD control account until it restarts.",
                     config.proxy.port,
@@ -1489,7 +1442,7 @@ pub async fn set_control(
         }
     }
 
-    let name = write_control_account(config_path, query, org)?;
+    let name = write_control_account(config_path, query)?;
     match name {
         Some(name) => println!("Set control account to '{name}'."),
         None => println!("Cleared the control account."),
@@ -2236,10 +2189,9 @@ fn render_accounts_json(
                     a.rate_limit_tier.as_deref(),
                     a.seat_tier.as_deref(),
                 ),
-                // The org, so a client can address this row unambiguously —
-                // `--org` is what every account verb narrows a duplicated email
-                // with, and without this on the wire a client holding only the
-                // name has nothing to pass. Real on both paths, like `groups`.
+                // The org, so a client can SHOW which one this row belongs to.
+                // It is not how the row is addressed — the name is. Real on
+                // both paths, like `groups`.
                 org_uuid: a.org_uuid.clone(),
                 org_name: a.org_name.clone(),
             };
@@ -2735,9 +2687,7 @@ mod tests {
     #[tokio::test]
     async fn remove_deletes_named_account_leaving_siblings() {
         let path = config_on_a_dead_port("remove").await;
-        remove_account(&path, "alice@example.com", None)
-            .await
-            .unwrap();
+        remove_account(&path, "alice@example.com").await.unwrap();
         let config = load(&path);
         assert_eq!(config.accounts.len(), 1);
         assert_eq!(config.accounts[0].name, "bob@example.com");
@@ -2747,9 +2697,7 @@ mod tests {
     #[tokio::test]
     async fn remove_preserves_unmodelled_extra_fields() {
         let path = config_on_a_dead_port("remove-extra").await;
-        remove_account(&path, "alice@example.com", None)
-            .await
-            .unwrap();
+        remove_account(&path, "alice@example.com").await.unwrap();
         let raw = fs::read_to_string(&path).unwrap();
         let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
         // The #1 silent-loss risk: unmodelled top-level keys survive the edit.
@@ -2762,7 +2710,7 @@ mod tests {
     async fn remove_nonexistent_errors_and_leaves_file_byte_identical() {
         let path = config_on_a_dead_port("remove-miss").await;
         let before = fs::read_to_string(&path).unwrap();
-        let result = remove_account(&path, "nobody@example.com", None).await;
+        let result = remove_account(&path, "nobody@example.com").await;
         assert!(result.is_err());
         let after = fs::read_to_string(&path).unwrap();
         assert_eq!(before, after, "a failed resolve must not write the config");
@@ -2793,9 +2741,7 @@ mod tests {
         doc["proxy"]["port"] = serde_json::json!(port);
         fs::write(&path, serde_json::to_string_pretty(&doc).unwrap()).unwrap();
 
-        remove_account(&path, "alice@example.com", None)
-            .await
-            .unwrap();
+        remove_account(&path, "alice@example.com").await.unwrap();
 
         // 1. THE RUNNING ROTATION: parked immediately, not just at next boot.
         let live = manager.snapshot(OffsetDateTime::now_utc());
@@ -2835,7 +2781,7 @@ mod tests {
         fs::write(&path, serde_json::to_string_pretty(&doc).unwrap()).unwrap();
         let before = fs::read_to_string(&path).unwrap();
 
-        let err = remove_account(&path, "alice@example.com", None)
+        let err = remove_account(&path, "alice@example.com")
             .await
             .expect_err("a rejected api-key must refuse the removal");
         assert!(
@@ -2861,21 +2807,25 @@ mod tests {
         let raw = fs::read_to_string(&path).unwrap();
         let mut doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
         doc["proxy"]["port"] = serde_json::json!(port);
-        doc["accounts"][1]["name"] = serde_json::json!("alice@example.com");
         fs::write(&path, serde_json::to_string_pretty(&doc).unwrap()).unwrap();
-        let before = fs::read_to_string(&path).unwrap();
 
-        let config = load(&path);
+        // The ambiguity is in the LIVE rotation only: the file keeps unique
+        // names (the loader guarantees that), and the running fleet is broken by
+        // hand afterwards. That is the split this test is about — the CLI must
+        // not resolve against the file when the server refused.
+        let mut config = load(&path);
+        config.accounts[1].name = "alice@example.com".to_string();
+        let before = fs::read_to_string(&path).unwrap();
         let manager = Manager::with_live_refresher(config, Some(path.clone()));
         tokio::spawn(async move { crate::mitm::serve(listener, manager, None).await });
 
-        let err = remove_account(&path, "alice@example.com", None)
+        let err = remove_account(&path, "alice@example.com")
             .await
             .expect_err("an ambiguous query must not be applied");
         let text = err.to_string();
         assert!(
-            text.contains("ambiguous") && text.contains("--org"),
-            "the refusal names the candidates and the fix: {text}"
+            text.contains("ambiguous") && text.matches("alice@example.com").count() >= 2,
+            "the refusal names the candidates: {text}"
         );
         assert_eq!(
             before,
@@ -2890,7 +2840,7 @@ mod tests {
     #[test]
     fn set_priority_explicit_writes_int() {
         let path = write_config("prio-n", TWO_ACCOUNTS);
-        set_priority(&path, "bob@example.com", PriorityArg::N(7), None).unwrap();
+        set_priority(&path, "bob@example.com", PriorityArg::N(7)).unwrap();
         let config = load(&path);
         assert_eq!(config.accounts[1].priority, Some(7));
         fs::remove_file(&path).ok();
@@ -2900,7 +2850,7 @@ mod tests {
     fn set_priority_first_is_min0_minus_one() {
         // Existing priorities are 0 and 1 → min(0, {0,1}) - 1 = -1.
         let path = write_config("prio-first", TWO_ACCOUNTS);
-        set_priority(&path, "bob@example.com", PriorityArg::First, None).unwrap();
+        set_priority(&path, "bob@example.com", PriorityArg::First).unwrap();
         let config = load(&path);
         assert_eq!(config.accounts[1].priority, Some(-1));
         fs::remove_file(&path).ok();
@@ -2910,7 +2860,7 @@ mod tests {
     fn set_priority_last_is_max0_plus_one() {
         // Existing priorities are 0 and 1 → max(0, {0,1}) + 1 = 2.
         let path = write_config("prio-last", TWO_ACCOUNTS);
-        set_priority(&path, "alice@example.com", PriorityArg::Last, None).unwrap();
+        set_priority(&path, "alice@example.com", PriorityArg::Last).unwrap();
         let config = load(&path);
         assert_eq!(config.accounts[0].priority, Some(2));
         fs::remove_file(&path).ok();
@@ -2920,7 +2870,7 @@ mod tests {
     fn set_priority_nonexistent_errors_and_leaves_file_byte_identical() {
         let path = write_config("prio-miss", TWO_ACCOUNTS);
         let before = fs::read_to_string(&path).unwrap();
-        let result = set_priority(&path, "nobody@example.com", PriorityArg::N(3), None);
+        let result = set_priority(&path, "nobody@example.com", PriorityArg::N(3));
         assert!(result.is_err());
         let after = fs::read_to_string(&path).unwrap();
         assert_eq!(before, after);
@@ -2970,22 +2920,19 @@ mod tests {
       ]
     }"#;
 
-    /// `--org` picks the Team row out of two rows sharing an email — the whole
-    /// reason the flag exists. The assertion is on the OTHER row too: labelling
+    /// The bare email names ONE row after the loader's migration — the Personal
+    /// one, which keeps it — and the Team row is addressed by the name that was
+    /// minted for it. The assertion is on the OTHER row every time: labelling
     /// the right account is only half of it, and a resolver that labelled both
     /// would pass a check that only looked at the one it was asked for.
     #[test]
-    fn group_add_with_an_org_labels_that_org_and_only_that_org() {
-        let path = write_config("group-add-org", DUPLICATED_EMAIL);
-        add_to_group(
-            &path,
-            "codereview",
-            "henry@example.com",
-            Some("22222222-2222-2222-2222-222222222222"),
-        )
-        .unwrap();
+    fn group_add_labels_exactly_the_named_row_of_a_migrated_duplicate() {
+        let path = write_config("group-add-migrated", DUPLICATED_EMAIL);
+        add_to_group(&path, "codereview", "henry@example.com/example-team").unwrap();
 
         let config = load(&path);
+        assert_eq!(config.accounts[0].name, "henry@example.com");
+        assert_eq!(config.accounts[1].name, "henry@example.com/example-team");
         assert_eq!(
             config.accounts[0].groups, None,
             "the Personal row was not asked for and must not be labelled"
@@ -2993,47 +2940,95 @@ mod tests {
         assert_eq!(
             config.accounts[1].groups,
             Some(vec!["codereview".to_string()]),
-            "the Team row is the one --org named"
+            "the Team row is the one the name pointed at"
+        );
+
+        add_to_group(&path, "burst", "henry@example.com").unwrap();
+        let config = load(&path);
+        assert_eq!(
+            config.accounts[0].groups,
+            Some(vec!["burst".to_string()]),
+            "the bare email is the Personal row and nothing else"
+        );
+        assert_eq!(
+            config.accounts[1].groups,
+            Some(vec!["codereview".to_string()]),
+            "the Team row keeps only its own label"
         );
     }
 
-    /// And without `--org` it REFUSES rather than guessing. This is the
-    /// regression: the old exact-name scan silently took `accounts[0]`, so the
-    /// operator saw "Added ... to group" about the wrong account.
+    /// A duplicate put back by hand is MIGRATED AGAIN on the next load, not
+    /// refused and not guessed at. That is what makes uniqueness a property of
+    /// the system rather than of one upgrade: every verb goes through
+    /// `config::load`, so nothing downstream ever sees two rows of one name.
+    ///
+    /// The original regression this replaces: an exact-name scan silently took
+    /// `accounts[0]`, so the operator saw "Added ... to group" about the wrong
+    /// account. Here the label lands on the row the name resolves to, and the
+    /// re-minted name is on disk for the next reader.
     #[test]
-    fn group_add_refuses_a_duplicated_email_with_no_org() {
-        let path = write_config("group-add-ambiguous", DUPLICATED_EMAIL);
-        let err = add_to_group(&path, "codereview", "henry@example.com", None)
-            .expect_err("an unbreakable tie must refuse rather than pick the first row");
-        assert!(err.to_string().contains("ambiguous"), "{err}");
+    fn a_hand_edited_duplicate_is_migrated_again_on_the_next_load() {
+        let path = write_config("group-add-rebroken", DUPLICATED_EMAIL);
+        assert_eq!(
+            load(&path).accounts[1].name,
+            "henry@example.com/example-team"
+        );
+        rename_account_in_file(&path, 1, "henry@example.com");
+
+        add_to_group(&path, "codereview", "henry@example.com").unwrap();
 
         let config = load(&path);
-        assert_eq!(config.accounts[0].groups, None);
+        assert_eq!(config.accounts[0].name, "henry@example.com");
+        assert_eq!(
+            config.accounts[1].name, "henry@example.com/example-team",
+            "the re-broken row is renamed again"
+        );
+        assert_eq!(
+            config.accounts[0].groups,
+            Some(vec!["codereview".to_string()]),
+            "the label landed on the row the bare email names"
+        );
         assert_eq!(config.accounts[1].groups, None);
     }
 
     /// `rm` resolves the same way — the panel's "remove from group" is the same
     /// menu as "add to group" and must not be able to strip the wrong row.
     #[test]
-    fn group_rm_narrows_by_org_and_refuses_without_one() {
-        let path = write_config("group-rm-org", DUPLICATED_EMAIL);
-        let team = Some("22222222-2222-2222-2222-222222222222");
-        add_to_group(&path, "codereview", "henry@example.com", team).unwrap();
+    fn group_rm_strips_exactly_the_named_row_of_a_migrated_duplicate() {
+        let path = write_config("group-rm-migrated", DUPLICATED_EMAIL);
+        let team = "henry@example.com/example-team";
+        add_to_group(&path, "codereview", team).unwrap();
+        add_to_group(&path, "codereview", "henry@example.com").unwrap();
 
-        let err = remove_from_group(&path, "codereview", Some("henry@example.com"), None, false)
-            .expect_err("no org means an unbreakable tie");
-        assert!(err.to_string().contains("ambiguous"), "{err}");
-        assert_eq!(
-            load(&path).accounts[1].groups,
-            Some(vec!["codereview".to_string()]),
-            "a refused removal changes nothing"
-        );
-
-        remove_from_group(&path, "codereview", Some("henry@example.com"), team, false).unwrap();
+        remove_from_group(&path, "codereview", Some("henry@example.com"), false).unwrap();
+        let config = load(&path);
         // Removing the last label DROPS the `groups` key rather than leaving an
         // empty array — `save_group_membership`'s contract, same shape as
         // `disabled == false` removing its key.
+        assert_eq!(config.accounts[0].groups, None);
+        assert_eq!(
+            config.accounts[1].groups,
+            Some(vec!["codereview".to_string()]),
+            "the row nobody named keeps its label"
+        );
+
+        remove_from_group(&path, "codereview", Some(team), false).unwrap();
         assert_eq!(load(&path).accounts[1].groups, None);
+    }
+
+    /// Rewrite one `accounts[]` entry's `name` in the file directly, bypassing
+    /// `config::load`. The only way to reach a duplicate name now, and therefore
+    /// the only way to test the refusals that guard one.
+    fn rename_account_in_file(path: &Path, index: usize, name: &str) {
+        let mut doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(path).expect("readable"))
+                .expect("the fixture is JSON");
+        doc["accounts"][index]["name"] = serde_json::Value::String(name.to_string());
+        std::fs::write(
+            path,
+            serde_json::to_string_pretty(&doc).expect("serializes"),
+        )
+        .expect("writable");
     }
 
     /// An unknown name still comes back with the whole roster, which is what
@@ -3042,7 +3037,7 @@ mod tests {
     #[test]
     fn group_add_names_every_configured_account_when_the_name_is_unknown() {
         let path = write_config("group-add-unknown", TWO_ACCOUNTS);
-        let err = add_to_group(&path, "codereview", "nobody@example.com", None)
+        let err = add_to_group(&path, "codereview", "nobody@example.com")
             .expect_err("an unknown account is an error");
         let text = err.to_string();
         assert!(text.contains("alice@example.com"), "{text}");
@@ -3052,7 +3047,7 @@ mod tests {
     #[test]
     fn group_add_labels_named_account_and_leaves_siblings_byte_identical() {
         let path = write_config("group-add", TWO_ACCOUNTS);
-        add_to_group(&path, "codereview", "alice@example.com", None).unwrap();
+        add_to_group(&path, "codereview", "alice@example.com").unwrap();
         let config = load(&path);
         assert_eq!(
             config.accounts[0].groups,
@@ -3073,8 +3068,8 @@ mod tests {
     #[test]
     fn group_add_twice_is_idempotent() {
         let path = write_config("group-add-twice", TWO_ACCOUNTS);
-        add_to_group(&path, "codereview", "alice@example.com", None).unwrap();
-        add_to_group(&path, "codereview", "alice@example.com", None).unwrap();
+        add_to_group(&path, "codereview", "alice@example.com").unwrap();
+        add_to_group(&path, "codereview", "alice@example.com").unwrap();
         let config = load(&path);
         assert_eq!(
             config.accounts[0].groups,
@@ -3087,7 +3082,7 @@ mod tests {
     #[test]
     fn group_rm_removes_only_named_label_leaving_others_intact() {
         let path = write_config("group-rm-one", GROUPED_ACCOUNTS);
-        remove_from_group(&path, "codereview", Some("alice@example.com"), None, false).unwrap();
+        remove_from_group(&path, "codereview", Some("alice@example.com"), false).unwrap();
         let config = load(&path);
         assert_eq!(config.accounts[0].groups, Some(vec!["dev".to_string()]));
         // bob still carries codereview — only alice's membership changed.
@@ -3101,7 +3096,7 @@ mod tests {
     #[test]
     fn group_rm_all_clears_label_from_every_member_and_nothing_else() {
         let path = write_config("group-rm-all", GROUPED_ACCOUNTS);
-        remove_from_group(&path, "codereview", None, None, true).unwrap();
+        remove_from_group(&path, "codereview", None, true).unwrap();
         let config = load(&path);
         // alice keeps `dev`, loses `codereview`.
         assert_eq!(config.accounts[0].groups, Some(vec!["dev".to_string()]));
@@ -3120,7 +3115,7 @@ mod tests {
     fn group_rm_all_on_a_group_with_no_members_is_a_success_no_op() {
         let path = write_config("group-rm-all-empty", GROUPED_ACCOUNTS);
         let before = fs::read_to_string(&path).unwrap();
-        remove_from_group(&path, "nonexistent-group", None, None, true).unwrap();
+        remove_from_group(&path, "nonexistent-group", None, true).unwrap();
         let after = fs::read_to_string(&path).unwrap();
         assert_eq!(
             before, after,
@@ -3132,7 +3127,7 @@ mod tests {
     #[test]
     fn group_add_unknown_account_errors_and_names_the_configured_accounts() {
         let path = write_config("group-add-unknown", GROUPED_ACCOUNTS);
-        let err = add_to_group(&path, "codereview", "nobody@example.com", None).unwrap_err();
+        let err = add_to_group(&path, "codereview", "nobody@example.com").unwrap_err();
         let message = err.to_string();
         for name in ["alice@example.com", "bob@example.com", "carol@example.com"] {
             assert!(
@@ -3146,8 +3141,8 @@ mod tests {
     #[test]
     fn group_rm_unknown_account_errors_and_names_the_configured_accounts() {
         let path = write_config("group-rm-unknown", GROUPED_ACCOUNTS);
-        let err = remove_from_group(&path, "codereview", Some("nobody@example.com"), None, false)
-            .unwrap_err();
+        let err =
+            remove_from_group(&path, "codereview", Some("nobody@example.com"), false).unwrap_err();
         let message = err.to_string();
         for name in ["alice@example.com", "bob@example.com", "carol@example.com"] {
             assert!(message.contains(name), "missing {name}: {message}");
@@ -3170,7 +3165,7 @@ mod tests {
         let bad_label = "bad\u{0}label";
 
         let path = write_config("group-add-bad-label", with_bad_label);
-        let err = add_to_group(&path, bad_label, "alice@example.com", None).unwrap_err();
+        let err = add_to_group(&path, bad_label, "alice@example.com").unwrap_err();
         assert!(
             err.to_string().contains("control character"),
             "add must name the character class at fault: {err}"
@@ -3183,7 +3178,7 @@ mod tests {
         );
 
         // `rm` does NOT run the validator — it must still remove the bad label.
-        remove_from_group(&path, bad_label, Some("alice@example.com"), None, false).unwrap();
+        remove_from_group(&path, bad_label, Some("alice@example.com"), false).unwrap();
         let config = load(&path);
         assert_eq!(config.accounts[0].groups, Some(vec!["good".to_string()]));
         fs::remove_file(&path).ok();
@@ -3192,7 +3187,7 @@ mod tests {
     #[test]
     fn group_mutation_preserves_unmodelled_extra_keys() {
         let path = write_config("group-extra", GROUPED_ACCOUNTS);
-        add_to_group(&path, "burst", "carol@example.com", None).unwrap();
+        add_to_group(&path, "burst", "carol@example.com").unwrap();
         let raw = fs::read_to_string(&path).unwrap();
         let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
         // Top-level unmodelled key.
@@ -3447,7 +3442,7 @@ mod tests {
     #[test]
     fn a_second_member_makes_the_group_route_again() {
         let path = write_config("routes-second-member", CONTROL_ONLY_GROUP);
-        add_to_group(&path, "research", "worker@example.com", None).unwrap();
+        add_to_group(&path, "research", "worker@example.com").unwrap();
         let config = load(&path);
         let research = group_line(&render_groups_text(&config), "research");
         assert!(
@@ -3809,9 +3804,7 @@ mod tests {
     #[tokio::test]
     async fn set_enabled_true_writes_disabled_true() {
         let path = config_on_a_dead_port("disable").await;
-        set_enabled(&path, "alice@example.com", None, true)
-            .await
-            .unwrap();
+        set_enabled(&path, "alice@example.com", true).await.unwrap();
         let raw = fs::read_to_string(&path).unwrap();
         let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
         assert_eq!(value["accounts"][0]["disabled"], serde_json::json!(true));
@@ -3822,10 +3815,8 @@ mod tests {
     async fn set_enabled_false_drops_the_disabled_key() {
         let path = config_on_a_dead_port("enable").await;
         // First disable, then re-enable — the key must vanish entirely.
-        set_enabled(&path, "alice@example.com", None, true)
-            .await
-            .unwrap();
-        set_enabled(&path, "alice@example.com", None, false)
+        set_enabled(&path, "alice@example.com", true).await.unwrap();
+        set_enabled(&path, "alice@example.com", false)
             .await
             .unwrap();
         let raw = fs::read_to_string(&path).unwrap();
@@ -3866,9 +3857,7 @@ mod tests {
         doc["proxy"]["port"] = serde_json::json!(port);
         fs::write(&path, serde_json::to_string_pretty(&doc).unwrap()).unwrap();
 
-        set_enabled(&path, "alice@example.com", None, true)
-            .await
-            .unwrap();
+        set_enabled(&path, "alice@example.com", true).await.unwrap();
 
         // 1. THE RUNNING ROTATION. Not a fresh Manager, not the file — the process
         //    that would serve the next request.
@@ -3894,7 +3883,7 @@ mod tests {
 
         // 3. Re-enable, live, and the key is DROPPED from the document — the same
         //    contract the file-only path has always had.
-        set_enabled(&path, "alice@example.com", None, false)
+        set_enabled(&path, "alice@example.com", false)
             .await
             .unwrap();
         assert!(
@@ -3913,32 +3902,32 @@ mod tests {
     /// An ambiguous query is refused by the SERVER and the CLI does not fall back:
     /// the file's own resolution could land on a different row than the one the
     /// server was talking about, and a disable applied to the wrong account is
-    /// worse than none. Both accounts share an email here, so `--org` is the fix
-    /// the message must name.
+    /// worse than none. The live rotation is broken by hand to hold two rows of
+    /// the same name; the file keeps unique names throughout, which is what
+    /// makes the byte-identical assertion below mean what it says.
     #[tokio::test]
     async fn set_enabled_refuses_an_ambiguous_query_without_writing() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
         let path = config_on_a_dead_port("live-ambiguous").await;
-        // Same email in two orgs — the shape `--org` exists for.
         let raw = fs::read_to_string(&path).unwrap();
         let mut doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
         doc["proxy"]["port"] = serde_json::json!(port);
-        doc["accounts"][1]["name"] = serde_json::json!("alice@example.com");
         fs::write(&path, serde_json::to_string_pretty(&doc).unwrap()).unwrap();
-        let before = fs::read_to_string(&path).unwrap();
 
-        let config = load(&path);
+        let mut config = load(&path);
+        config.accounts[1].name = "alice@example.com".to_string();
+        let before = fs::read_to_string(&path).unwrap();
         let manager = Manager::with_live_refresher(config, Some(path.clone()));
         tokio::spawn(async move { crate::mitm::serve(listener, manager, None).await });
 
-        let err = set_enabled(&path, "alice@example.com", None, true)
+        let err = set_enabled(&path, "alice@example.com", true)
             .await
             .expect_err("an ambiguous query must not be applied");
         let text = err.to_string();
         assert!(
-            text.contains("ambiguous") && text.contains("--org"),
-            "the refusal names the candidates and the fix: {text}"
+            text.contains("ambiguous") && text.matches("alice@example.com").count() >= 2,
+            "the refusal names the candidates: {text}"
         );
         assert_eq!(
             before,
@@ -4149,13 +4138,14 @@ mod tests {
                 { "name": "user-two", "type": "oauth", "accessToken": "at2" }
             ] }"#,
         );
-        let idx = resolve_account(&config.accounts, "user", None).unwrap();
+        let idx = resolve_account(&config.accounts, "user").unwrap();
         assert_eq!(idx, 0, "exact name resolves to that account");
     }
 
-    /// Two accounts sharing the SAME email in different orgs — the finding #8
-    /// scenario. Keying on name alone silently returned the first; `--org` must
-    /// now disambiguate.
+    /// Two accounts sharing the SAME email in different orgs — the shape the
+    /// whole unique-names contract exists for. `load_from` parses without
+    /// migrating (there is no file to write back to), so this is the one place
+    /// the pre-migration fleet can be looked at directly.
     const DUP_EMAIL_TWO_ORGS: &str = r#"{
       "accounts": [
         { "name": "me@example.com", "type": "oauth", "accountUuid": "uuid-person",
@@ -4166,10 +4156,9 @@ mod tests {
     }"#;
 
     #[test]
-    fn resolve_ambiguous_across_two_orgs_errors_listing_candidates() {
-        // The same email in two orgs → ambiguous without --org.
+    fn resolve_a_duplicated_name_errors_listing_candidates() {
         let accounts = load_from(DUP_EMAIL_TWO_ORGS).accounts;
-        let err = resolve_account(&accounts, "me@example.com", None).unwrap_err();
+        let err = resolve_account(&accounts, "me@example.com").unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("ambiguous"), "ambiguous error: {msg}");
         assert!(
@@ -4178,15 +4167,22 @@ mod tests {
         );
     }
 
+    /// The migrated names each resolve to their own row, and nothing resolves
+    /// by the email PORTION of a qualified name — that fallback is what let one
+    /// query name two accounts.
     #[test]
-    fn resolve_org_narrows_to_one() {
-        let accounts = load_from(DUP_EMAIL_TWO_ORGS).accounts;
-        // The ambiguous email, narrowed by org name, resolves uniquely.
-        let idx = resolve_account(&accounts, "me@example.com", Some("Org B")).unwrap();
-        assert_eq!(idx, 1);
-        // And --org matching the uuid (exact or prefix) works too.
-        let idx = resolve_account(&accounts, "me@example.com", Some("uuid-a")).unwrap();
-        assert_eq!(idx, 0);
+    fn resolve_after_migration_gives_each_row_its_own_name() {
+        let path = write_config("resolve-migrated", DUP_EMAIL_TWO_ORGS);
+        let accounts = load(&path).accounts;
+        assert_eq!(accounts[0].name, "me@example.com");
+        assert_eq!(accounts[1].name, "me@example.com/org-b");
+
+        assert_eq!(resolve_account(&accounts, "me@example.com").unwrap(), 0);
+        assert_eq!(
+            resolve_account(&accounts, "me@example.com/org-b").unwrap(),
+            1
+        );
+        assert!(resolve_account(&accounts, "org-b").is_err());
     }
 
     // --- render_accounts ---------------------------------------------------
@@ -5422,8 +5418,8 @@ mod tests {
         usage: Option<tcr_status_wire::UsageRow>,
         // `plan` is `(organizationType, rateLimitTier, seatTier)` — the three
         // raw strings, exactly as the profile endpoint spells them. `org` is
-        // `(orgUuid, orgName)`, what a client passes to `--org` to address this
-        // row when a name is ambiguous. Grouped rather than five more
+        // `(orgUuid, orgName)`, the org a client shows beside this row.
+        // Grouped rather than five more
         // positional `Option<&str>` arguments, which at this arity is a call
         // site nobody can read.
         plan: (Option<&str>, Option<&str>, Option<&str>),

--- a/src/config.rs
+++ b/src/config.rs
@@ -691,33 +691,25 @@ impl ThrottleConfig {
     }
 }
 
-/// The `controlAccount` key on disk: either the legacy bare account name every
-/// config written before this change carries, or an identity object — the same
-/// `name`/`accountUuid`/`orgUuid`/`orgName` fields `accounts[]` entries store —
-/// that survives a restart when an email is duplicated across two rows.
-/// `#[serde(untagged)]` is unambiguous here because the two shapes are
-/// structurally disjoint: a JSON string can never parse as the object variant
-/// and vice versa.
+/// The `controlAccount` key on disk: an account `name`, or the identity object
+/// (`name`/`accountUuid`/`orgUuid`/`orgName`) a `tcr` from the duplicated-email
+/// era wrote. `#[serde(untagged)]` is unambiguous here because the two shapes
+/// are structurally disjoint: a JSON string can never parse as the object
+/// variant and vice versa.
 ///
-/// [`save_control_account`] always WRITES the identity shape once a real
-/// [`Account`] is known — it never re-emits the legacy string — but every
-/// reader (this type's own `Deserialize`, and boot resolution in
-/// `crate::manager::Manager::assemble`) keeps accepting the legacy shape
-/// unchanged, so a config nobody has re-saved since this change still loads
-/// and resolves exactly as before.
+/// A name is the whole key now — `Account.name` is unique across a config by
+/// construction (see [`crate::identity`]) — so [`save_control_account`] always
+/// writes the STRING, and the object shape survives only as something older
+/// configs are read back from. Reading one costs nothing and collapses it to
+/// its name on the next write.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(untagged, rename_all = "camelCase")]
 pub enum ControlAccountRef {
-    /// Written by every `tcr` build before this change: just the account's
-    /// `name`. Resolved by name/email alone (no org filter) — see
-    /// [`Self::org_filter`] — which is byte-identical to the old
-    /// `position(|a| a.name == *name)` lookup for the common case, a unique
-    /// name, and only starts refusing (rather than guessing) once that name is
-    /// duplicated.
-    Legacy(String),
-    /// The shape a `set` writes going forward: the same identity fields
-    /// `accounts[]` entries carry, so a duplicated email round-trips onto the
-    /// specific row it was set on.
+    /// The account's `name`, which resolves to exactly one row.
+    Name(String),
+    /// The identity object a `tcr` between `8411f3e` and this change wrote, when
+    /// a name could name two rows. Accepted, never written; only `name` is read
+    /// from it.
     ///
     /// `rename_all = "camelCase"` is repeated here, not just at the enum
     /// level, because serde's container `rename_all` renames VARIANT names for
@@ -736,38 +728,19 @@ pub enum ControlAccountRef {
 }
 
 impl ControlAccountRef {
-    /// The account name/email, present in both shapes.
+    /// The account name, present in both shapes.
     pub fn name(&self) -> &str {
         match self {
-            Self::Legacy(name) => name,
+            Self::Name(name) => name,
             Self::Identity { name, .. } => name,
-        }
-    }
-
-    /// The org discriminator to narrow a name/email match by, for boot
-    /// resolution — `None` for the legacy shape (it never carried one) and for
-    /// an identity object that itself has neither field. Prefers the uuid over
-    /// the name, matching [`crate::identity::org_key_of`]'s own preference.
-    pub fn org_filter(&self) -> Option<&str> {
-        match self {
-            Self::Legacy(_) => None,
-            Self::Identity {
-                org_uuid, org_name, ..
-            } => crate::identity::org_key_of(org_uuid.as_deref(), org_name.as_deref()),
         }
     }
 }
 
 impl From<&Account> for ControlAccountRef {
-    /// Always builds the IDENTITY shape — see this type's doc-comment for why
-    /// a set always upgrades the key rather than re-writing the legacy string.
+    /// Always the NAME — see this type's doc-comment.
     fn from(account: &Account) -> Self {
-        Self::Identity {
-            name: account.name.clone(),
-            account_uuid: account.account_uuid.clone(),
-            org_uuid: account.org_uuid.clone(),
-            org_name: account.org_name.clone(),
-        }
+        Self::Name(account.name.clone())
     }
 }
 
@@ -945,6 +918,34 @@ pub struct Config {
     /// migrated install self-heals instead of re-warning on every start.
     #[serde(skip)]
     pub migrated_legacy_throttle: bool,
+    /// The renames [`load`] applied on this load because two `accounts[]`
+    /// entries carried the same `name`. Empty on every load of an already-unique
+    /// config, which after the first migration is every load.
+    ///
+    /// `#[serde(skip)]`, same pattern and same reason as
+    /// [`Self::quarantined_accounts`]. Read by the boot path to rewrite the
+    /// session-affinity pin file, which is keyed by name, so warm sessions
+    /// survive the migration.
+    #[serde(skip)]
+    pub renamed_accounts: Vec<AccountRename>,
+    /// Why the durable half of the rename migration did not happen, when it did
+    /// not. The in-memory `accounts` are renamed either way — a server must boot
+    /// — but a CLI verb about to WRITE this config refuses on it, because a
+    /// second process would re-derive different names from the same duplicates.
+    #[serde(skip)]
+    pub rename_write_error: Option<String>,
+}
+
+/// One account [`load`] renamed to restore unique names.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccountRename {
+    /// The duplicated name the entry carried on disk.
+    pub from: String,
+    /// The unique name it now carries, minted by [`crate::identity::mint_name`].
+    pub to: String,
+    /// The org the new name was derived from, for the log line. `None` when the
+    /// entry stored no org at all and the name fell through to a counter.
+    pub org: Option<String>,
 }
 
 impl Config {
@@ -1199,17 +1200,28 @@ pub fn load(path: &Path) -> Result<Config, ConfigError> {
     }
 
     let mut quarantined = Vec::new();
+    // Where each surviving account sat in the FILE's `accounts` array, before
+    // the quarantine drop shifted the in-memory indices. The rename migration
+    // below writes by that index, so it must be the on-disk one.
+    let mut file_index = Vec::new();
 
     if let Some(accounts) = doc.get_mut("accounts").and_then(Value::as_array_mut) {
         let had_accounts = !accounts.is_empty();
-        accounts.retain(|entry| match unusable_account(entry) {
-            None => true,
+        let mut position = 0usize;
+        accounts.retain(|entry| {
+            let index = position;
+            position += 1;
+            match unusable_account(entry) {
+            None => {
+                file_index.push(index);
+                true
+            }
             Some((name, reason)) => {
                 tracing::warn!(account = %name, missing = reason, "No token for \"{name}\", skipping");
                 quarantined.push(name);
                 false
             }
-        });
+        }});
         if had_accounts && accounts.is_empty() {
             return Err(ConfigError::Parse(
                 <serde_json::Error as serde::de::Error>::custom(format!(
@@ -1224,7 +1236,208 @@ pub fn load(path: &Path) -> Result<Config, ConfigError> {
     let mut config: Config = serde_json::from_value(doc)?;
     config.quarantined_accounts = quarantined;
     config.migrated_legacy_throttle = migrated_legacy_throttle;
+    migrate_duplicate_names(path, &mut config, &file_index);
     Ok(config)
+}
+
+/// Restore unique account names on a config that has duplicates, in memory AND
+/// on disk, once.
+///
+/// Never refuses. A loader that rejected a duplicated config would take the
+/// whole fleet down the moment it upgraded — the config is what it is, and it
+/// was written by earlier `tcr` builds that permitted it. So: rename, log a line
+/// per rename, continue. The durable write failing is recorded on
+/// [`Config::rename_write_error`] rather than returned, because a server has to
+/// boot either way; the CLI's own load ([`crate::cli::load_for_edit`]) reads
+/// that field and refuses to run an edit verb on top of it, since a rename that
+/// never reached disk is one every future process re-derives.
+fn migrate_duplicate_names(path: &Path, config: &mut Config, file_index: &[usize]) {
+    let renames = plan_renames(&config.accounts);
+    if renames.is_empty() {
+        return;
+    }
+
+    // The control account, if it names a duplicated row, currently resolves to
+    // the FIRST row in file order carrying that name — that is what the running
+    // server does with it today, so that is the row it must keep pointing at.
+    let control_rename = config.control_account.as_ref().and_then(|control| {
+        let first = config
+            .accounts
+            .iter()
+            .position(|a| a.name == control.name())?;
+        renames
+            .iter()
+            .find(|(index, _)| *index == first)
+            .map(|(_, rename)| rename.to.clone())
+    });
+
+    for (index, rename) in &renames {
+        match &rename.org {
+            Some(org) => tracing::warn!(
+                "renamed account: {} -> {} (org {org})",
+                rename.from,
+                rename.to
+            ),
+            None => tracing::warn!(
+                "renamed account: {} -> {} (no org on file)",
+                rename.from,
+                rename.to
+            ),
+        }
+        config.accounts[*index].name = rename.to.clone();
+    }
+    if let Some(name) = &control_rename {
+        tracing::warn!(
+            "control account followed the rename to '{name}' — it named the first row in file \
+             order, which is the row the server resolved it to"
+        );
+        config.control_account = Some(ControlAccountRef::Name(name.clone()));
+    }
+
+    let writes: Vec<(usize, &str)> = renames
+        .iter()
+        .filter_map(|(index, rename)| Some((*file_index.get(*index)?, rename.to.as_str())))
+        .collect();
+    if writes.len() != renames.len() {
+        config.rename_write_error =
+            Some("could not map every renamed account back to its entry in the file".to_string());
+    } else if let Err(err) = save_renames(path, &writes, control_rename.as_deref()) {
+        tracing::error!(error = %err, "could not persist the account renames");
+        config.rename_write_error = Some(err.to_string());
+    }
+
+    config.renamed_accounts = renames.into_iter().map(|(_, rename)| rename).collect();
+}
+
+/// The rename each duplicated-name account needs, as `(index into `accounts`,
+/// rename)`, in fleet order. Empty when every name is already unique.
+///
+/// One row per duplicated name keeps the bare email: the one whose
+/// `organizationType` is a personal plan (`claude_max` / `claude_pro`), else the
+/// lowest priority number, else the first in file order. That is the row a
+/// person means when they type their own email — the personal account is the one
+/// they had before their company gave them a seat.
+fn plan_renames(accounts: &[Account]) -> Vec<(usize, AccountRename)> {
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for account in accounts {
+        *counts.entry(account.name.as_str()).or_default() += 1;
+    }
+    let duplicated: HashSet<&str> = counts
+        .iter()
+        .filter(|(_, n)| **n > 1)
+        .map(|(name, _)| *name)
+        .collect();
+    if duplicated.is_empty() {
+        return Vec::new();
+    }
+
+    // Every name in the fleet is off-limits as a minted name, and so is every
+    // name minted earlier in this same pass.
+    let mut taken: HashSet<String> = accounts.iter().map(|a| a.name.clone()).collect();
+    let mut renames = Vec::new();
+    for name in {
+        // Deterministic order, so two runs over one file plan the same renames.
+        let mut names: Vec<&str> = duplicated.into_iter().collect();
+        names.sort_unstable();
+        names
+    } {
+        let rows: Vec<usize> = accounts
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| a.name == name)
+            .map(|(i, _)| i)
+            .collect();
+        let keeper = rows
+            .iter()
+            .copied()
+            .find(|&i| is_personal_plan(accounts[i].organization_type.as_deref()))
+            .unwrap_or_else(|| {
+                // `min_by_key` keeps the FIRST row on a tie, which is the file
+                // order this falls back to when no priority distinguishes them.
+                rows.iter()
+                    .copied()
+                    .min_by_key(|&i| accounts[i].priority.unwrap_or(0))
+                    .expect("a duplicated name has at least two rows")
+            });
+        for index in rows {
+            if index == keeper {
+                continue;
+            }
+            let account = &accounts[index];
+            let minted = crate::identity::mint_name(
+                crate::identity::email_of(&account.name),
+                account.org_name.as_deref(),
+                account.org_uuid.as_deref(),
+                &taken,
+            );
+            taken.insert(minted.clone());
+            renames.push((
+                index,
+                AccountRename {
+                    from: account.name.clone(),
+                    to: minted,
+                    org: account
+                        .org_name
+                        .clone()
+                        .or_else(|| account.org_uuid.clone()),
+                },
+            ));
+        }
+    }
+    renames.sort_by_key(|(index, _)| *index);
+    renames
+}
+
+/// Whether an `organizationType` names a plan a person holds in their own right
+/// rather than through a seat someone granted them.
+fn is_personal_plan(organization_type: Option<&str>) -> bool {
+    matches!(organization_type, Some("claude_max") | Some("claude_pro"))
+}
+
+/// Write the migration's renames — and the `controlAccount` that followed one —
+/// into the file at `path`, touching NOTHING else.
+///
+/// Same targeted read-modify-write shape as [`save_disabled`], and for the same
+/// reason it spells out: a whole-`Config` [`save`] would reformat and re-emit
+/// every key in the document, including ones this process never modelled, at the
+/// worst possible moment — the boot of a build the operator just upgraded to.
+///
+/// Entries are addressed by their INDEX in the file's own `accounts` array, not
+/// by identity. Identity is exactly what cannot distinguish these rows: the
+/// migration exists for duplicates, and a pair written before org UUIDs were
+/// stored is two rows `same_identity` calls one.
+fn save_renames(
+    path: &Path,
+    renames: &[(usize, &str)],
+    control_account: Option<&str>,
+) -> Result<(), ConfigError> {
+    let mut doc = read_document(path)?;
+    let entries = doc
+        .get_mut("accounts")
+        .and_then(Value::as_array_mut)
+        .ok_or_else(|| {
+            ConfigError::Parse(<serde_json::Error as serde::de::Error>::custom(
+                "the accounts key is not an array",
+            ))
+        })?;
+    for (index, name) in renames {
+        let entry = entries
+            .get_mut(*index)
+            .and_then(Value::as_object_mut)
+            .ok_or_else(|| {
+                ConfigError::Parse(<serde_json::Error as serde::de::Error>::custom(format!(
+                    "accounts[{index}] is not an object"
+                )))
+            })?;
+        entry.insert("name".to_string(), Value::String((*name).to_string()));
+    }
+    if let Some(name) = control_account {
+        doc.insert(
+            "controlAccount".to_string(),
+            Value::String(name.to_string()),
+        );
+    }
+    write_atomic(path, &serde_json::to_string_pretty(&doc)?)
 }
 
 /// Persist `config` to `path` atomically (temp file in the same dir + rename),
@@ -3736,12 +3949,13 @@ mod tests {
                 .unwrap();
         assert_eq!(
             config.control_account,
-            Some(ControlAccountRef::Legacy("alice@example.com".to_string()))
+            Some(ControlAccountRef::Name("alice@example.com".to_string()))
         );
     }
 
-    /// The identity-object shape — what a `set` writes going forward — parses
-    /// back to the exact fields it carries, `orgUuid` included.
+    /// The identity-object shape an older `tcr` wrote still parses back to the
+    /// exact fields it carries, `orgUuid` included — nothing writes it now, and
+    /// a config that has one must still load.
     #[test]
     fn control_account_parses_identity_object() {
         let config: Config = serde_json::from_str(
@@ -4575,9 +4789,10 @@ mod tests {
 
     // --- save_control_account -----------------------------------------------
 
-    /// Setting `controlAccount` writes the top-level key — as the identity
-    /// object, not the legacy string — and changes nothing else — same "raw
-    /// document, not a `Config` round trip" contract as `save_disabled`. This is
+    /// Setting `controlAccount` writes the top-level key — the account's NAME,
+    /// which is unique and therefore the whole key — and changes nothing else,
+    /// same "raw document, not a `Config` round trip" contract as
+    /// `save_disabled`. This is
     /// also `control_persist_preserves_unmodelled_top_level_keys` from the
     /// bridge: a key nothing here models (`routes`) survives the write.
     #[test]
@@ -4591,7 +4806,7 @@ mod tests {
         );
 
         let mut after = read_json(&path);
-        assert_eq!(after["controlAccount"], json!({"name": "acct-a"}));
+        assert_eq!(after["controlAccount"], json!("acct-a"));
         after
             .as_object_mut()
             .expect("document is an object")
@@ -4683,13 +4898,16 @@ mod tests {
         fs::remove_file(&path).ok();
     }
 
-    /// An identity object carrying an `accountUuid` shared by both on-disk rows
-    /// PLUS `orgUuid` resolves the write to the RIGHT one of the two —
-    /// the "legacy two-org shape" `locate_account_entry`'s doc-comment
-    /// describes: one person, two orgs, one uuid. (Without a shared
-    /// `accountUuid` on both sides, `same_identity` cannot use the org at all —
-    /// see `control_write_on_duplicated_identity_is_refused` — so this is the
-    /// realistic disambiguating shape, not an arbitrary one.)
+    /// A target carrying an `accountUuid` shared by both on-disk rows PLUS
+    /// `orgUuid` resolves the write to the RIGHT one of the two — the "legacy
+    /// two-org shape" `locate_account_entry`'s doc-comment describes: one
+    /// person, two orgs, one uuid. That resolution is still how a WRITE finds
+    /// its row, and it is the one thing `--org` never was: an identity
+    /// comparison, not a query.
+    ///
+    /// The file here is fed to `save_control_account` directly rather than
+    /// through `config::load`, which would have renamed the second row first.
+    /// This is the layer below that.
     #[test]
     fn control_write_with_org_uuid_disambiguates_duplicated_email() {
         let path = tmp_path("control-org-disambiguates");
@@ -4718,14 +4936,7 @@ mod tests {
         );
 
         let after = read_json(&path);
-        assert_eq!(
-            after["controlAccount"],
-            json!({
-                "name": "dup@example.com",
-                "accountUuid": "33333333-3333-3333-3333-333333333333",
-                "orgUuid": "22222222-2222-2222-2222-222222222222"
-            })
-        );
+        assert_eq!(after["controlAccount"], json!("dup@example.com"));
         fs::remove_file(&path).ok();
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1271,26 +1271,34 @@ fn migrate_duplicate_names(path: &Path, config: &mut Config, file_index: &[usize
             .map(|(_, rename)| rename.to.clone())
     });
 
+    // Both channels, deliberately, matching what `main.rs` already does for the
+    // legacy-`throttle` migration a dozen lines from its own call to this.
+    // `tracing` alone reaches nobody here: a CLI verb never installs a
+    // subscriber at all, and `run_server` loads the config BEFORE
+    // `init_tracing`, so the tracing line is dropped on the floor on every path
+    // that can reach this code. Renaming a person's accounts under them is the
+    // last thing that may happen silently.
+    let say = |line: &str| {
+        tracing::warn!("{line}");
+        eprintln!("[tcr] {line}");
+    };
+
     for (index, rename) in &renames {
-        match &rename.org {
-            Some(org) => tracing::warn!(
-                "renamed account: {} -> {} (org {org})",
-                rename.from,
-                rename.to
-            ),
-            None => tracing::warn!(
-                "renamed account: {} -> {} (no org on file)",
-                rename.from,
-                rename.to
-            ),
-        }
+        let where_from = match &rename.org {
+            Some(org) => format!("org {org}"),
+            None => "no org on file".to_string(),
+        };
+        say(&format!(
+            "renamed account: {} -> {} ({where_from})",
+            rename.from, rename.to
+        ));
         config.accounts[*index].name = rename.to.clone();
     }
     if let Some(name) = &control_rename {
-        tracing::warn!(
+        say(&format!(
             "control account followed the rename to '{name}' — it named the first row in file \
              order, which is the row the server resolved it to"
-        );
+        ));
         config.control_account = Some(ControlAccountRef::Name(name.clone()));
     }
 
@@ -1303,6 +1311,7 @@ fn migrate_duplicate_names(path: &Path, config: &mut Config, file_index: &[usize
             Some("could not map every renamed account back to its entry in the file".to_string());
     } else if let Err(err) = save_renames(path, &writes, control_rename.as_deref()) {
         tracing::error!(error = %err, "could not persist the account renames");
+        eprintln!("[tcr] could not persist the account renames: {err}");
         config.rename_write_error = Some(err.to_string());
     }
 
@@ -4902,7 +4911,7 @@ mod tests {
     /// `orgUuid` resolves the write to the RIGHT one of the two — the "legacy
     /// two-org shape" `locate_account_entry`'s doc-comment describes: one
     /// person, two orgs, one uuid. That resolution is still how a WRITE finds
-    /// its row, and it is the one thing `--org` never was: an identity
+    /// its row, and it is the one thing the old org flag never was: an identity
     /// comparison, not a query.
     ///
     /// The file here is fed to `save_control_account` directly rather than
@@ -5713,6 +5722,275 @@ mod tests {
         let ok = load(&path).expect("the renamed key must load");
         assert_eq!(ok.account_throttle.effective_burst(), 4);
         assert!(!ok.migrated_legacy_throttle);
+
+        fs::remove_file(&path).ok();
+    }
+
+    // ---- the duplicate-name migration -------------------------------------
+
+    /// The fleet's actual shape: one person, a personal Max org and a company
+    /// Team org, one email between them, and `controlAccount` naming it.
+    const DUPLICATE_NAME_FILE: &str = r#"{
+      "upstream": "https://api.anthropic.com",
+      "controlAccount": "henry@example.com",
+      "routes": { "hand-edited": "must survive" },
+      "accounts": [
+        { "name": "henry@example.com", "type": "oauth", "accessToken": "at-personal",
+          "refreshToken": "rt-personal", "expiresAt": 1893456000000, "priority": 1,
+          "accountUuid": "aaaaaaaa-1111-1111-1111-111111111111",
+          "orgUuid": "11111111-1111-1111-1111-111111111111",
+          "orgName": "Henry Personal", "organizationType": "claude_max",
+          "groups": ["gil"] },
+        { "name": "henry@example.com", "type": "oauth", "accessToken": "at-team",
+          "refreshToken": "rt-team", "expiresAt": 1893456000000, "priority": 0,
+          "accountUuid": "aaaaaaaa-1111-1111-1111-111111111111",
+          "orgUuid": "22222222-2222-2222-2222-222222222222",
+          "orgName": "Henry Token", "organizationType": "claude_team" },
+        { "name": "alice@example.com", "type": "oauth", "accessToken": "at-alice",
+          "expiresAt": 1893456000000, "priority": 2, "sx": "unmodelled" }
+      ]
+    }"#;
+
+    /// The whole contract of the migration, in one pass: the personal row keeps
+    /// the bare email, the Team row takes its org's slug, `controlAccount`
+    /// still names the personal row, and NOTHING else in the document moves.
+    ///
+    /// Note the priorities are deliberately inverted (`claude_max` carries the
+    /// HIGHER number). A keeper chosen by priority would pick the Team row, so
+    /// this only passes if the personal-plan rule is what actually ran.
+    #[test]
+    fn load_renames_a_duplicated_name_and_touches_nothing_else() {
+        let path = tmp_path("rename-migration");
+        fs::write(&path, DUPLICATE_NAME_FILE).unwrap();
+        let before = read_json(&path);
+
+        let config = load(&path).expect("a duplicated name loads, it never refuses");
+
+        assert_eq!(config.accounts[0].name, "henry@example.com");
+        assert_eq!(config.accounts[1].name, "henry@example.com/henry-token");
+        assert_eq!(config.accounts[2].name, "alice@example.com");
+        assert_eq!(
+            config.control_account,
+            Some(ControlAccountRef::Name("henry@example.com".to_string())),
+            "control stays on the personal row, which kept the bare email"
+        );
+        assert_eq!(config.renamed_accounts.len(), 1);
+        assert_eq!(config.renamed_accounts[0].from, "henry@example.com");
+        assert_eq!(
+            config.renamed_accounts[0].to,
+            "henry@example.com/henry-token"
+        );
+        assert_eq!(
+            config.renamed_accounts[0].org.as_deref(),
+            Some("Henry Token")
+        );
+        assert_eq!(config.rename_write_error, None);
+
+        // The rename is DURABLE, and it is the only thing that changed. Diffing
+        // the whole document — not just re-reading the field we wrote — is what
+        // catches a targeted edit that quietly dropped an unmodelled key.
+        let mut after = read_json(&path);
+        assert_eq!(
+            after["accounts"][1]["name"],
+            json!("henry@example.com/henry-token")
+        );
+        after["accounts"][1]["name"] = json!("henry@example.com");
+        assert_eq!(
+            after, before,
+            "the write touched something other than the renamed row's name"
+        );
+
+        fs::remove_file(&path).ok();
+    }
+
+    /// Loading the migrated file again renames nothing and rewrites nothing.
+    /// Without this the migration could be "working" by renaming on every boot,
+    /// handing out a new name each time.
+    #[test]
+    fn a_second_load_of_a_migrated_file_changes_nothing() {
+        let path = tmp_path("rename-idempotent");
+        fs::write(&path, DUPLICATE_NAME_FILE).unwrap();
+        load(&path).expect("first load migrates");
+        let after_first = fs::read_to_string(&path).unwrap();
+
+        let second = load(&path).expect("second load");
+        assert!(second.renamed_accounts.is_empty(), "nothing left to rename");
+        assert_eq!(second.accounts[1].name, "henry@example.com/henry-token");
+        assert_eq!(
+            after_first,
+            fs::read_to_string(&path).unwrap(),
+            "the second load must leave the file byte-identical"
+        );
+
+        fs::remove_file(&path).ok();
+    }
+
+    /// When the row that gets renamed is the FIRST one in file order — the row
+    /// a running server resolves `controlAccount` to today — the key follows it,
+    /// so control lands on the same account it was on before the upgrade.
+    #[test]
+    fn control_follows_the_rename_when_it_named_the_renamed_row() {
+        let path = tmp_path("rename-control-follows");
+        // No personal plan on either row, so the keeper is decided by priority:
+        // the SECOND row (priority 0) keeps the bare email, and the first — the
+        // one `controlAccount` resolves to today — is the one renamed.
+        fs::write(
+            &path,
+            r#"{
+              "controlAccount": "henry@example.com",
+              "accounts": [
+                { "name": "henry@example.com", "type": "oauth", "accessToken": "at-a",
+                  "priority": 1, "accountUuid": "aaaa-1", "orgUuid": "org-a",
+                  "orgName": "Henry Token" },
+                { "name": "henry@example.com", "type": "oauth", "accessToken": "at-b",
+                  "priority": 0, "accountUuid": "aaaa-1", "orgUuid": "org-b",
+                  "orgName": "Henry Personal" }
+              ]
+            }"#,
+        )
+        .unwrap();
+
+        let config = load(&path).expect("loads");
+        assert_eq!(config.accounts[0].name, "henry@example.com/henry-token");
+        assert_eq!(config.accounts[1].name, "henry@example.com");
+        assert_eq!(
+            config.control_account,
+            Some(ControlAccountRef::Name(
+                "henry@example.com/henry-token".to_string()
+            )),
+            "control must follow the FIRST row, which is the one the server resolved it to"
+        );
+        assert_eq!(
+            read_json(&path)["controlAccount"],
+            json!("henry@example.com/henry-token"),
+            "and durably, not only in memory"
+        );
+
+        fs::remove_file(&path).ok();
+    }
+
+    /// With no `orgName` to slug, the name falls back to the first eight
+    /// characters of the org uuid — a name is still needed, and a stable one.
+    #[test]
+    fn a_row_with_no_org_name_is_named_from_its_org_uuid() {
+        let path = tmp_path("rename-uuid-fallback");
+        fs::write(
+            &path,
+            r#"{ "accounts": [
+                { "name": "henry@example.com", "type": "oauth", "accessToken": "at-a",
+                  "priority": 0, "accountUuid": "aaaa-1", "orgUuid": "abcdefgh-1111" },
+                { "name": "henry@example.com", "type": "oauth", "accessToken": "at-b",
+                  "priority": 1, "accountUuid": "aaaa-1", "orgUuid": "zyxwvuts-2222" }
+            ] }"#,
+        )
+        .unwrap();
+
+        let config = load(&path).expect("loads");
+        assert_eq!(config.accounts[0].name, "henry@example.com");
+        assert_eq!(config.accounts[1].name, "henry@example.com/zyxwvuts");
+
+        fs::remove_file(&path).ok();
+    }
+
+    /// A quarantined entry sits BEFORE the duplicated pair in the file, so the
+    /// in-memory index and the on-disk index differ. The rename must land on the
+    /// on-disk row — writing by the in-memory index would rename the wrong
+    /// account, and the two indices agree in every other fixture here, so
+    /// nothing else in this file could catch it.
+    #[test]
+    fn the_rename_writes_by_the_files_own_index_not_the_in_memory_one() {
+        let path = tmp_path("rename-after-quarantine");
+        fs::write(
+            &path,
+            r#"{ "accounts": [
+                { "name": "credential-less@example.com", "type": "oauth", "importFrom": "elsewhere" },
+                { "name": "henry@example.com", "type": "oauth", "accessToken": "at-a",
+                  "priority": 0, "accountUuid": "aaaa-1", "orgUuid": "org-a",
+                  "orgName": "Henry Personal" },
+                { "name": "henry@example.com", "type": "oauth", "accessToken": "at-b",
+                  "priority": 1, "accountUuid": "aaaa-1", "orgUuid": "org-b",
+                  "orgName": "Henry Token" }
+            ] }"#,
+        )
+        .unwrap();
+
+        let config = load(&path).expect("loads");
+        assert_eq!(
+            config.quarantined_accounts,
+            vec!["credential-less@example.com"]
+        );
+        assert_eq!(config.accounts[0].name, "henry@example.com");
+        assert_eq!(config.accounts[1].name, "henry@example.com/henry-token");
+
+        // On disk the rows are at 1 and 2, and the quarantined row is still
+        // there untouched — `load` drops it from memory, never from the file.
+        let after = read_json(&path);
+        assert_eq!(
+            after["accounts"][0]["name"],
+            json!("credential-less@example.com")
+        );
+        assert_eq!(after["accounts"][0]["importFrom"], json!("elsewhere"));
+        assert_eq!(after["accounts"][1]["name"], json!("henry@example.com"));
+        assert_eq!(
+            after["accounts"][2]["name"],
+            json!("henry@example.com/henry-token")
+        );
+
+        fs::remove_file(&path).ok();
+    }
+
+    /// Three rows on one email: the personal row keeps it and the other two get
+    /// distinct names. A minting rule that only ever considered the ORIGINAL
+    /// names would hand the same name to both.
+    #[test]
+    fn three_rows_sharing_a_name_all_end_up_distinct() {
+        let path = tmp_path("rename-three-way");
+        fs::write(
+            &path,
+            r#"{ "accounts": [
+                { "name": "henry@example.com", "type": "oauth", "accessToken": "at-a",
+                  "priority": 0, "orgName": "Acme" },
+                { "name": "henry@example.com", "type": "oauth", "accessToken": "at-b",
+                  "priority": 1, "orgName": "Acme", "organizationType": "claude_max" },
+                { "name": "henry@example.com", "type": "oauth", "accessToken": "at-c",
+                  "priority": 2, "orgName": "Acme" }
+            ] }"#,
+        )
+        .unwrap();
+
+        let config = load(&path).expect("loads");
+        let names: Vec<&str> = config.accounts.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "henry@example.com/acme",
+                "henry@example.com",
+                "henry@example.com/acme-2"
+            ],
+            "the Max row keeps the email; the other two get distinct names"
+        );
+        assert_eq!(
+            names.iter().collect::<HashSet<_>>().len(),
+            3,
+            "the whole point: three rows, three names"
+        );
+
+        fs::remove_file(&path).ok();
+    }
+
+    /// A config that never had a duplicate is not rewritten at all — no rename
+    /// pass, no write, and `renamed_accounts` empty. The migration must be
+    /// invisible to the fleets it does not concern.
+    #[test]
+    fn a_config_with_unique_names_is_left_byte_identical() {
+        let path = tmp_path("rename-noop");
+        fs::write(&path, DISABLE_SAMPLE).unwrap();
+        let before = fs::read_to_string(&path).unwrap();
+
+        let config = load(&path).expect("loads");
+        assert!(config.renamed_accounts.is_empty());
+        assert_eq!(config.rename_write_error, None);
+        assert_eq!(before, fs::read_to_string(&path).unwrap());
 
         fs::remove_file(&path).ok();
     }

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -1,22 +1,34 @@
-//! Account identity helpers, ported 1:1 from `teamclaude/src/identity.js`.
+//! Account identity helpers.
 //!
-//! An OAuth account is identified by its Anthropic account UUID (the *person*)
-//! plus the organization it is scoped to. The same email/person can belong to
-//! multiple organizations — e.g. a corporate Pro org and a personal Max org —
-//! each with its own OAuth token and quota. The org must therefore be part of
-//! the identity; otherwise multi-org logins overwrite each other, removals match
-//! the wrong entry, and token rotation persists onto the wrong account.
+//! Two different questions live here, and keeping them apart is the whole point
+//! of the module.
+//!
+//! **Which row did the user mean?** [`match_one`] — an EXACT match on
+//! `Account.name`, and nothing else. `Account.name` is unique across a config by
+//! construction: `config::load` renames duplicates on sight ([`mint_name`] is
+//! the rule), and a login mints a free name rather than colliding. So a name is
+//! a complete answer to that question, and every earlier way of narrowing one —
+//! matching the email portion of a name, then narrowing that by org — is
+//! gone. Those existed only because a name could name two rows, and the bugs
+//! they produced (a group label on the row nobody asked for, a copied token from
+//! the wrong org) were bugs of a lookup that had to guess.
+//!
+//! **Is this the same account re-logging-in?** [`same_identity`] / [`resolve`] —
+//! the Anthropic account UUID (the *person*) plus the organization it is scoped
+//! to. The same person routinely belongs to several organizations, each with its
+//! own OAuth token and quota, so the org has to be part of that comparison or
+//! multi-org logins overwrite each other. This pair is still what `upsert_account`
+//! and `save_account` decide a write's destination with. It is NOT a query key:
+//! nothing takes a user's argument and resolves it this way.
 //!
 //! The org discriminator prefers the org UUID but falls back to the org name
 //! (the profile endpoint has always returned a name), so identity still works on
-//! entries created before org UUIDs were stored.
-//!
-//! Backward compatibility: when the identity fields (`account_uuid`, `org_uuid`,
-//! `org_name`) are all absent — the shape of every config written before this
-//! change — every comparison falls back to name equality, so single-org
-//! behaviour is byte-identical.
+//! entries created before org UUIDs were stored. When the identity fields are all
+//! absent — the shape of every config written before they existed — the
+//! comparison falls back to name equality, which unique names make exact.
 
 use crate::config::Account;
+use std::collections::HashSet;
 
 /// Stable org discriminator for an account record: org UUID, else org name, else
 /// `None` (an empty string is treated as absent).
@@ -140,17 +152,92 @@ where
     }
 }
 
-/// The email portion of a display name, stripping a trailing " (org)" suffix.
+/// The separator between the email and the org slug in a minted account name.
+///
+/// `/` is legal in every argv, can never occur inside an email address, and
+/// reads as "this account, in that org". A name therefore splits back into its
+/// two parts unambiguously — which is what [`email_of`] relies on.
+pub const ORG_SEPARATOR: char = '/';
+
+/// The email portion of an account name: everything before the first
+/// [`ORG_SEPARATOR`], or the whole name when it carries no org suffix.
+///
+/// Only the OAuth `login_hint` uses this. Nothing resolves an account by it —
+/// that was the old email-portion matching, and it is exactly what made
+/// `henry@example.com` name two rows.
 pub fn email_of(name: &str) -> &str {
-    if name.ends_with(')') {
-        if let Some(i) = name.rfind(" (") {
-            return &name[..i];
-        }
-    }
-    name
+    name.split_once(ORG_SEPARATOR)
+        .map_or(name, |(email, _)| email)
 }
 
-/// The three fields a user-supplied account query is matched against.
+/// An org name reduced to the suffix half of an account name: lower-cased, every
+/// run of non-`[a-z0-9]` collapsed to a single `-`, and leading/trailing `-`
+/// trimmed. `Henry Token` → `henry-token`.
+///
+/// Empty when the org name contains nothing usable (`"---"`, `"…"`); callers
+/// treat that exactly as an absent org name and fall back to the org UUID.
+pub fn org_slug(org_name: &str) -> String {
+    let mut slug = String::with_capacity(org_name.len());
+    for ch in org_name.chars() {
+        if ch.is_ascii_alphanumeric() {
+            slug.extend(ch.to_lowercase());
+        } else if !slug.ends_with('-') {
+            slug.push('-');
+        }
+    }
+    slug.trim_matches('-').to_string()
+}
+
+/// The suffix half of a name for an account in this org: the slugged org name,
+/// or — when there is no usable org name — the first 8 characters of the org
+/// UUID. `None` when neither is available, which is the only case a minted name
+/// cannot carry an org suffix at all.
+pub fn org_suffix(org_name: Option<&str>, org_uuid: Option<&str>) -> Option<String> {
+    let from_name = org_name.map(org_slug).filter(|s| !s.is_empty());
+    from_name.or_else(|| {
+        org_uuid
+            .map(|uuid| uuid.chars().take(8).collect::<String>())
+            .filter(|s| !s.is_empty())
+    })
+}
+
+/// Mint a UNIQUE account name for an account with this email, in this org.
+///
+/// The bare `email` when no name in `taken` is that email; otherwise
+/// `email/<org-suffix>` ([`org_suffix`]); and if that is somehow taken too —
+/// the same org twice cannot happen, since identity is `(account_uuid,
+/// org_uuid)`, but a hand-edited config is not bound by that — `-2`, `-3`, and
+/// so on until one is free.
+///
+/// This is ONE rule with two callers by design: a login mints through it, and
+/// `config::load`'s duplicate-name migration renames through it. Two copies is
+/// how a fleet ends up with a row the migration called `a/acme` and a re-login
+/// calls something else, which puts the duplicate straight back.
+pub fn mint_name(
+    email: &str,
+    org_name: Option<&str>,
+    org_uuid: Option<&str>,
+    taken: &HashSet<String>,
+) -> String {
+    if !taken.contains(email) {
+        return email.to_string();
+    }
+    let base = match org_suffix(org_name, org_uuid) {
+        Some(suffix) => format!("{email}{ORG_SEPARATOR}{suffix}"),
+        // No org to name it by. Fall straight through to the numeric suffixes,
+        // which are the only thing left that can make it unique.
+        None => email.to_string(),
+    };
+    if !taken.contains(&base) {
+        return base;
+    }
+    (2..)
+        .map(|n| format!("{base}-{n}"))
+        .find(|candidate| !taken.contains(candidate))
+        .expect("an unbounded range always yields a free name")
+}
+
+/// The one field a user-supplied account query is matched against.
 ///
 /// It exists so ONE resolution rule runs over both representations of the fleet:
 /// the config file's [`Account`] records (what the CLI edits) and the running
@@ -161,74 +248,47 @@ pub fn email_of(name: &str) -> &str {
 /// account.
 pub trait Queryable {
     fn query_name(&self) -> &str;
-    fn query_org_name(&self) -> Option<&str>;
-    fn query_org_uuid(&self) -> Option<&str>;
 }
 
 impl Queryable for Account {
     fn query_name(&self) -> &str {
         &self.name
     }
-    fn query_org_name(&self) -> Option<&str> {
-        self.org_name.as_deref()
-    }
-    fn query_org_uuid(&self) -> Option<&str> {
-        self.org_uuid.as_deref()
-    }
 }
 
-/// Indices of accounts matching `query` (exact name, else email), narrowed by
-/// `org_filter` (org name exact, or org uuid exact/prefix). Caller decides on
-/// 0/1/many.
-pub fn match_accounts<T: Queryable>(
-    accounts: &[T],
-    query: &str,
-    org_filter: Option<&str>,
-) -> Vec<usize> {
-    let mut matches: Vec<usize> = accounts
+/// Indices of accounts whose name is EXACTLY `query`. Caller decides on 0/1/many.
+///
+/// Unique names make "many" unreachable through any path that went through
+/// `config::load`; it survives as a return shape because a hand-edited file is
+/// still a file, and refusing beats writing to whichever row came first.
+pub fn match_accounts<T: Queryable>(accounts: &[T], query: &str) -> Vec<usize> {
+    accounts
         .iter()
         .enumerate()
         .filter(|(_, a)| a.query_name() == query)
         .map(|(i, _)| i)
-        .collect();
-    if matches.is_empty() {
-        matches = accounts
-            .iter()
-            .enumerate()
-            .filter(|(_, a)| email_of(a.query_name()) == query)
-            .map(|(i, _)| i)
-            .collect();
-    }
-    if let Some(f) = org_filter {
-        matches.retain(|&i| {
-            let a = &accounts[i];
-            a.query_org_name().is_some_and(|n| n == f)
-                || a.query_org_uuid()
-                    .is_some_and(|u| u == f || u.starts_with(f))
-        });
-    }
-    matches
+        .collect()
 }
 
-/// What a user-supplied `(query, org)` resolved to.
+/// What a user-supplied query resolved to.
 ///
 /// Separate from [`Resolved`], which resolves a stored IDENTITY against records.
 /// This one resolves a human's argument, so its ambiguous arm carries the
-/// candidate NAMES: every caller has to put them in front of the person who
-/// typed the query, or `--org` is unusable advice.
+/// candidate NAMES — the operator has to be told which file to go fix.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Match {
     /// Exactly one account matched, at this index.
     One(usize),
     /// Nothing matched.
     None,
-    /// Two or more matched; these are their names, in fleet order.
+    /// Two or more matched; these are their names, in fleet order. Only
+    /// reachable on a config edited by hand behind the loader's back.
     Ambiguous(Vec<String>),
 }
 
 /// [`match_accounts`] collapsed to the 0 / 1 / many decision every caller makes.
-pub fn match_one<T: Queryable>(accounts: &[T], query: &str, org_filter: Option<&str>) -> Match {
-    let candidates = match_accounts(accounts, query, org_filter);
+pub fn match_one<T: Queryable>(accounts: &[T], query: &str) -> Match {
+    let candidates = match_accounts(accounts, query);
     match candidates.as_slice() {
         [] => Match::None,
         [only] => Match::One(*only),
@@ -512,24 +572,114 @@ mod tests {
     }
 
     #[test]
-    fn email_of_strips_org_suffix() {
-        assert_eq!(email_of("me@example.com (Acme)"), "me@example.com");
+    fn email_of_splits_at_the_org_separator() {
+        assert_eq!(email_of("me@example.com/acme"), "me@example.com");
         assert_eq!(email_of("me@example.com"), "me@example.com");
-        // Only a trailing " (…)" is stripped, not a mid-string parenthesis.
-        assert_eq!(email_of("weird (x) name"), "weird (x) name");
+        // A suffix carrying its own separator still yields the email half.
+        assert_eq!(email_of("me@example.com/acme/eu"), "me@example.com");
+        // A name that is not an email at all comes back whole.
+        assert_eq!(email_of("work"), "work");
     }
 
     #[test]
-    fn match_accounts_exact_name_then_email_then_org() {
-        let accounts = vec![
-            acct(
-                "me@example.com (Corp)",
-                Some("u1"),
-                Some("org-corp"),
-                Some("Corp"),
+    fn org_slug_lowercases_and_collapses_punctuation() {
+        assert_eq!(org_slug("Henry Token"), "henry-token");
+        assert_eq!(org_slug("ACME, Inc."), "acme-inc");
+        assert_eq!(org_slug("  spaced  out  "), "spaced-out");
+        assert_eq!(org_slug("already-slugged"), "already-slugged");
+        // Nothing usable survives — the caller must fall back to the org uuid.
+        assert_eq!(org_slug("---"), "");
+        assert_eq!(org_slug(""), "");
+    }
+
+    #[test]
+    fn org_suffix_prefers_the_name_then_eight_uuid_chars() {
+        assert_eq!(
+            org_suffix(Some("Henry Token"), Some("abcdefgh-1111")),
+            Some("henry-token".to_string())
+        );
+        assert_eq!(
+            org_suffix(None, Some("abcdefgh-1111")),
+            Some("abcdefgh".to_string())
+        );
+        // An org name that slugs to nothing is treated as absent.
+        assert_eq!(
+            org_suffix(Some("---"), Some("abcdefgh-1111")),
+            Some("abcdefgh".to_string())
+        );
+        assert_eq!(org_suffix(None, None), None);
+    }
+
+    fn taken(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|n| (*n).to_string()).collect()
+    }
+
+    #[test]
+    fn mint_name_takes_the_bare_email_when_it_is_free() {
+        assert_eq!(
+            mint_name(
+                "me@example.com",
+                Some("Acme"),
+                Some("org-1"),
+                &taken(&["other@example.com"])
             ),
+            "me@example.com"
+        );
+    }
+
+    #[test]
+    fn mint_name_qualifies_with_the_org_when_the_email_is_taken() {
+        assert_eq!(
+            mint_name(
+                "me@example.com",
+                Some("Henry Token"),
+                Some("org-1"),
+                &taken(&["me@example.com"])
+            ),
+            "me@example.com/henry-token"
+        );
+    }
+
+    #[test]
+    fn mint_name_appends_a_counter_when_the_qualified_name_is_taken_too() {
+        assert_eq!(
+            mint_name(
+                "me@example.com",
+                Some("Acme"),
+                Some("org-1"),
+                &taken(&["me@example.com", "me@example.com/acme"])
+            ),
+            "me@example.com/acme-2"
+        );
+        assert_eq!(
+            mint_name(
+                "me@example.com",
+                Some("Acme"),
+                Some("org-1"),
+                &taken(&[
+                    "me@example.com",
+                    "me@example.com/acme",
+                    "me@example.com/acme-2",
+                ])
+            ),
+            "me@example.com/acme-3"
+        );
+    }
+
+    #[test]
+    fn mint_name_with_no_org_at_all_falls_through_to_the_counter() {
+        assert_eq!(
+            mint_name("me@example.com", None, None, &taken(&["me@example.com"])),
+            "me@example.com-2"
+        );
+    }
+
+    #[test]
+    fn match_accounts_is_exact_on_the_name_and_nothing_else() {
+        let accounts = vec![
+            acct("me@example.com", Some("u1"), Some("org-corp"), Some("Corp")),
             acct(
-                "me@example.com (Personal)",
+                "me@example.com/personal",
                 Some("u1"),
                 Some("org-pers"),
                 Some("Personal"),
@@ -537,35 +687,26 @@ mod tests {
             acct("other@example.com", None, None, None),
         ];
 
-        // Exact display-name wins outright.
+        assert_eq!(match_accounts(&accounts, "me@example.com"), vec![0]);
         assert_eq!(
-            match_accounts(&accounts, "me@example.com (Corp)", None),
-            vec![0]
-        );
-
-        // No exact name → email match finds both org variants.
-        assert_eq!(
-            match_accounts(&accounts, "me@example.com", None),
-            vec![0, 1]
-        );
-
-        // Email + org filter narrows to one (by org name).
-        assert_eq!(
-            match_accounts(&accounts, "me@example.com", Some("Personal")),
+            match_accounts(&accounts, "me@example.com/personal"),
             vec![1]
         );
-        // Org filter by uuid prefix.
-        assert_eq!(
-            match_accounts(&accounts, "me@example.com", Some("org-corp")),
-            vec![0]
-        );
-        assert_eq!(
-            match_accounts(&accounts, "me@example.com", Some("org-")),
-            vec![0, 1],
-            "shared uuid prefix keeps both"
-        );
+        // The email PORTION of a qualified name resolves nothing on its own —
+        // the bare email is a different, and here a real, account.
+        assert_eq!(match_accounts(&accounts, "personal"), Vec::<usize>::new());
+        assert!(match_accounts(&accounts, "nobody@example.com").is_empty());
+    }
 
-        // No match at all.
-        assert!(match_accounts(&accounts, "nobody@example.com", None).is_empty());
+    #[test]
+    fn match_one_still_refuses_a_hand_edited_duplicate() {
+        let accounts = vec![
+            acct("me@example.com", Some("u1"), Some("org-a"), Some("A")),
+            acct("me@example.com", Some("u2"), Some("org-b"), Some("B")),
+        ];
+        assert_eq!(
+            match_one(&accounts, "me@example.com"),
+            Match::Ambiguous(vec!["me@example.com".to_string(); 2])
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,12 +87,9 @@ struct RemoveArgs {
     /// Path to the config file (default: ~/.config/teamclaude.json).
     #[arg(long)]
     config: Option<PathBuf>,
-    /// Account name, or its bare email if the name carries an org suffix. Exact
-    /// and case-sensitive — not a substring.
+    /// Account name — exact and case-sensitive, not a substring. Names are
+    /// unique, so this always names one row; `tcr accounts` prints them.
     query: String,
-    /// Narrow an ambiguous match to a single org (name or uuid).
-    #[arg(long)]
-    org: Option<String>,
 }
 
 #[derive(clap::Args)]
@@ -100,12 +97,9 @@ struct TokenArgs {
     /// Path to the config file (default: ~/.config/teamclaude.json).
     #[arg(long)]
     config: Option<PathBuf>,
-    /// Account name, or its bare email if the name carries an org suffix. Exact
-    /// and case-sensitive — not a substring.
+    /// Account name — exact and case-sensitive, not a substring. Names are
+    /// unique, so this always names one row; `tcr accounts` prints them.
     query: String,
-    /// Narrow an ambiguous match to a single org (name or uuid).
-    #[arg(long)]
-    org: Option<String>,
 }
 
 #[derive(clap::Args)]
@@ -113,8 +107,8 @@ struct PriorityArgs {
     /// Path to the config file (default: ~/.config/teamclaude.json).
     #[arg(long)]
     config: Option<PathBuf>,
-    /// Account name, or its bare email if the name carries an org suffix. Exact
-    /// and case-sensitive — not a substring.
+    /// Account name — exact and case-sensitive, not a substring. Names are
+    /// unique, so this always names one row; `tcr accounts` prints them.
     query: String,
     /// The explicit priority value (lower = preferred). Omit with --first/--last.
     #[arg(conflicts_with_all = ["first", "last"])]
@@ -125,9 +119,6 @@ struct PriorityArgs {
     /// Move the account to the back of rotation (max priority + 1).
     #[arg(long)]
     last: bool,
-    /// Narrow an ambiguous match to a single org (name or uuid).
-    #[arg(long)]
-    org: Option<String>,
 }
 
 #[derive(clap::Args)]
@@ -135,12 +126,9 @@ struct EnableArgs {
     /// Path to the config file (default: ~/.config/teamclaude.json).
     #[arg(long)]
     config: Option<PathBuf>,
-    /// Account name, or its bare email if the name carries an org suffix. Exact
-    /// and case-sensitive — not a substring.
+    /// Account name — exact and case-sensitive, not a substring. Names are
+    /// unique, so this always names one row; `tcr accounts` prints them.
     query: String,
-    /// Narrow an ambiguous match to a single org (name or uuid).
-    #[arg(long)]
-    org: Option<String>,
 }
 
 #[derive(clap::Args)]
@@ -148,12 +136,9 @@ struct DisableArgs {
     /// Path to the config file (default: ~/.config/teamclaude.json).
     #[arg(long)]
     config: Option<PathBuf>,
-    /// Account name, or its bare email if the name carries an org suffix. Exact
-    /// and case-sensitive — not a substring.
+    /// Account name — exact and case-sensitive, not a substring. Names are
+    /// unique, so this always names one row; `tcr accounts` prints them.
     query: String,
-    /// Narrow an ambiguous match to a single org (name or uuid).
-    #[arg(long)]
-    org: Option<String>,
 }
 
 #[derive(clap::Args)]
@@ -161,13 +146,10 @@ struct ControlArgs {
     /// Path to the config file (default: ~/.config/teamclaude.json).
     #[arg(long)]
     config: Option<PathBuf>,
-    /// Account name, or its bare email if the name carries an org suffix. Exact
-    /// and case-sensitive — not a substring. Omit with `--clear` or `--show`.
+    /// Account name — exact and case-sensitive, not a substring. Omit with
+    /// `--clear` or `--show`.
     #[arg(conflicts_with_all = ["clear", "show"])]
     query: Option<String>,
-    /// Narrow an ambiguous match to a single org (name or uuid).
-    #[arg(long)]
-    org: Option<String>,
     /// Clear the control account (identity traffic resolves to none).
     #[arg(long, conflicts_with = "show")]
     clear: bool,
@@ -226,12 +208,8 @@ struct GroupAddArgs {
     config: Option<PathBuf>,
     /// The group label to add.
     group: String,
-    /// Account name (its bare email — `Account.name` IS the email). Exact,
-    /// case-sensitive.
+    /// Account name — exact and case-sensitive.
     account: String,
-    /// Narrow an ambiguous match to a single org (name or uuid).
-    #[arg(long)]
-    org: Option<String>,
 }
 
 #[derive(clap::Args)]
@@ -246,11 +224,6 @@ struct GroupRmArgs {
     /// "both" and "neither".
     #[arg(required_unless_present = "all", conflicts_with = "all")]
     account: Option<String>,
-    /// Narrow an ambiguous match to a single org (name or uuid). Meaningless
-    /// with `--all`, which walks every member by identity and has no name to
-    /// disambiguate.
-    #[arg(long, conflicts_with = "all")]
-    org: Option<String>,
     /// Remove the group from every member instead of one account — deletes
     /// the group, since groups exist only while some account carries the
     /// label.
@@ -350,10 +323,6 @@ struct LoginArgs {
     /// match, or nothing is written.
     #[arg(long)]
     account: Option<String>,
-    /// Narrow an ambiguous `--account` match to a single org (name or uuid) —
-    /// the same flag `tcr enable`/`tcr disable`/`tcr remove`/`tcr priority` take.
-    #[arg(long)]
-    org: Option<String>,
     /// Add an account from a `claude setup-token` credential instead of the
     /// browser flow — no value here. The token is read from stdin (prompted
     /// when stdin is a TTY), never from argv: an argv value is visible in
@@ -362,14 +331,17 @@ struct LoginArgs {
     /// there is no refresh token (the account serves until the token expires,
     /// about a year, then goes dead — see the warning `tcr login --token`
     /// prints) and usually no email (name it with `--name`, or answer the
-    /// prompt). Refuses to combine with `--account`/`--org`: an
-    /// inference-only token carries no identity for either flag to confirm,
-    /// and an assertion that cannot be evaluated must fail closed.
+    /// prompt). Refuses to combine with `--account`: an inference-only token
+    /// carries no identity for that flag to confirm, and an assertion that
+    /// cannot be evaluated must fail closed.
     #[arg(long)]
     token: bool,
-    /// Name the account added by `--token`, since its profile fetch usually
-    /// comes back empty (no email to name it from). Ignored by the browser
-    /// flow, which always has an email or its own prompt.
+    /// Name this account explicitly, overriding the name login would mint for
+    /// it. Refused if some other account already has that name — names are
+    /// unique, and taking one from an existing row is how a login overwrites
+    /// the wrong credential. `--token` needs it most (an inference-only
+    /// credential's profile fetch usually comes back with no email to name it
+    /// from), but the browser flow honours it too.
     #[arg(long)]
     name: Option<String>,
 }
@@ -453,20 +425,20 @@ async fn run_accounts(args: AccountsArgs) -> anyhow::Result<()> {
     cli::list_accounts(&config_path, args.probe).await
 }
 
-/// `tcr remove <query> [--org]` — delete an account from the config, applying
+/// `tcr remove <query>` — delete an account from the config, applying
 /// a live disable through the RUNNING proxy first where there is one.
 async fn run_remove(args: RemoveArgs) -> anyhow::Result<()> {
     let config_path = args.config.unwrap_or_else(config::default_path);
-    cli::remove_account(&config_path, &args.query, args.org.as_deref()).await
+    cli::remove_account(&config_path, &args.query).await
 }
 
-/// `tcr token <query> [--org]` — print the account's access token.
+/// `tcr token <query>` — print the account's access token.
 fn run_token(args: TokenArgs) -> anyhow::Result<()> {
     let config_path = args.config.unwrap_or_else(config::default_path);
-    cli::print_access_token(&config_path, &args.query, args.org.as_deref())
+    cli::print_access_token(&config_path, &args.query)
 }
 
-/// `tcr priority <query> [N|--first|--last] [--org]` — set rotation priority.
+/// `tcr priority <query> [N|--first|--last]` — set rotation priority.
 fn run_priority(args: PriorityArgs) -> anyhow::Result<()> {
     let config_path = args.config.unwrap_or_else(config::default_path);
     let priority = if args.first {
@@ -478,24 +450,24 @@ fn run_priority(args: PriorityArgs) -> anyhow::Result<()> {
     } else {
         anyhow::bail!("provide a priority value, or one of --first / --last");
     };
-    cli::set_priority(&config_path, &args.query, priority, args.org.as_deref())
+    cli::set_priority(&config_path, &args.query, priority)
 }
 
-/// `tcr enable <query> [--org]` — clear an account's `disabled` flag, in the
+/// `tcr enable <query>` — clear an account's `disabled` flag, in the
 /// RUNNING proxy where there is one (async for that reason alone).
 async fn run_enable(args: EnableArgs) -> anyhow::Result<()> {
     let config_path = args.config.unwrap_or_else(config::default_path);
-    cli::set_enabled(&config_path, &args.query, args.org.as_deref(), false).await
+    cli::set_enabled(&config_path, &args.query, false).await
 }
 
-/// `tcr disable <query> [--org]` — hold an account out of rotation, in the RUNNING
+/// `tcr disable <query>` — hold an account out of rotation, in the RUNNING
 /// proxy where there is one.
 async fn run_disable(args: DisableArgs) -> anyhow::Result<()> {
     let config_path = args.config.unwrap_or_else(config::default_path);
-    cli::set_enabled(&config_path, &args.query, args.org.as_deref(), true).await
+    cli::set_enabled(&config_path, &args.query, true).await
 }
 
-/// `tcr control <query> [--org] | --clear | --show` — set, clear, or show the
+/// `tcr control <query> | --clear | --show` — set, clear, or show the
 /// identity-bound control account, in the RUNNING proxy where there is one.
 async fn run_control(args: ControlArgs) -> anyhow::Result<()> {
     let config_path = args.config.unwrap_or_else(config::default_path);
@@ -503,12 +475,12 @@ async fn run_control(args: ControlArgs) -> anyhow::Result<()> {
         return cli::show_control(&config_path).await;
     }
     if args.clear {
-        return cli::set_control(&config_path, None, args.org.as_deref()).await;
+        return cli::set_control(&config_path, None).await;
     }
     let Some(query) = args.query else {
         anyhow::bail!("provide an account query, or --clear / --show");
     };
-    cli::set_control(&config_path, Some(&query), args.org.as_deref()).await
+    cli::set_control(&config_path, Some(&query)).await
 }
 
 /// `tcr group ls|add|rm|reserve|unreserve|allow-control|disallow-control|color` — manage account group membership. Argument shape is
@@ -521,17 +493,11 @@ fn run_group(args: GroupArgs) -> anyhow::Result<()> {
         }
         GroupAction::Add(a) => {
             let config_path = a.config.unwrap_or_else(config::default_path);
-            cli::add_to_group(&config_path, &a.group, &a.account, a.org.as_deref())
+            cli::add_to_group(&config_path, &a.group, &a.account)
         }
         GroupAction::Rm(a) => {
             let config_path = a.config.unwrap_or_else(config::default_path);
-            cli::remove_from_group(
-                &config_path,
-                &a.group,
-                a.account.as_deref(),
-                a.org.as_deref(),
-                a.all,
-            )
+            cli::remove_from_group(&config_path, &a.group, a.account.as_deref(), a.all)
         }
         GroupAction::Reserve(a) => {
             let config_path = a.config.unwrap_or_else(config::default_path);
@@ -1102,7 +1068,6 @@ async fn run_login(args: LoginArgs) -> anyhow::Result<()> {
             args.force,
             args.name.as_deref(),
             args.account.as_deref(),
-            args.org.as_deref(),
         )
         .await
         .context("setup-token login failed")?;
@@ -1113,7 +1078,7 @@ async fn run_login(args: LoginArgs) -> anyhow::Result<()> {
         &config_path,
         args.force,
         args.account.as_deref(),
-        args.org.as_deref(),
+        args.name.as_deref(),
     )
     .await
     .context("OAuth login failed")?;

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -511,18 +511,12 @@ pub(crate) fn build_serving_client(http1_only: bool) -> Arc<reqwest::Client> {
     Arc::new(builder.build().expect("build reqwest client"))
 }
 
-/// A rotation slot answers a user's account query by the same three fields a
-/// config record does, so [`Manager::set_disabled_by_query`] can run the CLI's
-/// own resolution rule over the LIVE fleet.
+/// A rotation slot answers a user's account query by the same field a config
+/// record does, so [`Manager::set_disabled_by_query`] can run the CLI's own
+/// resolution rule over the LIVE fleet.
 impl crate::identity::Queryable for AccountRuntime {
     fn query_name(&self) -> &str {
         &self.name
-    }
-    fn query_org_name(&self) -> Option<&str> {
-        self.org_name.as_deref()
-    }
-    fn query_org_uuid(&self) -> Option<&str> {
-        self.org_uuid.as_deref()
     }
 }
 
@@ -531,14 +525,12 @@ impl crate::identity::Queryable for AccountRuntime {
 /// `Applied` carries the RESOLVED name plus the durable half's fate, which the
 /// caller must surface — see [`DisablePersist::warning`].
 ///
-/// The name is resolved, not echoed, because the query may have been the account's
-/// bare EMAIL where its stored name carries an org suffix (`me@example.com
-/// (Acme)`) — so the answer has to say what was actually parked. It is NOT a
-/// substring or case-insensitive match: [`crate::identity::match_accounts`] tries
-/// exact name, then exact email, byte-for-byte and untrimmed. Do not "fix"
-/// resolution to match a looser description; a widened rule is how a query
-/// silently parks an account nobody named, which is exactly what the `Ambiguous`
-/// arm below exists to refuse.
+/// The name is resolved, not echoed, so the answer says what was actually
+/// parked. It is NOT a substring or case-insensitive match:
+/// [`crate::identity::match_accounts`] is the account's exact name,
+/// byte-for-byte and untrimmed. Do not "fix" resolution to match a looser
+/// description; a widened rule is how a query silently parks an account nobody
+/// named, which is exactly what the `Ambiguous` arm below exists to refuse.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SetDisabledOutcome {
     Applied {
@@ -547,8 +539,9 @@ pub enum SetDisabledOutcome {
     },
     /// The query named no account in the live rotation.
     NoMatch,
-    /// The query named more than one, listed here so the caller can tell the user
-    /// what to pass `--org` for.
+    /// The query named more than one — only reachable on a config hand-edited
+    /// past the loader's rename migration. Listed here so the caller can tell
+    /// the user which rows to go fix.
     Ambiguous(Vec<String>),
 }
 
@@ -725,8 +718,9 @@ pub enum SetControlOutcome {
     },
     /// The query named no account in the live rotation.
     NoMatch,
-    /// The query named more than one, listed so the caller can tell the user
-    /// what to pass `--org` for.
+    /// The query named more than one — only reachable on a config hand-edited
+    /// past the loader's rename migration. Listed so the caller can tell the
+    /// user which rows to go fix.
     Ambiguous(Vec<String>),
 }
 
@@ -1304,8 +1298,7 @@ impl Manager {
             i64::from(config.reset_urgency_tier_hours).saturating_mul(3_600_000);
 
         let control_idx = config.control_account.as_ref().and_then(|identity| {
-            match crate::identity::match_one(&accounts[..], identity.name(), identity.org_filter())
-            {
+            match crate::identity::match_one(&accounts[..], identity.name()) {
                 crate::identity::Match::One(idx) => Some(idx),
                 crate::identity::Match::None => {
                     let names: Vec<&str> = accounts.iter().map(|a| a.name.as_str()).collect();
@@ -1315,9 +1308,9 @@ impl Manager {
                     );
                     None
                 }
-                // Two or more accounts share this identity (the reason
-                // `save_control_account` now stores org alongside the name):
-                // picking the first one silently, as the old `position(...)`
+                // Two or more accounts share this name — only reachable on a
+                // config hand-edited past `config::load`'s rename migration.
+                // Picking the first one silently, as the old `position(...)`
                 // scan did, risks binding control to a disabled Team-seat row
                 // while the account that resolved it live stays unpinned.
                 crate::identity::Match::Ambiguous(candidates) => {
@@ -2147,15 +2140,10 @@ impl Manager {
     ///
     /// The read guard is released before `set_disabled` takes its write guard —
     /// `RwLock` is not reentrant, so holding it across the call would deadlock.
-    pub fn set_disabled_by_query(
-        &self,
-        query: &str,
-        org: Option<&str>,
-        disabled: bool,
-    ) -> SetDisabledOutcome {
+    pub fn set_disabled_by_query(&self, query: &str, disabled: bool) -> SetDisabledOutcome {
         let (idx, name) = {
             let accounts = self.accounts.read().expect("accounts lock poisoned");
-            match crate::identity::match_one(&accounts[..], query, org) {
+            match crate::identity::match_one(&accounts[..], query) {
                 crate::identity::Match::One(idx) => (idx, accounts[idx].name.clone()),
                 crate::identity::Match::None => return SetDisabledOutcome::NoMatch,
                 crate::identity::Match::Ambiguous(names) => {
@@ -2337,18 +2325,14 @@ impl Manager {
         self.persist_control(target)
     }
 
-    /// Resolve a user-supplied `(query, org)` against the LIVE rotation and set
+    /// Resolve a user-supplied `query` against the LIVE rotation and set
     /// the control account to whatever it names — the whole operation the
     /// control endpoint performs. `query = None` CLEARS the control account
     /// (there is nothing to resolve, so this never reaches `match_one`).
     ///
     /// Resolution runs over `self.accounts` — never the boot-time config
     /// snapshot — for the same reason [`Self::set_disabled_by_query`] does.
-    pub fn set_control_by_query(
-        &self,
-        query: Option<&str>,
-        org: Option<&str>,
-    ) -> SetControlOutcome {
+    pub fn set_control_by_query(&self, query: Option<&str>) -> SetControlOutcome {
         let Some(query) = query else {
             return SetControlOutcome::Applied {
                 name: None,
@@ -2357,7 +2341,7 @@ impl Manager {
         };
         let (idx, name) = {
             let accounts = self.accounts.read().expect("accounts lock poisoned");
-            match crate::identity::match_one(&accounts[..], query, org) {
+            match crate::identity::match_one(&accounts[..], query) {
                 crate::identity::Match::One(idx) => (idx, accounts[idx].name.clone()),
                 crate::identity::Match::None => return SetControlOutcome::NoMatch,
                 crate::identity::Match::Ambiguous(names) => {
@@ -2423,7 +2407,7 @@ impl Manager {
     /// — the SAME rule the durable half ([`config::save_account`]) and `tcr
     /// login` (`oauth::upsert_account`) already run — never
     /// [`crate::identity::match_one`]. `match_one` goes through
-    /// [`crate::identity::Queryable`], which exposes only name and org: it
+    /// [`crate::identity::Queryable`], which exposes only the name: it
     /// cannot compare `account_uuid`, so it was structurally unable to tell two
     /// different people sharing a display name apart. Unifying on `resolve`
     /// fixes that (a differing `account_uuid` never matches, so a same-named
@@ -2434,16 +2418,12 @@ impl Manager {
     /// which one account that is, on both halves, every time — not only when
     /// there happen to be two orgs in play.
     ///
-    /// One `match_one`-style fallback survives, deliberately narrow: when
-    /// `account` carries NO identity fields at all (a bare name — the ordinary
-    /// single-account case), `resolve`'s exact name-equality miss is retried
-    /// through `match_one` so a bare email still finds a stored display name
-    /// carrying an org suffix (`email (Org)`), the way the CLI's own query
-    /// resolution always has. It is gated on "no identity fields submitted"
-    /// and nothing looser: widening it to a submission that DOES carry an
-    /// `account_uuid` would resurrect the exact bug this rewrite fixes, by
-    /// matching on name/email again after the uuid comparison already said
-    /// "different person".
+    /// A submission carrying no identity fields at all (a bare name) still
+    /// finds its row: `same_identity` falls back to name equality when either
+    /// side has no uuid, and names are unique, so `resolve` answers that case
+    /// on its own. It used to need a `match_one` retry on top, because a bare
+    /// email had to find a stored `email (Org)` display name — a shape that
+    /// existed only while names were not unique.
     ///
     /// Resolve AND mutate under ONE write-lock acquisition of `self.accounts` —
     /// closing a TOCTOU the old two-lock version had: it resolved under a READ
@@ -2502,9 +2482,6 @@ impl Manager {
             account.org_uuid.clone(),
             account.org_name.clone(),
         );
-        let bare_identity = account.account_uuid.is_none()
-            && account.org_uuid.is_none()
-            && account.org_name.is_none();
 
         /// What the locked resolve-and-mutate section below produced, so the
         /// durable write can run after `self.accounts`'s lock is released —
@@ -2589,15 +2566,6 @@ impl Manager {
                                 .map(|a| a.name.clone())
                                 .collect();
                             return AddAccountOutcome::Ambiguous(names);
-                        }
-                        crate::identity::Resolved::None if bare_identity => {
-                            match crate::identity::match_one(&accounts[..], &account.name, None) {
-                                crate::identity::Match::One(idx) => Some(idx),
-                                crate::identity::Match::None => None,
-                                crate::identity::Match::Ambiguous(names) => {
-                                    return AddAccountOutcome::Ambiguous(names);
-                                }
-                            }
                         }
                         crate::identity::Resolved::None => None,
                     };
@@ -3052,6 +3020,8 @@ mod tests {
         Config {
             quarantined_accounts: Vec::new(),
             migrated_legacy_throttle: false,
+            renamed_accounts: Vec::new(),
+            rename_write_error: None,
             proxy: ProxyConfig::default(),
             upstream: "https://api.anthropic.com".to_string(),
             switch_threshold: 0.90,
@@ -4399,9 +4369,7 @@ mod tests {
 
     fn config_with_control(accounts: Vec<Account>, control: &str) -> Config {
         let mut config = config_with(accounts);
-        config.control_account = Some(crate::config::ControlAccountRef::Legacy(
-            control.to_string(),
-        ));
+        config.control_account = Some(crate::config::ControlAccountRef::Name(control.to_string()));
         config
     }
 
@@ -4526,23 +4494,24 @@ mod tests {
         );
     }
 
-    /// An identity object carrying `orgUuid` resolves boot control to the RIGHT
-    /// one of two same-email rows — the fix's other half: a `controlAccount`
-    /// written with org information survives a restart instead of collapsing
-    /// back to the ambiguous legacy behaviour.
+    /// A `controlAccount` written by an OLDER tcr — the identity object, with
+    /// its org fields — still resolves at boot, by its `name` alone. Nothing
+    /// writes that shape now, and a config carrying one must still come up on
+    /// the right row rather than with no control account at all.
+    ///
+    /// The two rows have distinct names here because `config::load` guarantees
+    /// that; the object's `orgUuid` is the field this deliberately no longer
+    /// reads, and the row it names is the one that must win.
     #[test]
-    fn assemble_resolves_identity_control_account_by_org_uuid() {
-        let dup_a = Account {
-            org_uuid: Some("11111111-1111-1111-1111-111111111111".to_string()),
-            ..account("dup@example.com", 0)
-        };
-        let dup_b = Account {
+    fn assemble_resolves_a_legacy_identity_control_account_by_name() {
+        let personal = account("dup@example.com", 0);
+        let team = Account {
             org_uuid: Some("22222222-2222-2222-2222-222222222222".to_string()),
-            ..account("dup@example.com", 0)
+            ..account("dup@example.com/team", 0)
         };
-        let mut config = config_with(vec![dup_a, dup_b]);
+        let mut config = config_with(vec![personal, team]);
         config.control_account = Some(crate::config::ControlAccountRef::Identity {
-            name: "dup@example.com".to_string(),
+            name: "dup@example.com/team".to_string(),
             account_uuid: None,
             org_uuid: Some("22222222-2222-2222-2222-222222222222".to_string()),
             org_name: None,
@@ -4551,20 +4520,22 @@ mod tests {
         assert_eq!(
             manager.control(),
             Some(1),
-            "orgUuid must pick the second row, not the first"
+            "the object's name must pick the second row, not the first"
         );
     }
 
-    /// Full round trip through the durable half: setting control on a
-    /// duplicated email via [`Manager::set_control_by_query`] persists the
-    /// IDENTITY shape (not the bare name), and a fresh `Manager` built from the
-    /// reloaded file resolves to the SAME row — not just "a" row. Both rows
-    /// share an `accountUuid` (one person, two orgs — the realistic shape a
-    /// duplicated email takes) so the durable write can disambiguate them at
-    /// all; see `control_write_with_org_uuid_disambiguates_duplicated_email` in
-    /// `config.rs` for why an org alone, with no shared uuid, cannot.
+    /// Full round trip through the durable half, on the fleet shape that used
+    /// to make this impossible: one person, two orgs, one email. The loader
+    /// gives the second row its own name; setting control by that name persists
+    /// the NAME (nothing else is needed — a name is unique), and a fresh
+    /// `Manager` built from the reloaded file resolves to the SAME row, not
+    /// just "a" row.
+    ///
+    /// The duplicated-email file is written first and read back through
+    /// `config::load` deliberately: the migration is the step under test as much
+    /// as the control write is.
     #[test]
-    fn set_control_on_duplicated_email_survives_a_reload() {
+    fn set_control_on_a_migrated_duplicate_survives_a_reload() {
         let path = tmp_config_path("control-survives-reload");
         let dup_a = Account {
             account_uuid: Some("33333333-3333-3333-3333-333333333333".to_string()),
@@ -4578,33 +4549,36 @@ mod tests {
             refresh_token: Some("rt-second".to_string()),
             ..account("dup@example.com", 0)
         };
-        let config = config_with(vec![dup_a, dup_b]);
-        config::save(&path, &config).expect("write test config");
-        let manager = build_manager_with_path(config, path.clone());
+        config::save(&path, &config_with(vec![dup_a, dup_b])).expect("write test config");
 
-        let outcome = manager.set_control_by_query(
-            Some("dup@example.com"),
-            Some("22222222-2222-2222-2222-222222222222"),
-        );
+        // The loader renames the second row — no org name on file, so the name
+        // falls back to the first eight characters of its org uuid.
+        let migrated = config::load(&path).expect("load migrates the duplicate");
+        assert_eq!(migrated.accounts[0].name, "dup@example.com");
+        assert_eq!(migrated.accounts[1].name, "dup@example.com/22222222");
+        let manager = build_manager_with_path(migrated, path.clone());
+
+        let outcome = manager.set_control_by_query(Some("dup@example.com/22222222"));
         assert_eq!(
             outcome,
             SetControlOutcome::Applied {
-                name: Some("dup@example.com".to_string()),
+                name: Some("dup@example.com/22222222".to_string()),
                 persist: ControlPersist::Persisted,
             }
         );
         assert_eq!(manager.control(), Some(1), "resolved the SECOND row live");
 
-        // The identity object, not the bare name, must be what landed on disk.
+        // The bare name is the whole key on disk now.
         let on_disk = config::load(&path).expect("reload persisted config");
         assert_eq!(
             on_disk.control_account,
-            Some(crate::config::ControlAccountRef::Identity {
-                name: "dup@example.com".to_string(),
-                account_uuid: Some("33333333-3333-3333-3333-333333333333".to_string()),
-                org_uuid: Some("22222222-2222-2222-2222-222222222222".to_string()),
-                org_name: None,
-            })
+            Some(crate::config::ControlAccountRef::Name(
+                "dup@example.com/22222222".to_string()
+            ))
+        );
+        assert!(
+            on_disk.renamed_accounts.is_empty(),
+            "the second load has nothing left to rename"
         );
 
         // A brand-new Manager built from the reloaded file resolves to the
@@ -4740,7 +4714,7 @@ mod tests {
         assert_eq!(pinned, 0);
 
         // Set the control account to `ctrl` (index 1) at runtime.
-        manager.set_control_by_query(Some("ctrl"), None);
+        manager.set_control_by_query(Some("ctrl"));
         assert_eq!(manager.control(), Some(1));
 
         // The SAME session's next identity-plane request must still return its
@@ -4790,7 +4764,7 @@ mod tests {
 
         // Set control to "c" (index 2) — a DIFFERENT account — after the pin
         // already exists.
-        manager.set_control_by_query(Some("c"), None);
+        manager.set_control_by_query(Some("c"));
         assert_eq!(manager.control(), Some(2));
 
         // Bias ordinary LRU firmly toward "b" (index 1): stamp "c" (control)
@@ -5196,7 +5170,7 @@ mod tests {
             lock_refresher(),
         );
 
-        let outcome = manager.set_control_by_query(Some("gil"), None);
+        let outcome = manager.set_control_by_query(Some("gil"));
         assert_eq!(
             outcome,
             SetControlOutcome::Applied {
@@ -5207,7 +5181,7 @@ mod tests {
         assert_eq!(manager.control(), Some(0));
         assert_eq!(manager.control_name(), Some("gil".to_string()));
 
-        let cleared = manager.set_control_by_query(None, None);
+        let cleared = manager.set_control_by_query(None);
         assert_eq!(
             cleared,
             SetControlOutcome::Applied {
@@ -5225,11 +5199,11 @@ mod tests {
             lock_refresher(),
         );
         assert_eq!(
-            manager.set_control_by_query(Some("ghost"), None),
+            manager.set_control_by_query(Some("ghost")),
             SetControlOutcome::NoMatch
         );
         assert_eq!(
-            manager.set_control_by_query(Some("dup"), None),
+            manager.set_control_by_query(Some("dup")),
             SetControlOutcome::Ambiguous(vec!["dup".to_string(), "dup".to_string()])
         );
         assert_eq!(
@@ -5971,7 +5945,7 @@ mod tests {
             config_with(vec![account("ok", 0), account("gil", 0)]),
             refresher,
         );
-        manager.set_control_by_query(Some("gil"), None);
+        manager.set_control_by_query(Some("gil"));
         manager.set_disabled(1, true);
 
         assert_eq!(
@@ -5993,7 +5967,7 @@ mod tests {
             config_with(vec![account("gil", 0), account("ok", 0), account("off", 0)]),
             refresher,
         );
-        manager.set_control_by_query(Some("gil"), None);
+        manager.set_control_by_query(Some("gil"));
         manager.set_disabled(0, true); // the control account itself, disabled
         manager.set_disabled(2, true); // an unrelated account, disabled
 
@@ -9760,39 +9734,51 @@ mod tests {
     }
 
     /// Preservation guard: a submission with NO identity fields at all (a bare
-    /// name) must still find a stored row whose display name carries an org
-    /// suffix, via the CLI's own email-of fallback — `identity::resolve`'s exact
-    /// name equality alone would miss it and append a duplicate. This is the
-    /// one case the bare-name `match_one` fallback exists for.
+    /// name) resolves on NAME EQUALITY alone — `same_identity`'s fallback when
+    /// either side has no uuid — and a name that matches nothing is APPENDED,
+    /// never merged onto a row whose name merely looks similar.
+    ///
+    /// This used to need a `match_one` retry on top, so a bare email could find
+    /// a stored `alice@example.com (Corp)`. That display-name shape existed only
+    /// because names were not unique; a submission naming a row that is not
+    /// there is now a new account, which is the honest reading.
     #[test]
-    fn add_or_update_account_bare_email_still_matches_a_display_name_with_org_suffix() {
-        let display_named = Account {
-            name: "alice@example.com (Corp)".to_string(),
+    fn add_or_update_account_with_a_bare_name_matches_only_that_exact_name() {
+        let stored = Account {
             refresh_token: Some("rt-old".to_string()),
-            ..account("alice@example.com (Corp)", 0)
+            ..account("alice@example.com/corp", 0)
         };
         let (manager, path) =
-            build_manager_with_disk(config_with(vec![display_named]), "f-bare-email-fallback");
+            build_manager_with_disk(config_with(vec![stored]), "f-bare-name-exact");
 
-        let submission = Account {
+        // The exact stored name updates in place.
+        let same_row = Account {
             access_token: "at-fresh".to_string(),
             refresh_token: Some("rt-fresh".to_string()),
+            ..account("alice@example.com/corp", 0)
+        };
+        match manager.add_or_update_account(same_row) {
+            AddAccountOutcome::Updated { idx, .. } => assert_eq!(idx, 0),
+            other => panic!("an exact name must update its own row: {other:?}"),
+        }
+
+        // A different name is a different account, appended.
+        let other_row = Account {
+            access_token: "at-other".to_string(),
+            refresh_token: Some("rt-other".to_string()),
             ..account("alice@example.com", 0)
         };
-        let outcome = manager.add_or_update_account(submission);
-        let idx = match outcome {
-            AddAccountOutcome::Updated { idx, .. } => idx,
-            other => panic!("a bare email must still match its display-named row: {other:?}"),
-        };
-        assert_eq!(idx, 0);
+        match manager.add_or_update_account(other_row) {
+            AddAccountOutcome::Added { idx, .. } => assert_eq!(idx, 1),
+            other => panic!("an unmatched name must be appended: {other:?}"),
+        }
         assert_eq!(
             manager
                 .accounts
                 .read()
                 .expect("accounts lock poisoned")
                 .len(),
-            1,
-            "no duplicate appended"
+            2
         );
 
         std::fs::remove_file(&path).ok();

--- a/src/manager/select.rs
+++ b/src/manager/select.rs
@@ -2596,6 +2596,8 @@ mod revalidation_sticky_tests {
         Config {
             quarantined_accounts: Vec::new(),
             migrated_legacy_throttle: false,
+            renamed_accounts: Vec::new(),
+            rename_write_error: None,
             proxy: ProxyConfig::default(),
             upstream: "https://api.anthropic.com".to_string(),
             switch_threshold: 0.90,
@@ -2746,6 +2748,8 @@ mod sticky_divert_replay_tests {
         Config {
             quarantined_accounts: Vec::new(),
             migrated_legacy_throttle: false,
+            renamed_accounts: Vec::new(),
+            rename_write_error: None,
             proxy: ProxyConfig::default(),
             upstream: "https://api.anthropic.com".to_string(),
             switch_threshold: 0.90,
@@ -3179,6 +3183,8 @@ mod reset_urgency_tests {
         Config {
             quarantined_accounts: Vec::new(),
             migrated_legacy_throttle: false,
+            renamed_accounts: Vec::new(),
+            rename_write_error: None,
             proxy: ProxyConfig::default(),
             upstream: "https://api.anthropic.com".to_string(),
             switch_threshold: 0.90,
@@ -3428,6 +3434,8 @@ mod fable_last_resort_tests {
         Config {
             quarantined_accounts: Vec::new(),
             migrated_legacy_throttle: false,
+            renamed_accounts: Vec::new(),
+            rename_write_error: None,
             proxy: ProxyConfig::default(),
             upstream: "https://api.anthropic.com".to_string(),
             switch_threshold,

--- a/src/mitm.rs
+++ b/src/mitm.rs
@@ -1352,6 +1352,8 @@ mod tests {
         let config = crate::config::Config {
             quarantined_accounts: Vec::new(),
             migrated_legacy_throttle: false,
+            renamed_accounts: Vec::new(),
+            rename_write_error: None,
             proxy: crate::config::ProxyConfig {
                 port: 0,
                 api_key: None,

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -1098,7 +1098,7 @@ pub async fn login(
     config_path: &Path,
     force: bool,
     account: Option<&str>,
-    org: Option<&str>,
+    name_override: Option<&str>,
 ) -> anyhow::Result<String> {
     let port = login_target_port(config_path);
     let incumbent = singleton::live_proxy_server(port);
@@ -1115,7 +1115,7 @@ pub async fn login(
     let hint = match account {
         Some(query) => {
             let probe_config = load_or_default(config_path)?;
-            let idx = crate::cli::resolve_account(&probe_config.accounts, query, org)?;
+            let idx = crate::cli::resolve_account(&probe_config.accounts, query)?;
             let email = crate::identity::email_of(&probe_config.accounts[idx].name);
             // Only ever send something address-shaped: a non-email display
             // name (e.g. an account named "work") produces `login_hint=work`
@@ -1155,13 +1155,9 @@ pub async fn login(
     // file surfaces as an error so login never clobbers it with defaults).
     let mut config = load_or_default(config_path)?;
 
-    // Fetch the account+org identity; name from the profile email, else prompt.
+    // Fetch the account+org identity, then MINT a name for it.
     let profile = fetch_profile(&tokens.access_token).await;
-    let fallback = format!("account-{}", config.accounts.len() + 1);
-    let name = match &profile.email {
-        Some(email) => email.clone(),
-        None => prompt_account_name(&fallback),
-    };
+    let name = mint_login_name(&config, &profile, account, name_override)?;
 
     finish_login_checked(
         config_path,
@@ -1171,9 +1167,67 @@ pub async fn login(
         &tokens,
         profile,
         account,
-        org,
     )
     .await
+}
+
+/// The name a browser login writes under.
+///
+/// Nothing is prompted for on the happy path. The profile's email is minted into
+/// a free name by [`crate::identity::mint_name`] — the bare email when no other
+/// row carries it, `email/<org-slug>` when one does — so a second org of the same
+/// person lands beside the first instead of on top of it.
+///
+/// Three things override or replace that, in order:
+///
+/// * `name_override` (`--name`) wins outright, and is REFUSED when some other
+///   account already holds it. Taking a name off an existing row is how a login
+///   overwrites the wrong credential, and it is the one case a name collision
+///   would be silent rather than migrated.
+/// * A RE-login (`--account`) keeps the name the row already has. Renaming a
+///   row on re-login would break the pins, groups and control-account key that
+///   name is the identity for; the row is confirmed to be the same account by
+///   [`assert_requested_identity`] a moment later.
+/// * A profile with no email at all — the inference-only case — is the only path
+///   left that prompts ([`prompt_account_name`]), and the name it comes back
+///   with is minted for uniqueness too.
+fn mint_login_name(
+    config: &Config,
+    profile: &Profile,
+    requested_account: Option<&str>,
+    name_override: Option<&str>,
+) -> anyhow::Result<String> {
+    let taken: std::collections::HashSet<String> =
+        config.accounts.iter().map(|a| a.name.clone()).collect();
+
+    if let Some(explicit) = name_override {
+        if taken.contains(explicit) {
+            bail!(
+                "'{explicit}' is already the name of another account — account names are unique. \
+                 Pick a different --name, or re-login that account with `tcr login --account \
+                 {explicit}`. Nothing was changed."
+            );
+        }
+        return Ok(explicit.to_string());
+    }
+
+    // A re-login keeps the row's own name: it IS the identity every pin, group
+    // and `controlAccount` key already points at.
+    if let Some(query) = requested_account {
+        let idx = crate::cli::resolve_account(&config.accounts, query)?;
+        return Ok(config.accounts[idx].name.clone());
+    }
+
+    let base = match &profile.email {
+        Some(email) => email.clone(),
+        None => prompt_account_name(&unnamed_fallback(&config.accounts)),
+    };
+    Ok(crate::identity::mint_name(
+        &base,
+        profile.org_name.as_deref(),
+        profile.org_uuid.as_deref(),
+        &taken,
+    ))
 }
 
 /// Our ASSUMPTION about a `claude setup-token` credential's lifetime — one
@@ -1215,7 +1269,7 @@ fn read_setup_token() -> anyhow::Result<String> {
 /// the Claude CLI that produces it never surfaces its refresh token to the
 /// caller, so there is genuinely nothing to store.
 ///
-/// `--account`/`--org` are refused up front (before the port probe or the
+/// `--account` is refused up front (before the port probe or the
 /// stdin read): an inference-only token carries no identity for
 /// [`assert_requested_identity`] to confirm, and an assertion that cannot be
 /// evaluated must fail closed rather than pass — so this calls [`finish_login`]
@@ -1230,10 +1284,6 @@ fn read_setup_token() -> anyhow::Result<String> {
 /// account serves until its (assumed) one-year expiry and then goes dead,
 /// with nothing to renew it, and — unlike the live-add wire route — this
 /// offline path has no other caller that would say so.
-/// Name a setup-token account: the profile's email when the (usually failed)
-/// fetch happened to carry one, else `name` (`--name`), else a prompt —
-/// split out of [`login_with_token`] so the fallback chain is directly
-/// testable without a real stdin prompt.
 /// The name a setup-token account falls back to when the operator declines to
 /// type one: `unnamed`, or the first free `unnamed-N` when that is taken.
 ///
@@ -1259,16 +1309,6 @@ fn unnamed_fallback(accounts: &[Account]) -> String {
         .map(|n| format!("{BASE}-{n}"))
         .find(|candidate| !accounts.iter().any(|a| &a.name == candidate))
         .expect("an unbounded range always yields a free name")
-}
-
-fn resolve_setup_token_name(profile: &Profile, name: Option<&str>, fallback: &str) -> String {
-    match &profile.email {
-        Some(email) => email.clone(),
-        None => match name {
-            Some(explicit) => explicit.to_string(),
-            None => prompt_account_name(fallback),
-        },
-    }
 }
 
 /// What one authenticated call said about a pasted setup token, before it is
@@ -1326,13 +1366,12 @@ pub async fn login_with_token(
     force: bool,
     name: Option<&str>,
     account: Option<&str>,
-    org: Option<&str>,
 ) -> anyhow::Result<String> {
-    if account.is_some() || org.is_some() {
+    if account.is_some() {
         bail!(
-            "--token cannot be combined with --account or --org: a `claude setup-token` \
+            "--token cannot be combined with --account: a `claude setup-token` \
              credential carries only the user:inference scope, so it has no email and no \
-             account id for either flag to confirm against — an identity assertion that \
+             account id for that flag to confirm against — an identity assertion that \
              cannot be evaluated must fail closed rather than pass. Log in with --token alone \
              (use --name to choose the account name), or drop --token and use the browser flow \
              with --account instead. Nothing was written."
@@ -1374,8 +1413,7 @@ pub async fn login_with_token(
     }
 
     let profile = fetch_profile(&tokens.access_token).await;
-    let fallback = unnamed_fallback(&config.accounts);
-    let resolved_name = resolve_setup_token_name(&profile, name, &fallback);
+    let resolved_name = mint_login_name(&config, &profile, None, name)?;
 
     let result = finish_login(
         config_path,
@@ -1422,16 +1460,15 @@ async fn finish_login_checked(
     tokens: &Tokens,
     profile: Profile,
     requested_account: Option<&str>,
-    requested_org: Option<&str>,
 ) -> anyhow::Result<String> {
     if let Some(query) = requested_account {
-        assert_requested_identity(config, query, requested_org, &profile)?;
+        assert_requested_identity(config, query, &profile)?;
     }
     finish_login(config_path, route, config, name, tokens, profile).await
 }
 
-/// The load-bearing half of `tcr login --account <query> [--org <org>]`:
-/// resolve `query`/`org` against `config` via [`crate::cli::resolve_account`]
+/// The load-bearing half of `tcr login --account <query>`:
+/// resolve `query` against `config` via [`crate::cli::resolve_account`]
 /// — the exact rule `tcr enable`/`tcr disable` and TcrBar's row buttons
 /// already rely on, not a second copy of it — then refuse to proceed unless
 /// the identity that came back from `fetch_profile` resolves, through
@@ -1458,10 +1495,9 @@ async fn finish_login_checked(
 fn assert_requested_identity(
     config: &Config,
     query: &str,
-    org: Option<&str>,
     profile: &Profile,
 ) -> anyhow::Result<()> {
-    let idx = crate::cli::resolve_account(&config.accounts, query, org)?;
+    let idx = crate::cli::resolve_account(&config.accounts, query)?;
     let requested = &config.accounts[idx];
 
     if profile.email.is_none() && profile.account_uuid.is_none() {
@@ -1648,8 +1684,8 @@ fn account_write_result(
             Ok(account.name.clone())
         }
         config::AccountWrite::Ambiguous => bail!(
-            "'{}' matches more than one account already in {} — narrow with --org or use an \
-             exact name. Nothing was changed.",
+            "'{}''s identity matches more than one account already in {} — give each row its own \
+             accountUuid/orgUuid and retry. Nothing was changed.",
             account.name,
             config_path.display()
         ),
@@ -3035,7 +3071,6 @@ mod tests {
             &tokens("at-new", "rt-new", 1_893_456_000_000),
             profile_named("mallory@example.com"),
             Some("alice@example.com"),
-            None,
         )
         .await
         .unwrap_err();
@@ -3071,7 +3106,6 @@ mod tests {
             &tokens("at-fresh", "rt-fresh", 1_893_456_000_000),
             profile_named("alice@example.com"),
             Some("alice@example.com"),
-            None,
         )
         .await
         .unwrap();
@@ -3118,7 +3152,6 @@ mod tests {
             &tokens("at-new", "rt-new", 1_893_456_000_000),
             all_none,
             Some("alice@example.com"),
-            None,
         )
         .await
         .unwrap_err();
@@ -3137,11 +3170,13 @@ mod tests {
         std::fs::remove_file(&path).ok();
     }
 
-    /// An ambiguous `--account` query is an error, not a guess — same
-    /// zero/one/many rule `crate::cli::resolve_account` already enforces for
-    /// every other command.
+    /// An `--account` naming no row is an error, not a guess — the same
+    /// zero/one/many rule `crate::cli::resolve_account` enforces for every other
+    /// command, and the arm that survives now that a name can never match two
+    /// rows. The query used here is the email PORTION of a migrated row's name,
+    /// which is precisely what used to match both of them.
     #[tokio::test]
-    async fn finish_login_checked_ambiguous_query_is_an_error() {
+    async fn finish_login_checked_unmatched_query_is_an_error() {
         let seed = r#"{ "accounts": [
             { "name": "dup@example.com", "type": "oauth", "accessToken": "at-1",
               "refreshToken": "rt-1", "expiresAt": 1893456000000, "priority": 0,
@@ -3156,7 +3191,10 @@ mod tests {
             line!()
         ));
         std::fs::write(&path, seed).unwrap();
+        // Migrates: the two rows become `dup@example.com` and
+        // `dup@example.com/corp-b`. `corp-b` on its own names neither.
         let mut config = load_or_default(&path).unwrap();
+        assert_eq!(config.accounts[1].name, "dup@example.com/corp-b");
         let before = std::fs::read_to_string(&path).unwrap();
 
         let err = finish_login_checked(
@@ -3166,29 +3204,31 @@ mod tests {
             "dup@example.com",
             &tokens("at-new", "rt-new", 1_893_456_000_000),
             profile_named("dup@example.com"),
-            Some("dup@example.com"),
-            None,
+            Some("corp-b"),
         )
         .await
         .unwrap_err();
         assert!(
-            err.to_string().to_lowercase().contains("more than one")
-                || err.to_string().to_lowercase().contains("ambiguous"),
+            err.to_string().contains("no account matches 'corp-b'"),
             "{}",
             err.to_string()
         );
 
         let after = std::fs::read_to_string(&path).unwrap();
-        assert_eq!(before, after, "an ambiguous query must not guess and write");
+        assert_eq!(before, after, "an unmatched query must not guess and write");
 
         std::fs::remove_file(&path).ok();
     }
 
-    /// The remedy `ambiguous_query_message` advises ("narrow with --org") must
-    /// actually be followable: `--org` plumbed through resolves the same
-    /// otherwise-ambiguous query to exactly one row.
+    /// The migration is what makes a re-login of one org addressable at all:
+    /// the loader gives each row its own name, and `--account <that name>`
+    /// resolves to exactly one row and writes only that row's credential.
+    ///
+    /// This is the same fleet shape that used to be an ambiguous refusal, then
+    /// a refusal plus an org flag. Note the assertion is on which row got
+    /// `rt-new`: a re-login that guessed would still return a plausible name.
     #[tokio::test]
-    async fn finish_login_checked_org_disambiguates_a_duplicate_email() {
+    async fn finish_login_checked_re_logs_in_the_named_row_of_a_migrated_duplicate() {
         let seed = r#"{ "accounts": [
             { "name": "dup@example.com", "type": "oauth", "accessToken": "at-1",
               "refreshToken": "rt-1", "expiresAt": 1893456000000, "priority": 0,
@@ -3203,7 +3243,11 @@ mod tests {
             line!()
         ));
         std::fs::write(&path, seed).unwrap();
+        // Loading migrates the duplicate: Corp A keeps the bare email (lower
+        // priority number), Corp B takes its org's slug.
         let mut config = load_or_default(&path).unwrap();
+        assert_eq!(config.accounts[0].name, "dup@example.com");
+        assert_eq!(config.accounts[1].name, "dup@example.com/corp-b");
 
         let name = finish_login_checked(
             &path,
@@ -3218,7 +3262,6 @@ mod tests {
                 Some("Corp A"),
             ),
             Some("dup@example.com"),
-            Some("org-a"),
         )
         .await
         .unwrap();
@@ -3309,7 +3352,6 @@ mod tests {
             &tokens("at-new", "rt-new", 1_893_456_000_000),
             wrong_org_profile,
             Some("me@example.com (Corp)"),
-            None,
         )
         .await
         .unwrap_err();
@@ -3370,7 +3412,6 @@ mod tests {
             &tokens("at-fresh-corp", "rt-fresh-corp", 1_893_456_000_000),
             right_profile,
             Some("me@example.com (Corp)"),
-            None,
         )
         .await
         .unwrap();
@@ -3429,7 +3470,6 @@ mod tests {
             &tokens("at-new", "rt-new", 1_893_456_000_000),
             profile_named("someone@example.com"),
             Some("work"),
-            None,
         )
         .await
         .unwrap_err();
@@ -3472,7 +3512,6 @@ mod tests {
             "carol@example.com",
             &tokens("at-carol", "rt-carol", 1_893_456_000_000),
             profile_named("carol@example.com"),
-            None,
             None,
         )
         .await
@@ -4218,7 +4257,7 @@ mod tests {
         std::fs::write(&path, two_account_seed()).unwrap();
         let before = std::fs::read_to_string(&path).unwrap();
 
-        let err = login_with_token(&path, false, None, Some("alice@example.com"), None)
+        let err = login_with_token(&path, false, None, Some("alice@example.com"))
             .await
             .expect_err("--token combined with --account must refuse");
         assert!(err.to_string().contains("--account"), "{}", err.to_string());
@@ -4232,31 +4271,91 @@ mod tests {
         std::fs::remove_file(&path).ok();
     }
 
-    /// `--token` combined with `--org` (no `--account`) must refuse too — the
-    /// same "no identity to confirm against" reasoning applies to either flag
-    /// alone.
-    #[tokio::test]
-    async fn login_with_token_refuses_with_org_and_writes_nothing() {
-        let path = std::env::temp_dir().join(format!(
-            "tcr-oauth-setup-token-refuse-org-{}-{}.json",
-            std::process::id(),
-            line!()
-        ));
-        std::fs::write(&path, two_account_seed()).unwrap();
-        let before = std::fs::read_to_string(&path).unwrap();
-
-        let err = login_with_token(&path, false, None, None, Some("Corp"))
-            .await
-            .expect_err("--token combined with --org must refuse");
-        assert!(err.to_string().contains("--org"), "{}", err.to_string());
-
-        let after = std::fs::read_to_string(&path).unwrap();
+    /// A login mints its own name, and never prompts on the happy path: the
+    /// bare email when nothing carries it, `email/<org-slug>` when something
+    /// does. This is the whole mechanism that stops a second org of the same
+    /// person from landing on the first one's row.
+    #[test]
+    fn a_login_mints_the_bare_email_when_free_and_qualifies_it_when_not() {
+        let empty: Config = serde_json::from_str(r#"{ "accounts": [] }"#).unwrap();
+        let profile = profile_with_identity(
+            "me@example.com",
+            Some("uuid-person"),
+            Some("22222222-2222"),
+            Some("Henry Token"),
+        );
         assert_eq!(
-            before, after,
-            "the file must be byte-identical — --token+--org must write nothing"
+            mint_login_name(&empty, &profile, None, None).unwrap(),
+            "me@example.com"
         );
 
-        std::fs::remove_file(&path).ok();
+        let occupied: Config = serde_json::from_str(
+            r#"{ "accounts": [
+                { "name": "me@example.com", "type": "oauth", "accessToken": "at-1" }
+            ] }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            mint_login_name(&occupied, &profile, None, None).unwrap(),
+            "me@example.com/henry-token"
+        );
+
+        // No org name on the profile: the org uuid's first eight characters.
+        let no_org_name = profile_with_identity(
+            "me@example.com",
+            Some("uuid-person"),
+            Some("22222222-2222"),
+            None,
+        );
+        assert_eq!(
+            mint_login_name(&occupied, &no_org_name, None, None).unwrap(),
+            "me@example.com/22222222"
+        );
+    }
+
+    /// `--name` wins over the minted name, and is REFUSED when another account
+    /// already holds it. Taking a name off an existing row is how a login
+    /// overwrites the wrong credential, and it is the one collision the loader's
+    /// migration would never see.
+    #[test]
+    fn a_name_override_wins_but_never_takes_a_name_already_in_use() {
+        let occupied: Config = serde_json::from_str(
+            r#"{ "accounts": [
+                { "name": "alice@example.com", "type": "oauth", "accessToken": "at-1" }
+            ] }"#,
+        )
+        .unwrap();
+        let profile = profile_named("bob@example.com");
+
+        assert_eq!(
+            mint_login_name(&occupied, &profile, None, Some("bob-work")).unwrap(),
+            "bob-work"
+        );
+
+        let err = mint_login_name(&occupied, &profile, None, Some("alice@example.com"))
+            .expect_err("a --name already in use must refuse");
+        assert!(
+            err.to_string()
+                .contains("already the name of another account"),
+            "{err}"
+        );
+    }
+
+    /// A re-login keeps the row's own name rather than re-minting one: that
+    /// name is what every pin, group label and `controlAccount` key points at.
+    #[test]
+    fn a_re_login_keeps_the_rows_existing_name() {
+        let config: Config = serde_json::from_str(
+            r#"{ "accounts": [
+                { "name": "me@example.com/corp", "type": "oauth", "accessToken": "at-1" }
+            ] }"#,
+        )
+        .unwrap();
+        let profile = profile_named("me@example.com");
+        assert_eq!(
+            mint_login_name(&config, &profile, Some("me@example.com/corp"), None).unwrap(),
+            "me@example.com/corp"
+        );
     }
 
     /// A canned upstream that answers every connection with `status_line` and an
@@ -4339,26 +4438,31 @@ mod tests {
     }
 
     /// An all-`None` profile plus `--name` must produce that exact name,
-    /// without ever reaching the stdin prompt — the profile-email branch is
-    /// skipped (no email), the `--name` branch is taken instead of falling
-    /// through to `prompt_account_name`.
+    /// without ever reaching the stdin prompt — the `--name` branch is taken
+    /// instead of falling through to `prompt_account_name`. This is the
+    /// setup-token case: an inference-only credential's profile fetch normally
+    /// comes back empty, so `--name` is the only name there is.
     #[test]
-    fn resolve_setup_token_name_prefers_explicit_name_over_prompt() {
-        let name = resolve_setup_token_name(&all_none_profile(), Some("bob-work"), "account-1");
+    fn a_name_override_skips_the_prompt_on_an_empty_profile() {
+        let empty: Config = serde_json::from_str(r#"{ "accounts": [] }"#).unwrap();
+        let name = mint_login_name(&empty, &all_none_profile(), None, Some("bob-work")).unwrap();
         assert_eq!(name, "bob-work");
     }
 
-    /// The profile's email still wins over `--name` when the fetch DID come
-    /// back with one — inference-only scope makes this the unlikely case,
-    /// not the impossible one.
+    /// `--name` wins over the profile's email too. It used to be the other way
+    /// round, which made the flag unusable exactly when a person wanted to name
+    /// their second org's row something they would recognise.
     #[test]
-    fn resolve_setup_token_name_prefers_profile_email_over_name() {
-        let name = resolve_setup_token_name(
+    fn a_name_override_wins_over_the_profile_email() {
+        let empty: Config = serde_json::from_str(r#"{ "accounts": [] }"#).unwrap();
+        let name = mint_login_name(
+            &empty,
             &profile_named("carol@example.com"),
-            Some("ignored"),
-            "account-1",
-        );
-        assert_eq!(name, "carol@example.com");
+            None,
+            Some("carol-personal"),
+        )
+        .unwrap();
+        assert_eq!(name, "carol-personal");
     }
 
     // --- the `unnamed` fallback ---------------------------------------------

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1236,6 +1236,28 @@ fn stamp_add_endpoint(response: Response) -> Response {
     stamp_endpoint_as(response, ADD_ACCOUNT_ENDPOINT)
 }
 
+/// Deserialize `bytes` into `T`, but ONLY from a JSON object — `None` for
+/// anything else, including a JSON ARRAY.
+///
+/// The array case is why this exists rather than a bare
+/// `serde_json::from_slice`. Serde will happily build a struct out of a
+/// sequence, positionally, when the element count matches the field count. So
+/// `["alice@example.com", true]` deserializes into a two-field
+/// [`SetDisabledRequest`] and parks an account — a body nobody meant as a
+/// request, accepted because of how many fields the struct happens to have
+/// today. Removing one field is all it took to open that: this route had three
+/// fields and the same array was a 400.
+///
+/// Requiring an object is the property the callers actually mean, and it does
+/// not move when a field is added or removed.
+fn parse_object<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> Option<T> {
+    let value: Value = serde_json::from_slice(bytes).ok()?;
+    if !value.is_object() {
+        return None;
+    }
+    serde_json::from_value(value).ok()
+}
+
 /// The request body of [`DISABLED_PATH`].
 ///
 /// `query` and `disabled` are `Option` rather than required fields so a body that
@@ -1245,8 +1267,6 @@ fn stamp_add_endpoint(response: Response) -> Response {
 #[derive(serde::Deserialize)]
 struct SetDisabledRequest {
     query: Option<String>,
-    #[serde(default)]
-    org: Option<String>,
     disabled: Option<bool>,
 }
 
@@ -1254,12 +1274,10 @@ struct SetDisabledRequest {
 /// read it, and both halves of the wire contract belong to one type.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct SetDisabledResponse {
-    /// The RESOLVED account name. The query may have been the account's bare
-    /// EMAIL where its stored name carries an org suffix (`me@example.com (Acme)`),
-    /// so the answer names what was actually parked.
+    /// The RESOLVED account name, so the answer names what was actually parked.
     ///
     /// It is NOT a partial or fuzzy match: [`crate::identity::match_accounts`] is
-    /// exact name, then exact email, byte-for-byte, case-sensitive and untrimmed.
+    /// the account's exact name, byte-for-byte, case-sensitive and untrimmed.
     /// Measured against a fleet holding `alice@example.com`: `alice`, `alice@`,
     /// `example`, `ALICE@EXAMPLE.COM` and a trailing space are each a 404.
     pub name: String,
@@ -1320,11 +1338,11 @@ async fn set_disabled_handler(State(manager): State<Arc<Manager>>, req: Request)
             None,
         ));
     };
-    let Ok(parsed) = serde_json::from_slice::<SetDisabledRequest>(&bytes) else {
+    let Some(parsed) = parse_object::<SetDisabledRequest>(&bytes) else {
         return stamp_endpoint(error_response(
             StatusCode::BAD_REQUEST,
             "invalid_request_error",
-            "Expected a JSON object: {\"query\": \"<account>\", \"org\": null, \"disabled\": true}.",
+            "Expected a JSON object: {\"query\": \"<account>\", \"disabled\": true}.",
             None,
         ));
     };
@@ -1345,7 +1363,7 @@ async fn set_disabled_handler(State(manager): State<Arc<Manager>>, req: Request)
         ));
     }
 
-    match manager.set_disabled_by_query(&query, parsed.org.as_deref(), disabled) {
+    match manager.set_disabled_by_query(&query, disabled) {
         SetDisabledOutcome::NoMatch => stamp_endpoint(error_response(
             StatusCode::NOT_FOUND,
             "not_found_error",
@@ -1409,8 +1427,6 @@ fn stamp_control_endpoint(response: Response) -> Response {
 struct SetControlRequest {
     #[serde(default)]
     query: Option<String>,
-    #[serde(default)]
-    org: Option<String>,
 }
 
 /// The 200 body of [`CONTROL_PATH`]. Deserializable too — `tcr control` reads
@@ -1475,11 +1491,11 @@ async fn set_control_handler(State(manager): State<Arc<Manager>>, req: Request) 
             None,
         ));
     };
-    let Ok(parsed) = serde_json::from_slice::<SetControlRequest>(&bytes) else {
+    let Some(parsed) = parse_object::<SetControlRequest>(&bytes) else {
         return stamp_control_endpoint(error_response(
             StatusCode::BAD_REQUEST,
             "invalid_request_error",
-            "Expected a JSON object: {\"query\": \"<account>\" | null, \"org\": null}.",
+            "Expected a JSON object: {\"query\": \"<account>\" | null}.",
             None,
         ));
     };
@@ -1493,7 +1509,7 @@ async fn set_control_handler(State(manager): State<Arc<Manager>>, req: Request) 
     }
     let cleared = parsed.query.is_none();
 
-    match manager.set_control_by_query(parsed.query.as_deref(), parsed.org.as_deref()) {
+    match manager.set_control_by_query(parsed.query.as_deref()) {
         SetControlOutcome::NoMatch => stamp_control_endpoint(error_response(
             StatusCode::NOT_FOUND,
             "not_found_error",
@@ -4278,6 +4294,8 @@ mod tests {
         Config {
             quarantined_accounts: Vec::new(),
             migrated_legacy_throttle: false,
+            renamed_accounts: Vec::new(),
+            rename_write_error: None,
             proxy: ProxyConfig {
                 port: 0,
                 api_key: api_key.map(str::to_string),
@@ -6062,14 +6080,16 @@ mod tests {
         std::fs::remove_file(&path).ok();
     }
 
-    /// An ambiguous query is a 409 that NAMES the candidates — otherwise `--org` is
-    /// advice the caller cannot act on. Refusing is not pedantry: guessing would
-    /// bench an account the operator did not ask about.
+    /// An ambiguous query is a 409 that NAMES the candidates, so the operator
+    /// knows which rows to go fix. Refusing is not pedantry: guessing would
+    /// bench an account nobody asked about.
+    ///
+    /// Only the LIVE rotation is broken here — `config::load` would have renamed
+    /// the duplicate — which is the only way this arm is still reachable.
     #[tokio::test]
     async fn control_endpoint_409s_an_ambiguous_query_naming_the_candidates() {
         let path = control_config_path("ambiguous");
         let mut config = two_account_config(None);
-        // The same person in two orgs: one email, two rows, `--org` the only fix.
         config.accounts[1].name = "alice@example.com".to_string();
         crate::config::save(&path, &config).expect("write the test config");
         let manager = Manager::with_live_refresher(config, Some(path.clone()));
@@ -6089,8 +6109,8 @@ mod tests {
         );
         let text = String::from_utf8_lossy(&body);
         assert!(
-            text.contains("ambiguous") && text.contains("--org"),
-            "the 409 says what to do about it: {text}"
+            text.contains("ambiguous") && text.matches("alice@example.com").count() >= 2,
+            "the 409 names the candidates: {text}"
         );
         let live = manager.snapshot(OffsetDateTime::now_utc());
         assert!(
@@ -6102,14 +6122,16 @@ mod tests {
         std::fs::remove_file(&path).ok();
     }
 
-    /// `--org` narrows the same ambiguous fleet to exactly one row, and it is the
-    /// row named — the resolution rule is the CLI's own
-    /// [`crate::identity::match_one`], run against the LIVE rotation slots.
+    /// The same two-org fleet with the names a migration would have given it:
+    /// the qualified name parks exactly its own row, live AND on disk. The
+    /// resolution rule is the CLI's own [`crate::identity::match_one`], run
+    /// against the LIVE rotation slots.
     #[tokio::test]
-    async fn control_endpoint_org_narrows_to_one_account() {
-        let path = control_config_path("org");
+    async fn control_endpoint_parks_the_row_a_qualified_name_points_at() {
+        let path = control_config_path("qualified-name");
         let mut config = two_account_config(None);
-        config.accounts[1].name = "alice@example.com".to_string();
+        config.accounts[0].name = "alice@example.com".to_string();
+        config.accounts[1].name = "alice@example.com/team".to_string();
         crate::config::save(&path, &config).expect("write the test config");
         let manager = Manager::with_live_refresher(config, Some(path.clone()));
 
@@ -6118,14 +6140,14 @@ mod tests {
             Method::POST,
             Some(loopback_peer()),
             None,
-            r#"{"query":"alice@example.com","org":"Org bbbbbbbbbbbb","disabled":true}"#,
+            r#"{"query":"alice@example.com/team","disabled":true}"#,
         )
         .await;
         assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
         let live = manager.snapshot(OffsetDateTime::now_utc());
         assert!(
             !live.accounts[0].disabled && live.accounts[1].disabled,
-            "the SECOND row — the one whose org was named — is the one parked"
+            "the SECOND row — the one the name points at — is the one parked"
         );
         assert_eq!(disabled_in_file(&path, 0), None);
         assert_eq!(disabled_in_file(&path, 1), Some(serde_json::json!(true)));
@@ -6355,17 +6377,11 @@ mod tests {
             "the live manager must resolve the new control account"
         );
 
-        // 2. …and the file's top-level key carries it too — as the identity
-        // object [`crate::config::save_control_account`] now writes (never the
-        // legacy bare string), so a duplicated email can survive a restart.
+        // 2. …and the file's top-level key carries it too — the account's NAME,
+        // which is unique across the config and so is the whole key.
         assert_eq!(
             control_account_in_file(&path),
-            Some(serde_json::json!({
-                "name": "alice@example.com",
-                "accountUuid": "22222222-a",
-                "orgUuid": "11111111-1111-1111-1111-aaaaaaaaaaaa",
-                "orgName": "Org aaaaaaaaaaaa",
-            }))
+            Some(serde_json::json!("alice@example.com"))
         );
 
         // Clearing (`query: null`) removes it from both halves.
@@ -6563,7 +6579,7 @@ mod tests {
             Some(CONTROL_ENDPOINT)
         );
         let text = String::from_utf8_lossy(&body);
-        assert!(text.contains("ambiguous") && text.contains("--org"));
+        assert!(text.contains("ambiguous") && text.matches("alice@example.com").count() >= 2);
         assert_eq!(manager.control(), None, "an unbreakable tie sets nothing");
         std::fs::remove_file(&path).ok();
     }
@@ -7322,13 +7338,13 @@ mod tests {
         }
     }
 
-    /// An ambiguous identity — the same email in two orgs — is a 409 naming the
-    /// candidates, never guessed. `--org` is the only fix.
+    /// An ambiguous identity is a 409 naming the candidates, never guessed. Only
+    /// the LIVE rotation is broken here — `config::load` would have renamed the
+    /// duplicate — which is the only way this arm is still reachable.
     #[tokio::test]
     async fn add_endpoint_409s_an_ambiguous_identity_naming_the_candidates() {
         let path = control_config_path("add-ambiguous");
         let mut config = two_account_config(None);
-        // The same person in two orgs: one email, two rows, `--org` the only fix.
         config.accounts[1].name = "alice@example.com".to_string();
         crate::config::save(&path, &config).expect("write the test config");
         let manager = Manager::with_live_refresher(config, Some(path.clone()));
@@ -7347,8 +7363,8 @@ mod tests {
         );
         let text = String::from_utf8_lossy(&body);
         assert!(
-            text.contains("ambiguous") && text.contains("--org"),
-            "the 409 says what to do about it: {text}"
+            text.contains("ambiguous") && text.matches("alice@example.com").count() >= 2,
+            "the 409 names the candidates: {text}"
         );
         assert_eq!(
             manager.snapshot(OffsetDateTime::now_utc()).accounts.len(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -709,6 +709,27 @@ pub async fn serve(options: ServeOptions) -> anyhow::Result<ServeOutcome> {
     }
     let port = config.proxy.port;
 
+    // `config::load` may have just renamed accounts to restore unique names. The
+    // pin file is keyed by name, so carry it across before anything reads it —
+    // otherwise every pin on a renamed account resolves to nothing and those
+    // sessions cold-start their prompt cache, which is the most expensive event
+    // in this system.
+    let renames: Vec<(String, String)> = config
+        .renamed_accounts
+        .iter()
+        .map(|rename| (rename.from.clone(), rename.to.clone()))
+        .collect();
+    if let Some(path) = &affinity_path {
+        let rewritten = affinity::rename_pins(path, &renames);
+        if rewritten > 0 {
+            tracing::info!(
+                path = %path.display(),
+                rewritten,
+                "carried session-affinity pins across the account rename"
+            );
+        }
+    }
+
     // Resolve the port to ONE proxy BEFORE the Manager starts probing/refreshing,
     // so our own startup can never token-war with the incumbent. Only a
     // command-verified teamclaude/tcr server on THIS port is ever signalled — a

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -121,12 +121,10 @@ pub struct AccountSnapshot {
     pub rate_limit_tier: Option<String>,
     pub seat_tier: Option<String>,
     /// The org this account is scoped to, carried from
-    /// [`crate::manager::AccountRuntime`]. Present so a CLIENT can DISAMBIGUATE
-    /// this row: every account verb (`tcr token`, `remove`, `enable`,
-    /// `disable`, `priority`) takes `--org <name-or-uuid-prefix>`, and without
-    /// an org on the row a caller holding only the name cannot narrow it — which
-    /// is exactly the state the panel was in when "Copy Access Token" failed on
-    /// a duplicated email with "matches 2 accounts".
+    /// [`crate::manager::AccountRuntime`]. A fact a CLIENT can show beside the
+    /// row; it is not how the row is addressed — `name` is unique, and every
+    /// account verb (`tcr token`, `remove`, `enable`, `disable`, `priority`)
+    /// takes that name alone.
     pub org_uuid: Option<String>,
     pub org_name: Option<String>,
     pub priority: i64,

--- a/src/status.rs
+++ b/src/status.rs
@@ -263,9 +263,8 @@ pub struct AccountStatus {
     pub rate_limit_tier: Option<String>,
     #[serde(default)]
     pub seat_tier: Option<String>,
-    /// The org this account is scoped to — see [`AccountSnapshot::org_uuid`]
-    /// for why a client needs it (every account verb takes `--org`, and a row
-    /// with only a name cannot narrow a duplicated email). `#[serde(default)]`
+    /// The org this account is scoped to — see [`AccountSnapshot::org_uuid`]:
+    /// a fact for a client to show, never an address. `#[serde(default)]`
     /// for the same forward-compat reason as the fields above.
     #[serde(default)]
     pub org_uuid: Option<String>,

--- a/tests/throttle_exempt.rs
+++ b/tests/throttle_exempt.rs
@@ -162,6 +162,8 @@ fn config(
     Config {
         quarantined_accounts: Vec::new(),
         migrated_legacy_throttle: false,
+        renamed_accounts: Vec::new(),
+        rename_write_error: None,
         proxy: ProxyConfig {
             port: 0,
             api_key: None,

--- a/tests/workload_scenarios.rs
+++ b/tests/workload_scenarios.rs
@@ -214,6 +214,8 @@ impl Fleet {
         let config = Config {
             quarantined_accounts: Vec::new(),
             migrated_legacy_throttle: false,
+            renamed_accounts: Vec::new(),
+            rename_write_error: None,
             proxy: ProxyConfig::default(),
             upstream: "https://api.anthropic.com".to_string(),
             switch_threshold: SWITCH_THRESHOLD,


### PR DESCRIPTION
🍄 One account, one name. `Account.name` is now unique by construction and is the only way to address an account — every `--org` flag and all org-matching lookup code are gone. Version 0.2.39.

## Why

Five of the fleet's 18 rows share an email with another row (a personal Max org and the company Team org). Identity was the email, so every by-name path was a latent bug, and they surfaced one verb at a time: copy-token refused as ambiguous, `group add` labelled the wrong row and reported success, the panel drew two rows as one, `controlAccount` marked both rows control. Before this PR: 128 identity-touching sites in Rust, 25 in the panel, 16 `--org` plumbing points added to compensate.

## What changes

- **Minted at login, never prompted.** Bare `email` when free; otherwise `email/<org-slug>` (`henry@example.com/henry-token`). `tcr login --name` remains as an explicit override and is refused if taken.
- **Existing fleets migrate themselves once.** `config::load` renames duplicates on sight — the row on a personal plan keeps the bare email, every other row becomes `email/<org-slug>` — with a targeted document write, and carries `controlAccount` and the session-affinity pins along. It never refuses. The rename lines go to stderr as well as `tracing`, because a CLI installs no subscriber and the server loads its config before `init_tracing` — the first positive-control run migrated correctly and printed nothing.
- **Exact-name lookup everywhere.** `match_one` is exact-name only; `identity::resolve` / `same_identity` survive solely as write-destination logic (upsert, persist, pin restore), never as a query key. 17 flag surfaces removed: 9 clap args, 2 wire fields, 6 Swift builders. `scripts/check-no-org-flag.sh` runs in CI so `--org` cannot come back.
- **The panel keys on `name`.** `AccountRef` collapses to the name; every per-row lookup and action uses it; `isControl` is finally correct on a duplicated email (the server-side debt its own doc-comment named). Line 1 shows the email half, the `/org-slug` half is the first designation tag on line 2, and a long email wraps rather than truncates — a name you are meant to type back is never cut.
- **Found on the way:** after the field removal, serde accepted a JSON *array* `["alice@example.com", true]` as a disable request (positional struct build); both account-control routes now require an object.

## Gates

`cargo fmt --all --check` 0 · `cargo clippy --all-targets --locked -- -D warnings` 0 · `cargo test --all --locked` 0 · `swift-format lint --strict` 0 · `swift build` 0 · `swift test` 0 (417) · `scripts/check-no-org-flag.sh` 0 · pre-commit 0. Migration mutation suite: 5 mutants, all caught. Positive control re-run by the lead: run 1 prints the rename line, run 2 prints nothing, `tcr token <email>/<slug>` exits 0. One pre-existing timing flake seen once in six full runs (`tests/headless_sigterm.rs`, outside this diff).

https://claude.ai/code/session_0154byNxtvz4fUkQPKkwAGBZ
