### PR TITLE
chore: add the 0.2.40 appcast entry

### DIFF
--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.40</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.40</link>
+      <sparkle:version>492</sparkle:version>
+      <sparkle:shortVersionString>0.2.40</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Mon, 07 Sep 2026 18:21:17 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.40/TcrBar-0.2.40.dmg" type="application/octet-stream" sparkle:edSignature="8PsD79jdIVTpVrLlwvaQo/oMKv+bKelfeb0loEock/IEblQbbBVrz0RMumUG9d77h+fBGpuYRZRutoucBzCeDA==" length="6619862" />
+    </item>
+    <item>
       <title>TcrBar 0.2.39</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.39</link>
       <sparkle:version>490</sparkle:version>


### PR DESCRIPTION
🍄 Appcast item for v0.2.40, written by `release-local.sh` after the DMG and `appcast.xml` were uploaded to the release.

https://claude.ai/code/session_0154byNxtvz4fUkQPKkwAGBZ
