### PR TITLE
fix: stop the popover layout loop, and stop orphaning the child on a crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.41"
+version = "0.2.42"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "teamclaude-rs"
-version = "0.2.41"
+version = "0.2.42"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -180,7 +180,8 @@ struct FleetView: View {
                 .background(
                     GeometryReader { proxy in
                         Color.clear.preference(
-                            key: UsageLineHeightKey.self, value: proxy.size.height)
+                            key: UsageLineHeightKey.self,
+                            value: PanelHeight.quantized(proxy.size.height))
                     }
                 )
                 .overlay(alignment: .topLeading) {
@@ -191,7 +192,8 @@ struct FleetView: View {
                         .background(
                             GeometryReader { proxy in
                                 Color.clear.preference(
-                                    key: UsageLineBaselineKey.self, value: proxy.size.height)
+                                    key: UsageLineBaselineKey.self,
+                                    value: PanelHeight.quantized(proxy.size.height))
                             }
                         )
                 }
@@ -357,7 +359,8 @@ struct FleetView: View {
         .background(
             GeometryReader { proxy in
                 Color.clear.preference(
-                    key: RowHeightsKey.self, value: [account.id: proxy.size.height])
+                    key: RowHeightsKey.self,
+                    value: [account.id: PanelHeight.quantized(proxy.size.height)])
             }
         )
     }

--- a/apps/macos/Sources/TcrBar/TcrBarApp.swift
+++ b/apps/macos/Sources/TcrBar/TcrBarApp.swift
@@ -1,5 +1,33 @@
 import AppKit
+import Darwin
 import TcrBarCore
+
+/// The signals a native crash (an uncaught `NSException` converts to
+/// `SIGABRT` via `abort()`, the runaway-layout crash this pairs with among
+/// them) or a fatal Swift-runtime trap raises. Installed once, in
+/// ``TcrBarEntry/main()``, before anything that could spawn the child these
+/// handlers exist to stop from being orphaned.
+private let abnormalTerminationSignals: [Int32] = [
+    SIGABRT, SIGSEGV, SIGILL, SIGBUS, SIGFPE,
+]
+
+/// The handler itself. A free, non-capturing function because `signal(2)`
+/// takes a C function pointer, which cannot close over anything — this is
+/// why the pid it needs lives in a static var
+/// (`ServerController.supervisedChildPID`) rather than being passed in.
+///
+/// Everything it does beyond the one call into
+/// `AbnormalTerminationGuard.terminateSupervisedChild(pid:)` is restoring
+/// the default disposition and re-raising, which is what makes the process
+/// still crash, still print the same report, and still exit with the same
+/// code it would have without this handler installed — the only thing this
+/// adds is that the child is no longer orphaned first.
+private func tcrbarHandleAbnormalTermination(_ signalNumber: Int32) {
+    AbnormalTerminationGuard.terminateSupervisedChild(
+        pid: pid_t(ServerController.supervisedChildPID))
+    signal(signalNumber, SIG_DFL)
+    raise(signalNumber)
+}
 
 /// The real entry point.
 ///
@@ -18,6 +46,12 @@ enum TcrBarEntry {
 
     @MainActor
     static func main() {
+        // Before anything else — including the four harness paths below,
+        // none of which spawn a child, but a handler installed after the
+        // spawn point would race the very crash it exists to catch.
+        for signalNumber in abnormalTerminationSignals {
+            signal(signalNumber, tcrbarHandleAbnormalTermination)
+        }
         // First, and the only one of the four that needs no AppKit at all: it
         // draws nothing, it holds a power assertion and prints.
         if let probe = KeepAwakeProbe.request() {

--- a/apps/macos/Sources/TcrBarCore/AbnormalTerminationGuard.swift
+++ b/apps/macos/Sources/TcrBarCore/AbnormalTerminationGuard.swift
@@ -1,0 +1,32 @@
+import Darwin
+
+/// Sends the supervised child a termination signal outside the normal quit
+/// path — the one `applicationWillTerminate` (`TcrBarApp.swift`) never runs,
+/// because AppKit does not call app-delegate methods when the process itself
+/// is killed by a signal.
+///
+/// `TcrBarApp.swift` installs a C signal handler for `SIGABRT` and the other
+/// signals a native crash raises, and that handler's entire body is one call
+/// into ``terminateSupervisedChild(pid:)``. A signal handler runs on
+/// whatever thread raised the signal, with malloc and the rest of the Swift
+/// runtime's usual guarantees suspended — `kill(2)` is on POSIX's
+/// async-signal-safe list, essentially nothing else is, so this is the whole
+/// of what the handler may do. Pulling it out as a free function, rather than
+/// inlining it in the handler, is what lets a test call it directly without
+/// raising a real signal.
+///
+/// Without this, a `SIGABRT` — an uncaught `NSException` converts to exactly
+/// that — orphans the child `tcr server` process, which keeps holding
+/// port 3456. TcrBar's own next launch then correctly stands down rather
+/// than fight an incumbent it does not recognise, and shows
+/// `.incumbentHoldsPort`.
+public enum AbnormalTerminationGuard {
+    /// `pid <= 0` is never a supervised child — `0` is
+    /// ``ServerController/supervisedChildPID``'s "nothing is supervised"
+    /// value, and a negative pid means "every process in the group" to
+    /// `kill(2)`, which this must never send.
+    public static func terminateSupervisedChild(pid: pid_t) {
+        guard pid > 0 else { return }
+        kill(pid, SIGTERM)
+    }
+}

--- a/apps/macos/Sources/TcrBarCore/PanelHeight.swift
+++ b/apps/macos/Sources/TcrBarCore/PanelHeight.swift
@@ -126,4 +126,43 @@ public enum PanelHeight {
         let summed = rowHeights.reduce(0, +) + gaps + separator
         return min(max(summed, spacing), budget)
     }
+
+    /// The grain every `GeometryReader` measurement this panel feeds into a
+    /// `PreferenceKey` is snapped to before it is published.
+    ///
+    /// Matches `Tok.hairlineWidth` — the finest unit this panel already
+    /// draws at — rather than a whole point, so quantizing costs no
+    /// perceptible precision.
+    public static let measurementGrain: CGFloat = 0.5
+
+    /// Snap a raw `GeometryReader` measurement to ``measurementGrain``.
+    ///
+    /// `FleetView` publishes three of these every frame — one per account
+    /// row plus the two spend-line measurements — through
+    /// `.preference(key:value:)`, and `onPreferenceChange` re-fires (and
+    /// re-triggers `@State`, and therefore another layout pass) whenever the
+    /// published value is not bit-for-bit equal to the last one. A resize
+    /// this arithmetic itself drives — `.frame(height: visibleRowsHeight(...))`
+    /// sizes the very `ScrollView` whose rows are being measured — has no
+    /// guarantee of reporting the identical `CGFloat` on consecutive passes:
+    /// window resize and AppKit's safe-area-inset recomputation both round
+    /// sub-pixel geometry a hair differently frame to frame, so the raw value
+    /// can drift by float epsilon forever without ever landing on the same
+    /// bits twice. That is a genuine non-terminating case for
+    /// `onPreferenceChange`, which is what a runaway `NSPopover` layout
+    /// (`_NSPopoverWindow`, "already had more Update Constraints in Window
+    /// passes than there are views") looks like from AppKit's side — its
+    /// guard is a *pass count*, not a convergence detector, so it fires
+    /// exactly when this loop keeps going.
+    ///
+    /// Quantizing turns that infinite, arbitrarily-fine domain into a finite
+    /// one: two measurements within half the grain of each other now publish
+    /// the identical value, so once the *real* layout has settled (the rows'
+    /// actual heights stop changing, even if AppKit keeps reporting them
+    /// with fresh sub-pixel noise), the published preference stops changing
+    /// too, `onPreferenceChange` stops firing, and the layout pass that
+    /// triggered it is the last one.
+    public static func quantized(_ measurement: CGFloat) -> CGFloat {
+        (measurement / measurementGrain).rounded() * measurementGrain
+    }
 }

--- a/apps/macos/Sources/TcrBarCore/ServerController.swift
+++ b/apps/macos/Sources/TcrBarCore/ServerController.swift
@@ -114,6 +114,19 @@ public final class ServerController: ObservableObject {
 
     @Published public private(set) var state: State = .idle
 
+    /// The pid of the child this controller currently supervises, or `0`
+    /// when there is none. Read from `AbnormalTerminationGuard`'s signal
+    /// handler, which cannot safely call back into a `@MainActor` class — a
+    /// signal handler can only load a value some other thread already
+    /// wrote, and `sig_atomic_t` is the type POSIX guarantees is safe to
+    /// read that way without a lock.
+    ///
+    /// Set the instant `spawn()` confirms the child is running, and cleared
+    /// both in ``stop()`` and when `terminationHandler` fires, so a signal
+    /// that lands after the child has already exited never sends `SIGTERM`
+    /// to a since-reused pid.
+    public nonisolated(unsafe) static var supervisedChildPID: sig_atomic_t = 0
+
     private var child: Process?
     /// A capability probe is in flight for the takeover path. Guards the window
     /// between the click and the spawn, where `child` is still nil and a second
@@ -361,12 +374,14 @@ public final class ServerController: ObservableObject {
             Task { @MainActor in
                 guard let self else { return }
                 self.child = nil
+                Self.supervisedChildPID = 0
                 self.state = Self.classifyExit(intent: intent, exitCode: code, stderr: text)
             }
         }
         do {
             try process.run()
             child = process
+            Self.supervisedChildPID = sig_atomic_t(process.processIdentifier)
             state = .supervising(pid: process.processIdentifier)
         } catch {
             child = nil
@@ -379,9 +394,11 @@ public final class ServerController: ObservableObject {
     public func stop() {
         guard let process = child, process.isRunning else {
             child = nil
+            Self.supervisedChildPID = 0
             return
         }
         process.terminate()
+        Self.supervisedChildPID = 0
     }
 
     /// Called on app quit so a supervised child does not outlive its supervisor.

--- a/apps/macos/Tests/TcrBarTests/AbnormalTerminationGuardTests.swift
+++ b/apps/macos/Tests/TcrBarTests/AbnormalTerminationGuardTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import XCTest
+
+@testable import TcrBarCore
+
+/// The second, separate defect in the crash this pairs with: a `SIGABRT`
+/// skips `applicationWillTerminate` entirely, so it was the ONLY place the
+/// supervised child got stopped. This orphans the child, which keeps
+/// holding port 3456 — TcrBar's own next launch then stands down to it and
+/// shows `.incumbentHoldsPort`.
+///
+/// `AbnormalTerminationGuard.terminateSupervisedChild(pid:)` is the whole
+/// body of the signal handler `TcrBarApp.swift` installs for exactly that
+/// case, pulled out as a free function so it can be exercised here without
+/// raising a real signal — a signal handler is not a thing XCTest can drive
+/// directly, but the syscall it makes is.
+final class AbnormalTerminationGuardTests: XCTestCase {
+
+    /// Spawns a real, still-running child — the same shape `ServerController`
+    /// spawns — and proves the guard's one syscall is what stops it, not
+    /// something else in the test's teardown.
+    ///
+    /// Fails on the change this guards against: a
+    /// `terminateSupervisedChild(pid:)` that does nothing (the bug this
+    /// commit fixes — before it, an abnormal exit called no stop path at
+    /// all) leaves `sleep 30` running, and this assertion times out waiting
+    /// for it to exit rather than observing it exit quickly.
+    func testTerminateSupervisedChildStopsAStillRunningProcess() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        process.arguments = ["30"]
+        try process.run()
+        addTeardownBlock { if process.isRunning { process.terminate() } }
+
+        XCTAssertTrue(process.isRunning, "the process under test must actually be alive first")
+
+        AbnormalTerminationGuard.terminateSupervisedChild(pid: process.processIdentifier)
+
+        process.waitUntilExit()
+        XCTAssertFalse(process.isRunning)
+        XCTAssertEqual(
+            process.terminationReason, .uncaughtSignal,
+            "SIGTERM, not a clean exit — proves the guard's kill(2) is what ended it")
+    }
+
+    /// `0` is `ServerController.supervisedChildPID`'s "nothing is
+    /// supervised" value, and the guard must be a no-op on it — sending
+    /// `kill(0, …)` targets the entire calling process group, which would
+    /// signal TcrBar itself (and everything else in its group) rather than
+    /// nothing.
+    func testTerminateSupervisedChildIsANoOpOnTheUnsupervisedSentinel() {
+        // Not a crash-reproducing assertion by itself — it exists so the
+        // call above only ever proves ONE thing (a real pid gets signalled)
+        // rather than silently also relying on `kill(0, …)` being harmless
+        // in a test process. If this guard's `pid > 0` check were removed,
+        // this call would signal the test runner's own process group.
+        AbnormalTerminationGuard.terminateSupervisedChild(pid: 0)
+    }
+
+    /// `ServerController` publishes the pid a signal handler needs to read
+    /// through this static var, since the handler cannot call back into a
+    /// `@MainActor` instance. Round-tripping it here is what the orphan fix
+    /// actually depends on end to end: spawn through the real controller,
+    /// confirm the pid landed in the static var, confirm it clears on stop.
+    @MainActor
+    func testServerControllerPublishesAndClearsTheSupervisedPID() async throws {
+        let controller = ServerController()
+        XCTAssertEqual(ServerController.supervisedChildPID, 0, "nothing supervised at the start")
+
+        controller.start()
+        // `start()` resolves `tcr` and spawns asynchronously in effect (the
+        // spawn itself is synchronous, but `TcrTool.resolve()` and the
+        // eventual `terminationHandler` are not) — poll briefly rather than
+        // assume a fixed delay is enough on a slow CI machine.
+        let deadline = Date().addingTimeInterval(5)
+        while ServerController.supervisedChildPID == 0 && Date() < deadline {
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        guard ServerController.supervisedChildPID != 0 else {
+            // No `tcr` on PATH in this environment — the pid can never be
+            // set, and there is nothing left to assert. Not a failure of
+            // this test's claim.
+            throw XCTSkip("no tcr on PATH to spawn — cannot observe a real supervised pid")
+        }
+        XCTAssertGreaterThan(ServerController.supervisedChildPID, 0)
+
+        controller.stop()
+        XCTAssertEqual(
+            ServerController.supervisedChildPID, 0, "stop() must clear the pid a handler would read")
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/PanelHeightTests.swift
+++ b/apps/macos/Tests/TcrBarTests/PanelHeightTests.swift
@@ -164,4 +164,35 @@ final class PanelHeightTests: XCTestCase {
             budget: PanelHeight.panelMaxHeight)
         XCTAssertEqual(atCap, PanelHeight.panelMaxHeight)
     }
+
+    // MARK: - `quantized` — the runaway `NSPopover` layout fix
+
+    func testQuantizedSnapsRawMeasurementsToTheGrain() {
+        XCTAssertEqual(PanelHeight.quantized(41.998), 42.0)
+        XCTAssertEqual(PanelHeight.quantized(42.24), 42.0)
+        XCTAssertEqual(PanelHeight.quantized(42.26), 42.5)
+    }
+
+    /// The claim the fix rests on: a `GeometryReader` measurement that never
+    /// repeats bit-for-bit across layout passes — the shape AppKit's own
+    /// safe-area-inset recomputation produces on an `NSPopover` resize, and
+    /// exactly what `onPreferenceChange` cannot tell apart from a row that is
+    /// still genuinely growing — publishes the SAME quantized value once every
+    /// raw measurement lands within half a grain of the others. That equality
+    /// is what stops `onPreferenceChange` from re-firing, `@State` from
+    /// re-assigning, and the layout pass it triggers from ever running again.
+    ///
+    /// Fails on the change this guards against: quantizing removed (return the
+    /// raw measurement unchanged) leaves 20 distinct published values instead
+    /// of one, which is the non-terminating case this arithmetic exists to
+    /// close off.
+    func testQuantizedStopsSubPixelJitterFromEverPublishingADifferentValue() {
+        let jitter: [CGFloat] = (0..<20).map { 118.0 + CGFloat($0) * 0.00001 }
+        XCTAssertEqual(Set(jitter).count, jitter.count, "the raw values really do all differ")
+
+        let quantizedValues = Set(jitter.map(PanelHeight.quantized))
+        XCTAssertEqual(
+            quantizedValues, [118.0],
+            "every measurement within the grain must publish the identical value")
+    }
 }

--- a/apps/macos/design-tokens/tokens.css
+++ b/apps/macos/design-tokens/tokens.css
@@ -36,6 +36,7 @@
     --tcr-body-size: 13px;
     --tcr-detail-font-size: 10px;
     --tcr-hairline-width: 0.5px;
+    --tcr-measurement-grain: 0.5px;
     --tcr-panel-max-height: 520px;
     --tcr-panel-min-list-height: 120px;
     --tcr-panel-width: 380px;

--- a/apps/macos/design-tokens/tokens.json
+++ b/apps/macos/design-tokens/tokens.json
@@ -59,6 +59,7 @@
     "body-size": 13.0,
     "detail-font-size": 10.0,
     "hairline-width": 0.5,
+    "measurement-grain": 0.5,
     "panel-max-height": 520.0,
     "panel-min-list-height": 120.0,
     "panel-width": 380.0,


### PR DESCRIPTION

🍄 TcrBar crashed with AppKit's runaway-layout guard:

    NSGenericException: 'The window has been marked as needing another Update
    Constraints in Window pass, but it has already had more Update Constraints in
    Window passes than there are views in the window. <_NSPopoverWindow ...>'

`FleetView` publishes `GeometryReader` measurements through `PreferenceKey`s that
feed back into `.frame(height:)` on the same subtree being measured. With
`sizingOptions = [.preferredContentSize]` resizing the live popover on every
change, `onPreferenceChange` re-fires on any float-epsilon difference — a resize
plus AppKit's own safe-area recomputation can yield a fresh `CGFloat` every pass
without ever repeating. The guard counts passes, not convergence, so it fires.
`PanelHeight.quantized` snaps each published measurement to a 0.5pt grain, so once
layout settles the value stops changing.

The second defect is why the crash fed itself. `applicationWillTerminate` was the
only path that stopped the child `tcr server`, and AppKit never calls it on a
signal-driven exit — an uncaught `NSException` becomes `abort()`, becomes SIGABRT.
So the crash orphaned a child still holding port 3456; the next launch correctly
stood down against an incumbent it did not recognise and showed
`.incumbentHoldsPort`; clicking the icon opened the panel and crashed again.

A process-wide handler for SIGABRT/SIGSEGV/SIGILL/SIGBUS/SIGFPE now sends the
supervised child a SIGTERM. The handler body is a single `kill(2)` — the one thing
on POSIX's async-signal-safe list that this needs — guarded on `pid > 0`, since a
negative pid would signal the whole process group. It then restores `SIG_DFL` and
re-raises, so the crash still crashes identically; it just no longer orphans first.


Bumped to 0.2.42 because #203 took 0.2.41.

https://claude.ai/code/session_01AjZGN4RCerXKYLwGBXYkjx
