### PR TITLE
fix: ship the Sparkle appcast on every release, not only app releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.43"
+version = "0.2.44"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "teamclaude-rs"
-version = "0.2.43"
+version = "0.2.44"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -13,3 +13,23 @@ installers = ["shell"]
 # musl (not gnu): static binary runs on alpine AND glibc distros. Deps are musl-clean
 # (rustls/ring, reqwest with rustls-tls; no openssl/native-tls, no system C libs to link).
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
+
+# Ship the Sparkle appcast on EVERY release, including a CLI-only one.
+#
+# Every installed TcrBar.app has `releases/latest/download/appcast.xml` compiled
+# in, and `/releases/latest/` follows whichever release is newest — not the newest
+# app release. A cargo-dist CLI release used to publish tarballs and no appcast,
+# become `latest`, and 404 the update feed for every install (0.2.27, 0.2.28, the
+# fifth failure of its class). The guard workflow cannot catch it: releases made
+# under GITHUB_TOKEN raise no `release:` events.
+#
+# Listing the committed appcast here puts it in `artifacts/*` so it goes up in the
+# same `gh release create` call that makes the release exist — no window at all.
+# For a CLI-only release the feed then serves the last APP entry and Sparkle
+# reports "up to date" instead of failing. An app release's own
+# `release-tcrbar.sh` still uploads its freshly signed appcast with --clobber on
+# top, so the two compose. This is config, not the generated workflow, so
+# `dist generate` keeps it.
+[[dist.extra-artifacts]]
+artifacts = ["appcast.xml"]
+build = ["cp", "apps/macos/appcast.xml", "appcast.xml"]


### PR DESCRIPTION
🍄 Every installed TcrBar.app has `releases/latest/download/appcast.xml` compiled in, and `/releases/latest/` follows whichever release is newest — not the newest *app* release. A cargo-dist CLI release published tarballs with no appcast, became `latest`, and 404'd the update feed for every install. That happened on 0.2.27 and 0.2.28 back to back and was described then as the fifth failure of its class.

`appcast-guard.yml` exists for exactly this and cannot fire: it triggers on `release: published`, and releases created under `GITHUB_TOKEN` raise no workflow events. Re-verified 2026-09-07 — two guard runs ever, nine releases cut since.

This lists the committed appcast as a dist `extra-artifact`. The existing `build-global-artifacts` job runs `dist build --artifacts=global` at CI time and reads `dist-workspace.toml` then, so the file lands in `artifacts/*` and goes up in the **same** `gh release create` call that makes the release exist. There is no window. A CLI-only release then serves the last app entry and Sparkle reports "up to date" instead of failing; an app release's own `release-tcrbar.sh` still uploads its freshly signed appcast with `--clobber` on top, so the two compose.

Because this is dist config and not the generated workflow, `dist generate` keeps it. `dist generate --check` exits 0 with no diff, and `dist plan` now lists `appcast.xml`.

Observed on tonight's v0.2.43: the release was born with `appcast.xml` already attached and the feed never returned anything but 200. That was luck of ordering — the app-release script happened to be waiting at stage 9. This makes it not luck.

Version 0.2.44 is the release-version hook's requirement, not a release.

https://claude.ai/code/session_01AjZGN4RCerXKYLwGBXYkjx
