### PR TITLE
chore: add the 0.2.43 appcast entry

### DIFF
--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.43</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.43</link>
+      <sparkle:version>496</sparkle:version>
+      <sparkle:shortVersionString>0.2.43</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Tue, 08 Sep 2026 07:59:47 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.43/TcrBar-0.2.43.dmg" type="application/octet-stream" sparkle:edSignature="xX5VrIsuJJ+gfm7y/hAAreMADSaTx1Fc4ZG213Arwztwlr98L1laOgxLDn+OTdY1EWK0RYL1V7UTDURyqTkvCQ==" length="7305804" />
+    </item>
+    <item>
       <title>TcrBar 0.2.40</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.40</link>
       <sparkle:version>492</sparkle:version>


### PR DESCRIPTION
🍄 Written by `release-tcrbar.sh` during the v0.2.43 release and deliberately left uncommitted by it. The same entry is already attached to the release, so this only brings the committed feed source up to date — and with #206 that committed file is what every future CLI-only release will ship.

https://claude.ai/code/session_01AjZGN4RCerXKYLwGBXYkjx
