### PR TITLE
fix: cut the popover's safe-area layout cycle, and log the reason when it aborts

### DIFF
--- a/apps/macos/Sources/TcrBar/MenuBarShell.swift
+++ b/apps/macos/Sources/TcrBar/MenuBarShell.swift
@@ -149,6 +149,39 @@ final class MenuBarShell {
         // rather than a missing line here. `--shell-probe` assertion 5 checks
         // the resulting `contentSize` numerically.
         hosting.sizingOptions = [.preferredContentSize]
+        // The line above sizes the popover; it is also one half of a layout
+        // cycle that aborts the app. The other half is safe-area.
+        // `NSHostingView` observes its own frame through KVO, and every frame
+        // change runs `invalidateSafeAreaInsets()`, which requests another
+        // SwiftUI update, which marks the window as needing another
+        // update-constraints pass. The popover resizes itself from those
+        // constraints, the hosting view's frame changes again, and AppKit
+        // throws from `_postWindowNeedsUpdateConstraints` once the pass count
+        // passes its guard. Nothing catches that `NSException`, so `abort()`.
+        //
+        // Three crash reports from a 0.2.43 build (2026-09-09, macOS 26.6.2,
+        // all three throwing at that same frame) show the cycle with no TcrBar
+        // frame anywhere in it: it runs entirely between `_NSPopoverWindow`,
+        // `NSPopoverFrame` and `NSHostingView`, driven from `stepIdle` with no
+        // user event in the stack.
+        //
+        // `PanelHeight.quantized` damps the OTHER loop, the one that runs
+        // through `onPreferenceChange`, and shipped in that same 0.2.43 build
+        // — which is the evidence that it is not sufficient alone. Preference
+        // quantization cannot reach a cycle that never reads a preference.
+        //
+        // A popover has no safe area to inset against: no notch, no title bar,
+        // no keyboard. Opting out is correct on its own terms, and it is the
+        // edge of the cycle that can be cut without giving up the preferred
+        // size that assertion 5 checks.
+        //
+        // Not reproduced locally: the machine that crashes is one point
+        // release ahead (26.6.2 vs 26.6.1) and the panel is stable here across
+        // days. This cuts a documented edge of the cycle in the crash stack;
+        // it has not been watched to fail and then pass.
+        if #available(macOS 13.3, *) {
+            hosting.safeAreaRegions = []
+        }
         popover.contentViewController = hosting
         // What restores click-outside dismissal, which a menu had by nature.
         popover.behavior = .transient

--- a/apps/macos/Sources/TcrBar/TcrBarApp.swift
+++ b/apps/macos/Sources/TcrBar/TcrBarApp.swift
@@ -52,6 +52,26 @@ enum TcrBarEntry {
         for signalNumber in abnormalTerminationSignals {
             signal(signalNumber, tcrbarHandleAbnormalTermination)
         }
+        // Installed alongside them, and it runs FIRST: an uncaught
+        // `NSException` unwinds through this handler before it reaches
+        // `abort()`, which is what raises the `SIGABRT` the loop above
+        // catches. So this logs, and then the signal handler still gets to
+        // stop the child being orphaned — the two do not compete.
+        //
+        // It exists because the crash report does not carry the reason
+        // string. `UncaughtExceptionReport` documents what that cost when the
+        // runaway-layout crash had to be diagnosed from frames alone. The
+        // closure captures nothing, which is required: the parameter is a C
+        // function pointer.
+        NSSetUncaughtExceptionHandler { exception in
+            for line in UncaughtExceptionReport.lines(
+                name: exception.name.rawValue,
+                reason: exception.reason,
+                callStack: exception.callStackSymbols)
+            {
+                NSLog("%@", line)
+            }
+        }
         // First, and the only one of the four that needs no AppKit at all: it
         // draws nothing, it holds a power assertion and prints.
         if let probe = KeepAwakeProbe.request() {

--- a/apps/macos/Sources/TcrBarCore/UncaughtExceptionReport.swift
+++ b/apps/macos/Sources/TcrBarCore/UncaughtExceptionReport.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// The lines an uncaught `NSException` writes to the unified log on its way out.
+///
+/// A crash report does not carry the exception's reason string. Three `.ips`
+/// files from the 2026-09-09 runaway-layout crash were read end to end and the
+/// only human-readable string in any of them is `abort() called`:
+/// `lastExceptionBacktrace` gives the throwing frames, and nothing gives the
+/// message the exception was constructed with. For an AppKit consistency
+/// exception that message IS the diagnosis — it names the offending window and,
+/// for the update-constraints guard, the pass count that tripped it. Without it
+/// a reader can see that the popover looped but not what it looped on, which is
+/// the difference between choosing a fix and guessing at one.
+///
+/// Pure, and in `TcrBarCore`, so the format is something a test runs rather than
+/// something only a crash produces.
+public enum UncaughtExceptionReport {
+    /// The prefix every line carries, so one `log show --predicate` finds the
+    /// whole report and a `grep` finds it in a pasted console dump.
+    public static let marker = "TcrBar-uncaught:"
+
+    /// `maxFrames` bounds what a crashing process writes. The handler runs with
+    /// the runtime already in an undefined state, so an unbounded walk over a
+    /// deep stack is a second way to die inside the first one. 24 is past the
+    /// AppKit/SwiftUI cycle in the reports that motivated this and well short of
+    /// the 65-frame stacks they carry.
+    ///
+    /// A nil `reason` renders explicitly rather than as an empty tail: "the
+    /// exception carried no message" and "the handler dropped the message" look
+    /// identical in a log otherwise, and they call for different fixes.
+    public static func lines(
+        name: String,
+        reason: String?,
+        callStack: [String],
+        maxFrames: Int = 24
+    ) -> [String] {
+        let limit = max(0, maxFrames)
+        var out = ["\(marker) \(name): \(reason ?? "(no reason)")"]
+        for (index, frame) in callStack.prefix(limit).enumerated() {
+            out.append("\(marker) \(index) \(frame)")
+        }
+        if callStack.count > limit {
+            out.append("\(marker) … \(callStack.count - limit) more frames")
+        }
+        return out
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/UncaughtExceptionReportTests.swift
+++ b/apps/macos/Tests/TcrBarTests/UncaughtExceptionReportTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+
+@testable import TcrBarCore
+
+final class UncaughtExceptionReportTests: XCTestCase {
+
+    /// The reason is the whole point of the handler: the crash report already
+    /// carries the frames and never carries this.
+    func testReasonIsCarriedOnTheFirstLine() {
+        let lines = UncaughtExceptionReport.lines(
+            name: "NSInternalInconsistencyException",
+            reason: "already had more Update Constraints in Window passes",
+            callStack: [])
+        XCTAssertEqual(lines.count, 1)
+        XCTAssertTrue(lines[0].contains("NSInternalInconsistencyException"))
+        XCTAssertTrue(lines[0].contains("Update Constraints in Window passes"))
+    }
+
+    /// "carried no message" and "the handler dropped it" must not look the same
+    /// in a log; they call for different fixes.
+    func testAbsentReasonRendersExplicitly() {
+        let lines = UncaughtExceptionReport.lines(
+            name: "NSGenericException", reason: nil, callStack: [])
+        XCTAssertTrue(lines[0].hasSuffix("(no reason)"))
+    }
+
+    /// Every line is findable by one predicate, including the truncation notice.
+    func testEveryLineCarriesTheMarker() {
+        let lines = UncaughtExceptionReport.lines(
+            name: "X", reason: "y",
+            callStack: (0..<40).map { "frame \($0)" }, maxFrames: 3)
+        XCTAssertTrue(lines.allSatisfy { $0.hasPrefix(UncaughtExceptionReport.marker) })
+    }
+
+    /// Bounded, and it says how much it dropped rather than ending silently.
+    func testStackIsTruncatedAndTheRemainderIsReported() {
+        let lines = UncaughtExceptionReport.lines(
+            name: "X", reason: "y",
+            callStack: (0..<40).map { "frame \($0)" }, maxFrames: 3)
+        // 1 header + 3 frames + 1 truncation notice.
+        XCTAssertEqual(lines.count, 5)
+        XCTAssertTrue(lines[1].contains("frame 0"))
+        XCTAssertTrue(lines[3].contains("frame 2"))
+        XCTAssertTrue(lines[4].contains("37 more frames"))
+    }
+
+    /// A stack shorter than the bound gets no truncation notice at all.
+    func testShortStackHasNoTruncationNotice() {
+        let lines = UncaughtExceptionReport.lines(
+            name: "X", reason: "y", callStack: ["a", "b"], maxFrames: 24)
+        XCTAssertEqual(lines.count, 3)
+        XCTAssertFalse(lines.contains { $0.contains("more frames") })
+    }
+
+    /// The handler runs in an undefined runtime state; a nonsense bound must
+    /// not become a negative `prefix` or a negative remainder.
+    func testNegativeBoundIsTreatedAsZero() {
+        let lines = UncaughtExceptionReport.lines(
+            name: "X", reason: "y", callStack: ["a", "b"], maxFrames: -5)
+        XCTAssertEqual(lines.count, 2)
+        XCTAssertTrue(lines[1].contains("2 more frames"))
+    }
+}


### PR DESCRIPTION
🍄 Three crash reports from a 0.2.43 build (macOS 26.6.2, 2026-09-09) all abort at the same frame — `-[NSWindow(NSDisplayCycle) _postWindowNeedsUpdateConstraints]`, an uncaught `NSException`.

## The cycle contains no TcrBar frame

It runs entirely inside AppKit, from `stepIdle`, with no user event in the stack:

```
stepIdle → CA::Transaction::commit → NSDisplayCycleFlush
  → -[NSWindow _changeWindowFrameFromConstraintsIfNecessary]
  → -[NSPopover _setContentView:size:canAnimate:]
  → -[_NSPopoverWindow setFrame:display:] → _layoutViewTree
  → -[NSVisualEffectView setFrameSize:] → KVO
  → NSHostingView.didChangeValue(forKey:)
  → NSHostingView.invalidateSafeAreaInsets()
  → NSHostingView.requestUpdate → setNeedsUpdateConstraints:
  → -[NSWindow _postWindowNeedsUpdateConstraints]   ← throws
```

The popover resizing is itself what makes the hosting view request another constraints pass.

## Why #204 was not enough

`PanelHeight.quantized` (cdc4362) shipped *in* 0.2.43 — the build these crashes came from. It damps the loop that runs through `onPreferenceChange`, and quantizing a published preference cannot reach a cycle that never reads one.

## The fix

`sizingOptions = [.preferredContentSize]` cannot go: without it the panel clips, and `--shell-probe` assertion 5 checks the resulting `contentSize` numerically. So this cuts the other edge. A popover has no notch, no title bar and no keyboard, so there is no safe area to inset against; `safeAreaRegions = []` is correct on its own terms as well as being the removable half of the cycle.

## The second commit exists because the reason string is missing

A crash report does not carry it. All three `.ips` files hold exactly one human-readable string between them, `abort() called`: `lastExceptionBacktrace` gives the throwing frames and nothing gives the message the exception was built with. For an AppKit consistency exception that message *is* the diagnosis, naming the offending window and the pass count that tripped the guard. This crash was diagnosed from frames alone and the fix above was chosen without it.

`NSSetUncaughtExceptionHandler` runs before `abort()` raises the `SIGABRT` that the existing handler catches, so it logs first and `AbnormalTerminationGuard` still stops the child being orphaned. The formatting is a pure function in `TcrBarCore`, so a test runs it rather than only a crash producing it. A future occurrence comes back with:

```
log show --last 1h --predicate 'eventMessage CONTAINS "TcrBar-uncaught:"'
```

## Not reproduced locally

The crashing machine is one point release ahead of the one this was written on, and the panel is stable here. This cuts a documented edge of the cycle in the crash stack; it has not been watched to fail and then pass. Please weigh it on that basis.

## A known remaining loop, deliberately untouched

`FleetView.swift:314-317` sets the `ScrollView`'s `.frame(height:)` from row heights measured inside that same `ScrollView`. Three fixes for it were considered and each is currently worse than the bug. Deriving the height from row count is what `PanelHeight`'s own doc-comment records as already tried and rejected, because rows are not uniform height. A monotone-up latch would prove termination, since a bounded non-decreasing sequence converges, but it reintroduces precisely the dead-space bug that `lineIsDrawn` exists to kill. Deferring the `onPreferenceChange` write to the next runloop turn is on-target in principle, because the guard is a per-cycle pass counter, but it converts a crash into a silent infinite relayout and trades a loud failure for a quiet one. The handler in the second commit is what lets the next occurrence decide this on evidence instead.

## Gates

`swift build` clean. `swift test`: 434 tests, 0 failures. Both new-test failure modes were watched — breaking the absent-reason rendering fails exactly `testAbsentReasonRendersExplicitly`, and breaking the truncation notice fails exactly `testNegativeBoundIsTreatedAsZero`.

https://claude.ai/code/session_01HaDRurSBw7PPHjoe59snMC
