### PR TITLE
chore: add the 0.2.44 appcast entry

### DIFF
--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.44</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.44</link>
+      <sparkle:version>499</sparkle:version>
+      <sparkle:shortVersionString>0.2.44</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Wed, 09 Sep 2026 06:36:58 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.44/TcrBar-0.2.44.dmg" type="application/octet-stream" sparkle:edSignature="ZNhhvBK/9HlIwmzFFsFGb5djHfrNdJ1nZm5f9psxt/QOKMWSIzgM1ixJvjOO3qsrNPC5BVSWO6TyglPJzYXfCA==" length="7304110" />
+    </item>
+    <item>
       <title>TcrBar 0.2.43</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.43</link>
       <sparkle:version>496</sparkle:version>


### PR DESCRIPTION
🍄 `release-tcrbar.sh` writes this entry during stage 8 and deliberately does not commit, branch or push, so every release leaves it outstanding by design.

The uploaded `appcast.xml` asset on the Release is what Sparkle actually reads, so v0.2.44 already updates correctly without this. What this fixes is `main`'s tracked copy disagreeing with what shipped.

Verified against the live feed at `releases/latest/download/appcast.xml`: same build (499), same enclosure URL, same EdDSA signature, same length (7304110).

https://claude.ai/code/session_01HaDRurSBw7PPHjoe59snMC
