### PR TITLE
panel sizing: dead band, size library, delta instrument, and group sections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.44"
+version = "0.2.45"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "teamclaude-rs"
-version = "0.2.44"
+version = "0.2.45"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -149,8 +149,12 @@ struct FleetView: View {
         // subtree disappears, which is the reset — a header that draws no
         // spend line has no overflow, and `listBudget` gives the list the
         // whole cap back.
-        .onPreferenceChange(UsageLineHeightKey.self) { usageLineHeight = $0 }
-        .onPreferenceChange(UsageLineBaselineKey.self) { usageLineBaseline = $0 }
+        .onPreferenceChange(UsageLineHeightKey.self) {
+            usageLineHeight = PanelHeight.settled(usageLineHeight, $0)
+        }
+        .onPreferenceChange(UsageLineBaselineKey.self) {
+            usageLineBaseline = PanelHeight.settled(usageLineBaseline, $0)
+        }
     }
 
     /// The fleet's spend, burn rate, model mix and cache hit rate, on one line:
@@ -181,7 +185,7 @@ struct FleetView: View {
                     GeometryReader { proxy in
                         Color.clear.preference(
                             key: UsageLineHeightKey.self,
-                            value: PanelHeight.quantized(proxy.size.height))
+                            value: proxy.size.height)
                     }
                 )
                 .overlay(alignment: .topLeading) {
@@ -193,7 +197,7 @@ struct FleetView: View {
                             GeometryReader { proxy in
                                 Color.clear.preference(
                                     key: UsageLineBaselineKey.self,
-                                    value: PanelHeight.quantized(proxy.size.height))
+                                    value: proxy.size.height)
                             }
                         )
                 }
@@ -314,7 +318,7 @@ struct FleetView: View {
                     accountList(fleet)
                 }
                 .frame(height: visibleRowsHeight(for: fleet))
-                .onPreferenceChange(RowHeightsKey.self) { rowHeights = $0 }
+                .onPreferenceChange(RowHeightsKey.self) { rowHeights = PanelHeight.settled(rowHeights, $0) }
             }
         }
     }
@@ -360,7 +364,7 @@ struct FleetView: View {
             GeometryReader { proxy in
                 Color.clear.preference(
                     key: RowHeightsKey.self,
-                    value: [account.id: PanelHeight.quantized(proxy.size.height)])
+                    value: [account.id: proxy.size.height])
             }
         )
     }

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -54,8 +54,27 @@ struct FleetView: View {
     /// nothing is worse than one that says why.
     @State private var loginError: String?
 
-    /// Measured height of each account row, keyed by account id (`Account.id`
-    /// is the account name).
+    /// Measured height of every child the list draws — each account row, each
+    /// group heading and each band heading — keyed by that child's identity in
+    /// the list, NOT by account id.
+    ///
+    /// **Keyed by ``FleetSectionRow/id``, and that is load-bearing.** An account
+    /// in two groups is drawn twice (see ``accountList(_:)`` for the override
+    /// that makes that correct), so `Account.id` — the account name — is no
+    /// longer unique among the drawn rows. Under the old keying the two rows of
+    /// one account wrote the same key, one measurement overwrote its twin, and
+    /// `visibleRowsHeight(for:)` then summed n−1 heights for n rows: a viewport
+    /// short of its own content by a whole row for every duplicated account,
+    /// which reads as a list clipped mid-card. The composite id is unique per
+    /// drawn row by construction (`FleetSectionsTests`), so each row owns its
+    /// own slot.
+    ///
+    /// The headings share this dictionary because they share the same problem:
+    /// they are children of the same `VStack` and cost the viewport their own
+    /// height plus a gap, and nothing else measures them. Their keys carry the
+    /// `b:`/`h:` prefixes from ``bandHeightKey(_:)`` and ``groupHeightKey(_:)``,
+    /// which cannot collide with a row key — every row key starts with a
+    /// ``FleetGroupKey/token``, i.e. `g:` or `u:`.
     ///
     /// A `ScrollView` has a flexible ideal height, and the window this panel
     /// lives in sizes itself to its content's *ideal* height — so a scroll view
@@ -68,10 +87,10 @@ struct FleetView: View {
     /// controller is set to `sizingOptions = [.preferredContentSize]`
     /// (`MenuBarShell.swift`) for exactly this reason.
     ///
-    /// Per-row rather than one summed total because rows are not uniform height
-    /// — the needs-relogin state and several conditional detail lines all grow a
-    /// row. `visibleRowsHeight(for:)` sums all of these and clamps the total to
-    /// what `PanelHeight.listBudget` leaves of `Tok.panelMaxHeight`.
+    /// Per-child rather than one summed total because rows are not uniform
+    /// height — the needs-relogin state and several conditional detail lines all
+    /// grow a row. `visibleRowsHeight(for:)` sums all of these and clamps the
+    /// total to what `PanelHeight.listBudget` leaves of `Tok.panelMaxHeight`.
     @State private var rowHeights: [String: CGFloat] = [:]
 
     /// The spend line as drawn, and the height one line of it would be.
@@ -323,32 +342,116 @@ struct FleetView: View {
         }
     }
 
-    /// A flat list of accounts — the only shape this panel draws now. Group
-    /// membership shows as a tag on the row (``AccountRow``'s pills line),
-    /// not as a section, card or separate view; see the bridge for why three
-    /// earlier attempts at the latter were all rejected.
+    /// The account list, cut into sections: a state band heading, then a group
+    /// heading inside it, then the rows.
+    ///
+    /// This comment used to say a flat list was "the only shape this panel draws
+    /// now", and cited `docs/plans/account-groups-plan.md:44-55` (decision \#4)
+    /// for three rejected attempts at sectioning. **Gil has overridden that**,
+    /// this session, knowing the cost. The objection was never that sectioning
+    /// looked wrong — it was that a list cut by group must either duplicate a
+    /// row for a multi-membership account or invent a "primary" group the data
+    /// does not have. The override takes the first: an account in two groups
+    /// gets TWO rows, one under each heading, and nothing here de-duplicates.
+    /// The price is that the row count is no longer the account count and an
+    /// operator will read the same email twice; the alternative was the app
+    /// asserting which group an account "really" belongs to, which is a fact
+    /// nobody has.
+    ///
+    /// Ordering, band membership and the duplication all live in
+    /// ``Fleet/sectionsInDisplayOrder(pinning:)`` and are unit-tested there
+    /// (`FleetSectionsTests`). Nothing is re-derived here: this function draws
+    /// the array it is handed, in array order, and asks
+    /// ``Array/isFirstOfBand(_:)`` when to open a band rather than comparing
+    /// bands itself.
+    ///
+    /// The control account's hairline separator is GONE with the flat list that
+    /// justified it. It marked the boundary under a globally pinned control row,
+    /// and there is no such row any more — `sectionsInDisplayOrder` pins the
+    /// control account to the front of each section it appears in, because
+    /// hoisting it above the first band heading would put it outside every group
+    /// and every state it belongs to. `visibleRowsHeight(for:)` therefore passes
+    /// no `controlHairline` term: it existed to pay for a separator this list no
+    /// longer draws, and charging for it now would make the viewport 8.5pt too
+    /// TALL — the same drift the old comment warned about, in the other
+    /// direction.
     private func accountList(_ fleet: Fleet) -> some View {
-        let rows = fleet.rowsInDisplayOrder(pinning: control.current)
+        let sections = fleet.sectionsInDisplayOrder(pinning: control.current)
         return VStack(alignment: .leading, spacing: Tok.rowSpacing) {
-            ForEach(Array(rows.enumerated()), id: \.element.id) { index, account in
-                accountRow(account, fleet: fleet)
-                // A thin separator between the pinned control row and the
-                // rotation pool below it — the same `Hairline` this panel
-                // already uses to mark a scope boundary (see `appActions`).
-                // Only drawn when the control row is actually first: index 0
-                // is an ordinary pool row on every fleet without one set.
-                // `hasControlHairline` is the same condition, and
-                // `visibleRowsHeight` sizes the viewport with it — they must
-                // stay one predicate or the list is short by 8.5pt again.
-                if index == 0, hasControlHairline(rows) {
-                    Hairline()
+            // Identified by `FleetSection.id` (band + group), not by group
+            // alone: a group whose accounts differ in state appears in more
+            // than one band, and two sections sharing a SwiftUI identity paint
+            // one section's rows into the other's slot.
+            ForEach(Array(sections.enumerated()), id: \.element.id) { index, section in
+                if sections.isFirstOfBand(index) {
+                    bandHeading(section.band)
+                }
+                groupHeading(section)
+                // `FleetSectionRow` is `Identifiable` on the composite
+                // (group, account) id, which is why this can be a plain
+                // `ForEach` over the rows: the duplicated account's two rows
+                // carry different identities.
+                ForEach(section.rows) { row in
+                    accountRow(row, fleet: fleet)
                 }
             }
         }
     }
 
-    private func accountRow(_ account: Account, fleet: Fleet) -> some View {
-        AccountRow(
+    /// The outer heading: what these accounts can do for you right now.
+    /// ``FleetBand/title`` supplies the words — "Live", "Out of tokens",
+    /// "Parked" — so the panel and any future caller cannot name a band two
+    /// different ways.
+    private func bandHeading(_ band: FleetBand) -> some View {
+        measured(bandHeightKey(band)) {
+            Text(band.title.uppercased())
+                .font(Tok.detailFont.weight(.semibold))
+                .tracking(Tok.pillTracking)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    /// The inner heading: one group, or the unlabelled pile. Set apart from the
+    /// band heading by case and weight rather than by an indent, so a row and
+    /// its heading keep the same left edge and the eye reads one column.
+    private func groupHeading(_ section: FleetSection) -> some View {
+        measured(groupHeightKey(section)) {
+            Text(section.title)
+                .font(Tok.secondaryFont.weight(.semibold))
+                .foregroundStyle(.primary)
+        }
+    }
+
+    /// Height key for a band heading. The `b:` prefix cannot collide with a row
+    /// key — those start with a ``FleetGroupKey/token``, `g:` or `u:` — and the
+    /// band's raw value rather than its title keeps it out of the operator's
+    /// typing entirely.
+    private func bandHeightKey(_ band: FleetBand) -> String { "b:\(band.rawValue)" }
+
+    /// Height key for a group heading, built on ``FleetSection/id`` so a group
+    /// split across two bands gets two keys, exactly as it gets two headings.
+    private func groupHeightKey(_ section: FleetSection) -> String { "h:\(section.id)" }
+
+    /// Publish a list child's measured height under `key`.
+    ///
+    /// Raw `proxy.size.height`, deliberately un-rounded: `PanelHeight.settled`
+    /// is the only place the grid is applied, and a dead band that cannot see
+    /// the raw value degenerates into the oscillation it exists to stop. Read
+    /// its doc-comment before changing what is published here.
+    private func measured<Content: View>(
+        _ key: String,
+        @ViewBuilder _ content: () -> Content
+    ) -> some View {
+        content().background(
+            GeometryReader { proxy in
+                Color.clear.preference(key: RowHeightsKey.self, value: [key: proxy.size.height])
+            }
+        )
+    }
+
+    private func accountRow(_ row: FleetSectionRow, fleet: Fleet) -> some View {
+        let account = row.account
+        return AccountRow(
             account: account,
             countersAreStructural: fleet.source.countersAreStructural,
             accounts: accounts,
@@ -362,9 +465,12 @@ struct FleetView: View {
         )
         .background(
             GeometryReader { proxy in
+                // `row.id`, never `account.id`: a duplicated account draws two
+                // of these and `account.id` would make the second overwrite the
+                // first's measurement.
                 Color.clear.preference(
                     key: RowHeightsKey.self,
-                    value: [account.id: proxy.size.height])
+                    value: [row.id: proxy.size.height])
             }
         )
     }
@@ -390,18 +496,15 @@ struct FleetView: View {
     /// empty and this returns the budget itself, so the panel never renders at
     /// zero or one-row height while waiting for a real measurement.
     private func visibleRowsHeight(for fleet: Fleet) -> CGFloat {
-        let rows = fleet.rowsInDisplayOrder(pinning: control.current)
-        let orderedHeights = rows.compactMap { rowHeights[$0.id] }
+        let sections = fleet.sectionsInDisplayOrder(pinning: control.current)
+        let orderedHeights = listChildKeys(sections).compactMap { rowHeights[$0] }
         return PanelHeight.visibleRowsHeight(
             rowHeights: orderedHeights,
             spacing: Tok.rowSpacing,
-            // The separator `accountList` draws under a PINNED control row.
-            // `rowHeights` is filled from `AccountRow`'s own GeometryReader and
-            // the hairline is not an `AccountRow`, so nothing in that array
-            // knows about it — and it costs the list its own thickness plus one
-            // more gap, 8.5pt the viewport was short of its content on every
-            // fleet with a control account set.
-            controlHairline: hasControlHairline(rows) ? Tok.hairlineWidth : nil,
+            // No `controlHairline` term. It paid for the separator the flat
+            // list drew under a globally pinned control row; sectioning removed
+            // both the pin and the separator, so charging for it here would
+            // hand the viewport 8.5pt of empty space under the last card.
             budget: PanelHeight.listBudget(
                 cap: Tok.panelMaxHeight,
                 headerOverflow: PanelHeight.headerOverflow(
@@ -414,10 +517,28 @@ struct FleetView: View {
                 minimum: Tok.panelMinListHeight))
     }
 
-    /// Whether `accountList` will insert its control-row separator — the same
-    /// condition, written once, so the drawing and the measuring cannot drift.
-    private func hasControlHairline(_ rows: [Account]) -> Bool {
-        rows.first?.name == control.current && control.current != nil
+    /// Every child `accountList` draws, in draw order, as its height key.
+    ///
+    /// One function for both jobs, which is the point: the drawing loop and the
+    /// measuring sum have to agree about which children exist, and they used to
+    /// drift over a single hairline (8.5pt of clipped card). Headings are
+    /// children of the same `VStack` as the rows, so each one costs the viewport
+    /// its own height plus one gap — and `PanelHeight.visibleRowsHeight` derives
+    /// the gaps from this array's COUNT, so listing the headings here is what
+    /// makes that arithmetic right rather than an approximation.
+    ///
+    /// A key with no measurement yet is dropped by the caller's `compactMap`,
+    /// which is the same first-frame behaviour the rows have always had.
+    private func listChildKeys(_ sections: [FleetSection]) -> [String] {
+        var keys: [String] = []
+        for (index, section) in sections.enumerated() {
+            if sections.isFirstOfBand(index) {
+                keys.append(bandHeightKey(section.band))
+            }
+            keys.append(groupHeightKey(section))
+            keys.append(contentsOf: section.rows.map(\.id))
+        }
+        return keys
     }
 
     private func offlineNotice(_ source: StatusSource) -> some View {
@@ -841,10 +962,15 @@ struct FleetView: View {
     }
 }
 
-/// Carries the measured height of each account row out of the scroll view,
-/// keyed by `Account.id`. A dictionary rather than one summed scalar because
-/// rows are not uniform height — `visibleRowsHeight(for:)` needs the first N
-/// individually, in display order, not just their total.
+/// Carries the measured height of each list child out of the scroll view,
+/// keyed by that child's list identity — ``FleetSectionRow/id`` for a row, the
+/// `b:`/`h:` heading keys for a band or group heading. **Not `Account.id`**: a
+/// multi-group account draws two rows, and two rows publishing one key means
+/// one measurement lands and the other is silently discarded.
+///
+/// A dictionary rather than one summed scalar because rows are not uniform
+/// height — `visibleRowsHeight(for:)` needs the first N individually, in
+/// display order, not just their total.
 struct RowHeightsKey: PreferenceKey {
     static let defaultValue: [String: CGFloat] = [:]
     static func reduce(value: inout [String: CGFloat], nextValue: () -> [String: CGFloat]) {

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -386,7 +386,13 @@ struct FleetView: View {
                 if sections.isFirstOfBand(index) {
                     bandHeading(section.band)
                 }
-                groupHeading(section)
+                // Gated, and `listChildKeys` below gates on the SAME call. The
+                // two must agree exactly: a heading drawn but unkeyed is a row
+                // the viewport never charges for, and a heading keyed but not
+                // drawn charges for a row that is not there. Both clip.
+                if sections.drawsGroupHeading(at: index) {
+                    groupHeading(section)
+                }
                 // `FleetSectionRow` is `Identifiable` on the composite
                 // (group, account) id, which is why this can be a plain
                 // `ForEach` over the rows: the duplicated account's two rows
@@ -535,7 +541,10 @@ struct FleetView: View {
             if sections.isFirstOfBand(index) {
                 keys.append(bandHeightKey(section.band))
             }
-            keys.append(groupHeightKey(section))
+            // Same predicate as the draw loop, deliberately. See there.
+            if sections.drawsGroupHeading(at: index) {
+                keys.append(groupHeightKey(section))
+            }
             keys.append(contentsOf: section.rows.map(\.id))
         }
         return keys

--- a/apps/macos/Sources/TcrBar/MenuBarShell.swift
+++ b/apps/macos/Sources/TcrBar/MenuBarShell.swift
@@ -218,6 +218,22 @@ final class MenuBarShell {
                 self?.updateMark(state: state, awake: isOn)
             }
             .store(in: &marks)
+
+        // Phase 3 of `docs/plans/panel-sizing-generalization.md`: predict the
+        // panel's size on every poll tick and log it beside the size SwiftUI
+        // actually produced. Its own sink rather than a line inside the one
+        // above, because that one exists to compose the menu bar mark and
+        // combines a second publisher to do it — a size measurement would then
+        // also fire on every keep-awake toggle, which changes nothing about the
+        // panel's height and would print a duplicate of the previous line.
+        //
+        // Nothing here writes anything. `sizingOptions` is untouched, the
+        // popover still sizes itself, and the only output is one `NSLog`.
+        self.poller.$state
+            .sink { [weak self] state in
+                self?.logPanelSize(state: state)
+            }
+            .store(in: &marks)
     }
 
     // MARK: - The mark
@@ -262,6 +278,47 @@ final class MenuBarShell {
             button.title = "tcr"
         }
         button.toolTip = Self.toolTip(state: state, awake: isOn)
+    }
+
+    // MARK: - The panel's size, predicted against what it really is
+
+    /// One line per poll tick: what ``PanelSize`` says the popover should be,
+    /// beside what the popover actually is.
+    ///
+    /// This is the whole of phase 3 and it changes no behaviour. The question
+    /// the five-phase plan rests on — does a TextKit estimate taken outside the
+    /// view graph track what SwiftUI lays out inside it — could not be answered
+    /// by argument in the design review, and cannot be answered on this machine
+    /// either: it wants a real fleet on a real Mac, and the one that crashes is
+    /// somebody else's. So the app answers it, and the only cost of being wrong
+    /// here is a wrong number in a log.
+    ///
+    /// `state` comes from the publisher and is never re-read off the poller.
+    /// `@Published` fires in `willSet`, so `poller.state` inside this call is
+    /// still the PREVIOUS poll — a line composed from it would pair one tick's
+    /// prediction with the next tick's account count, which is exactly the kind
+    /// of quiet mismatch a reader has no way to see. The same rule the mark's
+    /// own sink follows, and for the same reason.
+    ///
+    /// `popover.contentSize` is read here rather than `hosting.view.frame`:
+    /// `contentSize` is what phase 4 will assign, so this measures the property
+    /// that is about to change owners rather than a proxy for it. With the
+    /// panel closed it is whatever the last open left behind, which is why the
+    /// line says `shown=no` instead of dropping the reading — a reader who
+    /// wants only live layouts can filter, and one debugging a panel that never
+    /// opens still gets lines.
+    private func logPanelSize(state: PollState) {
+        let delta = PanelSizeProbe.delta(
+            state: state,
+            update: updater.updateState,
+            server: server.state,
+            actualContentSize: popover.contentSize,
+            isPanelShown: popover.isShown)
+        // `"%@"` and not the string itself: `NSLog` takes a format string, and
+        // a panel line carries `%` in it the moment a cache-hit percentage
+        // reaches the header — `TcrBarApp.swift:72` logs through the same guard
+        // for the same reason.
+        NSLog("%@", delta.logLine)
     }
 
     // MARK: - The panel

--- a/apps/macos/Sources/TcrBar/MenuBarShell.swift
+++ b/apps/macos/Sources/TcrBar/MenuBarShell.swift
@@ -165,10 +165,17 @@ final class MenuBarShell {
         // `NSPopoverFrame` and `NSHostingView`, driven from `stepIdle` with no
         // user event in the stack.
         //
-        // `PanelHeight.quantized` damps the OTHER loop, the one that runs
-        // through `onPreferenceChange`, and shipped in that same 0.2.43 build
-        // — which is the evidence that it is not sufficient alone. Preference
-        // quantization cannot reach a cycle that never reads a preference.
+        // `PanelHeight.settled` damps the OTHER loop, the one that runs
+        // through `onPreferenceChange`. Its predecessor `PanelHeight.quantized`
+        // shipped in that same 0.2.43 build, which is the evidence that damping
+        // that loop is not sufficient alone: preference quantization cannot
+        // reach a cycle that never reads a preference, and none of the three
+        // 0.2.43 stacks contains a TcrBar frame at all.
+        //
+        // `quantized` is no longer called from this target — `settled` owns the
+        // publish path and calls it internally, and it was made internal to
+        // `TcrBarCore` so that re-adding it at a `GeometryReader` emitter fails
+        // to compile rather than silently reverting the fix.
         //
         // A popover has no safe area to inset against: no notch, no title bar,
         // no keyboard. Opting out is correct on its own terms, and it is the

--- a/apps/macos/Sources/TcrBar/PanelSizeProbe.swift
+++ b/apps/macos/Sources/TcrBar/PanelSizeProbe.swift
@@ -1,0 +1,201 @@
+import AppKit
+import TcrBarCore
+
+/// The AppKit half of the panel-sizing instrument: the text engine
+/// ``TextMetrics`` is a protocol for, and the description of `FleetView`'s
+/// chrome that `PanelSize` needs in order to predict a height.
+///
+/// It lives in this target because `TcrBarCore` deliberately cannot import
+/// AppKit — `Package.swift`'s doc-comment and `PanelHeight.swift:20-23` are one
+/// decision, and `docs/plans/panel-sizing-generalization.md` §10 item 5 forbids
+/// the obvious shortcut of adding `"TcrBar"` to the test target. So the
+/// arithmetic sits in the library where a test runs it, and the two things a
+/// test cannot have — a font, and a view — sit here.
+///
+/// Nothing here changes what the panel draws. Phase 3 computes a prediction
+/// beside the popover's real `contentSize` and logs the pair; `sizingOptions`
+/// is untouched and `FleetView` is not opened at all.
+
+/// ``TextMetrics`` through TextKit.
+///
+/// `NSString.boundingRect(with:options:attributes:)` is what
+/// `docs/plans/panel-sizing-generalization.md` §2 specifies, and its value is
+/// that it runs OUTSIDE any view graph: the wrapped height of a string is
+/// geometry, and the design's whole distinction is between measuring it in a
+/// text engine before the layout pass and measuring it with a `GeometryReader`
+/// inside the pass that consumes the answer.
+///
+/// **Two known sources of under-measurement, both deliberate and both the
+/// reason phase 3 exists rather than phase 4 shipping directly.** The protocol
+/// carries a font SIZE and not a font, so the semibold faces `FleetView` uses
+/// for `.headline` and `.subheadline` are measured at the regular weight and
+/// come out narrower than they draw; and whether TextKit's wrap point agrees
+/// with SwiftUI `Text`'s at all is the one assumption the design review could
+/// not test without running the panel. Neither is fixed here. They are what the
+/// log line is for.
+struct AppKitTextMetrics: TextMetrics {
+    func height(of text: String, fontSize: CGFloat, width: CGFloat) -> CGFloat {
+        guard width > 0 else { return 0 }
+        // An empty string measures zero, and a `Text("")` in a `VStack` draws a
+        // full line box. Measuring a space instead keeps the two agreeing —
+        // reserving nothing for a line that is on screen is the direction that
+        // costs the footer its place.
+        let subject = text.isEmpty ? " " : text
+        let box = NSSize(width: width, height: .greatestFiniteMagnitude)
+        let rect = (subject as NSString).boundingRect(
+            with: box,
+            // `.usesLineFragmentOrigin` is what makes this a MULTI-line
+            // measurement; without it the call answers for one line and every
+            // wrapping string in the panel is reported at a third of its
+            // height. `.usesFontLeading` matches how TextKit lays the text out
+            // when it is actually drawn.
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: [.font: NSFont.systemFont(ofSize: fontSize)])
+        // Up, never down. A half-point lost per line is a line lost over a tall
+        // header, and the estimate is only allowed to be wrong in the direction
+        // the residual scroll region absorbs.
+        return rect.height.rounded(.up)
+    }
+}
+
+/// What the shell hands `PanelSize` about `FleetView`, and the prediction it
+/// gets back.
+///
+/// Every figure here is a claim about a view in this target, which is why it is
+/// beside that view rather than in the library: `Tok`'s tokens are exact and
+/// read straight from `Tokens.swift`, while the two heights nobody declares —
+/// a card in the account list, and the footer's block of controls — are
+/// ESTIMATES, marked as such, and are precisely what the phase-3 log line
+/// exists to correct.
+enum PanelSizeProbe {
+    static let metrics: TextMetrics = AppKitTextMetrics()
+
+    /// A representative account card.
+    ///
+    /// Rows are not uniform height — that is why a row-count cap was rejected
+    /// twice in writing (`Tokens.swift:254`, `PanelHeight.swift:47`) — so this
+    /// is an average and is treated as one. 42pt is the repo's own figure for
+    /// one row (`docs/plans/panel-sizing-generalization.md` §8: "a fleet that
+    /// really has one row should draw 42pt"). Being wrong here moves the list,
+    /// which is the part the design lets be wrong.
+    static let estimatedRowHeight: CGFloat = 42
+
+    /// The footer's controls, which reserve their height whether or not the
+    /// footer draws any text above them. They are what the original bug pushed
+    /// off the bottom of the popover (`PanelHeight.swift:6-19`), so they are
+    /// reserved unconditionally.
+    ///
+    /// Summed from `FleetView.footer` (`:449-494`) at the rows it draws, with
+    /// the six `Tok.tightSpacing` gaps between the seven of them:
+    ///
+    /// | row | pt | from |
+    /// |---|---|---|
+    /// | `fleetActions` | 24 | one bordered button row |
+    /// | `appActions` | 28 | the same, plus its `.padding(.top, tightSpacing)` (`:479`) |
+    /// | `launchAtLogin` | 29 | toggle 16 + its detail caption 13 (`:854`) |
+    /// | `startServerToggle` | 29 | toggle 16 + the supervision warning (`:743`) |
+    /// | `keepAwakeToggle` | 29 | toggle 16 + the AC-power caption (`:796`) |
+    /// | `dangerZone` | 32.5 | top padding 4 + `Hairline` 0.5 + gap 4 + button row 24 |
+    /// | six gaps | 24 | `VStack(spacing: Tok.tightSpacing)` (`:450`) |
+    ///
+    /// An estimate, and the least certain number in this file: SwiftUI's
+    /// control heights are not declared anywhere, and the three captions are
+    /// conditional. It is here rather than hidden inside the arithmetic so the
+    /// reader of a log line can see which number was assumed.
+    static let estimatedFixedControlsHeight: CGFloat = 195.5
+
+    /// `Tok`'s figures, passed in rather than read from the library — `Tok`
+    /// lives in this target and `TcrBarCore` cannot see it, which is what keeps
+    /// the arithmetic testable without linking a view.
+    static let geometry = PanelSize.Geometry(
+        panelWidth: Tok.panelWidth,
+        gutter: Tok.gutter,
+        sectionSpacing: Tok.rowSpacing,
+        lineSpacing: Tok.tightSpacing,
+        rowSpacing: Tok.rowSpacing,
+        hairlineWidth: Tok.hairlineWidth,
+        rowHeight: estimatedRowHeight,
+        fixedControlsHeight: estimatedFixedControlsHeight
+    )
+
+    /// The chrome strings the HEADER is drawing right now — the same
+    /// conditions `FleetView.header` (`:106-155`) draws them under, in the same
+    /// order.
+    ///
+    /// Reserving a line the panel is not rendering is the failure
+    /// `PanelHeight.headerOverflow`'s `lineIsDrawn` parameter exists to
+    /// prevent, arriving from the other end, so every `if` in the view is
+    /// mirrored here rather than approximated by a worst case.
+    static func headerLines(state: PollState, update: UpdateState) -> [PanelSize.Line] {
+        var lines: [PanelSize.Line] = [
+            // The title row. One line by construction — the timestamp beside it
+            // is in the same `HStack` — but it still costs its height.
+            PanelSize.Line("tcr fleet", fontSize: NSFont.preferredFont(forTextStyle: .headline).pointSize)
+        ]
+        if !state.isHealthyRead {
+            lines.append(PanelSize.Line(state.summary, fontSize: Tok.secondaryFontSize))
+        }
+        if case .loaded(let fleet) = state, !fleet.accounts.isEmpty {
+            // Concatenated `Text` runs, drawn as one wrapping paragraph
+            // (`FleetView.swift:236-249`) — so it is measured as one string,
+            // not as one line per tally.
+            let tallies = fleet.breakdown.map { " · \($0.label)" }.joined()
+            lines.append(
+                PanelSize.Line(
+                    fleet.capacitySummary + tallies,
+                    fontSize: NSFont.preferredFont(forTextStyle: .subheadline).pointSize))
+        }
+        if case .loaded(let fleet) = state, let usage = fleet.usageSummaryLine {
+            lines.append(PanelSize.Line(usage, fontSize: Tok.secondaryFontSize))
+        }
+        if let message = update.headerMessage {
+            lines.append(PanelSize.Line(message, fontSize: Tok.secondaryFontSize))
+        }
+        return lines
+    }
+
+    /// The chrome strings the FOOTER is drawing, above its fixed controls
+    /// (`FleetView.footer:455-467`).
+    ///
+    /// `server <sha>` shares the server summary's `HStack` and carries
+    /// `.lineLimit(1)`, so it adds no height of its own and is not a line here.
+    /// `loginError` (`:481-486`) is `FleetView`'s own `@State` and the shell
+    /// cannot see it; it is left out rather than guessed at, which makes the
+    /// prediction short on exactly the ticks a login has just failed — a known
+    /// gap, and one a reader of the log can identify because it does not move
+    /// with anything else on the line.
+    static func footerLines(server: ServerController.State) -> [PanelSize.Line] {
+        [PanelSize.Line(server.summary, fontSize: Tok.secondaryFontSize)]
+    }
+
+    /// The prediction for this tick, beside what the popover actually is.
+    static func delta(
+        state: PollState,
+        update: UpdateState,
+        server: ServerController.State,
+        actualContentSize: CGSize,
+        isPanelShown: Bool
+    ) -> PanelSizeDelta {
+        let header = headerLines(state: state, update: update)
+        let footer = footerLines(server: server)
+        // Accounts, not rows-in-general: an undecodable row is reported in the
+        // header's own words and draws no card, so it is chrome and not a row.
+        let rowCount: Int = {
+            if case .loaded(let fleet) = state { return fleet.accounts.count }
+            return 0
+        }()
+        let plan = PanelSize.plan(
+            rowCount: rowCount,
+            header: header,
+            footer: footer,
+            geometry: geometry,
+            metrics: metrics)
+        return PanelSizeDelta(
+            predicted: plan,
+            actualContentSize: actualContentSize,
+            rowCount: rowCount,
+            headerLines: header.count,
+            footerLines: footer.count,
+            isPanelShown: isPanelShown)
+    }
+}

--- a/apps/macos/Sources/TcrBarCore/FleetSections.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetSections.swift
@@ -232,6 +232,31 @@ extension Array where Element == FleetSection {
         guard index > 0 else { return true }
         return self[index - 1].band != self[index].band
     }
+
+    /// Whether the section at `index` should draw its group heading.
+    ///
+    /// A heading has to earn its line. Every one costs the panel its own height
+    /// PLUS a gap, and `PanelHeight.visibleRowsHeight` charges the viewport for
+    /// both, so a heading that carries no information is not free — it is a row
+    /// of dead space in a panel whose whole design is a fight for height.
+    ///
+    /// The one case where it carries nothing: a band holding a single
+    /// ``FleetGroupKey/ungrouped`` section. "LIVE / Ungrouped" tells a reader
+    /// exactly what "LIVE" already told them. On a fleet with no groups
+    /// configured at all that is every band, so the panel grew three heading
+    /// rows and said nothing three times — caught by rendering the states and
+    /// looking at them, not by any test.
+    ///
+    /// A single NAMED section still draws: "PARKED / henry-team" says which
+    /// group was parked, which the band heading cannot. And an ungrouped
+    /// section alongside a named one still draws, because there it is the thing
+    /// that separates the two.
+    public func drawsGroupHeading(at index: Int) -> Bool {
+        guard indices.contains(index) else { return false }
+        let section = self[index]
+        guard section.group == .ungrouped else { return true }
+        return filter { $0.band == section.band }.count > 1
+    }
 }
 
 extension Fleet {

--- a/apps/macos/Sources/TcrBarCore/FleetSections.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetSections.swift
@@ -1,0 +1,318 @@
+/// The panel's account list, cut into real sections: a state band, then a group
+/// heading inside it, then the rows.
+///
+/// This reverses a decision the group plan made three times.
+/// `docs/plans/account-groups-plan.md:44-55` (decision \#4, "Row chips, not list
+/// sections") rejected sectioning on the grounds that a list cut by group must
+/// either duplicate a row for a multi-membership account or invent a "primary"
+/// group that the data does not have. The objection was correct and is not
+/// retracted here — it is OVERRIDDEN, by Gil, this session, with the cost taken
+/// deliberately: an account in two groups gets **two rows**, one under each
+/// group heading, and there is no primary-group concept anywhere in this file.
+/// The cost is that the row count in the panel is no longer the account count,
+/// and an operator reading down the list will see the same email twice. That is
+/// the price of not inventing a fact about which group an account "really"
+/// belongs to.
+///
+/// The second decision, also Gil's and also explicit: **state is the outer
+/// level, group orders within it.** A group whose accounts are in different
+/// states is therefore split across bands and its heading appears more than
+/// once. That is truthful — a half-spent group is not one thing — and it is the
+/// direct consequence of the panel existing to answer "what can serve me right
+/// now", which is the same premise ``Fleet/rowsInDisplayOrder`` sorts on.
+///
+/// Everything here is pure: a `Fleet` in, an array out, no view state and
+/// nothing read from the environment. It lives in the library rather than in
+/// `FleetView` for the reason ``PanelHeight`` does — the test target links
+/// `TcrBarCore` only, so a view-private helper is a helper nothing can test,
+/// and grouping/ordering is exactly the kind of rule that silently drifts.
+
+/// The outer level of the list: what an account can do for you right now.
+///
+/// Three bands, and the membership test is deliberately NOT
+/// ``Account/displayOrder``. That key has seven values and answers "how far
+/// down the list does this row go"; a heading needs a coarse answer an operator
+/// can read as a sentence. `needsRelogin` and never-probed rows are LIVE here
+/// even though `displayOrder` sinks them, because neither is known to be out of
+/// tokens and neither was parked by the operator — putting them under "Out of
+/// tokens" would state a quota fact this app has not measured, and putting them
+/// under "Parked" would blame the operator for a broken credential.
+public enum FleetBand: Int, CaseIterable, Equatable, Sendable, Comparable {
+    /// Anything that is neither spent nor parked.
+    case live = 0
+    /// `quotaState == .spent` — the server says the tokens are gone.
+    case outOfTokens = 1
+    /// The operator took it out of rotation — `disabled` on the row itself, OR
+    /// ``Account/isParkedByGroup``.
+    ///
+    /// Checked FIRST, exactly as ``Account/displayOrder`` checks `disabled`
+    /// first: a parked account keeps reporting whatever quota it had when it
+    /// left rotation, so a disabled row with a spent quota is parked, not out
+    /// of tokens. Reading it the other way would put an operator decision under
+    /// a heading that says "wait for the reset".
+    ///
+    /// **`isParkedByGroup` is in this test on purpose, and it is the one place
+    /// this file goes past its brief** (which said the band was `disabled`).
+    /// `tcr group park` does not set the account's own `disabled` flag — the
+    /// two are deliberately distinct on the wire (`src/stats.rs:108-115`) — but
+    /// it does block the account for EVERY request at account level
+    /// (`Manager::parked_blocks`, `src/manager/mod.rs:8895-8899`). Classifying
+    /// on `disabled` alone would file six accounts of a wholly-parked group
+    /// under "Live" while the router sends them nothing, and "live" is the one
+    /// word in this panel that must not be guessed: the panel exists to answer
+    /// "what can serve me right now".
+    case parked = 2
+
+    /// Which band a row belongs to. The whole classification, in one place, so
+    /// the section builder and any future caller cannot disagree about it.
+    public init(_ account: Account) {
+        if account.disabled || account.isParkedByGroup {
+            self = .parked
+        } else if account.quotaState == .spent {
+            self = .outOfTokens
+        } else {
+            self = .live
+        }
+    }
+
+    /// The heading text. `outOfTokens` says "Out of tokens" and not "Spent"
+    /// because the panel's other spent-facing copy is a countdown to a reset,
+    /// and a one-word heading that shares a name with ``QuotaState/spent``
+    /// invites a reader to think the band IS that enum case — it is not; a
+    /// disabled account can also be spent and lands elsewhere.
+    public var title: String {
+        switch self {
+        case .live: return "Live"
+        case .outOfTokens: return "Out of tokens"
+        case .parked: return "Parked"
+        }
+    }
+
+    public static func < (lhs: FleetBand, rhs: FleetBand) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+/// The inner level: one group, or the absence of one.
+///
+/// `ungrouped` is a case rather than an empty string because the two are not
+/// the same kind of thing and a string would let a group actually NAMED
+/// "" or "Ungrouped" impersonate it.
+public enum FleetGroupKey: Hashable, Sendable, Comparable {
+    case named(String)
+    /// No group label on the wire.
+    ///
+    /// **This collapses `groups == nil` and `groups == []` into one section, on
+    /// purpose.** ``Account/groups`` keeps those distinct — `nil` is "this
+    /// server is too old to report groups", `[]` is "reported, and there are
+    /// none" — and that distinction stays on the account, where a future
+    /// caller can still read it. It does not become a section, because the
+    /// section list is a thing an operator ACTS on: against a `tcr` that
+    /// predates the field, every row would land under a heading like "Groups
+    /// not reported", which is a fact about the server's version rendered as if
+    /// it were a property of the accounts, and no click in this panel resolves
+    /// it. Both cases render as ungrouped, which is what ``Account/groupTags``
+    /// already does with them.
+    case ungrouped
+
+    /// The heading text.
+    public var title: String {
+        switch self {
+        case .named(let name): return name
+        case .ungrouped: return "Ungrouped"
+        }
+    }
+
+    /// A collision-free string for identity. Prefixed, so a group literally
+    /// named `Ungrouped` cannot produce the same token as ``ungrouped`` — the
+    /// exact way a by-name identity collapsed two different rows into one
+    /// SwiftUI identity once already (``AccountRef``'s doc-comment has that
+    /// story).
+    public var token: String {
+        switch self {
+        case .named(let name): return "g:\(name)"
+        case .ungrouped: return "u:"
+        }
+    }
+
+    /// Named groups sort alphabetically; ungrouped sorts LAST within its band,
+    /// because it is the fallback bucket and a reader scanning for a group
+    /// heading should not have to step over the unlabelled pile first.
+    public static func < (lhs: FleetGroupKey, rhs: FleetGroupKey) -> Bool {
+        switch (lhs, rhs) {
+        case (.named(let a), .named(let b)): return a < b
+        case (.named, .ungrouped): return true
+        case (.ungrouped, .named): return false
+        case (.ungrouped, .ungrouped): return false
+        }
+    }
+}
+
+/// One account, as it appears under ONE group heading.
+///
+/// Not an `Account`: the same account is rendered more than once when it is in
+/// more than one group, so the thing the view iterates cannot be identified by
+/// the account alone. ``id`` is the composite (group, account) identity, and it
+/// is a property HERE rather than something `FleetView` synthesises inline,
+/// because a `ForEach` identity that collides does not crash — it silently
+/// paints one row's data onto another, which is precisely the bug
+/// ``AccountRef`` exists to document.
+public struct FleetSectionRow: Identifiable, Equatable, Sendable {
+    public let account: Account
+    /// The group heading this row sits under.
+    public let group: FleetGroupKey
+    /// The band this row sits under. Derived from `account`, carried anyway so
+    /// a caller holding a single row never has to re-derive it and cannot
+    /// derive it differently.
+    public let band: FleetBand
+    /// True when this row is the identity-bound control account
+    /// (`tcr control --show`, via `ControlAccountController`).
+    public let isControl: Bool
+
+    public init(account: Account, group: FleetGroupKey, band: FleetBand, isControl: Bool) {
+        self.account = account
+        self.group = group
+        self.band = band
+        self.isControl = isControl
+    }
+
+    /// Stable composite identity: group, then account.
+    ///
+    /// The separator is ASCII US (`0x1F`), not `|` or `/`: a group name is
+    /// operator-typed and an account name already contains `/` on a fleet where
+    /// one person holds two orgs (``AccountRef/displayHalves``), so any printable
+    /// separator is a character that can appear on both sides of it and let two
+    /// different (group, account) pairs produce one string.
+    ///
+    /// The band is deliberately NOT part of this. Band is a function of the
+    /// account, so (group, account) is already unique across the whole list, and
+    /// including it would mean a row's identity changes the moment an account
+    /// runs out of tokens — SwiftUI would treat that as a delete plus an insert
+    /// and animate a row that merely changed color.
+    public var id: String { "\(group.token)\u{1F}\(account.id)" }
+}
+
+/// One heading and the rows under it.
+public struct FleetSection: Identifiable, Equatable, Sendable {
+    public let band: FleetBand
+    public let group: FleetGroupKey
+    /// Already ordered — the caller renders these in array order and derives
+    /// nothing.
+    public let rows: [FleetSectionRow]
+
+    public init(band: FleetBand, group: FleetGroupKey, rows: [FleetSectionRow]) {
+        self.band = band
+        self.group = group
+        self.rows = rows
+    }
+
+    /// The group heading. The band heading is ``FleetBand/title`` and is drawn
+    /// once per run of sections sharing a band — see ``isFirstOfBand`` on the
+    /// array.
+    public var title: String { group.title }
+
+    /// Same construction rule as ``FleetSectionRow/id``, one level up: a group
+    /// appears in more than one band whenever its accounts are in different
+    /// states, so the band IS part of a section's identity even though it is
+    /// not part of a row's.
+    public var id: String { "\(band.rawValue)\u{1F}\(group.token)" }
+
+    /// True when any row here is the control account — so a view can decorate
+    /// the heading without walking `rows` itself.
+    public var containsControl: Bool { rows.contains(where: \.isControl) }
+}
+
+extension Array where Element == FleetSection {
+    /// Whether the section at `index` opens a new band — the view's cue to draw
+    /// a band heading above it. Computed here so the render loop stays a plain
+    /// `ForEach` over one array instead of a nested one over a dictionary,
+    /// whose iteration order would be unordered by construction.
+    public func isFirstOfBand(_ index: Int) -> Bool {
+        guard indices.contains(index) else { return false }
+        guard index > 0 else { return true }
+        return self[index - 1].band != self[index].band
+    }
+}
+
+extension Fleet {
+    /// The whole account list as ordered sections: band, then group, then rows.
+    ///
+    /// Ordering, top to bottom: ``FleetBand/live``, ``FleetBand/outOfTokens``,
+    /// ``FleetBand/parked``; within a band, group sections alphabetically with
+    /// ``FleetGroupKey/ungrouped`` last; within a section, accounts by name.
+    ///
+    /// **By name, not by ``Account/displayOrder``**, and that is a real
+    /// difference from ``rowsInDisplayOrder``: inside one band the remaining
+    /// `displayOrder` spread is small and sorting by it would reorder a group's
+    /// rows on every poll as quotas drift, which reads as flicker in a list
+    /// whose headings are stable. The state question is answered by the band
+    /// the section is in; within a section the operator is looking a name up,
+    /// not ranking.
+    ///
+    /// `controlName` pins the control account to the front **of each section it
+    /// appears in**, not to the front of the list the way
+    /// ``rowsInDisplayOrder(pinning:)`` does. A global pin cannot survive
+    /// sectioning: hoisting the control row above the first band heading would
+    /// put a row outside every group it is in and outside the state band it
+    /// belongs to, which is the "primary group" fiction under another name. It
+    /// stays reachable instead — first row of its own section(s), and flagged
+    /// by ``FleetSectionRow/isControl`` so the view can mark it wherever it
+    /// lands. `nil` — no control account, or a build that cannot ask — orders
+    /// everything strictly by name.
+    ///
+    /// An account in two groups yields two rows. A group whose accounts differ
+    /// in state yields one section per band. Neither is de-duplicated; see this
+    /// file's own header for the override that makes that correct.
+    public func sectionsInDisplayOrder(pinning controlName: String? = nil) -> [FleetSection] {
+        // One entry per (band, group, account). An account in N groups
+        // contributes N of them — the duplication IS the feature, so it happens
+        // here, at the point where membership is read, rather than being undone
+        // later by anything that looks like de-duplication.
+        var buckets: [FleetBand: [FleetGroupKey: [FleetSectionRow]]] = [:]
+        for account in accounts {
+            let band = FleetBand(account)
+            // `nil` and `[]` collapse here, and only here — see
+            // ``FleetGroupKey/ungrouped`` for why the distinction stays on the
+            // account instead of becoming a section.
+            let names = account.groups ?? []
+            let keys: [FleetGroupKey] =
+                names.isEmpty ? [.ungrouped] : names.map { .named($0) }
+            let row = { (key: FleetGroupKey) in
+                FleetSectionRow(
+                    account: account,
+                    group: key,
+                    band: band,
+                    isControl: controlName != nil && account.name == controlName
+                )
+            }
+            // `Set(keys)` — a wire array that repeats a group label must not
+            // produce two identical rows under one heading, which would be a
+            // duplicate SwiftUI identity rather than the deliberate duplication
+            // across DIFFERENT headings above.
+            for key in Set(keys) {
+                buckets[band, default: [:]][key, default: []].append(row(key))
+            }
+        }
+
+        // Empty bands and empty groups are never emitted: the loop walks what
+        // the fleet actually produced, not `FleetBand.allCases`, so a fleet with
+        // nothing spent draws no "Out of tokens" heading over nothing.
+        return buckets.keys.sorted().flatMap { band -> [FleetSection] in
+            let groups = buckets[band] ?? [:]
+            return groups.keys.sorted().map { key in
+                FleetSection(band: band, group: key, rows: sortRows(groups[key] ?? []))
+            }
+        }
+    }
+
+    /// By name, with the control account first. A single `sorted(by:)` on the
+    /// pair rather than a partition, because the pin here is inside one section
+    /// and there is no pre-existing relative order to preserve — unlike
+    /// ``rowsInDisplayOrder(pinning:)``, whose input is already sorted on three
+    /// keys it must not disturb.
+    private func sortRows(_ rows: [FleetSectionRow]) -> [FleetSectionRow] {
+        rows.sorted {
+            ($0.isControl ? 0 : 1, $0.account.name) < ($1.isControl ? 0 : 1, $1.account.name)
+        }
+    }
+}

--- a/apps/macos/Sources/TcrBarCore/PanelHeight.swift
+++ b/apps/macos/Sources/TcrBarCore/PanelHeight.swift
@@ -162,7 +162,16 @@ public enum PanelHeight {
     /// with fresh sub-pixel noise), the published preference stops changing
     /// too, `onPreferenceChange` stops firing, and the layout pass that
     /// triggered it is the last one.
-    public static func quantized(_ measurement: CGFloat) -> CGFloat {
+    /// Internal, not public, and that is load-bearing. After ``settled(_:_:)``
+    /// took over the publish path this had no caller outside this file, and the
+    /// one edit that would silently undo the fix — restoring
+    /// `PanelHeight.quantized(proxy.size.height)` at a `GeometryReader` emitter
+    /// in `FleetView` — is the kind of tidy-up that reads as harmless. `FleetView`
+    /// is in the `TcrBar` target and cannot reach an internal symbol in
+    /// `TcrBarCore`, so that edit is now a compile error rather than a green test
+    /// run with the fix dead. No test could have caught it: `Package.swift:39-43`
+    /// gives the test target `TcrBarCore` only, on purpose.
+    static func quantized(_ measurement: CGFloat) -> CGFloat {
         (measurement / measurementGrain).rounded() * measurementGrain
     }
 
@@ -175,12 +184,21 @@ public enum PanelHeight {
     /// than a damper on them: a raw measurement sitting on a cell BOUNDARY
     /// snaps alternately to the two neighbouring grid points, so a signal that
     /// was merely noisy becomes a clean two-state oscillation that never
-    /// settles. Measured on the shipped code: the same 1e-5 jitter publishes
-    /// one value when centred on 118.0 and two when centred on 118.25, and
-    /// republishes on 199 of 200 passes. Every republish re-fires the
+    /// settles. Measured on a model of this arithmetic, not on a running panel,
+    /// with the shipped fixture as its control: the same 1e-5 jitter publishes
+    /// one value when centred on 118.0 — which is the centring
+    /// `PanelHeightTests` has always used, and why it never caught this — and
+    /// two when centred on 118.25, republishing on 199 of 200 passes. Every republish re-fires the
     /// observer, moves the list's frame by half a point and runs
-    /// `NSHostingView.setFrameSize`, which is the edge the popover's layout
-    /// cycle closes through.
+    /// `NSHostingView.setFrameSize`.
+    ///
+    /// What that costs is a pass budget, and that is the whole claim. Whether
+    /// this is the loop that aborts on the crashing machine is NOT established
+    /// and nothing here should be read as saying it is: the same investigation
+    /// records that the crash cycle reads no preference at all
+    /// (`MenuBarShell.swift`, the #208 comment), and that all three 0.2.43 stacks
+    /// contain no TcrBar frame anywhere. This removes a demonstrated 199-in-200
+    /// republish. It may or may not remove the crash.
     ///
     /// A dead band fixes what the grid cannot: hold the previous value while
     /// the new one is within one grain of it, and only then snap. The band has
@@ -192,7 +210,30 @@ public enum PanelHeight {
     /// place the grid is applied.
     ///
     /// A genuine content change still moves: it is larger than a grain, so it
-    /// falls outside the band on the first pass.
+    /// falls outside the band on the first pass. Continuous drift is not
+    /// swallowed either — the band compares against the last PUBLISHED value, so
+    /// the error never exceeds one grain and the value keeps moving.
+    ///
+    /// Two costs, both found by review rather than by me, both recorded here
+    /// rather than argued away:
+    ///
+    /// A permanent SUB-GRAIN step is held indefinitely — a row that genuinely
+    /// settles at 40.4 goes on publishing 40.0, where quantizing alone would
+    /// have published 40.5. The error is one-sided, and
+    /// ``visibleRowsHeight(rowHeights:spacing:controlHairline:budget:)`` sums it
+    /// across rows, so a fleet under budget can get a viewport up to
+    /// `0.5 × rowCount` shorter than its content — the same symptom class the
+    /// `controlHairline` term above exists to fix. Bounded, and it only bites
+    /// below the cap; above it the list clamps and scrolls regardless.
+    ///
+    /// And the emitters publishing raw gives up a gate that used to sit below
+    /// this code: `onPreferenceChange` requires `Equatable` and skips the
+    /// callback when the published value is unchanged, so on a quantized
+    /// preference SwiftUI itself absorbed sub-grain jitter and the closure never
+    /// ran. It now runs every pass and writes `@State` with a value equal to
+    /// what is already there. That is inert as far as `.frame(height:)` is
+    /// concerned — the same `CGFloat` produces the same frame — but SwiftUI does
+    /// not document it, and it was not measurable without a running panel.
     public static func settled(_ previous: CGFloat, _ measured: CGFloat) -> CGFloat {
         abs(measured - previous) < measurementGrain ? previous : quantized(measured)
     }

--- a/apps/macos/Sources/TcrBarCore/PanelHeight.swift
+++ b/apps/macos/Sources/TcrBarCore/PanelHeight.swift
@@ -165,4 +165,49 @@ public enum PanelHeight {
     public static func quantized(_ measurement: CGFloat) -> CGFloat {
         (measurement / measurementGrain).rounded() * measurementGrain
     }
+
+    /// The value to publish for a freshly measured height, given what was
+    /// published last.
+    ///
+    /// ``quantized(_:)`` alone is not enough, and under one centring it is
+    /// actively harmful. Snapping to a grid is a uniform quantizer, and a
+    /// quantizer inside a feedback loop is a source of limit cycles rather
+    /// than a damper on them: a raw measurement sitting on a cell BOUNDARY
+    /// snaps alternately to the two neighbouring grid points, so a signal that
+    /// was merely noisy becomes a clean two-state oscillation that never
+    /// settles. Measured on the shipped code: the same 1e-5 jitter publishes
+    /// one value when centred on 118.0 and two when centred on 118.25, and
+    /// republishes on 199 of 200 passes. Every republish re-fires the
+    /// observer, moves the list's frame by half a point and runs
+    /// `NSHostingView.setFrameSize`, which is the edge the popover's layout
+    /// cycle closes through.
+    ///
+    /// A dead band fixes what the grid cannot: hold the previous value while
+    /// the new one is within one grain of it, and only then snap. The band has
+    /// to see the RAW measurement — applying it after ``quantized(_:)`` cannot
+    /// work, because two adjacent grid points differ by exactly
+    /// ``measurementGrain`` and `0.5 < 0.5` is false, so the alternation would
+    /// pass straight through. That is why the three `GeometryReader` emitters
+    /// publish `proxy.size.height` unrounded now and this function is the only
+    /// place the grid is applied.
+    ///
+    /// A genuine content change still moves: it is larger than a grain, so it
+    /// falls outside the band on the first pass.
+    public static func settled(_ previous: CGFloat, _ measured: CGFloat) -> CGFloat {
+        abs(measured - previous) < measurementGrain ? previous : quantized(measured)
+    }
+
+    /// The per-row form. A row absent from `measured` has gone from the fleet
+    /// and is dropped rather than held; a row with no previous value is
+    /// published on the grid, since there is nothing to hold to.
+    public static func settled(
+        _ previous: [String: CGFloat],
+        _ measured: [String: CGFloat]
+    ) -> [String: CGFloat] {
+        var out = measured
+        for (id, value) in measured {
+            out[id] = previous[id].map { settled($0, value) } ?? quantized(value)
+        }
+        return out
+    }
 }

--- a/apps/macos/Sources/TcrBarCore/PanelSize.swift
+++ b/apps/macos/Sources/TcrBarCore/PanelSize.swift
@@ -1,0 +1,296 @@
+import CoreGraphics
+
+/// The wrapped height of a string, measured OUTSIDE any view graph.
+///
+/// A protocol with no implementation in this target, and that is the whole
+/// point of it. The only honest way to know how tall `"$12.4 today · $3.10/hr ·
+/// opus-5 62% · …"` renders is to ask a text engine, and the text engine on
+/// this platform is `NSString.boundingRect(with:options:attributes:)` — which
+/// needs AppKit, which lives in the `TcrBar` executable target. Depending on it
+/// here would mean adding `"TcrBar"` to the test target to test this
+/// arithmetic, and `Package.swift:39-43` gives that target `TcrBarCore` alone
+/// on purpose: `PanelHeight.swift:20-23` records what a view-private height
+/// helper cost the last time, which was a rule a wrapped header broke silently
+/// with every test green.
+///
+/// So the measurement is injected. `TcrBar` conforms an AppKit implementation
+/// to this and hands it in; the tests hand in a deterministic fake. Neither
+/// side of that is a compromise — see ``PanelSize`` for why the estimate is
+/// allowed to be wrong in the first place.
+///
+/// `width` is the width the string will actually be DRAWN at, not the panel's:
+/// the caller subtracts the gutters (``PanelSize/Geometry/textWidth``).
+/// Measuring at the panel's full width under-counts every wrapping line in the
+/// panel, and under-counting is the one direction that puts the footer over the
+/// edge.
+public protocol TextMetrics {
+    func height(of text: String, fontSize: CGFloat, width: CGFloat) -> CGFloat
+}
+
+/// The size the popover should be AUTHORED at, as arithmetic a test can run.
+///
+/// Nothing calls this yet. It is phase 2 of
+/// `docs/plans/panel-sizing-generalization.md`; phase 3 computes it beside the
+/// popover's real `contentSize` and logs the delta, and phase 4 assigns it.
+///
+/// **The one property everything here exists to hold: a wrong estimate lands
+/// on the account list, never on the footer.** The panel today sizes itself to
+/// its content (`sizingOptions = [.preferredContentSize]`), so a header that
+/// wrapped further than anyone predicted pushed Quit and the three settings
+/// checkboxes off the bottom of the popover, with no scroll region around them
+/// to recover with — `PanelHeight.swift:6-19` records that bug and the whole of
+/// `headerOverflow`/`listBudget` exists to charge the list for it in advance.
+/// Charging in advance requires the prediction to be right. This does not: the
+/// container is authored, every child but one hugs its content, and the
+/// account list's `ScrollView` is the single flexible child that absorbs the
+/// residual. An estimate that is 50pt short scrolls 50pt early. An estimate
+/// that is 50pt short under the old shape moved the footer 50pt off screen.
+///
+/// That is also why nothing here tries to be exact. The measured gap between
+/// five wrapping chrome lines drawn at once and a one-line-each prediction is
+/// 49.45pt (`docs/plans/panel-sizing-generalization.md` §4c), and whether
+/// TextKit's wrap point agrees with SwiftUI `Text`'s to the point is the one
+/// assumption the design could not test without running the panel. It does not
+/// have to: the residual scroll region is what makes being wrong survivable,
+/// and it is not decoration.
+///
+/// The two CLAMPS stay in ``PanelHeight`` under their current names and are
+/// read from there, never restated — `scripts/tcrbar-palette.py:501-502` reads
+/// that file by path and publishes both as design tokens, so moving or
+/// renaming them deletes two tokens and reddens the pre-commit gate without
+/// saying why. Everything else this arithmetic runs on is a PARAMETER supplied
+/// by the caller, for the reason `PanelHeight`'s own doc-comment gives: a test
+/// that drives the inputs with its own values tests the rule, while a test that
+/// restates a clamp proves an identity about a number.
+public enum PanelSize {
+    /// One wrapping line of chrome — a header or footer string, with the size
+    /// of the font it is drawn in.
+    ///
+    /// `fontSize` rather than a font, because a font is an AppKit type and this
+    /// target has no AppKit; the conforming ``TextMetrics`` on the other side
+    /// owns the mapping from a size to a face. Every string the panel draws
+    /// outside the account list is one of these, including the ones that
+    /// usually render as a single line: `FleetView.swift` has nineteen
+    /// `.fixedSize(horizontal: false, vertical: true)` sites and exactly one
+    /// carries a `lineLimit`, so "this one never wraps" is not a fact about any
+    /// of the other eighteen.
+    public struct Line: Equatable, Sendable {
+        public let text: String
+        public let fontSize: CGFloat
+
+        public init(_ text: String, fontSize: CGFloat) {
+            self.text = text
+            self.fontSize = fontSize
+        }
+    }
+
+    /// The panel's geometry, as the caller declares it.
+    ///
+    /// Every figure here is an INPUT. `Tok` holds the shipped values
+    /// (`Tokens.swift:250`, `:281-283`, `:312`) and lives in the executable
+    /// target, which the tests cannot link — so `TcrBar` passes them in and the
+    /// tests pass their own, which is what makes the arithmetic testable rather
+    /// than the constants.
+    public struct Geometry: Equatable, Sendable {
+        /// `Tok.panelWidth`. Authored, never measured — the panel has been a
+        /// fixed-width column since it was written.
+        public let panelWidth: CGFloat
+
+        /// `Tok.gutter`, the `.padding()` around `FleetView.body`. Costs the
+        /// height twice and the text width twice.
+        public let gutter: CGFloat
+
+        /// `Tok.rowSpacing`, the spacing of `FleetView.body`'s own `VStack` —
+        /// the gap between header, hairline, content, hairline and footer.
+        public let sectionSpacing: CGFloat
+
+        /// `Tok.tightSpacing`, the spacing INSIDE the header's and the footer's
+        /// `VStack`s (`FleetView.swift:109`, `:450`).
+        public let lineSpacing: CGFloat
+
+        /// `Tok.rowSpacing` again, in its other role: the gap between two
+        /// account cards inside the scrolling list.
+        public let rowSpacing: CGFloat
+
+        /// `Tok.hairlineWidth`. Two `Hairline()`s sit in the body, and their
+        /// thickness is small enough to look ignorable — which is how the
+        /// viewport came out 8.5pt shorter than its content once already
+        /// (`PanelHeight.swift:102-113`).
+        public let hairlineWidth: CGFloat
+
+        /// A representative account row. Rows are NOT uniform height — that is
+        /// exactly why the row-count cap was rejected twice in writing
+        /// (`Tokens.swift:254`, `PanelHeight.swift:47`) — so this is an
+        /// estimate and is treated as one. It is allowed to be wrong because
+        /// the list is the residual; see the type's doc-comment.
+        public let rowHeight: CGFloat
+
+        /// Everything in the footer that does not wrap: the two button rows and
+        /// the three settings checkboxes. Reserved whether or not the footer
+        /// draws any text, because those controls are what the whole bug was
+        /// about.
+        public let fixedControlsHeight: CGFloat
+
+        public init(
+            panelWidth: CGFloat,
+            gutter: CGFloat,
+            sectionSpacing: CGFloat,
+            lineSpacing: CGFloat,
+            rowSpacing: CGFloat,
+            hairlineWidth: CGFloat,
+            rowHeight: CGFloat,
+            fixedControlsHeight: CGFloat
+        ) {
+            self.panelWidth = panelWidth
+            self.gutter = gutter
+            self.sectionSpacing = sectionSpacing
+            self.rowSpacing = rowSpacing
+            self.lineSpacing = lineSpacing
+            self.hairlineWidth = hairlineWidth
+            self.rowHeight = rowHeight
+            self.fixedControlsHeight = fixedControlsHeight
+        }
+
+        /// The width a chrome string is really drawn at: the panel less both
+        /// gutters. The single most consequential line in this file to get
+        /// wrong — measuring at `panelWidth` reports fewer wrapped lines than
+        /// the panel will draw, and an under-estimate is the direction that
+        /// costs the footer its place.
+        public var textWidth: CGFloat { panelWidth - 2 * gutter }
+    }
+
+    /// The authored size, with the parts it is made of kept separately.
+    ///
+    /// ``contentSize`` is what phase 4 assigns. The four parts are public
+    /// because phase 3's whole job is logging this against the popover's real
+    /// size on a live fleet, and a bare total says only "wrong by 40pt" — the
+    /// parts say which of the header, the footer or the list it was.
+    public struct Plan: Equatable, Sendable {
+        public let width: CGFloat
+        public let headerHeight: CGFloat
+        public let footerHeight: CGFloat
+        public let listHeight: CGFloat
+
+        /// The structure of `FleetView.body` itself: both gutters, both
+        /// hairlines, and the gaps between its children.
+        public let frameHeight: CGFloat
+
+        public var chromeHeight: CGFloat { headerHeight + footerHeight + frameHeight }
+        public var height: CGFloat { chromeHeight + listHeight }
+        public var contentSize: CGSize { CGSize(width: width, height: height) }
+    }
+
+    /// How many children `FleetView.body`'s `VStack` has — header, `Hairline`,
+    /// content, `Hairline`, footer (`FleetView.swift:93-103`) — so the gaps
+    /// between them can be counted rather than guessed. A claim about that
+    /// view, asserted in `PanelSizeTests`: add a sixth child without changing
+    /// this and the authored size is one gap short, which is the last thing in
+    /// the panel hanging over the edge again.
+    public static let bodyChildren = 5
+
+    /// The height to reserve for the scrolling account list.
+    ///
+    /// **Biased down by one row and one gap, on purpose.** The estimate will be
+    /// wrong in one direction or the other; too short scrolls slightly early,
+    /// too tall leaves a void under the last row that nothing fills and no
+    /// scroll recovers. Scrolling early is the cheaper mistake. The bias is a
+    /// whole row rather than a fudge factor so a reader can name the unit, and
+    /// it is an order of magnitude larger than the terms it therefore does not
+    /// need to model — the control-row separator's `spacing + hairlineWidth`
+    /// (8.5pt, `PanelHeight.swift:102-113`) among them.
+    ///
+    /// The floor is ONE ROW, not ``PanelHeight/panelMinListHeight``. Those are
+    /// different figures: 120 is the floor on the old list BUDGET — the space a
+    /// long header was not allowed to take away — while this is the space the
+    /// content actually wants. A fleet with one account should draw one row,
+    /// not 120pt of panel with 78pt of nothing in it.
+    ///
+    /// The cap is ``PanelHeight/panelMaxHeight``, and it is a cap on the LIST
+    /// and not on the panel — its own doc-comment says so
+    /// (`PanelHeight.swift:44-50`). Capping the total instead is precisely how
+    /// a long header came out of the footer.
+    public static func listHeight(rowCount: Int, geometry: Geometry) -> CGFloat {
+        guard rowCount > 0 else { return 0 }
+        let natural =
+            CGFloat(rowCount) * geometry.rowHeight
+            + CGFloat(rowCount - 1) * geometry.rowSpacing
+        let biased = natural - geometry.rowHeight - geometry.rowSpacing
+        return min(PanelHeight.panelMaxHeight, max(geometry.rowHeight, biased))
+    }
+
+    /// The height of one stack of chrome lines: every line measured at the
+    /// drawn width, plus the gaps BETWEEN them.
+    ///
+    /// `n - 1` gaps, and the empty stack reserves nothing at all — a footer
+    /// with no text still gets its controls, but it does not also get a gap
+    /// above nothing. Both are `VStack` semantics, and both are the kind of
+    /// off-by-one that shows up as a panel a few points wrong on one state and
+    /// right on every other.
+    public static func stackHeight(
+        _ lines: [Line], geometry: Geometry, metrics: TextMetrics
+    ) -> CGFloat {
+        guard !lines.isEmpty else { return 0 }
+        let text = lines.reduce(CGFloat(0)) {
+            $0 + metrics.height(of: $1.text, fontSize: $1.fontSize, width: geometry.textWidth)
+        }
+        return text + CGFloat(lines.count - 1) * geometry.lineSpacing
+    }
+
+    /// The authored size for a fleet of `rowCount` accounts, given the chrome
+    /// strings actually on screen.
+    ///
+    /// `header` and `footer` are what the panel is DRAWING right now, not every
+    /// line it could draw: most of them are conditional — the poll summary only
+    /// on an unhealthy read (`FleetView.swift:127`), the update line only for
+    /// two of four `UpdateState` cases, the spend line only when a row carries
+    /// usage. Reserving a line that is not rendered is the same failure
+    /// `PanelHeight.headerOverflow`'s `lineIsDrawn` parameter exists to
+    /// prevent, arriving from the other end.
+    public static func plan(
+        rowCount: Int,
+        header: [Line],
+        footer: [Line],
+        geometry: Geometry,
+        metrics: TextMetrics
+    ) -> Plan {
+        // Header first, footer second — the order they are drawn in, and the
+        // order a `TextMetrics` that records its asks will see. Nothing else is
+        // measured: an implementation that asks the text engine about a string
+        // the panel is not drawing is reserving height for a line that is not
+        // there.
+        let headerText = stackHeight(header, geometry: geometry, metrics: metrics)
+        let footerText = stackHeight(footer, geometry: geometry, metrics: metrics)
+        let gapAboveControls =
+            (footer.isEmpty || geometry.fixedControlsHeight == 0) ? 0 : geometry.lineSpacing
+
+        return Plan(
+            width: geometry.panelWidth,
+            headerHeight: headerText,
+            footerHeight: footerText + gapAboveControls + geometry.fixedControlsHeight,
+            listHeight: listHeight(rowCount: rowCount, geometry: geometry),
+            frameHeight: 2 * geometry.gutter + 2 * geometry.hairlineWidth
+                + CGFloat(bodyChildren - 1) * geometry.sectionSpacing
+        )
+    }
+
+    /// ``plan(rowCount:header:footer:geometry:metrics:)`` for a decoded fleet.
+    ///
+    /// Counts `accounts`, which is every row the list draws — an unreadable row
+    /// is reported in the header's own words (`Fleet.unreadableNotice`) and
+    /// draws no card, so it is chrome here and not a row.
+    public static func forFleet(
+        _ fleet: Fleet,
+        header: [Line],
+        footer: [Line],
+        geometry: Geometry,
+        metrics: TextMetrics
+    ) -> CGSize {
+        plan(
+            rowCount: fleet.accounts.count,
+            header: header,
+            footer: footer,
+            geometry: geometry,
+            metrics: metrics
+        ).contentSize
+    }
+}

--- a/apps/macos/Sources/TcrBarCore/PanelSizeDelta.swift
+++ b/apps/macos/Sources/TcrBarCore/PanelSizeDelta.swift
@@ -1,0 +1,183 @@
+import CoreGraphics
+import Foundation
+
+/// What the panel's authored-size arithmetic PREDICTED, beside what SwiftUI
+/// actually produced — and the one line that carries both to a reader.
+///
+/// This is phase 3 of `docs/plans/panel-sizing-generalization.md`, and it is an
+/// instrument rather than a fix. ``PanelSize`` estimates the popover's height
+/// by measuring the chrome strings through TextKit, outside the view graph;
+/// whether that estimate tracks what SwiftUI lays out is the one fact the whole
+/// five-phase plan rests on and that nobody in the design review had. Phase 3
+/// computes the estimate on every poll tick, logs it against the popover's real
+/// `contentSize`, and changes no behaviour at all: `sizingOptions` is untouched
+/// and the panel still sizes itself.
+///
+/// **Why the parts and not the total.** "The panel came out 40pt taller than we
+/// said" does not name a bug. The header, the footer and the account list are
+/// predicted by three different pieces of arithmetic and fail in three
+/// different ways — a header wrapping to a line TextKit did not count, a footer
+/// whose fixed controls were estimated at the wrong height, a row height that
+/// is not the average row — so a single total leaves the reader to guess which.
+/// Every part of the prediction is on the line, with the counts that generated
+/// it (`rows=`, `/Nln`), because the person reading these lines is on another
+/// Mac with a different fleet and gets one look at them.
+///
+/// **What this instrument can and cannot attribute.** From a single line it can
+/// say the total error and, on a `rows=0` tick, that the whole of that error is
+/// chrome — the list term is zero by construction there, so nothing else is
+/// mixed in. Separating the header from the footer needs two lines whose header
+/// line count differs, which a real fleet supplies on its own: every header
+/// line in `FleetView` is conditional (the poll summary only on an unhealthy
+/// read, the update line for two of four `UpdateState` cases, the spend line
+/// only when a row carries usage), so `/Nln` moves through a session without
+/// anybody arranging it. Claiming more than that from one line would be
+/// arithmetic with three unknowns in it.
+///
+/// The maths lives here and the I/O lives in `MenuBarShell`, which is the split
+/// ``PanelHeight``, ``PanelSize`` and ``UncaughtExceptionReport`` already have:
+/// a log line that only exists inside an `NSLog` call is a log line no test can
+/// read, and this one is the deliverable.
+public struct PanelSizeDelta: Equatable, Sendable {
+    /// The fixed prefix every line carries, so one
+    /// `log show --predicate 'eventMessage CONTAINS "TCRBAR-PANELSIZE"'` finds
+    /// all of them and nothing else. A marker rather than a subsystem because
+    /// the app logs through `NSLog` throughout (`TcrBarApp.swift:72`, `:136`,
+    /// `:186`) and a second logging mechanism for one phase would be a second
+    /// thing to explain to the person collecting the lines.
+    public static let marker = "TCRBAR-PANELSIZE"
+
+    /// The field set, versioned. Phase 4 changes what is worth logging — the
+    /// prediction stops being a shadow and starts being the assignment — and a
+    /// reader holding a mixed log must be able to tell the shapes apart without
+    /// counting fields.
+    public static let version = "v1"
+
+    /// What ``PanelSize/plan(rowCount:header:footer:geometry:metrics:)``
+    /// returned for this tick.
+    public let predicted: PanelSize.Plan
+
+    /// The popover's own `contentSize` — `nil` when there is no measurement
+    /// yet, which is not the same thing as a measurement of zero. See
+    /// ``init(predicted:actualContentSize:rowCount:headerLines:footerLines:isPanelShown:)``.
+    public let actual: CGSize?
+
+    /// Accounts drawn as cards in the scrolling list.
+    public let rowCount: Int
+
+    /// How many chrome strings the header stack drew this tick. All of them are
+    /// conditional, so this moves on its own — which is what makes two lines
+    /// able to separate header error from footer error.
+    public let headerLines: Int
+
+    /// How many chrome strings the footer stack drew, not counting its fixed
+    /// controls (the button rows and the settings checkboxes), which are
+    /// reserved whether or not any footer text is drawn.
+    public let footerLines: Int
+
+    /// Whether the popover was on screen when the size was read. A
+    /// `contentSize` read with the panel closed is whatever the last open left
+    /// behind, so these lines are droppable — and a reader who cannot tell them
+    /// apart would average a stale number into a live one.
+    public let isPanelShown: Bool
+
+    /// A non-positive `contentSize` is recorded as NO measurement.
+    ///
+    /// An `NSPopover` that has never been laid out reports zero. Subtracting a
+    /// 533pt prediction from it yields `-533.0`, which reads exactly like a
+    /// catastrophic mis-estimate and is in fact the absence of one — the single
+    /// worst thing this instrument could print, because its whole job is to be
+    /// believed once by somebody who cannot re-run it. Either dimension being
+    /// non-positive is enough: a popover caught mid-configuration can report a
+    /// width with no height, and the height is the entire subject.
+    public init(
+        predicted: PanelSize.Plan,
+        actualContentSize: CGSize,
+        rowCount: Int,
+        headerLines: Int,
+        footerLines: Int,
+        isPanelShown: Bool
+    ) {
+        self.predicted = predicted
+        self.actual =
+            (actualContentSize.width > 0 && actualContentSize.height > 0)
+            ? actualContentSize : nil
+        self.rowCount = rowCount
+        self.headerLines = headerLines
+        self.footerLines = footerLines
+        self.isPanelShown = isPanelShown
+    }
+
+    /// Positive means SwiftUI drew MORE height than predicted — the estimate
+    /// was short, and under phase 4's shape the list would scroll that much
+    /// early. Negative means it drew less, which under that shape leaves a void
+    /// under the last row that no scroll region recovers. The sign is the
+    /// finding, so it is never dropped.
+    public var heightDelta: CGFloat? {
+        actual.map { $0.height - predicted.height }
+    }
+
+    /// The panel has been a fixed-width column since it was written, so a
+    /// non-zero width delta is a different fault from a height mis-estimate:
+    /// it means the popover is not honouring the authored width at all, and
+    /// every chrome string was therefore measured at a width the panel does not
+    /// draw at. Logged separately because it invalidates the height figures
+    /// rather than adding to them.
+    public var widthDelta: CGFloat? {
+        actual.map { $0.width - predicted.width }
+    }
+
+    /// The height the panel really had left after the chrome we predicted.
+    ///
+    /// This is the number phase 4's residual scroll region will absorb, and it
+    /// is worth naming rather than leaving the reader to subtract three fields
+    /// under a deadline. It differs from ``heightDelta`` by exactly the
+    /// predicted list height, which is the statement the design makes in
+    /// arithmetic: whatever the chrome estimate got wrong lands on the list.
+    public var impliedListHeight: CGFloat? {
+        actual.map { $0.height - predicted.chromeHeight }
+    }
+
+    /// One line, `key=value`, marker first.
+    ///
+    /// Greppable on purpose and in two directions: the marker selects the
+    /// lines, and every figure is a named key so a reader can `sed`/`awk` a
+    /// column out of a session's worth of them without writing a parser. It is
+    /// deliberately not JSON — `log show` output is already a wrapper around
+    /// each message, and a nested quote-heavy payload inside it is what makes
+    /// people give up and read with their eyes.
+    public var logLine: String {
+        let head = [
+            "\(Self.marker) \(Self.version)",
+            "shown=\(isPanelShown ? "yes" : "no")",
+            "rows=\(rowCount)",
+            "header=\(Self.pt(predicted.headerHeight))/\(headerLines)ln",
+            "footer=\(Self.pt(predicted.footerHeight))/\(footerLines)ln",
+            "list=\(Self.pt(predicted.listHeight))",
+            "frame=\(Self.pt(predicted.frameHeight))",
+            "predicted=\(Self.pt(predicted.width))x\(Self.pt(predicted.height))",
+        ]
+        let tail = [
+            "actual=\(actual.map { "\(Self.pt($0.width))x\(Self.pt($0.height))" } ?? "unlaid")",
+            "delta-height=\(heightDelta.map(Self.signed) ?? "unknown")",
+            "delta-width=\(widthDelta.map(Self.signed) ?? "unknown")",
+            "implied-list=\(impliedListHeight.map(Self.pt) ?? "unknown")",
+        ]
+        return (head + tail).joined(separator: " ")
+    }
+
+    /// One decimal place, always. The panel's own grain is 0.5pt
+    /// (``PanelHeight/measurementGrain``), so a whole-point figure would round
+    /// away the half-points two `Hairline`s put into every total, and more
+    /// places would print float noise as if it were a measurement.
+    private static func pt(_ value: CGFloat) -> String {
+        String(format: "%.1f", Double(value))
+    }
+
+    /// A delta always carries its sign, `+0.0` included: an unsigned zero and a
+    /// missing figure look the same in a column of numbers, and "exactly right"
+    /// is a result worth being able to see.
+    private static func signed(_ value: CGFloat) -> String {
+        String(format: "%+.1f", Double(value))
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/FleetSectionKeyNamespaceTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetSectionKeyNamespaceTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+
+@testable import TcrBarCore
+
+/// The key namespace `FleetView` keys its measured-height dictionary on.
+///
+/// `FleetView.rowHeights` is one `[String: CGFloat]` shared by three kinds of
+/// list child: account rows under ``FleetSectionRow/id``, group headings under
+/// `"h:" + FleetSection.id`, and band headings under `"b:" + FleetBand.rawValue`.
+/// Two children sharing a key is not a cosmetic bug — the second measurement
+/// overwrites the first, `visibleRowsHeight(for:)` then sums fewer heights than
+/// there are children, and the scroll viewport comes out short of its own
+/// content and clips the last card mid-line. That is the exact failure the
+/// `controlHairline` term in ``PanelHeight`` already exists to undo once.
+///
+/// The view cannot be tested here — the test target links `TcrBarCore` only
+/// (`Package.swift:39-43`) — so what is asserted is the half of the invariant
+/// that lives in the library: the shape of the ids the view builds those keys
+/// from. If a row id could begin `b:` or `h:`, the view's prefixes would stop
+/// being safe and this file goes red before the panel does.
+///
+/// Account names are obviously fake — this repository is public.
+final class FleetSectionKeyNamespaceTests: XCTestCase {
+
+    /// The prefixes `FleetView` reserves for its heading keys. Named here so
+    /// the test states what it is protecting rather than hiding it in a string.
+    private let headingPrefixes = ["b:", "h:"]
+
+    /// Every row id opens with a ``FleetGroupKey/token`` — `g:` or `u:` — so no
+    /// row can ever land on a heading key, whatever the operator names a group.
+    func testNoRowIdentityCanCollideWithAHeadingKey() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("a@example.com", groups: ["b", "h"]),
+            sectionAccount("b@example.com", groups: ["b:0", "h:0\u{1F}x"]),
+            sectionAccount("c@example.com", groups: nil),
+        ])
+
+        let ids = fleet.sectionsInDisplayOrder().flatMap { $0.rows }.map(\.id)
+        XCTAssertFalse(ids.isEmpty, "positive control: the fixture must produce rows")
+        for id in ids {
+            XCTAssertTrue(
+                id.hasPrefix("g:") || id.hasPrefix("u:"),
+                "row id \(id) left the group-token namespace the heading keys are safe against")
+            for prefix in headingPrefixes {
+                XCTAssertFalse(id.hasPrefix(prefix), "row id \(id) collides with heading prefix \(prefix)")
+            }
+        }
+    }
+
+    /// A section id opens with its band's raw value, so `"h:" + id` is likewise
+    /// out of reach of every row key and of the `b:` band keys.
+    func testSectionIdentitiesStayOutOfTheRowAndBandNamespaces() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("live@example.com", groups: ["dev"]),
+            sectionAccount("spent@example.com", groups: ["dev"], quotaState: .spent),
+            sectionAccount("parked@example.com", groups: ["dev"], disabled: true),
+        ])
+
+        let sectionIds = fleet.sectionsInDisplayOrder().map(\.id)
+        XCTAssertEqual(sectionIds.count, 3, "positive control: dev is split across all three bands")
+        for id in sectionIds {
+            XCTAssertTrue(
+                id.first.map { $0.isNumber } == true,
+                "section id \(id) no longer starts with its band's raw value")
+            XCTAssertFalse(id.hasPrefix("g:") || id.hasPrefix("u:"))
+        }
+    }
+
+    /// The whole drawn list, keyed the way `FleetView` keys it: one key per
+    /// child, all distinct. This is the assertion the panel's viewport
+    /// arithmetic actually rests on — the count of keys IS the count of gaps.
+    func testEveryDrawnChildGetsItsOwnKeyOnAFleetFullOfDuplicates() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("both@example.com", groups: ["dev", "ops"]),
+            sectionAccount("spent@example.com", groups: ["dev", "ops"], quotaState: .spent),
+            sectionAccount("plain@example.com", groups: nil),
+        ])
+        let sections = fleet.sectionsInDisplayOrder()
+
+        var keys: [String] = []
+        for (index, section) in sections.enumerated() {
+            if sections.isFirstOfBand(index) { keys.append("b:\(section.band.rawValue)") }
+            keys.append("h:\(section.id)")
+            keys.append(contentsOf: section.rows.map(\.id))
+        }
+
+        // 2 band headings (live, out of tokens) + 5 group headings (dev, ops
+        // and ungrouped in the live band; dev and ops in the spent one)
+        // + 5 rows: `both` and `spent` are each drawn twice, `plain` once.
+        XCTAssertEqual(keys.count, 12)
+        XCTAssertEqual(Set(keys).count, keys.count, "two list children share a measured-height key")
+    }
+}
+
+/// Same fixture shape as `FleetSectionsTests`, so the two files cannot drift.
+private func sectionAccount(
+    _ name: String,
+    groups: [String]?,
+    quotaState: QuotaState = .ok,
+    disabled: Bool = false
+) -> Account {
+    Account(
+        name: name,
+        priority: 1,
+        status: "active",
+        disabled: disabled,
+        quota: 0,
+        quotaState: quotaState,
+        fiveHour: 0,
+        sevenDay: 0,
+        sevenDayOi: 0,
+        held: [],
+        requests: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheHitRatio: nil,
+        probeStatus: .ok,
+        probeError: nil,
+        lastStreamError: nil,
+        streamErrorCount: 0,
+        source: .live,
+        serverSha: "abc1234",
+        serverDirty: false,
+        groups: groups,
+        reservedGroups: nil,
+        parkedGroups: nil,
+        groupColors: nil
+    )
+}

--- a/apps/macos/Tests/TcrBarTests/FleetSectionsTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetSectionsTests.swift
@@ -294,6 +294,50 @@ final class FleetSectionsTests: XCTestCase {
         XCTAssertEqual(FleetBand.outOfTokens.title, "Out of tokens")
         XCTAssertEqual(FleetBand.parked.title, "Parked")
     }
+
+    /// A lone "Ungrouped" heading under a band heading says nothing the band
+    /// heading did not, and costs the viewport its own height plus a gap. On a
+    /// fleet with no groups configured that was EVERY band — three dead rows
+    /// saying nothing three times. Caught by rendering the panel and looking at
+    /// the PNG, not by any test, which is why this one exists.
+    func testALoneUngroupedSectionDrawsNoGroupHeading() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("a@example.com", groups: []),
+            sectionAccount("b@example.com", groups: []),
+        ])
+        let sections = fleet.sectionsInDisplayOrder()
+        XCTAssertEqual(sections.count, 1, "no groups configured — one ungrouped section")
+        XCTAssertFalse(
+            sections.drawsGroupHeading(at: 0),
+            "the only section in its band, and ungrouped — the heading is dead space")
+    }
+
+    /// A lone NAMED section still draws: "PARKED / henry-team" says WHICH group
+    /// was parked, which the band heading cannot.
+    func testALoneNamedSectionStillDrawsItsHeading() {
+        let fleet = Fleet(accounts: [sectionAccount("a@example.com", groups: ["dev"])])
+        let sections = fleet.sectionsInDisplayOrder()
+        XCTAssertEqual(sections.count, 1)
+        XCTAssertTrue(
+            sections.drawsGroupHeading(at: 0),
+            "a named group is information the band heading does not carry")
+    }
+
+    /// Ungrouped alongside a named section DOES draw — there it is the thing
+    /// separating the two.
+    func testUngroupedDrawsWhenItSharesABandWithANamedSection() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("a@example.com", groups: ["dev"]),
+            sectionAccount("b@example.com", groups: []),
+        ])
+        let sections = fleet.sectionsInDisplayOrder()
+        XCTAssertEqual(sections.count, 2)
+        for index in sections.indices {
+            XCTAssertTrue(
+                sections.drawsGroupHeading(at: index),
+                "two sections in one band — both headings separate something")
+        }
+    }
 }
 
 /// A row with everything but the group/state fields fixed — the same shape

--- a/apps/macos/Tests/TcrBarTests/FleetSectionsTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetSectionsTests.swift
@@ -1,0 +1,338 @@
+import XCTest
+
+@testable import TcrBarCore
+
+/// `Fleet.sectionsInDisplayOrder(pinning:)` — the panel's list cut into state
+/// bands, then group sections, then rows.
+///
+/// The two decisions under test are Gil's overrides of
+/// `docs/plans/account-groups-plan.md:44-55`: real sections with DUPLICATED
+/// rows (no primary group, no de-duplication), and state as the outer level so
+/// a group split across states appears in two bands. Both are asserted here
+/// rather than described, because both are the kind of rule a later "cleanup"
+/// deletes as an apparent bug.
+///
+/// Account names are obviously fake — this repository is public.
+final class FleetSectionsTests: XCTestCase {
+
+    // MARK: - Duplication, which is the point
+
+    /// An account in two groups appears under BOTH headings — two rows, one
+    /// account. The override's whole cost, asserted so nobody "fixes" it.
+    func testAccountInTwoGroupsAppearsUnderBoth() {
+        let fleet = Fleet(accounts: [sectionAccount("both@example.com", groups: ["dev", "ops"])])
+        let sections = fleet.sectionsInDisplayOrder()
+
+        XCTAssertEqual(sections.map(\.group), [.named("dev"), .named("ops")])
+        XCTAssertEqual(
+            sections.flatMap { $0.rows }.map(\.account.name),
+            ["both@example.com", "both@example.com"])
+    }
+
+    /// The two rows of one account carry DIFFERENT identities, because a
+    /// `ForEach` identity that collides paints one row's data onto the other
+    /// rather than crashing.
+    func testDuplicatedRowsCarryDistinctCompositeIdentities() {
+        let fleet = Fleet(accounts: [sectionAccount("both@example.com", groups: ["dev", "ops"])])
+        let ids = fleet.sectionsInDisplayOrder().flatMap { $0.rows }.map(\.id)
+
+        XCTAssertEqual(ids.count, 2)
+        XCTAssertEqual(Set(ids).count, 2, "two rows of one account must not share a SwiftUI identity")
+    }
+
+    /// Every id across the whole list is unique, on a fleet that has all the
+    /// collision shapes at once: multi-membership, a group named after the
+    /// ungrouped heading, and two accounts in the same group.
+    func testEveryRowIdentityIsUniqueAcrossTheWholeList() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("a@example.com", groups: ["dev", "Ungrouped"]),
+            sectionAccount("b@example.com", groups: ["dev"]),
+            sectionAccount("c@example.com", groups: nil),
+        ])
+        let ids = fleet.sectionsInDisplayOrder().flatMap { $0.rows }.map(\.id)
+
+        XCTAssertEqual(ids.count, 4)
+        XCTAssertEqual(Set(ids).count, ids.count)
+    }
+
+    // MARK: - Bands
+
+    /// Band order is live, then out of tokens, then parked — and a group whose
+    /// accounts differ in state is SPLIT, appearing once per band.
+    func testGroupSplitAcrossBandsAppearsInEachBandInBandOrder() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("live@example.com", groups: ["dev"]),
+            sectionAccount("spent@example.com", groups: ["dev"], quotaState: .spent),
+            sectionAccount("off@example.com", groups: ["dev"], disabled: true),
+        ])
+        let sections = fleet.sectionsInDisplayOrder()
+
+        XCTAssertEqual(sections.map(\.band), [.live, .outOfTokens, .parked])
+        XCTAssertEqual(sections.map(\.group), [.named("dev"), .named("dev"), .named("dev")])
+        XCTAssertEqual(
+            sections.map { $0.rows.map(\.account.name) },
+            [["live@example.com"], ["spent@example.com"], ["off@example.com"]])
+    }
+
+    /// The three sections of one split group have distinct identities too —
+    /// band is part of a SECTION's id even though it is not part of a row's.
+    func testSplitGroupSectionsHaveDistinctIdentities() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("live@example.com", groups: ["dev"]),
+            sectionAccount("spent@example.com", groups: ["dev"], quotaState: .spent),
+            sectionAccount("off@example.com", groups: ["dev"], disabled: true),
+        ])
+        let ids = fleet.sectionsInDisplayOrder().map(\.id)
+        XCTAssertEqual(Set(ids).count, 3)
+    }
+
+    /// A wholly-parked group — `tcr group park`, which is the live fleet's
+    /// `henry-token` — lands entirely in the parked band even though no row
+    /// carries `disabled`. Parking blocks the account for every request
+    /// (`Manager::parked_blocks`), so filing it under "Live" would claim
+    /// capacity the router will never use.
+    func testWhollyParkedGroupLandsInTheParkedBand() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("p1@example.com", groups: ["henry-token"], parkedGroups: ["henry-token"]),
+            sectionAccount("p2@example.com", groups: ["henry-token"], parkedGroups: ["henry-token"]),
+        ])
+        let sections = fleet.sectionsInDisplayOrder()
+
+        XCTAssertEqual(sections.count, 1)
+        XCTAssertEqual(sections.first?.band, .parked)
+        XCTAssertEqual(sections.first?.rows.map(\.account.name), ["p1@example.com", "p2@example.com"])
+    }
+
+    /// A disabled row is parked even when its quota says spent — the operator's
+    /// decision outranks the reset countdown, exactly as `displayOrder` orders
+    /// them.
+    func testDisabledOutranksSpent() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("x@example.com", groups: ["dev"], quotaState: .spent, disabled: true)
+        ])
+        XCTAssertEqual(fleet.sectionsInDisplayOrder().map(\.band), [.parked])
+    }
+
+    /// A never-probed row and a dead-credential row are LIVE, not spent and not
+    /// parked: neither is measured as out of tokens and neither was parked by
+    /// the operator.
+    func testUnmeasuredAndNeedsReloginAreLive() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("u@example.com", groups: ["dev"], quota: nil),
+            sectionAccount("r@example.com", groups: ["dev"], status: "error"),
+        ])
+        XCTAssertEqual(fleet.sectionsInDisplayOrder().map(\.band), [.live])
+        XCTAssertEqual(fleet.sectionsInDisplayOrder().first?.rows.count, 2)
+    }
+
+    // MARK: - Group keys
+
+    /// `groups == nil` (a server too old to report the field) and `groups == []`
+    /// (reported, none) both render as ungrouped — one section, not two, and no
+    /// "not reported" heading nobody can act on.
+    func testNilAndEmptyGroupsBothRenderUngroupedInOneSection() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("nil@example.com", groups: nil),
+            sectionAccount("empty@example.com", groups: []),
+        ])
+        let sections = fleet.sectionsInDisplayOrder()
+
+        XCTAssertEqual(sections.count, 1)
+        XCTAssertEqual(sections.first?.group, .ungrouped)
+        XCTAssertEqual(
+            sections.first?.rows.map(\.account.name),
+            ["empty@example.com", "nil@example.com"])
+    }
+
+    /// A fleet with no groups at all is one ungrouped section — the panel still
+    /// renders a list, it does not go empty.
+    func testFleetWithNoGroupsAtAllIsOneUngroupedSection() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("b@example.com", groups: nil),
+            sectionAccount("a@example.com", groups: nil),
+        ])
+        let sections = fleet.sectionsInDisplayOrder()
+
+        XCTAssertEqual(sections.map(\.group), [.ungrouped])
+        XCTAssertEqual(sections.first?.rows.map(\.account.name), ["a@example.com", "b@example.com"])
+        XCTAssertEqual(sections.first?.title, "Ungrouped")
+    }
+
+    /// Ungrouped sorts LAST within its band; named groups sort alphabetically
+    /// regardless of the wire's array order.
+    func testUngroupedSortsLastAndNamedGroupsAlphabetically() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("z@example.com", groups: nil),
+            sectionAccount("m@example.com", groups: ["ops"]),
+            sectionAccount("a@example.com", groups: ["dev"]),
+        ])
+        XCTAssertEqual(
+            fleet.sectionsInDisplayOrder().map(\.group),
+            [.named("dev"), .named("ops"), .ungrouped])
+    }
+
+    /// A group actually named "Ungrouped" is a different section from the
+    /// unlabelled bucket, and their rows' identities do not collide.
+    func testGroupNamedUngroupedDoesNotImpersonateTheUnlabelledBucket() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("a@example.com", groups: ["Ungrouped"]),
+            sectionAccount("a@example.com", groups: nil),
+        ])
+        let sections = fleet.sectionsInDisplayOrder()
+
+        XCTAssertEqual(sections.map(\.group), [.named("Ungrouped"), .ungrouped])
+        XCTAssertEqual(Set(sections.flatMap { $0.rows }.map(\.id)).count, 2)
+    }
+
+    /// An empty fleet yields no sections — no empty headings.
+    func testEmptyFleetYieldsNoSections() {
+        XCTAssertEqual(Fleet(accounts: []).sectionsInDisplayOrder().count, 0)
+    }
+
+    // MARK: - Row ordering and the control account
+
+    /// Within a section, accounts sort by name.
+    func testRowsWithinASectionSortByName() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("c@example.com", groups: ["dev"]),
+            sectionAccount("a@example.com", groups: ["dev"]),
+            sectionAccount("b@example.com", groups: ["dev"]),
+        ])
+        XCTAssertEqual(
+            fleet.sectionsInDisplayOrder().first?.rows.map(\.account.name),
+            ["a@example.com", "b@example.com", "c@example.com"])
+    }
+
+    /// The control account is pinned first inside EVERY section it appears in,
+    /// and flagged — it is not hoisted above the bands, which would put it
+    /// outside its own group and state.
+    func testControlAccountIsPinnedFirstInEverySectionItAppearsIn() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("a@example.com", groups: ["dev"]),
+            sectionAccount("z@example.com", groups: ["dev", "ops"]),
+            sectionAccount("b@example.com", groups: ["ops"]),
+        ])
+        let sections = fleet.sectionsInDisplayOrder(pinning: "z@example.com")
+
+        XCTAssertEqual(
+            sections.map { $0.rows.map(\.account.name) },
+            [["z@example.com", "a@example.com"], ["z@example.com", "b@example.com"]])
+        XCTAssertEqual(sections.map { $0.rows.map(\.isControl) }, [[true, false], [true, false]])
+        XCTAssertEqual(sections.map(\.containsControl), [true, true])
+    }
+
+    /// A control account that is spent stays in its own band — the pin is
+    /// within a section, never across one. State wins, which is decision two.
+    func testControlAccountIsNotHoistedOutOfItsBand() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("live@example.com", groups: ["dev"]),
+            sectionAccount("ctl@example.com", groups: ["dev"], quotaState: .spent),
+        ])
+        let sections = fleet.sectionsInDisplayOrder(pinning: "ctl@example.com")
+
+        XCTAssertEqual(sections.map(\.band), [.live, .outOfTokens])
+        XCTAssertEqual(sections.first?.rows.map(\.account.name), ["live@example.com"])
+        XCTAssertEqual(sections.last?.rows.map(\.isControl), [true])
+    }
+
+    /// A `nil` control name — none set, or a build that cannot ask — leaves
+    /// everything ordered strictly by name and nothing flagged.
+    func testNilControlNameLeavesPlainNameOrder() throws {
+        let fleet = Fleet(accounts: [
+            sectionAccount("z@example.com", groups: ["dev"]),
+            sectionAccount("a@example.com", groups: ["dev"]),
+        ])
+        let rows = try XCTUnwrap(fleet.sectionsInDisplayOrder(pinning: nil).first?.rows)
+
+        XCTAssertEqual(rows.map(\.account.name), ["a@example.com", "z@example.com"])
+        XCTAssertEqual(rows.map(\.isControl), [false, false])
+    }
+
+    /// A control name that matches no row changes nothing — the controller can
+    /// report a name this fleet no longer holds.
+    func testUnknownControlNameChangesNothing() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("z@example.com", groups: ["dev"]),
+            sectionAccount("a@example.com", groups: ["dev"]),
+        ])
+        XCTAssertEqual(
+            fleet.sectionsInDisplayOrder(pinning: "ghost@example.com").first?
+                .rows.map(\.account.name), ["a@example.com", "z@example.com"])
+    }
+
+    // MARK: - What the row and the view need
+
+    /// A row's band matches the section it is in — the carried copy cannot
+    /// disagree with the heading above it.
+    func testRowBandMatchesItsSection() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("a@example.com", groups: ["dev"]),
+            sectionAccount("s@example.com", groups: ["dev"], quotaState: .spent),
+        ])
+        for section in fleet.sectionsInDisplayOrder() {
+            XCTAssertTrue(section.rows.allSatisfy { $0.band == section.band && $0.group == section.group })
+        }
+    }
+
+    /// `isFirstOfBand` marks exactly the sections that open a band, so the view
+    /// draws one band heading per run rather than one per section.
+    func testIsFirstOfBandMarksOnlyTheOpeningSectionOfEachRun() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("a@example.com", groups: ["dev"]),
+            sectionAccount("b@example.com", groups: ["ops"]),
+            sectionAccount("s@example.com", groups: ["dev"], quotaState: .spent),
+        ])
+        let sections = fleet.sectionsInDisplayOrder()
+
+        XCTAssertEqual(sections.count, 3)
+        XCTAssertEqual(sections.indices.map { sections.isFirstOfBand($0) }, [true, false, true])
+    }
+
+    /// Band headings read as sentences an operator can act on.
+    func testBandTitles() {
+        XCTAssertEqual(FleetBand.live.title, "Live")
+        XCTAssertEqual(FleetBand.outOfTokens.title, "Out of tokens")
+        XCTAssertEqual(FleetBand.parked.title, "Parked")
+    }
+}
+
+/// A row with everything but the group/state fields fixed — the same shape
+/// `GroupTagTests` uses, so the two files' fixtures cannot drift.
+private func sectionAccount(
+    _ name: String,
+    groups: [String]?,
+    parkedGroups: [String]? = nil,
+    quotaState: QuotaState = .ok,
+    quota: Double? = 0,
+    status: String = "active",
+    disabled: Bool = false
+) -> Account {
+    Account(
+        name: name,
+        priority: 1,
+        status: status,
+        disabled: disabled,
+        quota: quota,
+        quotaState: quotaState,
+        fiveHour: 0,
+        sevenDay: 0,
+        sevenDayOi: 0,
+        held: [],
+        requests: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheHitRatio: nil,
+        probeStatus: .ok,
+        probeError: nil,
+        lastStreamError: nil,
+        streamErrorCount: 0,
+        source: .live,
+        serverSha: "abc1234",
+        serverDirty: false,
+        groups: groups,
+        reservedGroups: nil,
+        parkedGroups: parkedGroups,
+        groupColors: nil
+    )
+}

--- a/apps/macos/Tests/TcrBarTests/PanelHeightTests.swift
+++ b/apps/macos/Tests/TcrBarTests/PanelHeightTests.swift
@@ -195,4 +195,72 @@ final class PanelHeightTests: XCTestCase {
             quantizedValues, [118.0],
             "every measurement within the grain must publish the identical value")
     }
+
+    /// Why ``PanelHeight/settled(_:_:)`` has to exist, stated as the failure it
+    /// prevents.
+    ///
+    /// The fixture above centres its jitter on 118.0 — a grid POINT — and so it
+    /// passes with quantizing alone and always would. Move the identical jitter
+    /// onto a cell BOUNDARY and the same code publishes two values forever:
+    /// half the samples round down and half round up. That is not damped noise,
+    /// it is a manufactured two-state oscillation, and each alternation re-fires
+    /// the observer and moves the list's frame half a point.
+    ///
+    /// The first assertion is this test's positive control. It is the shipped
+    /// fixture's centring, so if it ever fails the harness is wrong rather than
+    /// the code.
+    func testQuantizingAloneRepublishesWhenJitterStraddlesACellBoundary() {
+        func jitter(around centre: CGFloat) -> [CGFloat] {
+            (0..<20).map { centre + (CGFloat($0) - 10) * 0.00001 }
+        }
+        XCTAssertEqual(
+            Set(jitter(around: 118.0).map(PanelHeight.quantized)).count, 1,
+            "positive control: on a grid point, quantizing alone already publishes one value")
+        XCTAssertEqual(
+            Set(jitter(around: 118.25).map(PanelHeight.quantized)).count, 2,
+            "on a cell boundary the identical jitter publishes two — the limit cycle")
+    }
+
+    /// The dead band holds one value wherever the jitter is centred.
+    ///
+    /// Fails on the change this guards against: make ``PanelHeight/settled(_:_:)``
+    /// return `quantized(measured)` unconditionally — today's shipped behaviour —
+    /// and the two boundary centres publish two values each.
+    func testSubGrainJitterPublishesOneValueWhereverItIsCentred() {
+        for centre in [118.0, 118.25, 42.75] as [CGFloat] {
+            let jitter: [CGFloat] = (0..<20).map { centre + (CGFloat($0) - 10) * 0.00001 }
+            XCTAssertEqual(
+                Set(jitter).count, jitter.count,
+                "the raw values really do all differ, centre \(centre)")
+
+            var previous = PanelHeight.quantized(jitter[0])
+            var published: Set<CGFloat> = [previous]
+            for raw in jitter {
+                previous = PanelHeight.settled(previous, raw)
+                published.insert(previous)
+            }
+            XCTAssertEqual(
+                published.count, 1,
+                "centre \(centre) published \(published.sorted()) — must publish exactly one")
+        }
+    }
+
+    /// A real content change is larger than a grain, so the band never swallows
+    /// it. Without this the fix would trade a crash for a panel that never
+    /// resizes.
+    func testARealChangeStillMoves() {
+        XCTAssertEqual(PanelHeight.settled(118.0, 130.0), 130.0)
+        XCTAssertEqual(PanelHeight.settled(118.0, 118.9), 119.0)
+    }
+
+    /// The per-row form holds each row independently, drops rows that left the
+    /// fleet, and publishes a new row on the grid since it has nothing to hold to.
+    func testPerRowSettlingHoldsDropsAndAdmits() {
+        let previous: [String: CGFloat] = ["a": 40.0, "gone": 12.0]
+        let measured: [String: CGFloat] = ["a": 40.2, "new": 17.26]
+        let out = PanelHeight.settled(previous, measured)
+        XCTAssertEqual(out["a"], 40.0, "within a grain of the last value — held")
+        XCTAssertEqual(out["new"], 17.5, "no previous value — published on the grid")
+        XCTAssertNil(out["gone"], "absent from the measurement — dropped, not held")
+    }
 }

--- a/apps/macos/Tests/TcrBarTests/PanelSizeDeltaTests.swift
+++ b/apps/macos/Tests/TcrBarTests/PanelSizeDeltaTests.swift
@@ -1,0 +1,191 @@
+import CoreGraphics
+import XCTest
+
+@testable import TcrBarCore
+
+/// The arithmetic behind phase 3's log line — the instrument that answers the
+/// question the whole of `docs/plans/panel-sizing-generalization.md` rests on:
+/// does the TextKit estimate track what SwiftUI actually lays out.
+///
+/// The shell does the I/O and this does the maths, which is the same split
+/// `PanelHeight`, `PanelSize` and `UncaughtExceptionReport` already have. What
+/// that buys is exactly this file: the log line a person on another Mac will
+/// read once, asserted here rather than eyeballed there.
+///
+/// Two properties are under test, and every assertion is a restatement of one
+/// of them.
+///
+/// 1. **The line names the parts, not only the total.** "wrong by 40pt" cannot
+///    say whether the header, the footer or the list was wrong, and telling
+///    those apart is the entire point of the phase.
+/// 2. **An absent measurement reads as absent.** A popover that has never been
+///    laid out reports a `contentSize` of zero, and subtracting a prediction
+///    from it yields a confident −500pt that looks exactly like a catastrophic
+///    mis-estimate. The one reader of these lines gets one look; a fabricated
+///    delta is worse than a gap.
+final class PanelSizeDeltaTests: XCTestCase {
+
+    /// A prediction with four parts that are all different from each other, so
+    /// an assertion cannot pass by reading the wrong field.
+    private let plan = PanelSize.Plan(
+        width: 380,
+        headerHeight: 88,
+        footerHeight: 176,
+        listHeight: 228,
+        frameHeight: 41
+    )
+
+    private func delta(
+        actual: CGSize,
+        rowCount: Int = 13,
+        headerLines: Int = 4,
+        footerLines: Int = 2,
+        shown: Bool = true,
+        predicted: PanelSize.Plan? = nil
+    ) -> PanelSizeDelta {
+        PanelSizeDelta(
+            predicted: predicted ?? plan,
+            actualContentSize: actual,
+            rowCount: rowCount,
+            headerLines: headerLines,
+            footerLines: footerLines,
+            isPanelShown: shown
+        )
+    }
+
+    // MARK: - The delta itself
+
+    /// `plan.height` is 88 + 176 + 41 + 228 = 533.
+    func testHeightDeltaIsWhatSwiftUIProducedMinusWhatWePredicted() {
+        XCTAssertEqual(delta(actual: CGSize(width: 380, height: 574.5)).heightDelta, 41.5)
+    }
+
+    /// The sign is the finding. An over-prediction leaves a void under the last
+    /// row that no scroll region recovers; an under-prediction scrolls early.
+    /// A magnitude-only delta cannot tell a reader which mistake was made.
+    func testAnOverPredictionKeepsItsNegativeSign() {
+        XCTAssertEqual(delta(actual: CGSize(width: 380, height: 520.5)).heightDelta, -12.5)
+    }
+
+    /// The panel has been a fixed-width column since it was written
+    /// (`PanelSize.Geometry.panelWidth`), so a non-zero width delta means the
+    /// popover is not honouring the authored width at all — a different fault
+    /// from a height mis-estimate, and invisible if only the height is logged.
+    func testWidthDeltaIsReportedSeparatelyFromHeight() {
+        XCTAssertEqual(delta(actual: CGSize(width: 392, height: 533)).widthDelta, 12)
+        XCTAssertEqual(delta(actual: CGSize(width: 392, height: 533)).heightDelta, 0)
+    }
+
+    /// The height the panel really had left over after the chrome we predicted
+    /// — 574.5 − (88 + 176 + 41) = 269.5 against a predicted list of 228. This
+    /// is the number phase 4's residual scroll region will absorb, so it is the
+    /// one worth naming rather than leaving the reader to subtract.
+    func testImpliedListHeightIsTheActualTotalLessThePredictedChrome() {
+        XCTAssertEqual(
+            delta(actual: CGSize(width: 380, height: 574.5)).impliedListHeight, 269.5)
+    }
+
+    // MARK: - An absent measurement
+
+    /// An `NSPopover` that has never been laid out reports a zero
+    /// `contentSize`. Treating that as a measurement produces `-533.0` — a
+    /// number that reads as a catastrophic mis-estimate and is in fact no
+    /// measurement at all.
+    func testAZeroContentSizeIsNoMeasurementRatherThanAHugeNegativeDelta() {
+        let unlaid = delta(actual: .zero, shown: false)
+        XCTAssertNil(unlaid.actual)
+        XCTAssertNil(unlaid.heightDelta)
+        XCTAssertNil(unlaid.widthDelta)
+        XCTAssertNil(unlaid.impliedListHeight)
+    }
+
+    /// Half a size is still not a size. A popover mid-configuration can report
+    /// a width with no height, and the height is the entire subject here.
+    func testAZeroHeightWithANonZeroWidthIsAlsoNoMeasurement() {
+        XCTAssertNil(delta(actual: CGSize(width: 380, height: 0)).actual)
+    }
+
+    func testAnUnlaidPanelSaysSoInWordsInsteadOfPrintingANumber() {
+        let line = delta(actual: .zero, shown: false).logLine
+        XCTAssertTrue(line.contains("actual=unlaid"), line)
+        XCTAssertTrue(line.contains("delta-height=unknown"), line)
+        XCTAssertTrue(line.contains("delta-width=unknown"), line)
+        XCTAssertTrue(line.contains("implied-list=unknown"), line)
+        XCTAssertFalse(line.contains("-533"), line)
+    }
+
+    // MARK: - The line a person reads once
+
+    /// One fixed marker at the head of the line, so a single
+    /// `log show --predicate 'eventMessage CONTAINS "TCRBAR-PANELSIZE"'` finds
+    /// every line and nothing else. The version is there because the field set
+    /// is going to change between phases and a reader must not have to guess
+    /// which shape they are holding.
+    func testTheLineStartsWithTheMarkerAndAVersion() {
+        XCTAssertTrue(
+            delta(actual: CGSize(width: 380, height: 574.5)).logLine
+                .hasPrefix("TCRBAR-PANELSIZE v1 "))
+    }
+
+    /// One line, or `log show` splits one observation across rows and the
+    /// key=value grep stops working.
+    func testTheLineIsOneLine() {
+        XCTAssertFalse(delta(actual: CGSize(width: 380, height: 574.5)).logLine.contains("\n"))
+    }
+
+    /// Property 1, stated directly: every part of the prediction is on the
+    /// line. A total alone cannot say which part was wrong.
+    func testTheLineBreaksThePredictionDownByPart() {
+        let line = delta(actual: CGSize(width: 380, height: 574.5)).logLine
+        XCTAssertTrue(line.contains("header=88.0/4ln"), line)
+        XCTAssertTrue(line.contains("footer=176.0/2ln"), line)
+        XCTAssertTrue(line.contains("list=228.0"), line)
+        XCTAssertTrue(line.contains("frame=41.0"), line)
+        XCTAssertTrue(line.contains("predicted=380.0x533.0"), line)
+        XCTAssertTrue(line.contains("actual=380.0x574.5"), line)
+        XCTAssertTrue(line.contains("delta-height=+41.5"), line)
+        XCTAssertTrue(line.contains("delta-width=+0.0"), line)
+        XCTAssertTrue(line.contains("implied-list=269.5"), line)
+    }
+
+    /// The chrome line counts are what let a reader separate a wrapping
+    /// header from a mis-sized footer across two ticks: `FleetView`'s header
+    /// lines are all conditional, so the count moves on its own as the fleet
+    /// changes state.
+    func testTheLineCarriesTheRowAndChromeLineCounts() {
+        let line = delta(
+            actual: CGSize(width: 380, height: 574.5), rowCount: 9,
+            headerLines: 3, footerLines: 1
+        ).logLine
+        XCTAssertTrue(line.contains("rows=9"), line)
+        XCTAssertTrue(line.contains("/3ln"), line)
+        XCTAssertTrue(line.contains("/1ln"), line)
+    }
+
+    /// The tick that measures the chrome estimate ALONE. With no accounts the
+    /// list term is zero by construction, so the whole delta on such a line is
+    /// header-and-footer error with nothing else mixed into it — which is the
+    /// only single-tick attribution this instrument can honestly make.
+    func testAnEmptyFleetLineCarriesAZeroListTermSoTheDeltaIsPureChrome() {
+        let empty = PanelSize.Plan(
+            width: 380, headerHeight: 44, footerHeight: 176, listHeight: 0, frameHeight: 41)
+        let line = delta(
+            actual: CGSize(width: 380, height: 268), rowCount: 0, headerLines: 2,
+            footerLines: 1, predicted: empty
+        ).logLine
+        XCTAssertTrue(line.contains("rows=0"), line)
+        XCTAssertTrue(line.contains("list=0.0"), line)
+        XCTAssertTrue(line.contains("delta-height=+7.0"), line)
+    }
+
+    /// A `contentSize` read while the popover is closed is last-open state, not
+    /// a fresh layout. The reader must be able to drop those lines.
+    func testTheLineSaysWhetherThePanelWasOnScreen() {
+        XCTAssertTrue(
+            delta(actual: CGSize(width: 380, height: 574.5), shown: true).logLine
+                .contains("shown=yes"))
+        XCTAssertTrue(
+            delta(actual: CGSize(width: 380, height: 574.5), shown: false).logLine
+                .contains("shown=no"))
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/PanelSizeTests.swift
+++ b/apps/macos/Tests/TcrBarTests/PanelSizeTests.swift
@@ -1,0 +1,320 @@
+import CoreGraphics
+import XCTest
+
+@testable import TcrBarCore
+
+/// The panel's AUTHORED size — the arithmetic `MenuBarShell` will hand to
+/// `NSPopover.contentSize` in phase 3, and nothing calls yet.
+///
+/// What is under test is one property, and every assertion below is a
+/// restatement of it: **a wrong chrome estimate lands on the account list and
+/// never on the footer.** `PanelHeight.swift:6-19` records what the other
+/// direction costs — a header that wrapped pushed Quit and the three settings
+/// checkboxes off the bottom of the popover — and `docs/plans/panel-sizing-generalization.md`
+/// §10 item 2 says the same thing as a rule: any design where a wrong header
+/// estimate moves the footer re-creates that bug by a new route.
+///
+/// ``FakeTextMetrics`` is not a claim about TextKit. The whole point of
+/// injecting `TextMetrics` is that the estimate is ALLOWED to be wrong, so a
+/// test whose fake agreed with `NSString.boundingRect` would be testing the
+/// wrong thing. What these tests drive through it is a relationship: whatever
+/// number the text engine returns, this is where it lands.
+///
+/// The geometry is likewise an INPUT, supplied here, not read from `Tok` —
+/// `Tok` lives in the executable target and this bundle links `TcrBarCore`
+/// only (`Package.swift:39-43`). The two CLAMPS are the exception and are read
+/// from `PanelHeight`, never restated, for the reason `PanelHeightTests`
+/// gives: a hand-copied clamp leaves the assertions green while the running
+/// panel clamps to a height nobody tested.
+final class PanelSizeTests: XCTestCase {
+
+    /// A text engine with no fonts in it: every character is `charWidth` wide
+    /// and every rendered line is `lineHeight` tall, both scaled by the font
+    /// size so a caller that forgets to forward the size is visible.
+    ///
+    /// Deterministic on purpose. `NSString.boundingRect` needs AppKit, and
+    /// adding AppKit here would mean adding `"TcrBar"` to the test target —
+    /// the one thing §10 item 5 forbids, and the reason `TextMetrics` is a
+    /// protocol at all.
+    private struct FakeTextMetrics: TextMetrics {
+        let charWidth: CGFloat = 6
+        let lineHeight: CGFloat = 12
+
+        func height(of text: String, fontSize: CGFloat, width: CGFloat) -> CGFloat {
+            let scale = fontSize / 12
+            let perLine = max(1, Int(width / (charWidth * scale)))
+            let lines = max(1, Int((Double(text.count) / Double(perLine)).rounded(.up)))
+            return CGFloat(lines) * lineHeight * scale
+        }
+    }
+
+    /// Records what it was asked, so a test can assert on the arguments rather
+    /// than only on the sum. Answers a constant: the arguments are the subject.
+    private final class RecordingTextMetrics: TextMetrics {
+        struct Ask: Equatable {
+            let text: String
+            let fontSize: CGFloat
+            let width: CGFloat
+        }
+        private(set) var asks: [Ask] = []
+
+        func height(of text: String, fontSize: CGFloat, width: CGFloat) -> CGFloat {
+            asks.append(Ask(text: text, fontSize: fontSize, width: width))
+            return 12
+        }
+    }
+
+    /// `Tok`'s figures as the panel passes them (`Tokens.swift:250, 281-283,
+    /// 312`), plus two the panel measures rather than declares. Inputs to the
+    /// arithmetic, not clamps on it — several tests vary them and assert the
+    /// relationship instead of the number.
+    private let geometry = PanelSize.Geometry(
+        panelWidth: 380,
+        gutter: 12,
+        sectionSpacing: 8,
+        lineSpacing: 4,
+        rowSpacing: 8,
+        hairlineWidth: 0.5,
+        rowHeight: 42,
+        fixedControlsHeight: 150
+    )
+
+    private let metrics = FakeTextMetrics()
+
+    private func line(_ chars: Int, fontSize: CGFloat = 12) -> PanelSize.Line {
+        PanelSize.Line(String(repeating: "x", count: chars), fontSize: fontSize)
+    }
+
+    private var someHeader: [PanelSize.Line] { [line(20), line(40)] }
+    private var someFooter: [PanelSize.Line] { [line(30)] }
+
+    private func plan(
+        rows: Int,
+        header: [PanelSize.Line]? = nil,
+        footer: [PanelSize.Line]? = nil,
+        geometry: PanelSize.Geometry? = nil
+    ) -> PanelSize.Plan {
+        PanelSize.plan(
+            rowCount: rows,
+            header: header ?? someHeader,
+            footer: footer ?? someFooter,
+            geometry: geometry ?? self.geometry,
+            metrics: metrics
+        )
+    }
+
+    // MARK: - the invariant
+
+    /// The whole design in one assertion. A header that grows from one
+    /// rendered line to five must not shorten the footer by a single point:
+    /// the panel gets taller instead, which is what "author the container"
+    /// means. Under the shipped `.preferredContentSize` path the popover's
+    /// height was capped and the growth came out of whatever was last in the
+    /// stack — the footer — which is `PanelHeight.swift:6-19`'s bug.
+    func testTheFooterKeepsItsFullHeightHoweverTheHeaderWraps() {
+        let short = plan(rows: 6, header: [line(10)])
+        let long = plan(rows: 6, header: [line(10_000)])
+
+        XCTAssertGreaterThan(
+            long.headerHeight, short.headerHeight * 5,
+            "the fake really does wrap a 10,000-character line onto many more lines")
+        XCTAssertEqual(
+            long.footerHeight, short.footerHeight,
+            "a wrapping header may not cost the footer one point")
+        XCTAssertEqual(
+            long.height - short.height, long.headerHeight - short.headerHeight,
+            accuracy: 0.0001,
+            "the panel absorbs the header's growth by getting taller, nothing else")
+    }
+
+    /// The other half: the list is a function of the fleet, so chrome the
+    /// estimate got wrong is not charged to it either. `headerOverflow`
+    /// (`PanelHeight.swift:75`) charged exactly this, and phase 5 deletes it —
+    /// under an authored container with a residual scroll region the list
+    /// absorbs the error by scrolling a little early, which costs nothing that
+    /// needs paying for in advance.
+    func testAWrappingHeaderTakesNothingFromTheList() {
+        XCTAssertEqual(
+            plan(rows: 6, header: [line(10_000)]).listHeight,
+            plan(rows: 6, header: [line(10)]).listHeight,
+            "the list's height is a fact about the fleet, not about the header")
+    }
+
+    // MARK: - the list estimate
+
+    /// Biased DOWN by one row and its gap, deliberately. The estimate is going
+    /// to be wrong in one direction or the other; too short scrolls slightly
+    /// early, too tall leaves a void under the last row that nothing can fill.
+    /// Scrolling early is the cheaper mistake, so the bias is one whole row
+    /// rather than a fudge factor — a unit a reader can name.
+    func testTheListEstimateIsBiasedDownByOneRow() {
+        let rows = 6
+        let natural =
+            CGFloat(rows) * geometry.rowHeight + CGFloat(rows - 1) * geometry.rowSpacing
+
+        XCTAssertEqual(
+            PanelSize.listHeight(rowCount: rows, geometry: geometry),
+            natural - geometry.rowHeight - geometry.rowSpacing,
+            accuracy: 0.0001,
+            "one row and one gap short of the content, so the list scrolls early rather than gapping")
+    }
+
+    /// The floor is one row, NOT `panelMinListHeight`. 120 is the floor on the
+    /// old list BUDGET — the space a long header may not take away — and
+    /// `docs/plans/panel-sizing-generalization.md` §8 is explicit that a fleet
+    /// which really has one row should draw 42pt and not 120. Clamping up to
+    /// the budget here would draw 78pt of empty panel under a single account.
+    func testAOneRowFleetGetsOneRowOfListNotTheOldMinimumBudget() {
+        XCTAssertEqual(
+            PanelSize.listHeight(rowCount: 1, geometry: geometry), geometry.rowHeight,
+            "one account draws one row of list")
+        XCTAssertLessThan(
+            PanelSize.listHeight(rowCount: 1, geometry: geometry),
+            PanelHeight.panelMinListHeight,
+            "and is allowed to be shorter than the budget floor, which is a different figure")
+    }
+
+    /// `panelMaxHeight` caps the LIST and not the panel — its own doc-comment
+    /// says so (`PanelHeight.swift:44-50`), and capping the panel instead is
+    /// how the footer went off the bottom. A 40-account fleet scrolls; its
+    /// chrome is still authored in full on top of the cap.
+    func testTheListIsCappedAtPanelMaxHeightAndTheChromeIsNot() {
+        let huge = plan(rows: 40)
+
+        XCTAssertEqual(
+            huge.listHeight, PanelHeight.panelMaxHeight,
+            "a fleet past the cap gets the cap and scrolls")
+        XCTAssertEqual(
+            huge.height, PanelHeight.panelMaxHeight + huge.chromeHeight,
+            accuracy: 0.0001,
+            "the cap is on the list; the chrome is added on top of it, never squeezed into it")
+        XCTAssertGreaterThan(
+            huge.height, PanelHeight.panelMaxHeight,
+            "so the authored PANEL is taller than the cap — capping the total is the bug")
+    }
+
+    func testAnEmptyFleetGetsNoList() {
+        XCTAssertEqual(
+            PanelSize.listHeight(rowCount: 0, geometry: geometry), 0,
+            "no accounts, no scroll region — `FleetView.content` draws a banner instead")
+    }
+
+    // MARK: - what the chrome reserves
+
+    /// Every structural piece of `FleetView.body` (`FleetView.swift:93-103`)
+    /// and nothing else: `.padding(Tok.gutter)` top and bottom, the two
+    /// `Hairline()`s, and the four gaps between its five children. Restated
+    /// here because it is a claim ABOUT that view: if a child is added or a
+    /// hairline removed and this number is not updated, the authored size is
+    /// wrong by a gap and the last thing in the panel hangs over the edge.
+    func testTheFrameReservesBothGuttersBothHairlinesAndEveryGap() {
+        XCTAssertEqual(
+            plan(rows: 3).frameHeight,
+            2 * geometry.gutter + 2 * geometry.hairlineWidth
+                + CGFloat(PanelSize.bodyChildren - 1) * geometry.sectionSpacing,
+            accuracy: 0.0001)
+    }
+
+    /// The height is the sum of its four named parts and nothing hidden. This
+    /// is what makes phase 3's log line readable: a delta against the popover's
+    /// real `contentSize` can be attributed to header, footer or list.
+    func testTheHeightIsExactlyItsFourParts() {
+        let p = plan(rows: 5)
+        XCTAssertEqual(
+            p.height, p.headerHeight + p.footerHeight + p.frameHeight + p.listHeight,
+            accuracy: 0.0001)
+        for part in [p.headerHeight, p.footerHeight, p.frameHeight, p.listHeight] {
+            XCTAssertGreaterThan(
+                part, 0,
+                "and every part carries weight — the identity above holds trivially if one is zero")
+        }
+    }
+
+    /// Text is measured at the width it will actually be drawn at — the panel
+    /// less both gutters — and the caller's font size is forwarded rather than
+    /// assumed. Measuring at `panelWidth` under-counts the wrapped lines of
+    /// every string in the panel, which is the estimate being wrong in the one
+    /// direction that puts the footer over the edge.
+    func testTextIsMeasuredAtThePanelWidthLessBothGuttersInTheCallersFont() {
+        let recorder = RecordingTextMetrics()
+        _ = PanelSize.plan(
+            rowCount: 3,
+            header: [PanelSize.Line("spend", fontSize: 11)],
+            footer: [PanelSize.Line("server abc1234", fontSize: 10)],
+            geometry: geometry,
+            metrics: recorder
+        )
+
+        XCTAssertEqual(
+            recorder.asks,
+            [
+                .init(text: "spend", fontSize: 11, width: geometry.panelWidth - 2 * geometry.gutter),
+                .init(
+                    text: "server abc1234", fontSize: 10,
+                    width: geometry.panelWidth - 2 * geometry.gutter),
+            ],
+            "every chrome string, at the drawn width, in its own font size")
+    }
+
+    /// The lines of one stack are separated by `Tok.tightSpacing`, the spacing
+    /// `header` and `footer` both give their `VStack` (`FleetView.swift:109`,
+    /// `:450`). Two lines is one gap, not two and not none.
+    func testAStackOfLinesReservesTheGapsBetweenThem() {
+        let one = PanelSize.stackHeight([line(5)], geometry: geometry, metrics: metrics)
+        let three = PanelSize.stackHeight(
+            [line(5), line(5), line(5)], geometry: geometry, metrics: metrics)
+
+        XCTAssertEqual(three, 3 * one + 2 * geometry.lineSpacing, accuracy: 0.0001)
+        XCTAssertEqual(
+            PanelSize.stackHeight([], geometry: geometry, metrics: metrics), 0,
+            "a stack that draws nothing reserves nothing, gap included")
+    }
+
+    /// The footer's fixed controls — the buttons and the three checkboxes —
+    /// are reserved whether or not the footer draws any wrapping text, and the
+    /// gap between text and controls only exists when both do.
+    func testTheFooterReservesItsFixedControlsWithOrWithoutText() {
+        let withText = plan(rows: 3, footer: [line(30)])
+        let textless = plan(rows: 3, footer: [])
+
+        XCTAssertEqual(
+            textless.footerHeight, geometry.fixedControlsHeight,
+            "no footer text still reserves Quit and the checkboxes")
+        XCTAssertEqual(
+            withText.footerHeight,
+            geometry.fixedControlsHeight + geometry.lineSpacing
+                + PanelSize.stackHeight([line(30)], geometry: geometry, metrics: metrics),
+            accuracy: 0.0001,
+            "and with text, one gap between the text and the controls")
+    }
+
+    // MARK: - from a fleet
+
+    /// `forFleet` counts the rows the panel will draw. Decoded from JSON
+    /// rather than built with the memberwise init, so the fixture is the shape
+    /// `tcr status --json` really emits.
+    func testForFleetSizesTheListFromTheAccountCount() throws {
+        let fleet = try Fleet.decode(Data(fleetJSON(rows: 7).utf8))
+        XCTAssertEqual(fleet.accounts.count, 7, "the fixture decoded")
+
+        let size = PanelSize.forFleet(
+            fleet, header: someHeader, footer: someFooter, geometry: geometry, metrics: metrics)
+
+        XCTAssertEqual(size, plan(rows: 7).contentSize)
+        XCTAssertEqual(size.width, geometry.panelWidth, "the panel's width is authored, not measured")
+    }
+
+    private func fleetJSON(rows: Int) -> String {
+        let accounts = (0..<rows).map { index in
+            """
+            {"name":"account\(index)@example.com","priority":\(index),"status":"active",
+             "disabled":false,"quota":0.5,"quotaState":"ok","fiveHour":0.5,"sevenDay":0.5,
+             "sevenDayOi":null,"held":[],"requests":1,"inputTokens":1,"outputTokens":1,
+             "cacheReadTokens":1,"cacheHitRatio":0.5,"probeStatus":"ok","probeError":null,
+             "lastStreamError":null,"streamErrorCount":0,"source":"live",
+             "serverSha":"abc1234","serverDirty":false}
+            """
+        }
+        return "[\(accounts.joined(separator: ","))]"
+    }
+}


### PR DESCRIPTION
🍄 Seven commits on two tracks. Design docs live in `docs/plans/` (gitignored, so not in this diff): `panel-sizing-findings.md` (three read-only lanes), `panel-sizing-lead-design.md`, `panel-sizing-generalization.md` (independent architect, five phases).

## Track 1 — the popover layout crash (phases 1–3 of 5)

`2356fb9` + `affd10d` — **the dead band.** `PanelHeight.quantized` snaps to a 0.5pt grid, and a quantizer inside a feedback loop is a source of limit cycles rather than a damper on them: a measurement sitting on a cell *boundary* snaps alternately to the two neighbours, republishing 199 times in 200 passes, each one re-firing `onPreferenceChange` and running `NSHostingView.setFrameSize`. The shipped fixture never caught it because it centres its jitter on a grid *point*, where quantizing alone does publish one value and always would.

`settled` holds the previous value while the new one is within a grain. The band must see the **raw** measurement — two adjacent grid points differ by exactly `measurementGrain`, so a band applied after quantizing compares `0.5 < 0.5`, is false, and lets the alternation through — so the three emitters now publish unrounded and `settled` is the only place the grid is applied. `quantized` is `internal` now: restoring it at an emitter reads as tidy-up, would keep every test green and kill the fix, and no test can catch that because the test bundle deliberately links `TcrBarCore` only. It is a compile error instead, watched firing.

`8e53ef7` — **`PanelSize` + a `TextMetrics` protocol**, called by nobody. The protocol keeps the test target linking `TcrBarCore` only rather than changing `Package.swift`.

`251439b` — **the instrument.** `MenuBarShell` computes the predicted size each poll tick and logs it beside what SwiftUI actually produced, broken down by header/footer/list/total. No behaviour change; `sizingOptions` untouched. An unlaid popover reports `actual=unlaid`, not a `-533.0` delta that reads as catastrophe to someone who gets one look.

**What this does not claim.** It is *not* established that this is the loop that aborts. The same investigation records that the crash cycle reads no preference at all and that no 0.2.43 stack contains a TcrBar frame. This removes a measured oscillation. Whether that is the crashing edge is unknown, and the doc-comments say so. Phase 3 exists to produce that evidence; phases 4–5 are deliberately not in this PR because they depend on it.

## Track 2 — group sections in the panel

`8451b6c` (library) + `3a9bd55` (view) + `a84b930` (heading rule). The list is now **live → out of tokens → parked**, group sections inside each band, names within a section.

An account in two groups appears under **both** — a deliberate override of `docs/plans/account-groups-plan.md:44-55`, which rejected sectioning three times on the grounds that groups are a set and not a partition. The cost is real and is recorded in the code: two rows for one account. The alternatives were duplicating, inventing a primary group, or not grouping.

Two hazards that creates, both handled: `ForEach` identity is the composite (group, account), not the account id, because a duplicated identity is undefined behaviour in SwiftUI; and `rowHeights` is re-keyed the same way, since a duplicated account otherwise overwrites its own twin's measured height. Headings are keyed too — they are children of the same `VStack` and cost the viewport their height plus a gap.

The parked band is `disabled || parked-by-group`. `tcr group park` does not set a row's `disabled` flag — `src/stats.rs` keeps them as separate fields on purpose — so the literal reading would have drawn six accounts as **Live** while the router sent them nothing.

`a84b930` came from rendering the states and looking at the PNGs: a band holding one ungrouped section drew `LIVE / Ungrouped`, which says what `LIVE` already said, and on a fleet with no groups that was every band. Suppressed where it carries nothing, kept where it separates something. 2653px → 2521px at 2× on the mixed-thirteen scene.

## Gates

`swift build` clean. `swift test` **490 tests, 0 failures**. Render harness run before and after, both scenes inspected.

Every new assertion was watched failing first, and against today's shipped behaviour rather than an arbitrary mutation. Where a stub-based red run left assertions green by accident, the shipped code was mutated once per survivor until each had failed — that convention was found by a worker on this branch and then applied by every one after it.

## Review

An independent review of phase 1 returned REVISE; all three findings are addressed in `affd10d`. It proved by compilation that the architect's phase 1 spec, left literally, would have failed its own gate, and swept 320,000 two-cycle signals: 69,700 strictly better, 250,300 identical, zero worse. It also caught the doc-comment overstating its own sources, which is now corrected along with its provenance.

Three of the five phase specs had defects found during implementation — one internally inconsistent, one naming a type that has never existed, one whose file list could not survive its own test gate. The design judgement held; the signatures did not.

https://claude.ai/code/session_01HaDRurSBw7PPHjoe59snMC
