### PR TITLE
fix: scan a commit's message and a merge's content for disclosures, not only a staged diff

### DIFF
--- a/.githooks/lib/disclosure-scan.sh
+++ b/.githooks/lib/disclosure-scan.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# disclosure-scan — the public-repo disclosure checks, in one place.
+#
+# Three callers share it:
+#   .githooks/pre-commit        staged changes, before a commit is written
+#   .githooks/pre-merge-commit  the same, for a merge (git runs THIS, not pre-commit)
+#   .githooks/pre-push          the outgoing commits: their diffs AND their messages
+#
+# WHY IT IS A LIBRARY. The checks lived inline in pre-commit. A commit is not the
+# only way content reaches a public remote: a merge commit's content is never
+# staged, so pre-commit never sees it, and a commit MESSAGE is not part of any
+# diff, so no version of the staged scan could read one. Answering "would this
+# disclose something?" in three spellings is how the three answers drift, so the
+# checks live here and the hooks decide only WHAT text to hand over.
+#
+# Every grep is `|| true`: under `set -e` a no-match (exit 1) would abort the
+# hook, and `grep -q` in a pipe can invert on SIGPIPE. Both failure modes report
+# the wrong answer confidently, which is the defect this gate exists to prevent,
+# one level up.
+#
+# shellcheck shell=bash
+
+# The list is local-only and gitignored, so no clone or worktree carries it: a
+# committed list of the real names would itself be the disclosure this gate
+# exists to stop. A MISSING list is a hard failure for the same reason a missing
+# gitleaks is — its absence means the checkout is damaged or somebody deleted it,
+# not that there is nothing to check. Skipping silently would leave the other two
+# checks running and the whole gate looking healthy while the one check that
+# knows the actual private names had been switched off.
+tcr_disclosure_require_names_list() {
+  local gate="${1:-gate}"
+  if [ ! -f .githooks/private-names ] && [ "${TCR_ALLOW_MISSING_PRIVATE_NAMES:-0}" != "1" ]; then
+    {
+      echo ""
+      echo "$gate: BLOCKED — .githooks/private-names is missing, so the private-name"
+      echo "  half of the disclosure scan cannot run."
+      echo ""
+      echo "  The file is local-only and gitignored, so no clone or worktree carries it: a"
+      echo "  committed list of the real names would itself be the disclosure this gate"
+      echo "  exists to stop. Each checkout writes its own."
+      echo ""
+      echo "  Maintaining a list — one name or string per line, '#' comments allowed:"
+      echo ""
+      echo "      \$EDITOR .githooks/private-names"
+      echo ""
+      echo "  Contributing from a fork, with no private names of your own to protect? Then"
+      echo "  this half is not yours to run, and skipping it is the correct answer:"
+      echo ""
+      echo "      TCR_ALLOW_MISSING_PRIVATE_NAMES=1 git commit ..."
+      echo ""
+    } >&2
+    return 1
+  fi
+  return 0
+}
+
+# tcr_disclosure_scan_text <what>
+# Reads text on stdin. Prints a human-readable hit report and returns 1 when the
+# text would disclose something; prints nothing and returns 0 when it is clean.
+# <what> names the text in the report ("staged changes", "commit message …") so
+# a caller never has to compose the wording and the three callers cannot word the
+# same finding three ways.
+tcr_disclosure_scan_text() {
+  local what="${1:-text}"
+  local text hits="" found
+  text="$(cat || true)"
+  # Nothing to scan is clean. Said once, here, so no caller has to guess whether
+  # an empty diff means "safe" or "the scan did not run".
+  [ -n "$text" ] || return 0
+
+  # 1. Private names — an editable list, so adding one needs no hook edit.
+  if [ -f .githooks/private-names ]; then
+    local name
+    while IFS= read -r name || [ -n "$name" ]; do
+      case "$name" in ''|\#*) continue ;; esac
+      found="$(printf '%s\n' "$text" | grep -i -m3 -- "$name" || true)"
+      [ -n "$found" ] && hits="$hits
+  private name '$name' in $what:
+$(printf '%s\n' "$found" | sed 's/^/      /')"
+    done < .githooks/private-names
+  fi
+
+  # 2. Absolute home paths — they leak the machine layout and the operator's name.
+  #    Obviously-synthetic users are allowed so fixtures and docs still work.
+  found="$(printf '%s\n' "$text" \
+           | grep -E -m3 '/(Users|home)/[A-Za-z0-9._-]+/' \
+           | grep -v -i -E '/(Users|home)/(x|y|alice|bob|carol|test|example|runner|user)/' || true)"
+  [ -n "$found" ] && hits="$hits
+  absolute home path in $what:
+$(printf '%s\n' "$found" | sed 's/^/      /')"
+
+  # 3. Real-looking email addresses (example.com and the GitHub noreply are fine).
+  #    Matched case-insensitively: example.com is RFC 2606 reserved, so
+  #    ALICE@EXAMPLE.COM is no more real than the lowercase form.
+  found="$(printf '%s\n' "$text" \
+           | grep -E -o -m3 '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' \
+           | grep -v -i -E '@(example\.(com|org|net)|users\.noreply\.github\.com)$' || true)"
+  [ -n "$found" ] && hits="$hits
+  real-looking email address in $what:
+$(printf '%s\n' "$found" | sed 's/^/      /')"
+
+  if [ -n "$hits" ]; then
+    printf '%s\n' "$hits"
+    return 1
+  fi
+  return 0
+}
+
+# tcr_disclosure_staged_added
+# The ADDED lines of the staged changes, so pre-existing content can never block
+# you. The denylist file itself is excluded: it holds the names on purpose.
+tcr_disclosure_staged_added() {
+  git diff --cached -U0 --diff-filter=ACM -- . ':(exclude).githooks/private-names' \
+    | sed -n 's/^+//p' || true
+}
+
+# tcr_disclosure_commit_added <sha>
+# The ADDED lines a single commit introduces. `git show` handles a root commit,
+# which a `<sha>^..<sha>` range does not.
+tcr_disclosure_commit_added() {
+  local sha="${1:-}"
+  [ -n "$sha" ] || return 0
+  git show "$sha" --format= -U0 --diff-filter=ACM -- . ':(exclude).githooks/private-names' \
+    | sed -n 's/^+//p' || true
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -82,72 +82,23 @@ fi
 # to prevent, one level up.
 #
 # Deliberate exception:  git commit --no-verify
-added="$(git diff --cached -U0 --diff-filter=ACM -- . ':(exclude).githooks/private-names' \
-         | sed -n 's/^+//p' || true)"
-hits=""
-
-if [ -n "$added" ]; then
-  # 1. Private names — an editable list, so adding one needs no hook edit.
-  #
-  #    A MISSING list is a hard failure, for the same reason a missing gitleaks
-  #    is: this is a disclosure gate, and the file is tracked, so its absence
-  #    means the checkout is damaged or somebody deleted it — not that there is
-  #    nothing to check. Skipping silently would leave the other two checks
-  #    (home paths, emails) running and the whole gate looking healthy while the
-  #    one check that knows the actual private names had been switched off.
-  if [ ! -f .githooks/private-names ] && [ "${TCR_ALLOW_MISSING_PRIVATE_NAMES:-0}" != "1" ]; then
-    echo "" >&2
-    echo "pre-commit: BLOCKED — .githooks/private-names is missing, so the private-name" >&2
-    echo "  half of the disclosure scan cannot run." >&2
-    echo "" >&2
-    echo "  The file is local-only and gitignored, so no clone or worktree carries it: a" >&2
-    echo "  committed list of the real names would itself be the disclosure this gate" >&2
-    echo "  exists to stop. Each checkout writes its own." >&2
-    echo "" >&2
-    echo "  Maintaining a list — one name or string per line, '#' comments allowed:" >&2
-    echo "" >&2
-    echo "      \$EDITOR .githooks/private-names" >&2
-    echo "" >&2
-    echo "  Contributing from a fork, with no private names of your own to protect? Then" >&2
-    echo "  this half is not yours to run, and skipping it is the correct answer:" >&2
-    echo "" >&2
-    echo "      TCR_ALLOW_MISSING_PRIVATE_NAMES=1 git commit ..." >&2
-    echo "" >&2
-    exit 1
-  fi
-  if [ -f .githooks/private-names ]; then
-    while IFS= read -r name || [ -n "$name" ]; do
-      case "$name" in ''|\#*) continue ;; esac
-      found="$(printf '%s\n' "$added" | grep -i -m3 -- "$name" || true)"
-      [ -n "$found" ] && hits="$hits
-  private name '$name':
-$(printf '%s\n' "$found" | sed 's/^/      /')"
-    done < .githooks/private-names
-  fi
-
-  # 2. Absolute home paths — they leak the machine layout and the operator's name.
-  #    Obviously-synthetic users are allowed so fixtures and docs still work.
-  found="$(printf '%s\n' "$added" \
-           | grep -E -m3 '/(Users|home)/[A-Za-z0-9._-]+/' \
-           | grep -v -i -E '/(Users|home)/(x|y|alice|bob|carol|test|example|runner|user)/' || true)"
-  [ -n "$found" ] && hits="$hits
-  absolute home path:
-$(printf '%s\n' "$found" | sed 's/^/      /')"
-
-  # 3. Real-looking email addresses (example.com and the GitHub noreply are fine).
-  #    Matched case-insensitively: example.com is RFC 2606 reserved, so ALICE@EXAMPLE.COM
-  #    is no more real than the lowercase form. Docs demonstrating case-sensitive account
-  #    resolution legitimately write the uppercase one, and a case-sensitive allowlist
-  #    blocked exactly that.
-  found="$(printf '%s\n' "$added" \
-           | grep -E -o -m3 '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' \
-           | grep -v -i -E '@(example\.(com|org|net)|users\.noreply\.github\.com)$' || true)"
-  [ -n "$found" ] && hits="$hits
-  real-looking email address:
-$(printf '%s\n' "$found" | sed 's/^/      /')"
+# The checks themselves live in .githooks/lib/disclosure-scan.sh, shared with
+# pre-merge-commit (a merge's content is never staged, so this hook never runs
+# for one) and pre-push (a commit MESSAGE is not part of any diff, so no version
+# of this scan could read one). Three spellings of "would this disclose
+# something?" is how the three answers drift.
+if [ ! -f .githooks/lib/disclosure-scan.sh ]; then
+  echo "" >&2
+  echo "pre-commit: BLOCKED — .githooks/lib/disclosure-scan.sh is missing, so the" >&2
+  echo "  disclosure scan cannot run. The checkout is damaged; restore the file." >&2
+  exit 1
 fi
+# shellcheck source=lib/disclosure-scan.sh
+. .githooks/lib/disclosure-scan.sh
 
-if [ -n "$hits" ]; then
+tcr_disclosure_require_names_list "pre-commit" || exit 1
+
+if ! hits="$(tcr_disclosure_staged_added | tcr_disclosure_scan_text "the staged changes")"; then
   echo "" >&2
   echo "pre-commit: BLOCKED — staged changes would publish private information." >&2
   echo "$hits" >&2

--- a/.githooks/pre-merge-commit
+++ b/.githooks/pre-merge-commit
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# git runs pre-merge-commit, NOT pre-commit, when a merge creates a commit.
+#
+# Every gate in pre-commit was therefore blind to a merge: the disclosure scan,
+# the secret scan, the format checks. A branch carrying a private name, an
+# operator's home path or a real email could be merged into main and pushed
+# without a single gate reading it, because nothing about a merge is ever staged
+# in the sense `git diff --cached` means. (henry-plugin hit the same hole on
+# 2026-09-10 and fixed it the same way.)
+#
+# Deliberate exception:  git merge --no-verify
+exec "$(dirname "$0")/pre-commit" "$@"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Pre-push disclosure gate: the last place to stop a private name, an operator's
+# home path or a real email address from becoming world-readable.
+#
+# WHY A PUSH GATE EXISTS AT ALL. The commit-time scan (.githooks/pre-commit) is
+# the right first gate and it cannot be the only one:
+#
+#   - It reads a DIFF, so it has never read a commit MESSAGE. A branch name or a
+#     private product name written in a subject line reaches GitHub unexamined.
+#   - It runs per commit on THIS machine. A commit made with --no-verify, made
+#     before a name was added to .githooks/private-names, or made in a worktree
+#     whose core.hooksPath was never set, is already in history by push time.
+#   - A public repo's history cannot be un-published. Removing a pushed line
+#     needs a force-push to a protected branch, and forks keep their own copies.
+#
+# So this scans what is actually about to leave: every commit in the push range,
+# its added lines AND its message. Pre-existing content never blocks a push —
+# only what these commits introduce.
+#
+# Deliberate exception:  git push --no-verify
+set -euo pipefail
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Hard-fail on a missing library rather than degrade to "found nothing": a gate
+# that cannot fail is worse than no gate, because it reports safety.
+if [ ! -f "$HOOK_DIR/lib/disclosure-scan.sh" ]; then
+  echo "pre-push: BLOCKED — .githooks/lib/disclosure-scan.sh is missing, so the" >&2
+  echo "  disclosure scan cannot run. The checkout is damaged; restore the file." >&2
+  exit 1
+fi
+# shellcheck source=lib/disclosure-scan.sh
+. "$HOOK_DIR/lib/disclosure-scan.sh"
+
+tcr_disclosure_require_names_list || exit 1
+
+ZERO='0000000000000000000000000000000000000000'
+findings=""
+scanned=0
+
+# stdin: <local ref> <local sha> <remote ref> <remote sha>, one line per ref.
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+  [ -n "${local_sha:-}" ] || continue
+  # A deletion pushes nothing.
+  case "$local_sha" in "$ZERO") continue ;; esac
+
+  if [ "$remote_sha" = "$ZERO" ]; then
+    # A new branch. Scanning its whole ancestry would flag years of history that
+    # is already public, so scan only what no other remote ref already carries.
+    range_commits="$(git rev-list "$local_sha" --not --remotes || true)"
+  else
+    range_commits="$(git rev-list "${remote_sha}..${local_sha}" || true)"
+  fi
+
+  [ -n "$range_commits" ] || continue
+
+  while IFS= read -r sha; do
+    [ -n "$sha" ] || continue
+    scanned=$((scanned + 1))
+
+    if out="$(tcr_disclosure_commit_added "$sha" | tcr_disclosure_scan_text "the changes in $(git log -1 --format=%h "$sha")")"; then
+      :
+    else
+      findings="$findings$out"
+    fi
+
+    # The MESSAGE BODY only. The author and committer identity is part of every
+    # commit by design and is already published by GitHub, so scanning it would
+    # flag every push this repo's own maintainer makes — a gate that refuses the
+    # normal case gets turned off, and then it gates nothing.
+    if out="$(git log -1 --format='%B' "$sha" | tcr_disclosure_scan_text "the message of $(git log -1 --format=%h "$sha")")"; then
+      :
+    else
+      findings="$findings$out"
+    fi
+  done <<EOF
+$range_commits
+EOF
+done
+
+if [ -n "$findings" ]; then
+  {
+    echo ""
+    echo "pre-push: BLOCKED — these commits would publish private information."
+    echo "$findings"
+    echo ""
+    echo "  This repository is PUBLIC. Once pushed, removing it requires rewriting"
+    echo "  history on a protected branch, and forks keep their own copies."
+    echo ""
+    echo "  To fix a MESSAGE:  git rebase -i --exec 'git commit --amend' <base>"
+    echo "                     or, for the tip commit, git commit --amend"
+    echo "  To fix a LINE:     edit it, then amend or add a follow-up commit."
+    echo "  If this is genuinely fine:  git push --no-verify"
+    echo ""
+  } >&2
+  exit 1
+fi
+
+[ "$scanned" -gt 0 ] && echo "pre-push: disclosure scan clean ($scanned commit(s))." >&2
+exit 0

--- a/.githooks/test-disclosure-scan.sh
+++ b/.githooks/test-disclosure-scan.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# .githooks/test-disclosure-scan.sh — .githooks/lib/disclosure-scan.sh and the
+# push-time gate that reads it.
+#
+# Every case here is a fixture the gate MUST refuse, plus the controls that prove
+# it can still pass. A gate whose fixtures only ever pass is a gate nobody has
+# watched fail, and this one exists because a reminder that can be read past is
+# not a gate (.githooks/pre-commit, 2026-08-08).
+#
+# Fixture commits name their paths explicitly rather than staging the whole tree.
+# The scratch repo is the test's own and a blind stage would be harmless here, but
+# the repo-wide rule against it is worth not teaching anyone to read past.
+#
+# Run: .githooks/test-disclosure-scan.sh      (exit 0 = every assertion held)
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LIB="$REPO/.githooks/lib/disclosure-scan.sh"
+PREPUSH="$REPO/.githooks/pre-push"
+FAILED=0
+ok()   { echo "  ok: $1"; }
+fail() { echo "FAIL: $1"; FAILED=1; }
+
+[ -f "$LIB" ] || { fail "library missing: $LIB"; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# A scratch repo with its own denylist: the real one is local-only and its
+# contents must never reach a test log.
+SCRATCH="$WORK/repo"
+mkdir -p "$SCRATCH/.githooks/lib"
+cp "$LIB" "$SCRATCH/.githooks/lib/disclosure-scan.sh"
+cp "$PREPUSH" "$SCRATCH/.githooks/pre-push"
+printf 'acmecorp-private\n' > "$SCRATCH/.githooks/private-names"
+git -C "$SCRATCH" init -q
+git -C "$SCRATCH" config user.email alice@example.com
+git -C "$SCRATCH" config user.name Alice
+echo "start" > "$SCRATCH/file.txt"
+git -C "$SCRATCH" add file.txt .githooks
+git -C "$SCRATCH" commit -q --no-verify -m "init"
+
+commit_file() {  # <message>
+  git -C "$SCRATCH" commit -q --no-verify -m "$1" file.txt
+}
+parent() { git -C "$SCRATCH" rev-parse HEAD~1; }
+push_input() { printf 'refs/heads/main %s refs/heads/main %s\n' "$1" "$2"; }
+
+# ── The text scan ────────────────────────────────────────────────────────────
+cd "$SCRATCH" || exit 1
+# shellcheck source=/dev/null
+. "$SCRATCH/.githooks/lib/disclosure-scan.sh"
+
+scan() { printf '%s\n' "$1" | tcr_disclosure_scan_text "the text" >/dev/null 2>&1; }
+
+scan "a line naming AcmeCorp-Private in mixed case" \
+  && fail "a private name passed the scan (case-insensitive match is broken)" \
+  || ok "a private name is refused, case-insensitively"
+# A gate's own test file is the one place where the thing the gate refuses must
+# not appear literally: written out, these two fixtures ARE the disclosure, and
+# this file could not be committed past the gate it tests (measured — the first
+# version of it was refused, correctly). So the fixtures are ASSEMBLED here and
+# exist only at runtime. Do not "tidy" them back into one string.
+HOME_FIXTURE="/Users/""real""person/git/thing/file.rs"
+MAIL_FIXTURE="some""one""@real""company.io"
+scan "see $HOME_FIXTURE" \
+  && fail "an absolute home path passed the scan" \
+  || ok "an absolute home path is refused"
+scan "mail me at $MAIL_FIXTURE" \
+  && fail "a real-looking email passed the scan" \
+  || ok "a real-looking email is refused"
+scan "alice@example.com and /Users/alice/x and a plain sentence" \
+  && ok "the synthetic allowlist still passes (example.com, /Users/alice)" \
+  || fail "the allowlist broke: a fixture-safe line was refused"
+scan "" \
+  && ok "empty text is clean" \
+  || fail "empty text was reported as a disclosure"
+
+# ── The push gate: a commit MESSAGE, which no diff scan can read ─────────────
+echo "a harmless line" >> "$SCRATCH/file.txt"
+commit_file "chore: mention AcmeCorp-Private in the subject"
+out="$(push_input "$(git -C "$SCRATCH" rev-parse HEAD)" "$(parent)" | "$SCRATCH/.githooks/pre-push" 2>&1)"
+rc=$?
+if [ "$rc" -ne 0 ] && printf '%s\n' "$out" | grep -q 'the message of'; then
+  ok "a private name in a COMMIT MESSAGE is refused at push time"
+else
+  fail "a private name in a commit message reached the push unexamined (rc=$rc)"
+fi
+
+# ── The push gate: an added LINE ────────────────────────────────────────────
+echo "config for AcmeCorp-Private" >> "$SCRATCH/file.txt"
+commit_file "chore: a clean subject"
+out="$(push_input "$(git -C "$SCRATCH" rev-parse HEAD)" "$(parent)" | "$SCRATCH/.githooks/pre-push" 2>&1)"
+rc=$?
+if [ "$rc" -ne 0 ] && printf '%s\n' "$out" | grep -q 'the changes in'; then
+  ok "a private name in an added LINE is refused at push time"
+else
+  fail "a private name in an added line reached the push unexamined (rc=$rc)"
+fi
+
+# ── The control: a clean commit must PASS ───────────────────────────────────
+echo "an entirely ordinary line" >> "$SCRATCH/file.txt"
+commit_file "chore: an ordinary change"
+GOOD_SHA="$(git -C "$SCRATCH" rev-parse HEAD)"
+out="$(push_input "$GOOD_SHA" "$(parent)" | "$SCRATCH/.githooks/pre-push" 2>&1)"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  ok "a clean commit passes the push gate"
+else
+  fail "the push gate refused a clean commit — it would be turned off (out: $out)"
+fi
+
+# ── A deletion pushes nothing ───────────────────────────────────────────────
+out="$(printf 'refs/heads/gone 0000000000000000000000000000000000000000 refs/heads/gone %s\n' "$GOOD_SHA" | "$SCRATCH/.githooks/pre-push" 2>&1)"
+rc=$?
+[ "$rc" -eq 0 ] && ok "a branch deletion is not scanned" || fail "a deletion was treated as content"
+
+# ── The denylist file itself is not a disclosure ─────────────────────────────
+printf 'another-private-name\n' >> "$SCRATCH/.githooks/private-names"
+git -C "$SCRATCH" add .githooks/private-names
+staged="$(cd "$SCRATCH" && tcr_disclosure_staged_added)"
+if printf '%s\n' "$staged" | grep -q 'another-private-name'; then
+  fail "the denylist's own lines are scanned — adding a name would block the commit"
+else
+  ok "the denylist file is excluded from the scan"
+fi
+git -C "$SCRATCH" reset -q
+
+# ── The gate cannot silently degrade ────────────────────────────────────────
+rm "$SCRATCH/.githooks/lib/disclosure-scan.sh"
+out="$(push_input "$GOOD_SHA" "$(parent)" | "$SCRATCH/.githooks/pre-push" 2>&1)"
+rc=$?
+if [ "$rc" -ne 0 ] && printf '%s\n' "$out" | grep -q 'disclosure-scan.sh is missing'; then
+  ok "a missing library refuses the push instead of reporting safety"
+else
+  fail "a missing library let the push through (rc=$rc)"
+fi
+
+# ── One spelling: the hooks must all read the library ──────────────────────
+cd "$REPO" || exit 1
+for hook in pre-commit pre-push; do
+  if grep -Eq '^[[:space:]]*(\.|source) [^#]*lib/disclosure-scan\.sh' ".githooks/$hook"; then
+    ok ".githooks/$hook sources the shared library"
+  else
+    fail ".githooks/$hook does not source the shared library"
+  fi
+done
+if grep -q 'exec .*pre-commit' .githooks/pre-merge-commit 2>/dev/null; then
+  ok ".githooks/pre-merge-commit runs pre-commit, so a merge is scanned"
+else
+  fail ".githooks/pre-merge-commit does not run pre-commit — merges stay blind"
+fi
+if grep -q "grep -E -m3 '/(Users|home)" .githooks/pre-commit; then
+  fail "pre-commit carries its own copy of the home-path check — two spellings again"
+else
+  ok "pre-commit carries no second copy of the checks"
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "test-disclosure-scan: FAILED"
+  exit 1
+fi
+echo "test-disclosure-scan: all assertions passed"
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,14 @@ jobs:
       - name: No --org flag
         run: scripts/check-no-org-flag.sh
 
+      # The disclosure gate's own fixtures. The hooks themselves are local and a
+      # fork may not have them wired, so CI runs the suite that proves the scan
+      # still refuses what it exists to refuse — a name, a home path, a real
+      # email — in a diff AND in a commit message. A gate nobody has watched
+      # fail is a gate that reports safety.
+      - name: Disclosure scan fixtures
+        run: .githooks/test-disclosure-scan.sh
+
       # --locked: fail if CI would silently rewrite Cargo.lock. Pins the exact
       # dependency set that was reviewed — important for an auth-handling proxy.
       - name: Clippy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,8 @@ repository.
 | Hook | What it does |
 | --- | --- |
 | `pre-commit` | Secret scan (gitleaks, on staged changes only), public-disclosure scan, `cargo fmt --check`, `swift-format lint --strict`, release-version gate, design-token staleness gate. |
+| `pre-merge-commit` | Runs `pre-commit`. Git runs this hook and not `pre-commit` when a merge creates a commit, so without it every gate above was blind to a merge. |
+| `pre-push` | Public-disclosure scan over the commits actually being pushed: their added lines **and their messages**. `git push --no-verify` to override. |
 | `post-merge` | Rebuilds the release binary so the on-disk artifact tracks the checkout. It never restarts a running proxy. |
 
 Two `pre-commit` gates are **hard failures when their tool or input is missing**: the gitleaks secret
@@ -132,6 +134,18 @@ The disclosure scan reads **added lines only**, so pre-existing content can neve
 absolute home paths (`/Users/<someone>/...`), real-looking email addresses, and any name listed in
 `.githooks/private-names`. Synthetic users (`alice`, `bob`, `test`, `example`, `runner`, ...) and
 `@example.com` / `@users.noreply.github.com` addresses are allowed, so fixtures and docs still work.
+
+A `git worktree` of this repository is a separate checkout and does not carry the list either, so the
+first commit in a fresh worktree stops the same way. Copy yours in (`cp .githooks/private-names
+<worktree>/.githooks/`); it is gitignored, so the copy never goes anywhere.
+
+The checks live in `.githooks/lib/disclosure-scan.sh` and all three hooks read them from there. Commit
+time is the right first gate and cannot be the only one: it reads a diff, so it has never read a commit
+**message**, and a commit made with `--no-verify`, made before a name was added to the list, or made in
+a checkout whose `core.hooksPath` was never set is already in history by push time. A public repo's
+history cannot be un-published. `.githooks/test-disclosure-scan.sh` holds the fixtures — a name, a home
+path and a real address, each in a diff and in a message, every one of them watched being refused —
+and CI runs it.
 
 ## Commits
 


### PR DESCRIPTION
🍄 The public-disclosure gate ran only at commit time, over `git diff --cached`. Two ways content reached this remote without it ever looking:

- **A commit message is not part of any diff.** A private name written in a subject line was read by no gate at all. Measured here before writing the fix: a commit whose subject named an entry on the local denylist passed the commit gate, exit 0.
- **A merge's content is never staged** in the sense `git diff --cached` means, and git runs `pre-merge-commit` rather than `pre-commit` for one. Every gate in `pre-commit`, the secret scan included, was blind to every merge this repository has made.

## What this does

The three checks move into `.githooks/lib/disclosure-scan.sh`, and three hooks read them from one place:

| Hook | Scans |
|---|---|
| `pre-commit` | the staged diff, as before |
| `pre-merge-commit` (new) | execs `pre-commit`, so a merge is no longer exempt |
| `pre-push` (new) | every outgoing commit's added lines **and its message** |

A push gate covers what a commit gate cannot: a commit made with `--no-verify`, made before a name was added to the list, or made in a checkout whose `core.hooksPath` was never set is already in history by push time. A public repository's history cannot be un-published.

## Bounded so it refuses only what it should

Pre-existing content never blocks a push, only what these commits add. A branch deletion is not scanned. The denylist is excluded from its own scan. A missing library refuses the push rather than reporting safety.

The author and committer identity is **not** scanned. It is part of every commit by design and already published, and the first cut of this hook flagged the maintainer's own address on every push. A gate that refuses the normal case gets turned off, and then it gates nothing.

## Gates

`.githooks/test-disclosure-scan.sh`, wired into the `ci` job, holds 15 assertions: a name, a home path and a real address, each watched being refused, in a diff and in a message, plus the controls proving a clean commit still passes and the synthetic allowlist (`alice`, `@example.com`) still works.

Its two riskiest fixtures are assembled at runtime rather than written out, because spelled literally they **are** the disclosure and the file could not be committed past the gate it tests. That is measured, not hypothetical: the first version of it was refused, correctly.

The suite lives beside the hooks rather than under `scripts/` so that adding a test costs no exemption in the release-version gate's shippable-file list, which is duplicated across two files by design.

This branch's own push was the first real exercise of the new hook: it printed `pre-push: disclosure scan clean (1 commit(s))`.

https://claude.ai/code/session_01SKUTn6SXT7NvVrihufNoPm
