### PR TITLE
fix: six audit findings, batched for one version bump

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -79,7 +79,17 @@ fi
 [ -n "$target_dir" ] || target_dir="${CARGO_TARGET_DIR:-$repo_root/target}"
 bin="$target_dir/release/tcr"
 
-log=$(mktemp -t tcr-post-merge)
+# `mktemp -t <name>` without X's is BSD-only. GNU coreutils refuses it outright
+# ("too few X's in template"), and a Claude Code session on this machine runs
+# with GNU tools first on PATH, so this line failed there while working perfectly
+# in a login zsh. The consequence was worse than a missing temp file: `log` came
+# back empty, `>"$log"` redirected to an empty path, the build never ran, and the
+# hook took its failure branch and reported a build failure for a build that was
+# never attempted. Measured 2026-09-12 on a real merge.
+log=$(mktemp -t tcr-post-merge.XXXXXX) || {
+  echo "post-merge: mktemp failed, so the release rebuild was NOT attempted." >&2
+  exit 0
+}
 if cargo build --release >"$log" 2>&1; then
   rm -f "$log"
   # Replacing the release binary does NOT disturb a running server: on Unix the

--- a/.github/workflows/appcast-guard.yml
+++ b/.github/workflows/appcast-guard.yml
@@ -36,6 +36,36 @@
 # real TcrBar release (which uploads its own, with the new version's entry and a
 # matching enclosure length) is never overwritten by the repository's copy.
 # Order does not matter: whichever of the two runs second is a no-op.
+#
+# KEPT, BUT REDUCED IN SCOPE — read before touching the `on:` block below.
+#
+# SUFeedURL no longer points at `/releases/latest/download/appcast.xml` as of
+# the gh-pages feed (apps/macos/scripts/publish-appcast-feed.sh,
+# docs/RELEASING.md § "The update feed"). For a build carrying that fix, the
+# whole class this guard exists for is structurally impossible: the feed lives
+# on refs/heads/gh-pages, which the CLI release workflow
+# (.github/workflows/release.yml) never touches, so a CLI-only release cannot
+# become the feed regardless of what `/releases/latest/` resolves to. This
+# guard is kept anyway because every copy built BEFORE that fix still carries
+# the old URL and stays exposed to exactly this failure until it updates —
+# which it can only do by successfully reaching the feed at least once, so
+# `/releases/latest/download/appcast.xml` must keep resolving for them in the
+# meantime.
+#
+# THE TRIGGER BELOW HAS BEEN DEAD SINCE THIS FILE WAS WRITTEN, not from any
+# change in this commit. GitHub does not fire `release: published` for a
+# release created by a workflow using the default `GITHUB_TOKEN` (the anti-
+# recursion rule that also keeps a `GITHUB_TOKEN`-authored push from
+# retriggering `push`-triggered workflows) — and `release.yml` (cargo-dist) is
+# exactly that: `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`. So the automatic path
+# has never once run against the release type that orphaned the feed on
+# 2026-08-27; only a release published by a human through the UI, or with a
+# personal token, would fire it. This is not being repaired here — see the
+# task this file's change came from — but it is also not a reason to delete
+# the job: `workflow_dispatch` does not depend on that event at all, so
+# `scripts/guard-appcast-window.sh`-style manual repair
+# (`gh workflow run "Appcast feed guard" -f tag=vX.Y.Z`) still works exactly as
+# documented, on demand, independent of whether the auto-trigger ever fires.
 name: Appcast feed guard
 
 on:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.45"
+version = "0.2.46"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "teamclaude-rs"
-version = "0.2.45"
+version = "0.2.46"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/apps/macos/scripts/build-tcrbar.sh
+++ b/apps/macos/scripts/build-tcrbar.sh
@@ -46,7 +46,17 @@ url_scheme="tcrbar"
 
 # Where the appcast lives. Sparkle reads this out of Info.plist at runtime, so it
 # is written once here rather than compiled into the app.
-feed_url="https://github.com/dhkts1/teamclaude-rs/releases/latest/download/appcast.xml"
+#
+# NOT `releases/latest/download/appcast.xml` any more. `/releases/latest/`
+# follows whichever GitHub Release is newest, including a CLI-only cargo-dist
+# release that carries no appcast — the fifth time that broke every installed
+# copy's updater was 2026-08-27 (v0.2.27). This points at a fixed location on
+# the `gh-pages` branch instead, which only `publish-appcast-feed.sh` ever
+# writes (see that script and docs/RELEASING.md § "The update feed"), so a
+# CLI-only release can no longer become the feed. raw.githubusercontent.com
+# needs no GitHub Pages configuration — it serves any branch's file content
+# directly.
+feed_url="https://raw.githubusercontent.com/dhkts1/teamclaude-rs/gh-pages/appcast.xml"
 
 # Build stamp. A missing or unreadable .git must never fail the build.
 #

--- a/apps/macos/scripts/publish-appcast-feed.sh
+++ b/apps/macos/scripts/publish-appcast-feed.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Publish apps/macos/appcast.xml to refs/heads/gh-pages as a single committed
+# file, so SUFeedURL (build-tcrbar.sh) is a FIXED location that stops
+# depending on which GitHub Release happens to be `latest`.
+#
+# WHY. `/releases/latest/download/appcast.xml` follows whichever release is
+# newest, including a CLI-only cargo-dist release that carries no appcast.xml.
+# That broke every installed copy's updater five times, most recently
+# 2026-08-27 (v0.2.27) — see docs/RELEASING.md § "The update feed" and the
+# history in .github/workflows/appcast-guard.yml's header. This script is the
+# fix: the feed now lives at a URL only THIS script ever writes, and the
+# tag-triggered cargo-dist workflow (.github/workflows/release.yml) never
+# touches the gh-pages branch, so it cannot become the feed by accident.
+#
+# HOW. Pure git plumbing (hash-object / mktree / commit-tree), never a
+# checkout. This never touches this worktree's index, working tree or HEAD —
+# the exact thing CLAUDE.md's "You are not alone" rule asks every state-
+# mutating git op here to rule out first. It reads one tracked file
+# (apps/macos/appcast.xml) and writes one ref (refs/heads/gh-pages); nothing
+# a sibling session has uncommitted can collide with either.
+#
+# NOT called by release-tcrbar.sh. That script's own header states it
+# performs no git writes, on purpose, because this checkout routinely holds
+# sibling sessions' uncommitted work — wiring this in automatically would make
+# that statement false for a script whose whole design rests on it being true.
+# Run this by hand, once per release, right after release-tcrbar.sh stage 9
+# and once apps/macos/appcast.xml's new <item> is committed to main (see
+# docs/RELEASING.md's "Cutting a release" steps).
+#
+# Usage:
+#   publish-appcast-feed.sh [--dry-run] [--branch gh-pages] [--repo owner/name]
+#
+# Environment:
+#   RELEASE_REPO   owner/name (default: dhkts1/teamclaude-rs, same default
+#                  build-tcrbar.sh's feed_url is hardcoded to)
+#
+# Exit status: 0 when the feed already serves these exact bytes (nothing to
+# push) or the push succeeded. Non-zero on anything else, including a push
+# rejected because refs/heads/gh-pages is protected or push access is
+# missing — this script never falls back to force-pushing around that.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+pkg_dir="$(dirname "$here")"
+repo_root="$(cd "$pkg_dir/../.." && pwd)"
+appcast_path="$pkg_dir/appcast.xml"
+
+die() { printf 'ERROR: %s\n' "$@" >&2; exit 1; }
+note() { printf '    %s\n' "$1"; }
+usage() { sed -n '2,33p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+
+branch="gh-pages"
+dry_run=0
+repo="${RELEASE_REPO:-dhkts1/teamclaude-rs}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) dry_run=1 ;;
+    --branch)  branch="${2:-}"; shift ;;
+    --repo)    repo="${2:-}"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *)         die "unknown argument: $1" ;;
+  esac
+  shift
+done
+
+[ -n "$branch" ] || die "--branch given an empty value."
+[ -n "$repo" ] || die "could not determine owner/repo; pass --repo or set RELEASE_REPO=owner/name."
+[ -f "$appcast_path" ] || die "no appcast at $appcast_path — nothing to publish." \
+  "release-tcrbar.sh stage 8 writes it; run that first."
+
+feed_url="https://raw.githubusercontent.com/$repo/$branch/appcast.xml"
+
+blob_sha="$(git -C "$repo_root" hash-object -w -- "$appcast_path")" \
+  || die "git hash-object failed on $appcast_path."
+
+# Fetch the branch's current tip, if it exists, so the new commit is a child
+# of it rather than a fresh root every time — cheap history, and it is what
+# lets a later `git log origin/gh-pages` show which release changed the feed.
+# A branch that does not exist yet (the very first run) fails this fetch;
+# swallowed, because "no parent" is the correct state for that case, not an
+# error.
+git -C "$repo_root" fetch --quiet origin "refs/heads/$branch" 2>/dev/null || true
+parent_sha="$(git -C "$repo_root" rev-parse --verify -q FETCH_HEAD 2>/dev/null || true)"
+
+if [ -n "$parent_sha" ]; then
+  existing_blob="$(git -C "$repo_root" ls-tree "$parent_sha" -- appcast.xml 2>/dev/null | awk '{print $3}')"
+  if [ "$existing_blob" = "$blob_sha" ]; then
+    note "refs/heads/$branch already serves this exact appcast.xml — nothing to push."
+    note "feed URL: $feed_url"
+    exit 0
+  fi
+fi
+
+tree_sha="$(printf '100644 blob %s\tappcast.xml\n' "$blob_sha" \
+  | git -C "$repo_root" mktree)" || die "git mktree failed."
+
+commit_args=(-m "chore: publish appcast.xml to the gh-pages feed")
+if [ -n "$parent_sha" ]; then
+  commit_args+=(-p "$parent_sha")
+fi
+commit_sha="$(git -C "$repo_root" commit-tree "$tree_sha" "${commit_args[@]}")" \
+  || die "git commit-tree failed."
+
+if [ "$dry_run" = 1 ]; then
+  note "dry run — would push $commit_sha to refs/heads/$branch on $repo"
+  note "(commit object was created locally; nothing was pushed)"
+  note "feed URL once pushed: $feed_url"
+  exit 0
+fi
+
+git -C "$repo_root" push origin "$commit_sha:refs/heads/$branch" \
+  || die "push of $commit_sha to $repo:$branch failed." \
+         "Check push access, and that refs/heads/$branch carries no branch" \
+         "protection this operator's token cannot satisfy."
+
+note "published $appcast_path -> refs/heads/$branch ($commit_sha)"
+note "feed URL: $feed_url"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -99,6 +99,63 @@ Flags:
 - `--tag vX.Y.Z` — must equal `v<Cargo.toml version>`. Mismatch aborts.
 - `--verify-only <path/to/TcrBar.app>` — run the signature asserts against an existing bundle.
 
+## The update feed
+
+`SUFeedURL` (in `apps/macos/scripts/build-tcrbar.sh`) is now a FIXED location:
+
+```
+https://raw.githubusercontent.com/dhkts1/teamclaude-rs/gh-pages/appcast.xml
+```
+
+It used to be `.../releases/latest/download/appcast.xml`, and `/releases/latest/`
+follows whichever GitHub Release is newest — including a CLI-only `release.yml`
+(cargo-dist) release that carries no appcast. That class of bug orphaned the
+feed five times, most recently 2026-08-27 (v0.2.27): the app cannot be fixed by
+shipping a new build, because the broken URL is already compiled into the
+installs that are failing. `.github/workflows/appcast-guard.yml`'s header has
+the full incident history.
+
+The fix removes the lookup rather than repairing it. The feed now lives on the
+`gh-pages` branch, a single committed `appcast.xml`, served directly by
+`raw.githubusercontent.com` — no GitHub Pages configuration needed, because
+that host serves any branch's file content whether or not Pages is enabled for
+the repository. Only `apps/macos/scripts/publish-appcast-feed.sh` ever writes
+that branch, and nothing in `.github/workflows/release.yml` (the CLI path)
+touches it, so a CLI-only release can no longer become the feed — the failure
+class is structurally impossible for any build carrying this fix.
+
+**Run it as its own step, after release-tcrbar.sh stage 9, once the appcast
+entry is committed to main:**
+
+```sh
+apps/macos/scripts/publish-appcast-feed.sh            # pushes gh-pages
+apps/macos/scripts/publish-appcast-feed.sh --dry-run   # shows what it would do, pushes nothing
+```
+
+It is deliberately NOT called by `release-tcrbar.sh` itself. That script's own
+header states it performs no git writes, on purpose, because this checkout
+routinely holds sibling sessions' uncommitted work; wiring a push in
+automatically would make that statement false. The script is idempotent (a
+second run against unchanged bytes is a no-op, reported as such) and writes
+through git plumbing only — `hash-object`/`mktree`/`commit-tree` — never a
+checkout, so it cannot touch this worktree's index or HEAD.
+
+**Old installs are not orphaned by this change.** `release-tcrbar.sh` stage 9
+still uploads `appcast.xml` to the GitHub Release asset, exactly as before, so
+`/releases/latest/download/appcast.xml` keeps resolving for every copy built
+before this fix — those copies still read `SUFeedURL` out of the Info.plist
+they were built with, and only stop depending on `/releases/latest/` once
+they've updated at least once to a build carrying the new URL.
+
+**`.github/workflows/appcast-guard.yml` is kept, not deleted**, specifically
+for that transition window — it still protects the old URL for not-yet-updated
+installs. Its automatic `release: published` trigger has been dead since
+before this change (GitHub does not fire that event for a release a workflow
+published with the default `GITHUB_TOKEN`, which is exactly how `release.yml`
+publishes), and that is documented in the workflow's own header now rather
+than left unsaid. `workflow_dispatch` — the manual repair hatch — does not
+depend on that event and still works.
+
 ## The app shows the release notes after an update
 
 On the first launch of a version the operator has not seen, TcrBar fetches the GitHub Release
@@ -127,6 +184,10 @@ only once notes were actually shown. A fresh install records the current version
 7. **Sparkle signature** — `sign_update` produces the EdDSA signature and byte length.
 8. **Appcast** — a new `<item>` is inserted at the marker comment in `apps/macos/appcast.xml`.
 9. **Publish** — `gh release upload` puts the DMG and `appcast.xml` on the release for the tag.
+10. **Publish the feed** — a separate, manual step: once that `<item>` is committed to main,
+    `apps/macos/scripts/publish-appcast-feed.sh` pushes it to `gh-pages`. This is the step
+    `SUFeedURL` actually reads; step 9's upload now exists only to keep pre-migration installs
+    working. See "The update feed" above.
 
 ## Why there are no signing secrets in GitHub
 
@@ -243,11 +304,17 @@ things they catch are not the same things a previous release passing catches.
 
 ## Known gap: a tag publishes the CLI release before the app is built
 
+**This section describes a gap in the retired `/releases/latest/` feed only.** A build carrying the
+fixed `gh-pages` URL (see "The update feed" above) never reads `/releases/latest/` at all, so this
+timing window cannot affect it — `SUFeedURL` simply doesn't move when `release.yml` fires. It still
+applies to every copy built before that fix, until it updates at least once to a build carrying the
+new URL, which is why the mitigation below is still worth running.
+
 `release.yml` (cargo-dist) fires on the tag push and publishes its GitHub Release immediately, with
 the CLI tarballs attached. The DMG and `appcast.xml` only arrive minutes later, when
 `release-local.sh` finishes. In that window the new tag is the **latest** release and carries no
-`appcast.xml`, so `releases/latest/download/appcast.xml` — the `SUFeedURL` every installed copy
-polls — returns **404**, and no install can check for updates.
+`appcast.xml`, so `releases/latest/download/appcast.xml` — the `SUFeedURL` those older copies
+poll — returns **404**, and they cannot check for updates.
 
 Observed on 0.2.26: confirmed 404 against the live URL, cleared by marking the tag prerelease so
 `latest` fell back to 0.2.25.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -539,6 +539,23 @@ of is how this repo once lost seven hours of prompt-cache to session-affinity be
 off. Check `tcr status` (`http1Only=` on the `source=` line, `http1Only` per row with
 `--json`) or the `"server started"` log line at boot.
 
+## Environment overrides
+
+Two keys are not part of the config file; they are read from the process environment by
+`tcr run` (and by `--group`'s version check, which also launches `claude`) to decide which
+`claude` binary to run. Neither exists in the file above because neither is a setting a
+config edit can change without a rebuild of the session's shell environment anyway.
+
+| env var | default | what it does |
+|---|---|---|
+| `TCR_CLAUDE_BIN` | absent | path or name of the `claude` binary to launch, outranking `CLAUDE_BIN` |
+| `CLAUDE_BIN` | absent | same, as a fallback when `TCR_CLAUDE_BIN` is unset; kept for whatever already sets it outside `tcr` |
+
+Neither set falls back to `claude` resolved from `PATH`, today's only behaviour. **An empty
+value in either counts as unset** — `TCR_CLAUDE_BIN=` left behind by a shell does not
+silently win over a real `CLAUDE_BIN`, and two empty values fall all the way through to the
+`PATH` default.
+
 ## File permissions and secrecy
 
 The config holds live OAuth access and refresh tokens for every account. It is written

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4445,6 +4445,7 @@ mod tests {
                     }),
                     seven_day: None,
                     seven_day_oi: None,
+                    extra_usage_usd: None,
                 })
             })
         }
@@ -5295,6 +5296,7 @@ mod tests {
                         }),
                         seven_day: None,
                         seven_day_oi: None,
+                        extra_usage_usd: None,
                     })
                 } else {
                     Ok(Usage {
@@ -5304,6 +5306,7 @@ mod tests {
                             reset_at_ms: Some(now + 3 * 24 * 60 * 60 * 1000),
                         }),
                         seven_day_oi: None,
+                        extra_usage_usd: None,
                     })
                 }
             })
@@ -5390,12 +5393,14 @@ mod tests {
                         }),
                         seven_day: None,
                         seven_day_oi: None,
+                        extra_usage_usd: None,
                     })
                 } else {
                     Ok(Usage {
                         five_hour: None,
                         seven_day: None,
                         seven_day_oi: None,
+                        extra_usage_usd: None,
                     })
                 }
             })
@@ -5598,6 +5603,7 @@ mod tests {
                     }),
                     seven_day: None,
                     seven_day_oi: None,
+                    extra_usage_usd: None,
                 })
             })
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1112,6 +1112,46 @@ pub fn default_path() -> PathBuf {
 /// An `importFrom`-shaped entry (a bare pointer at another file, resolved by
 /// upstream at startup — not implemented here, see `config-bridge-coder.md`)
 /// has no inline token either, so it falls out through the same check.
+/// The credential-envelope version a later move to the OS keystore will need
+/// to tell an old plaintext shape from a new one. Bumped only when the
+/// on-disk SHAPE of `accessToken`/`refreshToken` changes — never for an
+/// unrelated `Account` field — so a reader can always tell which shape it is
+/// holding before trying to interpret it. `1` is the only shape that has ever
+/// existed: today's plaintext `accessToken`/`refreshToken` strings.
+///
+/// Deliberately NOT an `Account` struct field: `Account` is constructed as a
+/// literal at several dozen call sites across the crate (tests, `oauth.rs`,
+/// `manager/`, …), and giving it a new required field would force every one
+/// of them to name a value that means nothing to them. The version lives
+/// instead as a raw `credentialVersion` key on the JSON object, read and
+/// written directly in [`load`] and [`save`] — the same layer that already
+/// migrates the legacy `throttle` key and renames duplicated accounts by
+/// editing the [`Value`] document rather than the typed struct. A config
+/// written through this path ends up with `credentialVersion` in an
+/// `Account`'s flattened `extra` map, which already exists to carry any key
+/// this crate does not model, and round-trips untouched like any other.
+const CREDENTIAL_VERSION: u64 = 1;
+
+/// `entry`'s `credentialVersion` key, read directly off the raw JSON so
+/// [`load`] can decide before anything is handed to `serde` for typed
+/// deserialization.
+///
+/// - `Ok(None)`: the key is absent — every config written before this lane,
+///   which means version 1 and needs no migration.
+/// - `Ok(Some(v))`: the key is present and reads as a version number.
+/// - `Err(())`: the key is present but is not a shape a version number could
+///   ever take (a string, an object, a negative number, a float) — refused
+///   the same as an unknown future version, because guessing what a
+///   malformed version key meant is exactly the silent reinterpretation this
+///   exists to prevent.
+fn credential_version_of(entry: &Value) -> Result<Option<u64>, ()> {
+    match entry.get("credentialVersion") {
+        None => Ok(None),
+        Some(Value::Number(n)) => n.as_u64().ok_or(()).map(Some),
+        Some(_) => Err(()),
+    }
+}
+
 fn unusable_account(entry: &Value) -> Option<(String, &'static str)> {
     let name = entry
         .get("name")
@@ -1139,6 +1179,11 @@ fn unusable_account(entry: &Value) -> Option<(String, &'static str)> {
 }
 
 /// Load and parse the config at `path`.
+///
+/// Checks every account's `credentialVersion` before anything else touches
+/// the entry — see [`CREDENTIAL_VERSION`] — backfilling an absent key to `1`
+/// in the document and refusing the whole file on a version number this
+/// build does not understand.
 ///
 /// Deserializes leniently at the account boundary: an `accounts[]` entry that
 /// cannot yield a usable credential ([`unusable_account`]) is dropped, with a
@@ -1235,6 +1280,51 @@ pub fn load(path: &Path) -> Result<Config, ConfigError> {
                         error = %err,
                         "legacy `throttle` key does not parse as a throttle config; dropping it"
                     );
+                }
+            }
+        }
+    }
+
+    // Credential-envelope version check, ahead of everything else that reads
+    // an account entry: refuse the whole file rather than silently
+    // reinterpreting a shape a future `tcr` wrote and this build has never
+    // seen. A missing key backfills to version 1 in the document itself, so
+    // the very next `save` writes it explicitly and no migration step is
+    // needed today — see [`CREDENTIAL_VERSION`]'s doc-comment for why this
+    // lives here rather than on `Account`.
+    if let Some(accounts) = doc.get_mut("accounts").and_then(Value::as_array_mut) {
+        for entry in accounts.iter_mut() {
+            let name = entry
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or("<unnamed>")
+                .to_string();
+            match credential_version_of(entry) {
+                Ok(None) => {
+                    if let Some(obj) = entry.as_object_mut() {
+                        obj.insert(
+                            "credentialVersion".to_string(),
+                            Value::Number(CREDENTIAL_VERSION.into()),
+                        );
+                    }
+                }
+                Ok(Some(v)) if v > CREDENTIAL_VERSION => {
+                    return Err(ConfigError::Parse(
+                        <serde_json::Error as serde::de::Error>::custom(format!(
+                            "account \"{name}\" carries credentialVersion {v}, which this build \
+                             only understands up to {CREDENTIAL_VERSION}; refusing to load rather \
+                             than silently reinterpret its credential shape"
+                        )),
+                    ));
+                }
+                Ok(Some(_)) => {}
+                Err(()) => {
+                    return Err(ConfigError::Parse(
+                        <serde_json::Error as serde::de::Error>::custom(format!(
+                            "account \"{name}\" carries a credentialVersion that is not a \
+                             version number; refusing to load rather than guess what it means"
+                        )),
+                    ));
                 }
             }
         }
@@ -3325,6 +3415,118 @@ mod tests {
         let reloaded: Config = serde_json::from_str(&fs::read_to_string(&tmp).unwrap()).unwrap();
         assert_eq!(reloaded.accounts[0].groups, config.accounts[0].groups);
         fs::remove_file(&tmp).ok();
+    }
+
+    // --- load: the credential envelope declares its version ------------------
+
+    /// A config written before `credentialVersion` existed loads exactly as
+    /// it always has (no version key at all), and the very next `save` now
+    /// writes `credentialVersion: 1` explicitly — nothing migrates by hand,
+    /// and a later build can tell "this file predates the key" from "this
+    /// file explicitly says version 1" apart, by there being no difference
+    /// left to see.
+    #[test]
+    fn missing_credential_version_loads_as_version_1_and_backfills_on_save() {
+        let path = tmp_path("cred-version-missing");
+        fs::write(
+            &path,
+            r#"{ "accounts": [
+                 { "name": "acct-a", "accessToken": "at-a", "refreshToken": "rt-a" }
+               ] }"#,
+        )
+        .unwrap();
+
+        let config = load(&path).unwrap();
+        assert_eq!(config.accounts.len(), 1);
+        assert_eq!(config.accounts[0].access_token, "at-a");
+
+        let saved = tmp_path("cred-version-missing-saved");
+        save(&saved, &config).unwrap();
+        let value = read_json(&saved);
+        assert_eq!(
+            value["accounts"][0]["credentialVersion"],
+            serde_json::json!(1),
+            "a config with no credentialVersion key must re-save with it: {value}"
+        );
+
+        fs::remove_file(&path).ok();
+        fs::remove_file(&saved).ok();
+    }
+
+    /// An explicit `"credentialVersion": 1` — what every config saved after
+    /// this lane carries — loads and round-trips unchanged.
+    #[test]
+    fn explicit_credential_version_1_round_trips() {
+        let path = tmp_path("cred-version-explicit");
+        fs::write(
+            &path,
+            r#"{ "accounts": [
+                 { "name": "acct-a", "accessToken": "at-a", "credentialVersion": 1 }
+               ] }"#,
+        )
+        .unwrap();
+
+        let config = load(&path).unwrap();
+        assert_eq!(config.accounts.len(), 1);
+
+        let saved = tmp_path("cred-version-explicit-saved");
+        save(&saved, &config).unwrap();
+        let value = read_json(&saved);
+        assert_eq!(
+            value["accounts"][0]["credentialVersion"],
+            serde_json::json!(1)
+        );
+
+        fs::remove_file(&path).ok();
+        fs::remove_file(&saved).ok();
+    }
+
+    /// A `credentialVersion` this build has never heard of refuses the WHOLE
+    /// file rather than guessing what the newer shape means — the exact
+    /// failure a later move to the OS keystore needs this lane to catch.
+    #[test]
+    fn unknown_future_credential_version_refuses_to_load() {
+        let path = tmp_path("cred-version-future");
+        fs::write(
+            &path,
+            r#"{ "accounts": [
+                 { "name": "acct-a", "accessToken": "at-a", "credentialVersion": 2 }
+               ] }"#,
+        )
+        .unwrap();
+
+        let err = load(&path).expect_err("an unknown credentialVersion must refuse to load");
+        let message = err.to_string();
+        assert!(
+            message.contains("acct-a") && message.contains('2'),
+            "error should name the account and the unknown version: {message}"
+        );
+
+        fs::remove_file(&path).ok();
+    }
+
+    /// A `credentialVersion` that is present but not a number at all (a
+    /// hand-edited file, a half-written migration from some other tool) is
+    /// refused the same way an unknown future number is — never silently
+    /// treated as version 1.
+    #[test]
+    fn malformed_credential_version_refuses_to_load() {
+        let path = tmp_path("cred-version-malformed");
+        fs::write(
+            &path,
+            r#"{ "accounts": [
+                 { "name": "acct-a", "accessToken": "at-a", "credentialVersion": "v1" }
+               ] }"#,
+        )
+        .unwrap();
+
+        let err = load(&path).expect_err("a non-numeric credentialVersion must refuse to load");
+        assert!(
+            err.to_string().contains("acct-a"),
+            "error should name the account: {err}"
+        );
+
+        fs::remove_file(&path).ok();
     }
 
     // --- load: skip unusable accounts, keep the rest -------------------------

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -67,6 +67,7 @@ fn base(name: &str, priority: i64) -> AccountRuntime {
         // a permanently un-warmable account.
         quota_known: true,
         consecutive_probe_failures: 0,
+        consecutive_5xx_probes: 0,
         consecutive_warms_without_evidence: 0,
         warm_evidence_retry_after_ms: None,
         input_tokens: 0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -693,6 +693,58 @@ fn run_ui() -> anyhow::Result<()> {
     anyhow::bail!("`tcr ui` opens the macOS menu-bar app, and this is not macOS.")
 }
 
+/// `TCR_CLAUDE_BIN` overrides which `claude` binary we launch, taking
+/// priority over the legacy `CLAUDE_BIN` (kept for compatibility with
+/// whatever already sets it outside tcr); neither set falls back to `claude`
+/// on `PATH`. An empty value in either counts as unset — `TCR_CLAUDE_BIN=`
+/// left behind by a shell must not silently win over a real `CLAUDE_BIN`.
+const TCR_CLAUDE_BIN_ENV: &str = "TCR_CLAUDE_BIN";
+/// See [`TCR_CLAUDE_BIN_ENV`].
+const CLAUDE_BIN_ENV: &str = "CLAUDE_BIN";
+
+/// Resolves which `claude` binary to launch, through the ordered pair of env
+/// keys documented at [`TCR_CLAUDE_BIN_ENV`]. Named generally — "harness",
+/// not "claude" — because a second external harness binary will need this
+/// exact resolution order later; that second binary is not built here, but
+/// the helper already takes its own key names and default so adding it is a
+/// new pair of constants and a one-line call, not a rewrite of this function.
+fn resolve_harness_bin(specific_key: &str, legacy_key: &str, default: &str) -> String {
+    resolve_harness_bin_from(
+        std::env::var(specific_key).ok(),
+        std::env::var(legacy_key).ok(),
+        default,
+    )
+}
+
+/// [`resolve_harness_bin`]'s pure half, split out so the precedence order and
+/// the empty-string-counts-as-unset rule are unit-testable without mutating
+/// process-global env vars (which is unsound to do from parallel tests).
+fn resolve_harness_bin_from(
+    specific: Option<String>,
+    legacy: Option<String>,
+    default: &str,
+) -> String {
+    for value in [specific, legacy].into_iter().flatten() {
+        if !value.is_empty() {
+            return value;
+        }
+    }
+    default.to_string()
+}
+
+/// The `claude` binary this process should launch or probe, per
+/// [`resolve_harness_bin`].
+fn claude_bin() -> String {
+    resolve_harness_bin(TCR_CLAUDE_BIN_ENV, CLAUDE_BIN_ENV, "claude")
+}
+
+/// A fresh [`std::process::Command`] for [`claude_bin`] — the one place that
+/// spawns or would spawn the user's harness, so every call site resolves the
+/// same way.
+fn claude_command() -> std::process::Command {
+    std::process::Command::new(claude_bin())
+}
+
 /// `tcr run [-- args…]` — launch Claude Code already pointed at this proxy.
 ///
 /// Mirrors the JS `teamclaude run` passthrough contract: if the proxy is not
@@ -733,7 +785,7 @@ fn run_claude(args: RunArgs) -> anyhow::Result<()> {
         }
     }
 
-    let mut cmd = std::process::Command::new("claude");
+    let mut cmd = claude_command();
     cmd.args(&args.args);
     mark_run_active(&mut cmd);
 
@@ -844,10 +896,7 @@ enum ClaudeVersionCheck {
 }
 
 fn check_claude_version() -> ClaudeVersionCheck {
-    let output = match std::process::Command::new("claude")
-        .arg("--version")
-        .output()
-    {
+    let output = match claude_command().arg("--version").output() {
         Ok(o) if o.status.success() => o,
         _ => return ClaudeVersionCheck::Unknown,
     };
@@ -1693,6 +1742,54 @@ mod tests {
         }
     }
 
+    /// `TCR_CLAUDE_BIN` outranks `CLAUDE_BIN` when both are set.
+    #[test]
+    fn tcr_claude_bin_wins_over_the_legacy_key() {
+        assert_eq!(
+            resolve_harness_bin_from(
+                Some("/opt/beta/claude".to_string()),
+                Some("/opt/legacy/claude".to_string()),
+                "claude",
+            ),
+            "/opt/beta/claude",
+        );
+    }
+
+    /// `CLAUDE_BIN` is used when the tcr-specific key is unset.
+    #[test]
+    fn claude_bin_is_the_fallback_when_tcr_claude_bin_is_unset() {
+        assert_eq!(
+            resolve_harness_bin_from(None, Some("/opt/legacy/claude".to_string()), "claude"),
+            "/opt/legacy/claude",
+        );
+    }
+
+    /// An empty value counts as unset, for either key — a shell that leaves
+    /// `TCR_CLAUDE_BIN=` behind must not silently win over a real `CLAUDE_BIN`.
+    #[test]
+    fn an_empty_value_is_treated_as_missing() {
+        assert_eq!(
+            resolve_harness_bin_from(
+                Some(String::new()),
+                Some("/opt/legacy/claude".to_string()),
+                "claude",
+            ),
+            "/opt/legacy/claude",
+            "an empty TCR_CLAUDE_BIN must fall through to CLAUDE_BIN"
+        );
+        assert_eq!(
+            resolve_harness_bin_from(Some(String::new()), Some(String::new()), "claude"),
+            "claude",
+            "two empty values must fall through to the default"
+        );
+    }
+
+    /// Neither key set falls back to the default (`claude` on `PATH`).
+    #[test]
+    fn neither_key_set_falls_back_to_the_default() {
+        assert_eq!(resolve_harness_bin_from(None, None, "claude"), "claude");
+    }
+
     /// Pins that a configured proxy key is withheld from `claude`, and says why.
     #[test]
     fn the_proxy_key_is_withheld_from_claude_with_the_reason() {
@@ -1733,7 +1830,7 @@ mod tests {
                 &(|cmd: &mut std::process::Command| apply_base_url_env(cmd, 3456)),
             ),
         ] {
-            let mut cmd = std::process::Command::new("claude");
+            let mut cmd = claude_command();
             apply(&mut cmd);
             assert!(
                 !cmd.get_envs()
@@ -1759,7 +1856,7 @@ mod tests {
              launcher that reads it ever runs"
         );
 
-        let mut cmd = std::process::Command::new("claude");
+        let mut cmd = claude_command();
         mark_run_active(&mut cmd);
         assert!(
             cmd.get_envs()

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -281,6 +281,14 @@ pub struct AccountRuntime {
     /// probe fails forever, so gating on it unconditionally makes keep-warm
     /// structurally dark. See [`PROBE_FAILURES_BEFORE_WARMING_UNPROBED`].
     pub consecutive_probe_failures: u32,
+    /// Consecutive 5xx probe reads, counted separately from
+    /// `consecutive_probe_failures` above: a 429 self-clears and must reset
+    /// this to `0` the same as a success does, so it is never conflated with a
+    /// real outage. Bumped and read by [`Manager::probe_account`] via its
+    /// private `note_5xx_probe` helper to escalate `ProbeStatus::RateLimited`
+    /// to the visible `ProbeStatus::UpstreamDown` once a run crosses
+    /// `SUSTAINED_5XX_THRESHOLD` (`manager/probing.rs`).
+    pub consecutive_5xx_probes: u32,
     /// Consecutive keep-warm requests ([`Manager::warm_account`]) that succeeded
     /// but carried none of the unified 5h rate-limit headers — a 200 that latched
     /// no evidence. Reset to `0` only by a response (warm or served) whose
@@ -611,6 +619,7 @@ impl AccountRuntime {
             // every account's quota is genuinely unread.
             quota_known: false,
             consecutive_probe_failures: 0,
+            consecutive_5xx_probes: 0,
             consecutive_warms_without_evidence: 0,
             warm_evidence_retry_after_ms: None,
             input_tokens: 0,
@@ -3286,6 +3295,7 @@ mod tests {
                         }),
                         seven_day: None,
                         seven_day_oi: None,
+                        extra_usage_usd: None,
                     })
                 } else {
                     Err(ProbeError {
@@ -3333,6 +3343,7 @@ mod tests {
                         }),
                         seven_day: None,
                         seven_day_oi: None,
+                        extra_usage_usd: None,
                     })
                 } else {
                     Err(ProbeError {
@@ -3362,6 +3373,7 @@ mod tests {
                         reset_at_ms: Some(crate::now_ms() + 86_400_000),
                     }),
                     seven_day_oi: None,
+                    extra_usage_usd: None,
                 })
             })
         }
@@ -6491,6 +6503,160 @@ mod tests {
         assert!(snap.accounts[0].probe_error.is_some());
     }
 
+    /// A prober that always fails with a fixed HTTP status — for pinning exactly
+    /// how many consecutive reads of a given status it takes (or does not take)
+    /// to move `probe_status` past the benign `RateLimited`.
+    struct AlwaysStatusProber {
+        status: u16,
+    }
+    impl UsageProber for AlwaysStatusProber {
+        fn probe(&self, _access_token: String) -> ProbeFuture {
+            let status = self.status;
+            Box::pin(async move {
+                Err(ProbeError {
+                    status: Some(status),
+                    message: "upstream boom".into(),
+                    retry_after_secs: None,
+                })
+            })
+        }
+    }
+
+    /// 1b, the half of the fix `probe_429_is_rate_limited_and_keeps_last_utilization`
+    /// does not cover: ONE 5xx read is still the same benign, self-clearing
+    /// `RateLimited` a 429 gets — it must NOT jump straight to the visible
+    /// escalated state on the first hiccup.
+    #[tokio::test]
+    async fn a_single_5xx_probe_stays_rate_limited() {
+        let manager = build_manager_with_prober(
+            config_with(vec![account("a", 0)]),
+            pacing_refresher(),
+            Arc::new(AlwaysStatusProber { status: 503 }),
+        );
+
+        manager.probe_all().await;
+        let snap = manager.snapshot(OffsetDateTime::now_utc());
+        assert_eq!(
+            snap.accounts[0].probe_status,
+            ProbeStatus::RateLimited,
+            "a lone 5xx is a hiccup, same as a 429 — not yet the sustained-outage state"
+        );
+    }
+
+    /// 1b, the other half: a SUSTAINED run of 5xx reads — as opposed to the
+    /// single hiccup above — is first-hand evidence the usage endpoint itself is
+    /// down, and must escalate to the visible `UpstreamDown` rather than keep
+    /// hiding behind `RateLimited` forever.
+    #[tokio::test]
+    async fn sustained_5xx_probes_escalate_to_upstream_down() {
+        let manager = build_manager_with_prober(
+            config_with(vec![account("a", 0)]),
+            pacing_refresher(),
+            Arc::new(AlwaysStatusProber { status: 502 }),
+        );
+
+        for sweep in 1..crate::manager::probing::SUSTAINED_5XX_THRESHOLD {
+            manager.probe_all().await;
+            let snap = manager.snapshot(OffsetDateTime::now_utc());
+            assert_eq!(
+                snap.accounts[0].probe_status,
+                ProbeStatus::RateLimited,
+                "sweep {sweep}: below the threshold, still the benign label"
+            );
+        }
+
+        // The crossing sweep.
+        manager.probe_all().await;
+        let snap = manager.snapshot(OffsetDateTime::now_utc());
+        assert_eq!(
+            snap.accounts[0].probe_status,
+            ProbeStatus::UpstreamDown,
+            "a sustained run of 5xx must surface as its own visible status"
+        );
+    }
+
+    /// The counters driving the two statuses above must be genuinely
+    /// independent: a 429 never contributes to the sustained-5xx count, so an
+    /// account that is merely self-throttled — however many times in a row —
+    /// must never be mistaken for a real outage.
+    #[tokio::test]
+    async fn repeated_429s_never_escalate_to_upstream_down() {
+        let manager = build_manager_with_prober(
+            config_with(vec![account("a", 0)]),
+            pacing_refresher(),
+            Arc::new(AlwaysStatusProber { status: 429 }),
+        );
+
+        for _ in 0..(crate::manager::probing::SUSTAINED_5XX_THRESHOLD * 3) {
+            manager.probe_all().await;
+        }
+        let snap = manager.snapshot(OffsetDateTime::now_utc());
+        assert_eq!(
+            snap.accounts[0].probe_status,
+            ProbeStatus::RateLimited,
+            "a self-throttle stays benign no matter how many times it repeats"
+        );
+    }
+
+    /// A success between two 5xx runs must reset the sustained-5xx count, the
+    /// same way it resets `consecutive_probe_failures` — a brief recovery in the
+    /// middle is not "the endpoint has been down the whole time".
+    #[tokio::test]
+    async fn a_success_between_5xx_runs_resets_the_sustained_count() {
+        let state = Arc::new(std::sync::Mutex::new(0usize));
+
+        struct FlakyProber {
+            state: Arc<std::sync::Mutex<usize>>,
+        }
+        impl UsageProber for FlakyProber {
+            fn probe(&self, _access_token: String) -> ProbeFuture {
+                let mut n = self.state.lock().expect("lock poisoned");
+                *n += 1;
+                // 5xx, 5xx, OK, 5xx, 5xx — never THREE in a row.
+                let fail = matches!(*n, 1 | 2 | 4 | 5);
+                let call = *n;
+                drop(n);
+                Box::pin(async move {
+                    if fail {
+                        Err(ProbeError {
+                            status: Some(500),
+                            message: format!("upstream boom #{call}"),
+                            retry_after_secs: None,
+                        })
+                    } else {
+                        Ok(Usage {
+                            five_hour: Some(UsageBucket {
+                                utilization: Some(0.1),
+                                reset_at_ms: Some(crate::now_ms() + 3_600_000),
+                            }),
+                            seven_day: None,
+                            seven_day_oi: None,
+                            extra_usage_usd: None,
+                        })
+                    }
+                })
+            }
+        }
+
+        let manager = build_manager_with_prober(
+            config_with(vec![account("a", 0)]),
+            pacing_refresher(),
+            Arc::new(FlakyProber { state }),
+        );
+
+        for _ in 0..5 {
+            manager.probe_all().await;
+        }
+        let snap = manager.snapshot(OffsetDateTime::now_utc());
+        assert_eq!(
+            snap.accounts[0].probe_status,
+            ProbeStatus::RateLimited,
+            "two 5xx, a success, then two more 5xx is never THREE IN A ROW — \
+             the intervening success must have reset the count, or this reads \
+             as UpstreamDown for a run that was never actually sustained"
+        );
+    }
+
     #[tokio::test]
     async fn probe_retry_after_blocks_the_next_probe_until_it_expires() {
         let calls = Arc::new(AtomicUsize::new(0));
@@ -8430,6 +8596,7 @@ mod tests {
                     utilization: Some(0.99),
                     reset_at_ms: Some(reset_ms),
                 }),
+                extra_usage_usd: None,
             },
         );
         // A FABLE request (`is_fable = true`) is the only one gated by the 7d_oi
@@ -10483,6 +10650,7 @@ mod tests {
             five_hour: None,
             seven_day: None,
             seven_day_oi: None,
+            extra_usage_usd: None,
         };
         for cycle in 0..5 {
             manager.apply_usage(0, &headerless_probe);

--- a/src/manager/probing.rs
+++ b/src/manager/probing.rs
@@ -4,6 +4,15 @@ use super::*;
 
 const PROBE_MAX_RETRY_AFTER_SECS: u64 = 7 * 24 * 60 * 60;
 
+/// Consecutive 5xx probe reads, counted separately from every other failure
+/// kind, that escalate an account's probe health from the benign `RateLimited`
+/// to the visible `ProbeStatus::UpstreamDown`. Mirrors
+/// `PROBE_FAILURES_BEFORE_WARMING_UNPROBED` in shape (three is a hiccup, not a
+/// verdict) but must stay its own counter: a 429 self-clears and must never
+/// feed this, or a benign self-throttle would get painted with the same
+/// "endpoint is down" signal a sustained 5xx run is.
+pub(crate) const SUSTAINED_5XX_THRESHOLD: u32 = 3;
+
 impl Manager {
     /// Record the health of account `idx`'s most recent probe. A failing probe
     /// stamps a visible status + message (never a silently-frozen bar), while an
@@ -42,7 +51,10 @@ impl Manager {
                 }
                 // Not a terminal outcome; it says nothing either way.
                 ProbeStatus::Never => false,
-                ProbeStatus::Error | ProbeStatus::Timeout | ProbeStatus::RateLimited => {
+                ProbeStatus::Error
+                | ProbeStatus::Timeout
+                | ProbeStatus::RateLimited
+                | ProbeStatus::UpstreamDown => {
                     account.consecutive_probe_failures =
                         account.consecutive_probe_failures.saturating_add(1);
                     if status == ProbeStatus::RateLimited {
@@ -74,6 +86,26 @@ impl Manager {
             // after becoming eligible.
             self.warm_wake.notify_one();
         }
+    }
+
+    /// Track SUSTAINED (not merely occasional) 5xx reads from the usage
+    /// endpoint, kept separately from `consecutive_probe_failures`: that counter
+    /// is bumped by every failure kind alike, so folding 5xx into it would let a
+    /// 429 and a real outage contribute to the same signal. A 429 self-clears
+    /// and must reset this counter to `0`, same as a success does. Returns the
+    /// count AFTER this update, so the caller compares it to
+    /// [`SUSTAINED_5XX_THRESHOLD`] in the same breath.
+    fn note_5xx_probe(&self, idx: usize, is_5xx: bool) -> u32 {
+        let mut accounts = self.accounts.write().expect("accounts lock poisoned");
+        let Some(account) = accounts.get_mut(idx) else {
+            return 0;
+        };
+        account.consecutive_5xx_probes = if is_5xx {
+            account.consecutive_5xx_probes.saturating_add(1)
+        } else {
+            0
+        };
+        account.consecutive_5xx_probes
     }
 
     /// The OAuth account indices eligible for a usage probe: an OAuth account with a
@@ -191,24 +223,45 @@ impl Manager {
         match result {
             Ok(usage) => {
                 self.apply_usage(idx, &usage);
+                // A successful read is first-hand evidence the endpoint is up —
+                // clear any run of 5xx reads the same way a 429's self-clearing
+                // resets it below.
+                self.note_5xx_probe(idx, false);
                 self.record_probe(idx, ProbeStatus::Ok, None, None);
             }
             Err(err) => {
                 let msg = err.message.to_lowercase();
                 let is_timeout = msg.contains("timed out") || msg.contains("timeout");
+                let is_5xx = matches!(err.status, Some(s) if (500..=599).contains(&s));
                 // A failing probe never blanks the last-learned bar (no apply_usage
                 // on this path), so the only question is how loud to be. Soften only
                 // ENDPOINT-side failures where the credential is provably fine: a 429
-                // (the usage endpoint throttling the probe itself) or a transient 5xx
-                // read as a benign, self-clearing `RateLimited`, never the false
-                // fleet-wide "error" a bursted sweep used to paint. But a TRANSPORT
-                // failure (no HTTP status, not a timeout — connection refused, DNS/TLS,
-                // a proxy-env regression) stays a visible `Error`: a persistent one is
-                // a real connectivity problem and must NOT hide behind a benign label
-                // (probe health is first-class — masking it defeats the point).
+                // (the usage endpoint throttling the probe itself) reads as a benign,
+                // self-clearing `RateLimited`, never the false fleet-wide "error" a
+                // bursted sweep used to paint — and it always stays `RateLimited`
+                // regardless of how many in a row, because a 429 is tcr's own
+                // self-throttle tripping the endpoint's burst limit and clears the
+                // moment the burst ends. A 5xx is different: one or two is still the
+                // same benign, self-clearing `RateLimited` a 429 gets, but a SUSTAINED
+                // run — `SUSTAINED_5XX_THRESHOLD` consecutive reads — is first-hand
+                // evidence the endpoint itself is down, not self-throttling, and must
+                // escalate to its own visible `UpstreamDown` rather than keep hiding
+                // behind the benign label forever. A TRANSPORT failure (no HTTP
+                // status, not a timeout — connection refused, DNS/TLS, a proxy-env
+                // regression) stays a visible `Error` from the first read: a
+                // persistent one is a real connectivity problem and must NOT hide
+                // behind a benign label (probe health is first-class — masking it
+                // defeats the point).
+                let consecutive_5xx = self.note_5xx_probe(idx, is_5xx);
                 let status = match err.status {
                     Some(429) => ProbeStatus::RateLimited,
-                    Some(s) if (500..=599).contains(&s) => ProbeStatus::RateLimited,
+                    Some(s) if (500..=599).contains(&s) => {
+                        if consecutive_5xx >= SUSTAINED_5XX_THRESHOLD {
+                            ProbeStatus::UpstreamDown
+                        } else {
+                            ProbeStatus::RateLimited
+                        }
+                    }
                     Some(_) => ProbeStatus::Error,
                     None if is_timeout => ProbeStatus::Timeout,
                     None => ProbeStatus::Error,

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -64,11 +64,20 @@ pub struct UsageBucket {
 
 /// The normalized buckets a single probe yields. `seven_day_oi` is the
 /// model-scoped (Fable) weekly, pulled from the payload's `limits[]` array.
+/// `extra_usage_usd` is not a bucket at all — see its own doc-comment.
 #[derive(Debug, Clone, Default)]
 pub struct Usage {
     pub five_hour: Option<UsageBucket>,
     pub seven_day: Option<UsageBucket>,
     pub seven_day_oi: Option<UsageBucket>,
+    /// Real, already-billed pay-as-you-go overage in USD, from the payload's
+    /// `extra_usage` field. Unlike the three buckets above this is not a
+    /// percentage of a limit — it is a dollar amount tcr cannot derive from
+    /// response headers, so today's display falls back to `src/pricing.rs`'s
+    /// synthetic token-counted estimate. `None` means "the endpoint did not
+    /// report this field" or "its shape was not one we recognise" — never a
+    /// fabricated `0.0`; see [`parse_extra_usage_usd`].
+    pub extra_usage_usd: Option<f64>,
 }
 
 /// Why a probe failed. `status` carries the HTTP code when there was one — the
@@ -181,6 +190,29 @@ pub fn find_scoped_weekly_limit(data: &Value, needle: &str) -> Option<Value> {
     Some(Value::Object(bucket))
 }
 
+/// Pull the real, already-billed pay-as-you-go overage (in USD) out of the
+/// payload's `extra_usage` field.
+///
+/// The endpoint's exact shape for this field is as undocumented as the
+/// `limits[]` naming [`find_scoped_weekly_limit`] works around, so the same
+/// style applies here: try the plausible key names instead of betting on one,
+/// and let anything that does not match read as absent rather than `0.0`. A
+/// bare numeric `extra_usage` (no wrapping object) is accepted too, since a
+/// scalar dollar figure is at least as plausible as an object carrying one.
+fn parse_extra_usage_usd(data: &Value) -> Option<f64> {
+    let value = data.get("extra_usage")?;
+    if value.is_null() {
+        return None;
+    }
+    if let Some(scalar) = parse_pct(value) {
+        return Some(scalar);
+    }
+    ["amount", "amount_usd", "usd", "total_usd", "cost", "value"]
+        .iter()
+        .find_map(|k| value.get(*k))
+        .and_then(parse_pct)
+}
+
 /// Turn a parsed usage-endpoint payload into normalized buckets.
 pub fn usage_from_payload(data: &Value) -> Usage {
     let fable = find_scoped_weekly_limit(data, "fable");
@@ -188,6 +220,7 @@ pub fn usage_from_payload(data: &Value) -> Usage {
         five_hour: normalize_usage_bucket(data.get("five_hour")),
         seven_day: normalize_usage_bucket(data.get("seven_day")),
         seven_day_oi: normalize_usage_bucket(fable.as_ref()),
+        extra_usage_usd: parse_extra_usage_usd(data),
     }
 }
 
@@ -369,6 +402,15 @@ pub enum ProbeStatus {
     /// (this path never calls `apply_usage`), so it must NOT read as a red error —
     /// a probe 429 painting "error" on every row is exactly the bug this fixes.
     RateLimited,
+    /// A SUSTAINED run of consecutive 5xx reads from the usage endpoint — as
+    /// opposed to one or a few, which still read as the benign `RateLimited`
+    /// above. One or two 5xx is a hiccup the endpoint clears on its own; a run
+    /// that keeps going is first-hand evidence the endpoint itself is down, and
+    /// probe health being first-class means that must surface as its own
+    /// visible state rather than keep hiding behind `RateLimited`'s "benign,
+    /// self-clearing" label forever. See `Manager::probe_account`'s
+    /// `SUSTAINED_5XX_THRESHOLD`.
+    UpstreamDown,
 }
 
 impl ProbeStatus {
@@ -379,6 +421,7 @@ impl ProbeStatus {
             ProbeStatus::Error => "error",
             ProbeStatus::Timeout => "timeout",
             ProbeStatus::RateLimited => "rate-limited",
+            ProbeStatus::UpstreamDown => "upstream-down",
         }
     }
 }
@@ -518,5 +561,70 @@ mod tests {
             serde_json::json!({ "used_percentage": 5, "resets_at": "2030-01-01T00:00:00Z" });
         let out = normalize_usage_bucket(Some(&bucket)).unwrap();
         assert!(out.reset_at_ms.is_some());
+    }
+
+    /// 1a: a payload carrying real billed overage under the object shape
+    /// (`{"amount": ...}`) must reach `Usage.extra_usage_usd`, not get dropped
+    /// on the floor the way it is today.
+    #[test]
+    fn extra_usage_object_shape_is_parsed() {
+        let data = serde_json::json!({
+            "five_hour": { "used_percentage": 10 },
+            "extra_usage": { "amount": "12.34" }
+        });
+        let usage = usage_from_payload(&data);
+        assert_eq!(usage.extra_usage_usd, Some(12.34));
+    }
+
+    /// A bare numeric `extra_usage` (no wrapping object) is at least as
+    /// plausible as an object carrying the figure, so it must parse too.
+    #[test]
+    fn extra_usage_bare_numeric_shape_is_parsed() {
+        let data = serde_json::json!({ "extra_usage": 5.5 });
+        let usage = usage_from_payload(&data);
+        assert_eq!(usage.extra_usage_usd, Some(5.5));
+    }
+
+    /// A payload that never mentions `extra_usage` at all must read as absent,
+    /// never as a fabricated `0.0` — the same rule `find_scoped_weekly_limit`'s
+    /// own tests pin for the weekly bucket.
+    #[test]
+    fn extra_usage_absent_field_is_none() {
+        let data = serde_json::json!({ "five_hour": { "used_percentage": 10 } });
+        let usage = usage_from_payload(&data);
+        assert_eq!(usage.extra_usage_usd, None);
+    }
+
+    /// An `extra_usage` present under a shape this parser does not recognise
+    /// (no numeric candidate key, not a bare number) must ALSO read as absent —
+    /// an unknown shape is "we could not read this", not "there is no overage".
+    #[test]
+    fn extra_usage_unrecognised_shape_is_none_not_zero() {
+        let data = serde_json::json!({ "extra_usage": { "currency": "USD", "note": "n/a" } });
+        let usage = usage_from_payload(&data);
+        assert_eq!(
+            usage.extra_usage_usd, None,
+            "an unrecognised shape must not silently become a real-looking 0.0"
+        );
+    }
+
+    /// End to end: a reported overage survives into the tracked `Quota`, and an
+    /// absent one leaves a prior reading in place rather than erasing it.
+    #[test]
+    fn extra_usage_reaches_quota_and_survives_an_unread_probe() {
+        let with_overage = usage_from_payload(&serde_json::json!({
+            "extra_usage": { "amount": 7.0 }
+        }));
+        let mut quota = crate::quota::Quota::default();
+        quota.apply_usage(&with_overage);
+        assert_eq!(quota.extra_usage_usd, Some(7.0));
+
+        let without_overage = usage_from_payload(&serde_json::json!({ "five_hour": {} }));
+        quota.apply_usage(&without_overage);
+        assert_eq!(
+            quota.extra_usage_usd,
+            Some(7.0),
+            "an unread probe must not erase a previously learned overage"
+        );
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -3854,11 +3854,27 @@ fn usage_record(
 }
 
 /// Parse the token breakdown from a non-streamed JSON messages body.
+///
+/// A body that is not JSON is logged once, at warn: it means this turn's tokens
+/// are missing from the ledger, which is exactly the kind of silent undercount
+/// the usage ledger's own write-failure policy exists to make visible. Only the
+/// serde error and the body LENGTH are logged, never any body content, because a
+/// request body carries the user's prompt and this repository is public.
 fn usage_from_json(bytes: &[u8]) -> ParsedUsage {
-    let Ok(value) = serde_json::from_slice::<Value>(bytes) else {
-        return ParsedUsage::default();
+    let value = match serde_json::from_slice::<Value>(bytes) {
+        Ok(value) => value,
+        Err(err) => {
+            tracing::warn!(
+                error = %err,
+                body_len = bytes.len(),
+                "a non-streamed 200 body did not parse as JSON, so this turn's tokens are \
+                 NOT in the usage ledger; totals for this window are an undercount"
+            );
+            return ParsedUsage::default();
+        }
     };
     let Some(usage) = value.get("usage") else {
+        // Ordinary, and deliberately silent: plenty of 200 bodies carry no usage.
         return ParsedUsage::default();
     };
     let output = usage
@@ -5203,6 +5219,90 @@ mod tests {
     /// specifically. Exercised directly against the extracted predicate
     /// rather than a network-level reproduction of the race, which the
     /// malformed-frame path alone cannot trigger.
+    /// A malformed non-streamed body must SAY so, and an ordinary body without a
+    /// `usage` key must stay quiet.
+    ///
+    /// Before this test both cases returned a default [`ParsedUsage`], the caller
+    /// skips recording when the totals are zero, and nothing anywhere named the
+    /// difference: a body the proxy could not parse silently cost the ledger a
+    /// turn. Asserting the log rather than the return value is deliberate, because
+    /// the return value is identical in both cases and that is exactly the point.
+    #[test]
+    fn a_malformed_non_streamed_body_is_logged_and_a_usage_less_one_is_not() {
+        use std::sync::{Arc, Mutex};
+        use tracing::field::{Field, Visit};
+
+        #[derive(Clone, Default)]
+        struct Capture(Arc<Mutex<Vec<(tracing::Level, String)>>>);
+        struct Msg(Option<String>);
+        impl Visit for Msg {
+            fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+                if field.name() == "message" {
+                    self.0 = Some(format!("{value:?}"));
+                }
+            }
+        }
+        impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for Capture {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                _ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                let mut m = Msg(None);
+                event.record(&mut m);
+                if let Some(msg) = m.0 {
+                    // The LEVEL is captured too. Asserting on the message text alone
+                    // let a mutant survive: downgrading this very warning to `trace!`
+                    // kept the word and the test stayed green (measured 2026-09-12,
+                    // before this line existed).
+                    self.0
+                        .lock()
+                        .expect("capture lock")
+                        .push((*event.metadata().level(), msg));
+                }
+            }
+        }
+
+        use tracing_subscriber::layer::SubscriberExt;
+        let cap = Capture::default();
+        let subscriber = tracing_subscriber::registry().with(cap.clone());
+
+        let parsed_bad = tracing::subscriber::with_default(subscriber, || {
+            usage_from_json(b"this is not json at all")
+        });
+        assert_eq!(
+            parsed_bad,
+            ParsedUsage::default(),
+            "a malformed body still yields no usage — the return value is unchanged"
+        );
+        let lines = cap.0.lock().expect("capture lock").clone();
+        let undercounts: Vec<_> = lines
+            .iter()
+            .filter(|(level, msg)| *level == tracing::Level::WARN && msg.contains("undercount"))
+            .collect();
+        assert_eq!(
+            undercounts.len(),
+            1,
+            "exactly one WARN should name the undercount, got {lines:?}"
+        );
+
+        let cap2 = Capture::default();
+        let subscriber2 = tracing_subscriber::registry().with(cap2.clone());
+        let parsed_no_usage = tracing::subscriber::with_default(subscriber2, || {
+            usage_from_json(br#"{"id":"msg_1","type":"message"}"#)
+        });
+        assert_eq!(
+            parsed_no_usage,
+            ParsedUsage::default(),
+            "a body without a usage key also yields no usage"
+        );
+        assert!(
+            cap2.0.lock().expect("capture lock").is_empty(),
+            "an ordinary body with no usage key must not warn: {:?}",
+            cap2.0.lock().expect("capture lock")
+        );
+    }
+
     #[test]
     fn evidence_loss_predicate_distinguishes_full_from_closed() {
         use tokio::sync::mpsc::error::TrySendError;

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -89,6 +89,12 @@ pub struct Quota {
     pub requests_remaining: Option<i64>,
     /// Reset for the standard token/request limits.
     pub standard_reset: Option<OffsetDateTime>,
+    /// Real, already-billed pay-as-you-go overage in USD, learned from a probe's
+    /// `extra_usage` field (see [`crate::probe::Usage::extra_usage_usd`]). `None`
+    /// means "never read", not "zero" — this display today falls back to
+    /// [`crate::pricing`]'s synthetic token-counted estimate, and a fabricated
+    /// `0.0` here would read as "no overage" instead of "we don't know yet".
+    pub extra_usage_usd: Option<f64>,
 }
 
 /// A generic view over "case-insensitive header name → value" so the same
@@ -349,6 +355,12 @@ impl Quota {
         apply_bucket(&mut self.five_hour, usage.five_hour, FIVE_HOUR);
         apply_bucket(&mut self.seven_day, usage.seven_day, SEVEN_DAY);
         apply_bucket(&mut self.seven_day_oi, usage.seven_day_oi, SEVEN_DAY);
+        // Same rule as the buckets above: only a reported value overwrites.
+        // `None` (unread this time) leaves whatever was last learned in place,
+        // rather than erasing it back to "unknown".
+        if let Some(extra) = usage.extra_usage_usd {
+            self.extra_usage_usd = Some(extra);
+        }
     }
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -986,6 +986,10 @@ fn probe_cell(account: &AccountSnapshot, now: OffsetDateTime) -> (String, Style)
         // — benign, not a serving failure. Yellow, never red: the account's own
         // quota bar is still valid; only the probe was deflected.
         ProbeStatus::RateLimited => (format!("busy {age}"), Style::default().fg(Color::Yellow)),
+        // A SUSTAINED run of 5xx, not a benign throttle — the usage endpoint
+        // itself is down. Red, like `Error`: this is the visible state
+        // `RateLimited`'s doc-comment says must not hide behind it forever.
+        ProbeStatus::UpstreamDown => (format!("DOWN {age}"), Style::default().fg(Color::Red)),
         ProbeStatus::Never => ("never".to_string(), Style::default().fg(Color::DarkGray)),
     }
 }

--- a/tests/usage-ledger-write-failure-policy.rs
+++ b/tests/usage-ledger-write-failure-policy.rs
@@ -1,0 +1,246 @@
+//! Pins the write-failure policy `Ledger::append` implements
+//! (`src/usage.rs:602-630`): a failed write is reported once per TRANSITION,
+//! not once per line, a recovery is reported once, and the shared
+//! `dropped_lines` count is never perturbed by a write failure or its
+//! recovery — `append` only ever READS that counter to put it in the log
+//! line, it does not own it.
+//!
+//! The failure is a real one: a ledger directory with its write bit removed,
+//! so `open_day_file`'s `OpenOptions::open(..).create(true)` gets a real
+//! `EACCES` without needing root. No mocking of the filesystem.
+//!
+//! Capturing `tracing::warn!`/`tracing::info!` output needs a subscriber, not
+//! a channel `UsageTracker` exposes — there is none, deliberately: the whole
+//! point of the policy under test is that it talks to logs, not to a caller.
+//! A minimal `tracing_subscriber::Layer` records each event's message and its
+//! `dropped_lines` field. The event of interest fires on the ledger's
+//! dedicated writer thread, not the test thread, so this installs the
+//! capturing subscriber as the PROCESS-WIDE default
+//! (`tracing::subscriber::set_global_default`) rather than scoping it with
+//! `with_default` — a thread-local default is invisible to a thread spawned
+//! after it is set. This file has exactly one test, so "global for the whole
+//! binary" and "global for this test" are the same thing.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::sync::{Arc, Mutex};
+
+use teamclaude_rs::pricing::PricingTable;
+use teamclaude_rs::usage::{LedgerAccount, UsageRecord, UsageTracker};
+use tracing_subscriber::layer::SubscriberExt;
+
+/// One captured event: its formatted message and every field tracing handed
+/// us, so a test can assert on `dropped_lines` without re-deriving tracing's
+/// own formatting.
+#[derive(Debug, Clone)]
+struct CapturedEvent {
+    message: String,
+    fields: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Default)]
+struct CaptureLayer {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+}
+
+struct FieldVisitor(BTreeMap<String, String>);
+
+impl tracing::field::Visit for FieldVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.0
+            .insert(field.name().to_string(), format!("{value:?}"));
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.0.insert(field.name().to_string(), value.to_string());
+    }
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CaptureLayer {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let mut visitor = FieldVisitor(BTreeMap::new());
+        event.record(&mut visitor);
+        let message = visitor
+            .0
+            .get("message")
+            .cloned()
+            .unwrap_or_else(|| "<no message field>".to_string());
+        self.events
+            .lock()
+            .expect("capture lock")
+            .push(CapturedEvent {
+                message,
+                fields: visitor.0,
+            });
+    }
+}
+
+impl CaptureLayer {
+    fn events(&self) -> Vec<CapturedEvent> {
+        self.events.lock().expect("capture lock").clone()
+    }
+
+    fn matching(&self, needle: &str) -> Vec<CapturedEvent> {
+        self.events()
+            .into_iter()
+            .filter(|e| e.message.contains(needle))
+            .collect()
+    }
+}
+
+/// A scratch directory named after this process and thread, so concurrent
+/// test runs never collide on it — same shape as `usage.rs`'s own `scratch`
+/// helper, duplicated here because that one is `#[cfg(test)]`-private to the
+/// crate and this file is a separate, external test crate.
+fn scratch(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "tcr-usage-write-failure-{tag}-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    let _ = fs::remove_dir_all(&dir);
+    dir
+}
+
+fn one_record(ts_ms: i64) -> UsageRecord {
+    UsageRecord::from_quota_input(
+        ts_ms,
+        Some("claude-opus-5".to_string()),
+        None,
+        10,
+        0,
+        0,
+        0,
+        0,
+    )
+}
+
+/// The whole policy, end to end: make the ledger directory unwritable, record
+/// through two failed writes, restore it, record through two successful
+/// ones, and check what got logged and what the drop counter says at every
+/// step.
+#[test]
+fn write_failure_warns_once_per_transition_and_never_touches_the_drop_count() {
+    let dir = scratch("policy");
+    fs::create_dir_all(&dir).expect("create the ledger dir");
+    // Remove the write bit. The directory stays traversable (so
+    // `ensure_dir`'s `dir.is_dir()` short-circuits true and takes no second
+    // path), but creating a new file inside it fails with EACCES, without
+    // needing root.
+    fs::set_permissions(&dir, fs::Permissions::from_mode(0o500)).expect("chmod read-only");
+
+    let capture = CaptureLayer::default();
+    let subscriber = tracing_subscriber::registry().with(capture.clone());
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("no other default is set in this test binary");
+
+    {
+        let tracker = UsageTracker::new(1, PricingTable::default());
+        let now = teamclaude_rs::now_ms();
+        let names = vec![LedgerAccount {
+            name: "alice@example.com".to_string(),
+            ..LedgerAccount::default()
+        }];
+        tracker.attach_ledger(dir.clone(), 90, &names, now);
+        assert!(
+            tracker.is_persisting(),
+            "control: nothing has been written yet, so nothing has failed yet"
+        );
+        assert_eq!(
+            tracker.dropped_lines(),
+            0,
+            "control: a write failure has not happened yet"
+        );
+
+        // First failed write: the unhealthy transition, warned once.
+        tracker.record(0, &one_record(now), "alice@example.com", None, None);
+        assert!(
+            tracker.flush_ledger(),
+            "the writer answers the flush even though its write failed"
+        );
+        assert!(
+            !tracker.is_persisting(),
+            "a failed write must say today's totals will not survive"
+        );
+        let stopped = capture.matching("stopped writing");
+        assert_eq!(
+            stopped.len(),
+            1,
+            "exactly one warning on the healthy-to-unhealthy transition, got {stopped:?}"
+        );
+        assert_eq!(
+            stopped[0].fields.get("dropped_lines").map(String::as_str),
+            Some("0"),
+            "no line has been dropped by a full queue, so the count the warning \
+             carries must be 0, not fabricated"
+        );
+        assert_eq!(
+            tracker.dropped_lines(),
+            0,
+            "a write failure is not a dropped line and must not be counted as one"
+        );
+
+        // Second failed write, same episode: must NOT warn again.
+        tracker.record(0, &one_record(now), "alice@example.com", None, None);
+        assert!(tracker.flush_ledger());
+        let stopped = capture.matching("stopped writing");
+        assert_eq!(
+            stopped.len(),
+            1,
+            "a second failed write inside the SAME episode must not warn again \
+             (warn-once-per-transition, not per line), got {stopped:?}"
+        );
+        assert_eq!(
+            tracker.dropped_lines(),
+            0,
+            "still not a dropped line on the second failure either"
+        );
+
+        // Recover: put the write bit back, then a write must succeed.
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o700)).expect("chmod writable");
+        tracker.record(0, &one_record(now), "alice@example.com", None, None);
+        assert!(tracker.flush_ledger());
+        assert!(
+            tracker.is_persisting(),
+            "a write that succeeds again must say so"
+        );
+        let recovered = capture.matching("writing again");
+        assert_eq!(
+            recovered.len(),
+            1,
+            "exactly one recovery report on the unhealthy-to-healthy transition, \
+             got {recovered:?}"
+        );
+        assert_eq!(
+            recovered[0].fields.get("dropped_lines").map(String::as_str),
+            Some("0"),
+            "recovery must report the SAME drop count the failure did — still 0, \
+             never reset to it, never fabricated"
+        );
+        assert_eq!(
+            tracker.dropped_lines(),
+            0,
+            "recovery must not zero or otherwise touch the counter it only reads"
+        );
+
+        // One more successful write: recovery must not be reported twice.
+        tracker.record(0, &one_record(now), "alice@example.com", None, None);
+        assert!(tracker.flush_ledger());
+        let recovered = capture.matching("writing again");
+        assert_eq!(
+            recovered.len(),
+            1,
+            "a second successful write inside the SAME healthy episode must not \
+             report recovery again, got {recovered:?}"
+        );
+
+        tracker.shutdown_ledger(std::time::Duration::from_secs(2));
+    }
+
+    let _ = fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
🍄 Six small fixes that came out of one evening's audit, batched into one pull request for one reason: the `release-version` pre-commit gate forces a `Cargo.toml` bump on any commit touching a shippable file, so five parallel branches each bumped to `0.2.46` independently. Five PRs would have been five claims on one version number and four rebases. This is one bump, one review.

Each commit stands alone and can be read on its own.

## `7f1799c` the update feed stops depending on which release is newest

`SUFeedURL` points at `/releases/latest/download/appcast.xml`, and `/releases/latest/` follows whichever release is newest, including a CLI-only one that carries no appcast. That has broken the updater five times, and the installed app cannot be fixed by shipping a new build because the dead URL is already compiled into the installs that are failing.

The guard written to catch it is wired to `on: release: types: [published]`, which GitHub does not fire for a release created with `GITHUB_TOKEN`. So the safety net could never fire, and its header did not say so.

This removes the lookup rather than repairing the guard: the feed is published to a fixed URL on `gh-pages` by the app-release path only. The existing asset upload stays, so installs pointing at the old URL are not orphaned. The guard is kept as a belt for pre-migration installs, with its dead trigger now documented. Verified against a local bare remote (commit shape, idempotency, both failure modes); what cannot be verified without a real publish is called out in `docs/RELEASING.md`.

## `e700214` the usage ledger's write-failure policy gets a test

`Ledger::append` already reports the health transition in both directions, warns once per transition rather than per line, and carries a drop count. Nothing proved any of it. The test chmods the ledger directory to `0500` to force a real write failure, asserts all three properties, restores `0700`, and asserts recovery is reported once. Watched failing first by breaking `set_healthy`'s return.

## `9c729dc` the credential envelope declares its version

Tokens are stored as plaintext JSON behind a carefully built `0600` atomic write. Moving them to the OS keystore is a separate, larger job; this is the cheap move that makes it possible without a migration that has to guess the old shape. A missing version reads as version 1, so every config already on disk keeps loading. An unknown future version refuses loudly rather than silently reinterpreting bytes. The discriminant sits at the document layer rather than as a struct field, which keeps the diff in one file instead of the ~60 exhaustive `Account { … }` literals.

## `3e8542b` the usage probe tells the whole truth

Two defects in one concern.

`extra_usage` was never parsed, so real billed pay-as-you-go overage was invisible and the only cost tcr showed was its own synthetic estimate. It is now read with the same multi-key fallback style the scoped-weekly lookup already uses, and carried as an `Option` that is never a fabricated `0.0`.

Sustained 5xx and 429 both mapped to `ProbeStatus::RateLimited`, the benign self-throttling label, three lines below a doc-comment saying probe health is first-class and must not hide behind one. A real upstream outage could sit there forever. Sustained 5xx now escalates to its own `UpstreamDown` status after three consecutive reads, while a single 5xx and any number of 429s stay benign, and a 429 always resets the 5xx counter so it can never feed the signal.

Both were watched failing first, with the expected mismatches.

## `3a33ecf` a body that will not parse says it cost the ledger a turn

`usage_from_json` returned a default for two different things: a body that is not JSON, and a body with no `usage` key. The caller records nothing when the totals are zero, so the first case produced no ledger line, no log and no counter. The ledger undercounted and said nothing. The second case stays silent on purpose, because plenty of 200 bodies have no usage object. Only the serde error and the body length are logged, never any content, since a messages body carries the user's prompt and this repository is public.

The test asserts the log rather than the return value, because the return value is identical in both cases and that is the point. Worth recording: the first version of that test passed a mutant that downgraded the warning to `trace!`, because it only looked for a word in the message. Capturing the level kills it.

## `148d324` the post-merge rebuild could not run under GNU coreutils

`mktemp -t tcr-post-merge` has no X's in its template. BSD accepts that, GNU refuses it. `log` came back empty, the redirect went to an empty path, the build never ran, and the hook reported a build failure for a build it never attempted. Seen on a real merge, not reasoned about.

## Gates

All run against the merged batch rather than the individual branches, each exit code redirected to a file and read rather than piped:

| gate | exit |
|---|---|
| `cargo fmt --all --check` | 0 |
| `cargo clippy --all-targets --locked -- -D warnings` | 0 |
| `cargo test --all --locked` | 0 |
| `scripts/check-no-org-flag.sh` | 0 |
| `.githooks/test-disclosure-scan.sh` | 0, 15 assertions |

One honest note on ordering: the first run of the disclosure fixture exited 127, file not found, because this branch was cut from `main` before #212 landed the gate. `main` is merged in here, that merge touches no `.rs` file (only `.githooks/`, `ci.yml` and `CONTRIBUTING.md`), and the fixture then passed. The Rust gates above were measured before that merge and still stand for exactly that reason.

The push itself exercised the new hook at scale: `pre-push: disclosure scan clean (13 commit(s))`.

Three bridge figures handed to the lanes turned out wrong, and each lane stopped rather than improvising: `usage_from_json` is in `src/proxy.rs` and not `src/usage.rs` (that fix is `3a33ecf`, done separately rather than folded into a lane whose files did not include it), `docs/configuration.md` had no environment-override section to extend, and the release-version gate was missing from the brief entirely.

https://claude.ai/code/session_01SKUTn6SXT7NvVrihufNoPm
