### PR TITLE
feat: mint long-lived OAuth tokens from the CLI and TcrBar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2163,9 +2163,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
  "log",
  "once_cell",
@@ -2197,9 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2767,9 +2767,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -464,6 +464,8 @@ struct FleetView: View {
             control: control,
             onChanged: { await poller.pollOnce() },
             onRelogin: { reloginAccount(account.ref) },
+            onMint: { mintAccountToken(account.ref) },
+            onMintGroup: { group in mintGroupTokens(group) },
             groupController: groupController,
             removeController: removeController,
             allAccounts: fleet.accounts,
@@ -846,6 +848,43 @@ struct FleetView: View {
         }
     }
 
+    /// Hand `tcr mint --account <name>` to a Terminal window for one row.
+    ///
+    /// Same hand-off reasoning as ``addAccount()``/``reloginAccount(_:)``, not
+    /// ``TokenCommand``: `tcr mint` prompts on stdin once per account and
+    /// puts the resulting token on the clipboard itself, so it needs a real
+    /// terminal exactly like `tcr login` does, and unlike the one-shot `tcr
+    /// token` whose entire stdout is the secret. Surfaces failure the same
+    /// way — a button that silently does nothing is worse than one that says
+    /// why — and never renders or logs a token.
+    private func mintAccountToken(_ account: AccountRef) {
+        if case .failure(let why) = LoginLauncher.launchMint(target: .account(account.name)) {
+            switch why {
+            case .toolMissing(let searched):
+                loginError = "tcr not found (searched \(searched.count) locations)."
+            case .couldNotWriteScript(let message):
+                loginError = "Could not open Terminal: \(message)"
+            }
+        } else {
+            loginError = nil
+        }
+    }
+
+    /// Same hand-off as ``mintAccountToken(_:)``, for every account carrying
+    /// `group`'s label at once (`tcr mint --group <name>`).
+    private func mintGroupTokens(_ group: String) {
+        if case .failure(let why) = LoginLauncher.launchMint(target: .group(group)) {
+            switch why {
+            case .toolMissing(let searched):
+                loginError = "tcr not found (searched \(searched.count) locations)."
+            case .couldNotWriteScript(let message):
+                loginError = "Could not open Terminal: \(message)"
+            }
+        } else {
+            loginError = nil
+        }
+    }
+
     /// App-level preference, deliberately beside Quit rather than among the
     /// account rows: it is about TcrBar, not about the fleet.
     private var launchAtLogin: some View {
@@ -1041,6 +1080,14 @@ struct AccountRow: View {
     /// Hands `tcr login` to a Terminal window for THIS account. Only drawn on a
     /// `.needsRelogin` row.
     let onRelogin: () -> Void
+    /// Hands `tcr mint --account <this row's name>` to a Terminal window. See
+    /// ``FleetView/mintAccountToken(_:)``.
+    let onMint: () -> Void
+    /// Hands `tcr mint --group <name>` to a Terminal window for every account
+    /// carrying that label — the group-level twin of ``onMint``, taking the
+    /// group name since this row's own account is not necessarily the one
+    /// whose tokens end up minted. See ``FleetView/mintGroupTokens(_:)``.
+    let onMintGroup: (String) -> Void
     /// Mutating THIS row's own group membership from its context menu — the
     /// affordance the bridge specifically asked for: before this round,
     /// membership could only be changed from a section-header menu, and the
@@ -1694,6 +1741,13 @@ struct AccountRow: View {
         Button("Copy Access Token") {
             Task { await performCopyToken() }
         }
+        // Distinct wording from the button above on purpose: "Copy" hands over
+        // a string that already exists and dies in hours, "Mint" makes a new
+        // one that does not — the confusion between the two is exactly what
+        // prompted this item to exist.
+        Button("Mint Long-Lived Token…") {
+            onMint()
+        }
         Divider()
         groupMenuItems
         Divider()
@@ -1751,6 +1805,12 @@ struct AccountRow: View {
                     arguments: GroupCommand.runArguments(group: group))
                 Button(copyRun.title) {
                     copyToPasteboard(copyRun.copiedText)
+                }
+                // Same distinction as the row-level item: this mints a NEW
+                // long-lived token for every member of the group, it does not
+                // copy anything that already exists.
+                Button("Mint Long-Lived Tokens for “\(group)”…") {
+                    onMintGroup(group)
                 }
                 // One click, either direction, with the current state on the
                 // item itself — the only administrative entry in this menu that

--- a/apps/macos/Sources/TcrBarCore/LoginLauncher.swift
+++ b/apps/macos/Sources/TcrBarCore/LoginLauncher.swift
@@ -49,6 +49,15 @@ public enum LoginLauncher {
         case couldNotWriteScript(String)
     }
 
+    /// Single-quote one shell argument, escaping any embedded single quote the
+    /// POSIX way (`'\''`), so the shell receives it as exactly one argument
+    /// whatever it contains. Shared by ``script(forExecutableAt:reloggingIn:)``
+    /// and ``mintScript(forExecutableAt:target:)`` so the two scripts this file
+    /// composes can never drift onto two different quoting rules.
+    static func posixQuote(_ argument: String) -> String {
+        "'" + argument.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
     /// Compose the shell script that a Terminal window will run.
     ///
     /// Split out and pure so the quoting is testable: an install path containing a
@@ -80,10 +89,7 @@ public enum LoginLauncher {
         forExecutableAt path: String,
         reloggingIn name: String? = nil
     ) -> String {
-        // Single-quote the path and escape any embedded single quote the POSIX
-        // way ('\'') so the shell receives exactly one argument whatever the path
-        // contains.
-        let quoted = "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        let quoted = posixQuote(path)
         let hint: String
         let accountArgument: String
         if let name {
@@ -95,14 +101,13 @@ public enum LoginLauncher {
             let message =
                 "Re-logging in \(name) — tcr requests that account, and refuses "
                 + "to save if the browser hands back a different one."
-            let quotedMessage = "'" + message.replacingOccurrences(of: "'", with: "'\\''") + "'"
+            let quotedMessage = posixQuote(message)
             hint = """
                 echo \(quotedMessage)
                 echo
 
                 """
-            let quotedName = "'" + name.replacingOccurrences(of: "'", with: "'\\''") + "'"
-            accountArgument = " --account \(quotedName)"
+            accountArgument = " --account \(posixQuote(name))"
         } else {
             hint = ""
             accountArgument = ""
@@ -119,21 +124,53 @@ public enum LoginLauncher {
             """
     }
 
-    /// Write the script somewhere Terminal will open, and open it.
+    /// Which rows `tcr mint` should run against — one account, or every
+    /// account carrying a group label. Mirrors the CLI's own two flags
+    /// (`tcr mint --account <name>` / `tcr mint --group <name>`) rather than
+    /// inventing a third shape.
+    public enum MintTarget: Equatable {
+        case account(String)
+        case group(String)
+    }
+
+    /// Compose the shell script for `tcr mint`, the same way
+    /// ``script(forExecutableAt:reloggingIn:)`` composes one for `tcr login`
+    /// and for the same reason: this hands off to a real Terminal rather than
+    /// spawning in the background. `tcr mint` prints an authorize URL and
+    /// waits for a pasted code on stdin, once per account, and puts the
+    /// resulting token(s) on the clipboard itself — nothing here ever reads
+    /// or renders one.
     ///
-    /// A `.command` file opened via LaunchServices starts Terminal directly. The
-    /// alternative — an AppleScript `do script` — needs Automation permission and
-    /// would put a consent dialog between the operator and a login they asked for.
-    ///
-    /// The filename carries a UUID (`uuid`, injectable for tests), not a fixed
-    /// `tcr-login.command`. Before `--account` shipped every invocation wrote
-    /// IDENTICAL bytes, so a fixed path was harmless — two clicks in quick
-    /// succession just overwrote the file with the same script. It is a
-    /// correctness surface now: the content is per-account, so two Re-login
-    /// clicks in quick succession could overwrite the file before the first
-    /// Terminal window reads it, letting window A run window B's
-    /// `--account`. A unique path per invocation makes that race structurally
-    /// impossible rather than merely unlikely.
+    /// `name` — an account or group name — is shell-quoted with the SAME
+    /// ``posixQuote(_:)`` helper the login script uses, for the same reason:
+    /// it is attacker-adjacent input landing on a command line, not just in an
+    /// `echo`.
+    static func mintScript(forExecutableAt path: String, target: MintTarget) -> String {
+        let quoted = posixQuote(path)
+        let flag: String
+        let name: String
+        switch target {
+        case .account(let value):
+            flag = "--account"
+            name = value
+        case .group(let value):
+            flag = "--group"
+            name = value
+        }
+        return """
+            #!/bin/sh
+            # Opened by TcrBar. `tcr mint` needs a terminal: it prints an
+            # authorize URL and waits for a pasted code, once per account, and
+            # puts the resulting token(s) on the clipboard itself.
+            echo "Running tcr mint — follow the prompts below."
+            echo
+            exec \(quoted) mint \(flag) \(posixQuote(name))
+            """
+    }
+
+    /// Write the login script somewhere Terminal will open, and open it. See
+    /// ``writeAndOpen(_:filenamePrefix:uuid:open:)`` for the shared shape and
+    /// why the filename carries a UUID.
     @discardableResult
     public static func launch(
         reloggingIn name: String? = nil,
@@ -148,8 +185,51 @@ public enum LoginLauncher {
         }
 
         let script = script(forExecutableAt: executable.path, reloggingIn: name)
+        return writeAndOpen(
+            script, filenamePrefix: "tcr-login", uuid: uuid(), open: open)
+    }
+
+    /// Same hand-off as ``launch(reloggingIn:uuid:resolve:open:)``, for
+    /// `tcr mint` rather than `tcr login`. Shares its resolve/write/open shape
+    /// exactly — the only difference is which script gets composed — so a
+    /// missing `tcr` or an unwritable temp directory fails the same way here
+    /// as it does there.
+    @discardableResult
+    public static func launchMint(
+        target: MintTarget,
+        uuid: () -> UUID = UUID.init,
+        resolve: () -> Result<URL, TcrTool.NotFound> = { TcrTool.resolve() },
+        open: (URL) -> Void = { NSWorkspace.shared.open($0) }
+    ) -> Result<URL, Failure> {
+        let executable: URL
+        switch resolve() {
+        case .success(let url): executable = url
+        case .failure(let missing): return .failure(.toolMissing(searched: missing.searched))
+        }
+
+        let script = mintScript(forExecutableAt: executable.path, target: target)
+        return writeAndOpen(
+            script, filenamePrefix: "tcr-mint", uuid: uuid(), open: open)
+    }
+
+    /// Write a composed script to a per-invocation temp path and open it, the
+    /// one path both ``launch(reloggingIn:uuid:resolve:open:)`` and
+    /// ``launchMint(target:uuid:resolve:open:)`` share. The filename carries a
+    /// UUID (`uuid`, injectable for tests), not a fixed name: the content is
+    /// per-account/per-group, so two clicks in quick succession could
+    /// overwrite the file before the first Terminal window reads it, letting
+    /// window A run window B's arguments. A unique path per invocation makes
+    /// that race structurally impossible rather than merely unlikely.
+    ///
+    /// A `.command` file opened via LaunchServices starts Terminal directly. The
+    /// alternative — an AppleScript `do script` — needs Automation permission and
+    /// would put a consent dialog between the operator and an action they asked
+    /// for.
+    private static func writeAndOpen(
+        _ script: String, filenamePrefix: String, uuid: UUID, open: (URL) -> Void
+    ) -> Result<URL, Failure> {
         let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("tcr-login-\(uuid().uuidString).command")
+            .appendingPathComponent("\(filenamePrefix)-\(uuid.uuidString).command")
 
         do {
             try script.write(to: url, atomically: true, encoding: .utf8)

--- a/apps/macos/Tests/TcrBarTests/LoginLauncherTests.swift
+++ b/apps/macos/Tests/TcrBarTests/LoginLauncherTests.swift
@@ -196,4 +196,106 @@ final class LoginLauncherTests: XCTestCase {
         let mode = try FileManager.default.attributesOfItem(atPath: url.path)[.posixPermissions]
         XCTAssertEqual(mode as? NSNumber, 0o700, "must be executable, and only by its owner")
     }
+
+    // MARK: - `tcr mint`
+
+    /// `tcr mint --account <name>` on the exec line for the account target.
+    func testMintAccountScriptRunsMintAccountFlag() {
+        let script = LoginLauncher.mintScript(
+            forExecutableAt: "/opt/homebrew/bin/tcr", target: .account("alice"))
+        XCTAssertTrue(
+            script.contains("exec '/opt/homebrew/bin/tcr' mint --account 'alice'"), script)
+    }
+
+    /// `tcr mint --group <name>` on the exec line for the group target.
+    func testMintGroupScriptRunsMintGroupFlag() {
+        let script = LoginLauncher.mintScript(
+            forExecutableAt: "/opt/homebrew/bin/tcr", target: .group("dev"))
+        XCTAssertTrue(
+            script.contains("exec '/opt/homebrew/bin/tcr' mint --group 'dev'"), script)
+    }
+
+    /// The injection case for an account name containing both a space and a
+    /// single quote — the brief's own minimum bar. Mirrors
+    /// ``testSingleQuoteInPathCannotEscapeTheQuoting`` for the login script:
+    /// the whole name must stay one shell argument.
+    func testMintAccountNameWithSpaceAndQuoteIsQuotedAsOneArgument() {
+        let script = LoginLauncher.mintScript(
+            forExecutableAt: "/opt/homebrew/bin/tcr", target: .account("ev'il name"))
+        XCTAssertTrue(
+            script.contains(#"exec '/opt/homebrew/bin/tcr' mint --account 'ev'\''il name'"#),
+            "a quote and a space in the account name must be escaped POSIX-style, got: \(script)"
+        )
+        // Nothing may follow the quoted name except the end of the line.
+        let execLine = script.split(separator: "\n").first { $0.hasPrefix("exec ") }
+        XCTAssertEqual(execLine?.hasSuffix("'"), true, "trailing text after the quoted account name")
+    }
+
+    /// Same injection case for a group name.
+    func testMintGroupNameWithSpaceAndQuoteIsQuotedAsOneArgument() {
+        let script = LoginLauncher.mintScript(
+            forExecutableAt: "/opt/homebrew/bin/tcr", target: .group("ev'il group"))
+        XCTAssertTrue(
+            script.contains(#"exec '/opt/homebrew/bin/tcr' mint --group 'ev'\''il group'"#),
+            "a quote and a space in the group name must be escaped POSIX-style, got: \(script)"
+        )
+        let execLine = script.split(separator: "\n").first { $0.hasPrefix("exec ") }
+        XCTAssertEqual(execLine?.hasSuffix("'"), true, "trailing text after the quoted group name")
+    }
+
+    /// A missing tool is reported the same way ``launch`` reports it, not
+    /// silently swallowed.
+    func testLaunchMintMissingToolIsReportedWithWhatWasSearched() {
+        var opened: URL?
+        let result = LoginLauncher.launchMint(
+            target: .account("alice"),
+            resolve: { .failure(TcrTool.NotFound(searched: ["/a/tcr", "/b/tcr"])) },
+            open: { opened = $0 }
+        )
+
+        guard case .failure(.toolMissing(let searched)) = result else {
+            return XCTFail("expected a toolMissing failure, got \(result)")
+        }
+        XCTAssertEqual(searched, ["/a/tcr", "/b/tcr"])
+        XCTAssertNil(opened, "nothing should be opened when tcr was never found")
+    }
+
+    /// Mirrors ``testSuccessWritesAnExecutableScriptAndOpensIt``: a real
+    /// invocation writes an executable `.command` file and opens it.
+    func testLaunchMintSuccessWritesAnExecutableScriptAndOpensIt() throws {
+        var opened: URL?
+        let result = LoginLauncher.launchMint(
+            target: .group("dev"),
+            resolve: { .success(URL(fileURLWithPath: "/usr/local/bin/tcr")) },
+            open: { opened = $0 }
+        )
+
+        guard case .success(let url) = result else {
+            return XCTFail("expected success, got \(result)")
+        }
+        XCTAssertEqual(opened, url)
+        XCTAssertEqual(url.pathExtension, "command", "Terminal opens .command files")
+
+        let written = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertTrue(written.contains("exec '/usr/local/bin/tcr' mint --group 'dev'"), written)
+
+        let mode = try FileManager.default.attributesOfItem(atPath: url.path)[.posixPermissions]
+        XCTAssertEqual(mode as? NSNumber, 0o700, "must be executable, and only by its owner")
+    }
+
+    /// Two mint launches must not race on one shared path, same reasoning as
+    /// ``testTwoLaunchesGetDifferentPaths`` for login.
+    func testTwoMintLaunchesGetDifferentPaths() throws {
+        var opened: [URL] = []
+        for _ in 0..<2 {
+            let result = LoginLauncher.launchMint(
+                target: .account("alice"),
+                resolve: { .success(URL(fileURLWithPath: "/usr/local/bin/tcr")) },
+                open: { opened.append($0) }
+            )
+            guard case .success = result else { return XCTFail("expected success") }
+        }
+        XCTAssertEqual(opened.count, 2)
+        XCTAssertNotEqual(opened[0], opened[1], "two launches must not race on one shared path")
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod config;
 pub mod demo;
 pub mod identity;
 pub mod manager;
+pub mod mint;
 pub mod mitm;
 pub mod model;
 pub mod oauth;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,9 @@ use clap::{Parser, Subcommand};
 use teamclaude_rs::cli::{self, validate_group_label_chars, PriorityArg};
 use teamclaude_rs::config::{self, Config, ConfigError};
 use teamclaude_rs::proxy::GROUP_HEADER_NAME;
-use teamclaude_rs::{affinity, build_info, demo, mitm, oauth, server, singleton, tui, update};
+use teamclaude_rs::{
+    affinity, build_info, demo, mint, mitm, oauth, server, singleton, tui, update,
+};
 
 #[derive(Parser)]
 #[command(
@@ -45,6 +47,10 @@ enum Command {
     Run(RunArgs),
     /// Authenticate a Claude account via the browser and add it to the config.
     Login(LoginArgs),
+    /// Mint a long-lived (365-day) token for an existing account, or every
+    /// account in a group, and put the result on the clipboard. Nothing is
+    /// stored — export only.
+    Mint(MintArgs),
     /// List the configured accounts (offline; `--probe` refreshes live quota).
     Accounts(AccountsArgs),
     /// Remove an account from the config.
@@ -373,6 +379,21 @@ struct LoginArgs {
 }
 
 #[derive(clap::Args)]
+struct MintArgs {
+    /// Path to the config file (default: ~/.config/teamclaude.json).
+    #[arg(long)]
+    config: Option<PathBuf>,
+    /// Mint a long-lived token for one existing account — exact name, not a
+    /// substring (see `resolve_account`). Exactly one of `--account` /
+    /// `--group` is required.
+    #[arg(long, required_unless_present = "group", conflicts_with = "group")]
+    account: Option<String>,
+    /// Mint a long-lived token for every account carrying this group label.
+    #[arg(long)]
+    group: Option<String>,
+}
+
+#[derive(clap::Args)]
 struct RunArgs {
     /// Path to the config file (default: ~/.config/teamclaude.json).
     #[arg(long)]
@@ -429,6 +450,7 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Server(args)) => run_server(args).await,
         Some(Command::Run(args)) => run_claude(args),
         Some(Command::Login(args)) => run_login(args).await,
+        Some(Command::Mint(args)) => run_mint(args).await,
         Some(Command::Accounts(args)) => run_accounts(args).await,
         Some(Command::Remove(args)) => run_remove(args).await,
         Some(Command::Token(args)) => run_token(args),
@@ -1166,6 +1188,21 @@ async fn run_login(args: LoginArgs) -> anyhow::Result<()> {
     .await
     .context("OAuth login failed")?;
     println!("Logged in as '{name}'.");
+    Ok(())
+}
+
+/// `tcr mint --account <name> | --group <name>` — mint a long-lived token for
+/// one account or every account in a group and put the result on the
+/// clipboard. Exits non-zero when any targeted account failed or mismatched,
+/// so a UI driving this (the TcrBar menu item) can surface the failure.
+async fn run_mint(args: MintArgs) -> anyhow::Result<()> {
+    let config_path = args.config.unwrap_or_else(config::default_path);
+    let all_ok = mint::run_mint(&config_path, args.account.as_deref(), args.group.as_deref())
+        .await
+        .context("mint failed")?;
+    if !all_ok {
+        std::process::exit(1);
+    }
     Ok(())
 }
 

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -1,0 +1,613 @@
+//! `tcr mint` — mint a long-lived (365-day) OAuth token for an existing
+//! account, or for every account carrying a group label, and put the result
+//! on the clipboard. Nothing is written to the config file: this command
+//! exports, it never stores (`docs/design/long-lived-tokens.md`).
+//!
+//! Deliberately separate from [`crate::oauth`]'s login flow rather than a new
+//! branch inside it: the authorize host (`claude.com/cai/oauth/authorize`,
+//! not [`oauth::AUTHORIZE_URL`]) and redirect target (an out-of-band paste
+//! page, not a local callback server) both differ, and `login_hint` here is
+//! load-bearing ergonomics for a KNOWN row rather than the add-a-new-account
+//! convenience it is in [`oauth::login`]. What IS shared — [`oauth::CLIENT_ID`],
+//! [`oauth::TOKEN_ENDPOINT`], [`oauth::OAUTH_SCOPES`],
+//! [`oauth::LOGIN_TOKEN_LIFETIME_SECS`] and the two headers the endpoint
+//! requires to avoid a bogus 429 — is reused by name, never re-typed.
+
+use std::io::IsTerminal as _;
+use std::io::Write as _;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use anyhow::Context as _;
+use oauth2::basic::BasicClient;
+use oauth2::{AuthUrl, ClientId, CsrfToken, PkceCodeChallenge, RedirectUrl, Scope, TokenUrl};
+use serde::Deserialize;
+
+use crate::config::{self, Account};
+use crate::identity;
+use crate::oauth;
+
+/// Authorize endpoint used by `tcr mint`. Measured against the live endpoint
+/// (`docs/design/long-lived-tokens.md`) — distinct from [`oauth::AUTHORIZE_URL`],
+/// which the browser-login flow uses.
+pub const MINT_AUTHORIZE_URL: &str = "https://claude.com/cai/oauth/authorize";
+
+/// The out-of-band redirect target: a paste page, not a callback server. Mint
+/// runs headless-friendly (no local port, no browser auto-open assumption) —
+/// the operator opens the URL themselves and pastes back `code#state`.
+pub const MINT_REDIRECT_URI: &str = "https://platform.claude.com/oauth/code/callback";
+
+/// PKCE + CSRF material for one mint attempt, plus the built authorize URL.
+struct MintFlow {
+    verifier: String,
+    state: String,
+    auth_url: String,
+}
+
+/// Build the authorize URL, a fresh PKCE challenge and a fresh CSRF state for
+/// one account. Called once per account in [`mint_one`] — never reused across
+/// accounts, so one account's leaked/expired code can never be replayed
+/// against another's exchange.
+fn build_mint_flow(login_hint: &str) -> anyhow::Result<MintFlow> {
+    let client = BasicClient::new(ClientId::new(oauth::CLIENT_ID.to_string()))
+        .set_auth_uri(
+            AuthUrl::new(MINT_AUTHORIZE_URL.to_string()).context("invalid mint authorize URL")?,
+        )
+        .set_token_uri(
+            TokenUrl::new(oauth::TOKEN_ENDPOINT.to_string()).context("invalid token URL")?,
+        )
+        .set_redirect_uri(
+            RedirectUrl::new(MINT_REDIRECT_URI.to_string()).context("invalid mint redirect URI")?,
+        );
+
+    let (challenge, verifier) = PkceCodeChallenge::new_random_sha256();
+
+    let (auth_url, csrf) = client
+        .authorize_url(|| CsrfToken::new_random_len(32))
+        .add_scope(Scope::new(oauth::OAUTH_SCOPES.to_string()))
+        .set_pkce_challenge(challenge)
+        .add_extra_param("code", "true")
+        .add_extra_param("login_hint", login_hint)
+        .url();
+
+    Ok(MintFlow {
+        verifier: verifier.secret().clone(),
+        state: csrf.secret().clone(),
+        auth_url: auth_url.to_string(),
+    })
+}
+
+/// Build the JSON body for [`exchange_mint_code`]'s `POST {TOKEN_ENDPOINT}`, as
+/// a pure function so the request shape is assertable without the network —
+/// mirrors `warm_request_spec` in `src/warmer.rs` and `exchange_request_body`
+/// in `src/oauth.rs`.
+fn mint_exchange_request_body(code: &str, verifier: &str, state: &str) -> serde_json::Value {
+    serde_json::json!({
+        "code": code,
+        "state": state,
+        "grant_type": "authorization_code",
+        "client_id": oauth::CLIENT_ID,
+        "redirect_uri": MINT_REDIRECT_URI,
+        "code_verifier": verifier,
+        "expires_in": oauth::LOGIN_TOKEN_LIFETIME_SECS,
+    })
+}
+
+/// The token-exchange response fields mint needs. [`oauth`]'s `RefreshResponse`
+/// does not model `account`/`organization` — refresh never needed identity —
+/// so this is its own struct rather than widening that one for a caller that
+/// isn't a refresh.
+#[derive(Debug, Deserialize)]
+struct MintExchangeResponse {
+    access_token: String,
+    #[serde(default)]
+    expires_in: Option<i64>,
+    #[serde(default)]
+    account: Option<MintAccount>,
+    #[serde(default)]
+    organization: Option<MintOrg>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MintAccount {
+    #[serde(default)]
+    email_address: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MintOrg {
+    #[serde(default)]
+    name: Option<String>,
+}
+
+/// Exchange the pasted authorization code for a long-lived token. A
+/// `.no_proxy()` client, exactly like [`oauth::exchange_code`]: an ambient
+/// `HTTPS_PROXY` points at tcr itself, and routing this exchange through it
+/// would loop back into the very proxy this token is meant to feed.
+async fn exchange_mint_code(
+    code: &str,
+    verifier: &str,
+    state: &str,
+) -> anyhow::Result<MintExchangeResponse> {
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .context("build mint token-exchange client")?;
+
+    let response = client
+        .post(oauth::TOKEN_ENDPOINT)
+        .header("Content-Type", "application/json")
+        .header("Accept", oauth::OAUTH_ACCEPT)
+        .header("User-Agent", oauth::OAUTH_USER_AGENT)
+        .json(&mint_exchange_request_body(code, verifier, state))
+        .send()
+        .await
+        .context("mint token exchange request failed")?;
+
+    let status = response.status();
+    let text = response.text().await.unwrap_or_default();
+    if !status.is_success() {
+        anyhow::bail!("mint token exchange failed ({}): {text}", status.as_u16());
+    }
+
+    serde_json::from_str(&text).context("parse mint token-exchange response")
+}
+
+/// What minting one account produced.
+#[derive(Debug, Clone, PartialEq)]
+enum MintOutcome {
+    /// Identity and lifetime both checked out; `token` is safe to present.
+    Minted {
+        token: String,
+        org: String,
+        granted_secs: i64,
+    },
+    /// The whole reason bulk minting is safe: `login_hint` is not proven to
+    /// override an already-signed-in browser session, so this is the check
+    /// that actually stops a `--group` loop from minting N tokens for one
+    /// account (`docs/design/long-lived-tokens.md`, "Identity arrives free at
+    /// exchange time"). The token is discarded — it never reaches
+    /// [`assemble_clipboard_block`].
+    IdentityMismatch { requested: String, actual: String },
+    /// The endpoint granted a different lifetime than requested. Reported
+    /// loudly rather than silently presenting a short-lived token as
+    /// long-lived; the token is still discarded, matching the identity-mismatch
+    /// case (an unexpected grant is exactly the moment to trust nothing else
+    /// about the response either).
+    LifetimeMismatch {
+        requested_secs: i64,
+        granted_secs: i64,
+    },
+    /// Network/parse/stdin failure — the exchange never produced a response to
+    /// check identity against.
+    Failed(String),
+}
+
+/// One account's mint attempt: the account name it was minted for, and what
+/// came of it.
+#[derive(Debug, Clone, PartialEq)]
+struct MintResult {
+    account_name: String,
+    outcome: MintOutcome,
+}
+
+/// Evaluate an exchange response against the row it was minted for. Pure and
+/// synchronous by design (test 3 in the bridge brief) — network I/O stops at
+/// [`exchange_mint_code`], everything after it is a plain function of data.
+fn evaluate_mint_response(requested_email: &str, response: MintExchangeResponse) -> MintOutcome {
+    let actual_email = response
+        .account
+        .as_ref()
+        .and_then(|a| a.email_address.clone())
+        .unwrap_or_default();
+    if actual_email != requested_email {
+        return MintOutcome::IdentityMismatch {
+            requested: requested_email.to_string(),
+            actual: actual_email,
+        };
+    }
+
+    let requested_secs = oauth::LOGIN_TOKEN_LIFETIME_SECS as i64;
+    let granted_secs = response.expires_in.unwrap_or(0);
+    if granted_secs != requested_secs {
+        return MintOutcome::LifetimeMismatch {
+            requested_secs,
+            granted_secs,
+        };
+    }
+
+    let org = response
+        .organization
+        .and_then(|o| o.name)
+        .unwrap_or_else(|| "unknown-org".to_string());
+    MintOutcome::Minted {
+        token: response.access_token,
+        org,
+        granted_secs,
+    }
+}
+
+/// Split a pasted `code#state` on `#`, keeping the part before it — exactly as
+/// [`oauth::login_with_token`] reads a bare line, per the bridge brief. Falls
+/// back to the whole trimmed string when no `#` is present rather than
+/// erroring: a caller that pasted a bare code (no state) should not be
+/// refused a value [`exchange_mint_code`] can still try.
+fn parse_pasted_code(pasted: &str) -> &str {
+    pasted.split_once('#').map_or(pasted, |(code, _state)| code)
+}
+
+/// Every account in `accounts` carrying `group` — exactly
+/// [`Account::in_group`], never a looser substring or prefix match.
+fn select_group_accounts<'a>(accounts: &'a [Account], group: &str) -> Vec<&'a Account> {
+    accounts.iter().filter(|a| a.in_group(group)).collect()
+}
+
+/// Assemble the WHOLE clipboard block: one `<account name>\t<token>` line per
+/// successfully minted account, in the order minted. Accounts that failed,
+/// mismatched identity, or mismatched lifetime contribute no line — their
+/// token (if any was ever held) never reaches this function's output.
+fn assemble_clipboard_block(results: &[MintResult]) -> String {
+    results
+        .iter()
+        .filter_map(|r| match &r.outcome {
+            MintOutcome::Minted { token, .. } => Some(format!("{}\t{}", r.account_name, token)),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// The stdout line for one account. Never the token — see this module's
+/// top-level doc comment and the bridge brief's "Output rules".
+///
+/// The second column is always `OK` or `REFUSED`, so a reader scanning a
+/// `--group` run of several accounts sees at a glance which rows did not work
+/// without reading every reason — the failing ones are also the ones worth
+/// reading closely.
+fn format_report_line(result: &MintResult) -> String {
+    match &result.outcome {
+        MintOutcome::Minted {
+            org, granted_secs, ..
+        } => {
+            let days = *granted_secs as f64 / 86_400.0;
+            format!("{}\tOK\t{days:.0}d\t{org}", result.account_name)
+        }
+        MintOutcome::IdentityMismatch { requested, actual } => {
+            format!(
+                "{}\tREFUSED\tidentity mismatch: requested {requested}, exchange returned {actual}",
+                result.account_name
+            )
+        }
+        MintOutcome::LifetimeMismatch {
+            requested_secs,
+            granted_secs,
+        } => {
+            format!(
+                "{}\tREFUSED\tlifetime mismatch: requested {requested_secs}s, granted \
+                 {granted_secs}s — not presented as long-lived",
+                result.account_name
+            )
+        }
+        MintOutcome::Failed(err) => format!("{}\tREFUSED\t{err}", result.account_name),
+    }
+}
+
+/// Read one pasted `code#state` line from stdin, prompting on stderr so stdout
+/// stays scoped to the account/org/lifetime report (see this module's
+/// top-level doc comment).
+fn read_pasted_code() -> anyhow::Result<String> {
+    eprint!("Paste code#state: ");
+    std::io::stderr().flush().ok();
+    let mut line = String::new();
+    std::io::stdin()
+        .read_line(&mut line)
+        .context("read pasted code from stdin")?;
+    let code = parse_pasted_code(line.trim());
+    if code.is_empty() {
+        anyhow::bail!("no authorization code pasted");
+    }
+    Ok(code.to_string())
+}
+
+/// Mint one account: build the flow, print the URL, block for the pasted
+/// code, exchange it, and check the response against `login_hint`. Never
+/// concurrent with another account's mint — the bridge brief is explicit that
+/// each needs a human at a browser, and [`run_mint`] calls this in a plain
+/// sequential loop, never `join_all`.
+async fn mint_one(account_name: &str, login_hint: &str) -> MintResult {
+    let outcome = match mint_one_inner(login_hint).await {
+        Ok(outcome) => outcome,
+        Err(err) => MintOutcome::Failed(err.to_string()),
+    };
+    MintResult {
+        account_name: account_name.to_string(),
+        outcome,
+    }
+}
+
+async fn mint_one_inner(login_hint: &str) -> anyhow::Result<MintOutcome> {
+    let flow = build_mint_flow(login_hint)?;
+    eprintln!("\n=== {login_hint} ===");
+    eprintln!("Open this URL, sign in as {login_hint}, then paste the resulting code#state:");
+    eprintln!("  {}\n", flow.auth_url);
+
+    let code = read_pasted_code()?;
+    let response = exchange_mint_code(&code, &flow.verifier, &flow.state).await?;
+    Ok(evaluate_mint_response(login_hint, response))
+}
+
+/// Pipe `block` to `pbcopy`'s stdin — never argv, which would put a token in
+/// `ps` output and shell history.
+fn copy_to_clipboard(block: &str) -> anyhow::Result<()> {
+    let mut child = Command::new("pbcopy")
+        .stdin(Stdio::piped())
+        .spawn()
+        .context("spawn pbcopy")?;
+    child
+        .stdin
+        .as_mut()
+        .context("pbcopy stdin")?
+        .write_all(block.as_bytes())
+        .context("write to pbcopy")?;
+    let status = child.wait().context("wait for pbcopy")?;
+    if !status.success() {
+        anyhow::bail!("pbcopy exited with {status}");
+    }
+    Ok(())
+}
+
+/// `tcr mint --account <name> | --group <name>` — mint a long-lived token for
+/// one account or every account carrying a group label, sequentially, and put
+/// the successfully-minted tokens on the clipboard. Returns `Ok(true)` only
+/// when every targeted account minted cleanly; the caller turns `Ok(false)`
+/// into a non-zero exit so a UI driving this can surface the failure.
+///
+/// Reads the config but never writes it: mint stores nothing
+/// (`docs/design/long-lived-tokens.md`; the operator explicitly chose
+/// export-only over storing).
+pub async fn run_mint(
+    config_path: &Path,
+    account: Option<&str>,
+    group: Option<&str>,
+) -> anyhow::Result<bool> {
+    let cfg = config::load(config_path).context("load config for mint")?;
+
+    let targets: Vec<&Account> = match (account, group) {
+        (Some(query), None) => {
+            let idx = crate::cli::resolve_account(&cfg.accounts, query)?;
+            vec![&cfg.accounts[idx]]
+        }
+        (None, Some(group)) => {
+            let matches = select_group_accounts(&cfg.accounts, group);
+            if matches.is_empty() {
+                anyhow::bail!("no account carries group '{group}'");
+            }
+            matches
+        }
+        (Some(_), Some(_)) | (None, None) => {
+            anyhow::bail!("provide exactly one of --account or --group")
+        }
+    };
+
+    let mut results = Vec::with_capacity(targets.len());
+    for target in targets {
+        let login_hint = identity::email_of(&target.name).to_string();
+        results.push(mint_one(&target.name, &login_hint).await);
+    }
+
+    for result in &results {
+        println!("{}", format_report_line(result));
+    }
+    let minted = results
+        .iter()
+        .filter(|r| matches!(r.outcome, MintOutcome::Minted { .. }))
+        .count();
+    println!("{minted}/{} minted", results.len());
+
+    let block = assemble_clipboard_block(&results);
+    if !block.is_empty() {
+        copy_to_clipboard(&block).context("copy minted tokens to clipboard")?;
+    }
+
+    wait_for_return_on_a_tty();
+
+    Ok(minted == results.len())
+}
+
+/// Hold the process open after the summary when stdin is a TTY, so a `--group`
+/// run launched via `exec` from a Terminal window (as TcrBar's menu item
+/// does — the same shape `tcr login` already runs under) does not have its
+/// per-account report vanish the instant the window closes. Mint stores
+/// nothing, so this report is the ONLY record of which rows were refused.
+///
+/// Guarded on [`IsTerminal`] exactly like `read_setup_token` in `src/oauth.rs`
+/// decides whether to prompt: a piped or scripted invocation has no one to
+/// wait for and must exit immediately. That TTY branch itself has no
+/// existing test in this codebase (`read_setup_token`'s is untested too) —
+/// driving a real terminal is outside what a unit test can assert, so this
+/// is exercised by hand rather than under `cargo test`.
+fn wait_for_return_on_a_tty() {
+    if !std::io::stdin().is_terminal() {
+        return;
+    }
+    eprint!("\nPress Return to close. ");
+    std::io::stderr().flush().ok();
+    let mut discard = String::new();
+    let _ = std::io::stdin().read_line(&mut discard);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- authorize URL -------------------------------------------------
+
+    #[test]
+    fn mint_authorize_url_carries_required_params() {
+        let flow = build_mint_flow("alice@example.com").unwrap();
+        let url = &flow.auth_url;
+        // Hardcoded, not `MINT_AUTHORIZE_URL` — asserting a constant against
+        // itself never catches the constant drifting to the wrong host.
+        assert!(url.starts_with("https://claude.com/cai/oauth/authorize"));
+        assert!(url.contains("code=true"));
+        assert!(url.contains("code_challenge="));
+        assert!(url.contains("code_challenge_method=S256"));
+        assert!(url.contains("login_hint=alice%40example.com"));
+        // The out-of-band redirect, percent-encoded by oauth2.
+        assert!(url
+            .contains("redirect_uri=https%3A%2F%2Fplatform.claude.com%2Foauth%2Fcode%2Fcallback"));
+
+        // Decode the `scope` param rather than substring-matching the raw URL:
+        // `:` and the space between scopes are both percent-encoded, so a raw
+        // `contains("user:inference")` check would never match.
+        let query = url.split_once('?').map(|(_, q)| q).unwrap_or_default();
+        let scope = form_urlencoded::parse(query.as_bytes())
+            .find(|(k, _)| k == "scope")
+            .map(|(_, v)| v.into_owned())
+            .expect("scope param present");
+        assert_eq!(scope, oauth::OAUTH_SCOPES);
+    }
+
+    // --- exchange body ---------------------------------------------------
+
+    #[test]
+    fn mint_exchange_body_requests_the_long_lived_lifetime() {
+        let body = mint_exchange_request_body("code123", "verifier", "state");
+        assert_eq!(body["expires_in"], oauth::LOGIN_TOKEN_LIFETIME_SECS);
+        assert_eq!(body["grant_type"], "authorization_code");
+        assert_eq!(body["redirect_uri"], MINT_REDIRECT_URI);
+    }
+
+    // --- identity guard ----------------------------------------------------
+
+    fn response(email: Option<&str>, expires_in: Option<i64>) -> MintExchangeResponse {
+        MintExchangeResponse {
+            access_token: "secret-token".to_string(),
+            expires_in,
+            account: Some(MintAccount {
+                email_address: email.map(str::to_string),
+            }),
+            organization: Some(MintOrg {
+                name: Some("acme-corp".to_string()),
+            }),
+        }
+    }
+
+    #[test]
+    fn matching_identity_and_lifetime_is_minted() {
+        let outcome = evaluate_mint_response(
+            "alice@example.com",
+            response(
+                Some("alice@example.com"),
+                Some(oauth::LOGIN_TOKEN_LIFETIME_SECS as i64),
+            ),
+        );
+        assert!(matches!(outcome, MintOutcome::Minted { .. }));
+    }
+
+    #[test]
+    fn mismatched_identity_is_rejected_and_the_token_never_reaches_the_block() {
+        let outcome = evaluate_mint_response(
+            "alice@example.com",
+            response(
+                Some("mallory@example.com"),
+                Some(oauth::LOGIN_TOKEN_LIFETIME_SECS as i64),
+            ),
+        );
+        assert!(matches!(outcome, MintOutcome::IdentityMismatch { .. }));
+
+        let results = vec![MintResult {
+            account_name: "alice@example.com".to_string(),
+            outcome,
+        }];
+        let block = assemble_clipboard_block(&results);
+        assert!(!block.contains("secret-token"), "block was: {block:?}");
+        assert_eq!(block, "", "a mismatch contributes no line at all");
+    }
+
+    #[test]
+    fn mismatched_lifetime_is_rejected_and_the_token_never_reaches_the_block() {
+        // The endpoint granted the default 8h instead of the requested 365d —
+        // must be reported loudly, never presented as long-lived.
+        let outcome = evaluate_mint_response(
+            "alice@example.com",
+            response(Some("alice@example.com"), Some(28_800)),
+        );
+        assert!(matches!(outcome, MintOutcome::LifetimeMismatch { .. }));
+
+        let results = vec![MintResult {
+            account_name: "alice@example.com".to_string(),
+            outcome,
+        }];
+        assert_eq!(assemble_clipboard_block(&results), "");
+    }
+
+    #[test]
+    fn a_minted_token_reaches_the_assembled_block() {
+        let results = vec![MintResult {
+            account_name: "alice@example.com".to_string(),
+            outcome: MintOutcome::Minted {
+                token: "secret-token".to_string(),
+                org: "acme-corp".to_string(),
+                granted_secs: oauth::LOGIN_TOKEN_LIFETIME_SECS as i64,
+            },
+        }];
+        assert_eq!(
+            assemble_clipboard_block(&results),
+            "alice@example.com\tsecret-token"
+        );
+    }
+
+    // --- pasted code -------------------------------------------------------
+
+    #[test]
+    fn pasted_code_is_split_on_hash_before_the_state() {
+        assert_eq!(parse_pasted_code("abc123#the-state"), "abc123");
+    }
+
+    #[test]
+    fn pasted_bare_code_with_no_hash_is_used_verbatim() {
+        assert_eq!(parse_pasted_code("abc123"), "abc123");
+    }
+
+    // --- target selection ----------------------------------------------
+
+    fn account(name: &str, groups: &[&str]) -> Account {
+        let mut value = serde_json::json!({
+            "name": name,
+            "accessToken": "t",
+            "refreshToken": "r",
+        });
+        if !groups.is_empty() {
+            value["groups"] = serde_json::json!(groups);
+        }
+        serde_json::from_value(value).unwrap()
+    }
+
+    #[test]
+    fn group_selects_exactly_the_members_and_account_selects_one() {
+        let accounts = vec![
+            account("alice@example.com", &["team-a"]),
+            account("bob@example.com", &["team-a", "team-b"]),
+            account("carol@example.com", &["team-b"]),
+        ];
+
+        let team_a = select_group_accounts(&accounts, "team-a");
+        assert_eq!(
+            team_a.iter().map(|a| a.name.as_str()).collect::<Vec<_>>(),
+            vec!["alice@example.com", "bob@example.com"]
+        );
+
+        let team_b = select_group_accounts(&accounts, "team-b");
+        assert_eq!(
+            team_b.iter().map(|a| a.name.as_str()).collect::<Vec<_>>(),
+            vec!["bob@example.com", "carol@example.com"]
+        );
+
+        let none = select_group_accounts(&accounts, "no-such-group");
+        assert!(none.is_empty());
+
+        let idx = crate::cli::resolve_account(&accounts, "carol@example.com").unwrap();
+        assert_eq!(accounts[idx].name, "carol@example.com");
+    }
+}

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -107,17 +107,21 @@ pub fn is_expiring_soon(expires_at_ms: Option<i64>, now_ms: i64) -> bool {
 }
 
 /// `Accept` header the token endpoint expects from a "recognised" client.
-/// Shared between [`refresh_access_token_at`] and [`exchange_code`] — see
-/// [`OAUTH_USER_AGENT`] for why sending it matters.
-const OAUTH_ACCEPT: &str = "application/json, text/plain, */*";
+/// Shared between [`refresh_access_token_at`], [`exchange_code`] and
+/// `mint::exchange_mint_code` — see [`OAUTH_USER_AGENT`] for why sending it
+/// matters. `pub(crate)` rather than private so `mint.rs` sends the identical
+/// value instead of a second copy that could drift.
+pub(crate) const OAUTH_ACCEPT: &str = "application/json, text/plain, */*";
 
 /// `User-Agent` header the token endpoint expects from a "recognised" client.
 /// Without this header (and [`OAUTH_ACCEPT`]) an otherwise-valid exchange was
 /// refused a bogus `{"type":"rate_limit_error"}` 21 times over 7 minutes; the
 /// identical payload with these headers was evaluated on the first attempt —
 /// measured against the live endpoint, `docs/design/long-lived-tokens.md`
-/// ("The endpoint 429s clients it does not recognise").
-const OAUTH_USER_AGENT: &str = "axios/1.13.6";
+/// ("The endpoint 429s clients it does not recognise"). `pub(crate)` for the
+/// same reason as [`OAUTH_ACCEPT`]: `mint.rs`'s exchange hits the same
+/// endpoint and must never fall behind this value.
+pub(crate) const OAUTH_USER_AGENT: &str = "axios/1.13.6";
 
 /// Refresh an access token against [`TOKEN_ENDPOINT`], retrying `5xx`/network
 /// failures with exponential backoff. Auth rejections are returned immediately.


### PR DESCRIPTION
🍄 Mint long-lived OAuth tokens: `tcr mint` plus TcrBar menu items.

Builds on #214, which made a one-year `expires_in` possible at code exchange. This adds the
command that uses it for tokens you hand to someone else, and the two menu items that drive it.

## What this adds

- `tcr mint --account <name>` and `tcr mint --group <name>`. Per account: an out-of-band
  authorize URL with `login_hint`, a pasted code, an exchange requesting
  `expires_in: 31536000`, then the token. Nothing is stored. Successful
  `name<TAB>token` lines go to the clipboard; tokens are never printed.
- TcrBar: **Mint long-lived token** on a row, **Mint long-lived tokens** on a group. Both hand
  off to a real Terminal window, for the reasons `LoginLauncher`'s header comment already gives
  for `tcr login`: the command prompts on stdin, once per account, and a background spawn would
  swallow those prompts.

## The identity guard is the load-bearing part

Each mint compares the `account.email_address` in the token response against the row it was
minted for, and discards the token on mismatch. `login_hint` is documented in this repo as
unproven against an already-signed-in browser session (`src/oauth.rs`), so without this a
`--group` loop could mint N tokens that all belong to whichever account the browser held, with
nothing to reveal it. That the token response carries identity at all, even on inference-only
scope, is a measured finding recorded in `docs/design/long-lived-tokens.md`.

## Verified

- `cargo test --all` and `cargo clippy --all-targets --locked`: exit 0 on the merged tree.
- `swift build`, `swift test` (497 tests), `swift-format lint --strict`: exit 0.
- Every new assertion was mutation-tested: the production behaviour was broken, the expected
  failure observed, then restored. One first-draft test was found vacuous this way, a
  `url.starts_with(CONST)` comparing the constant to the one the code built the URL from.
- The two source branches were proved file-disjoint with `comm -12` before merging, and the
  combined diff was checked to be exactly their union.

## NOT verified

- The TTY hold that keeps the Terminal window open so the per-account report survives. It is
  gated on `stdin().is_terminal()`, mirroring `read_setup_token`, whose equivalent branch has no
  test here either: driving a real terminal is outside `cargo test`. No test was invented for it.
- Whether `login_hint` actually switches an already-signed-in browser session. The identity
  guard exists precisely because this is unknown; a group run is the first real evidence.
- Whether a long-lived token is revoked earlier in practice than the year it is granted.
