### PR TITLE
fix: do not rescan commits a remote already carries

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -38,18 +38,27 @@ findings=""
 scanned=0
 
 # stdin: <local ref> <local sha> <remote ref> <remote sha>, one line per ref.
-while read -r _local_ref local_sha _remote_ref remote_sha; do
+while read -r _local_ref local_sha _remote_ref _remote_sha; do
   [ -n "${local_sha:-}" ] || continue
   # A deletion pushes nothing.
   case "$local_sha" in "$ZERO") continue ;; esac
 
-  if [ "$remote_sha" = "$ZERO" ]; then
-    # A new branch. Scanning its whole ancestry would flag years of history that
-    # is already public, so scan only what no other remote ref already carries.
-    range_commits="$(git rev-list "$local_sha" --not --remotes || true)"
-  else
-    range_commits="$(git rev-list "${remote_sha}..${local_sha}" || true)"
-  fi
+  # Only what NO remote ref already carries, for a new branch and an existing one
+  # alike. `--not --remotes` is the whole point and it is not an optimisation:
+  #
+  # Merging `main` into a feature branch makes main's commits new to THIS ref, so
+  # a plain `remote..local` range hands them to the scan even though every one of
+  # them is already public. That is not hypothetical. This hook refused its own
+  # author's push on 2026-09-12, naming two addresses in the message of a
+  # dependabot commit that was already on `main` and already world-readable, at
+  # the exact moment the branch was brought up to date in order to merge it. A
+  # gate that refuses the ordinary act of updating a branch is a gate someone
+  # turns off, and then it gates nothing.
+  #
+  # The range for a brand-new branch is identical under this reading, so the two
+  # cases collapse into one and the remote sha is not needed at all: a deletion is
+  # already told apart above by its all-zero LOCAL sha.
+  range_commits="$(git rev-list "$local_sha" --not --remotes || true)"
 
   [ -n "$range_commits" ] || continue
 

--- a/.githooks/test-disclosure-scan.sh
+++ b/.githooks/test-disclosure-scan.sh
@@ -40,6 +40,16 @@ echo "start" > "$SCRATCH/file.txt"
 git -C "$SCRATCH" add file.txt .githooks
 git -C "$SCRATCH" commit -q --no-verify -m "init"
 
+# A remote from the start, because the gate's range is "what no remote ref already
+# carries". A repo with no remote at all has nothing to subtract, so every case
+# below would scan the whole history and trip over an earlier case's fixtures.
+# Reality always has a remote; the fixture should too.
+SCRATCH_REMOTE="$WORK/remote.git"
+git init -q --bare "$SCRATCH_REMOTE"
+git -C "$SCRATCH" remote add origin "$SCRATCH_REMOTE"
+git -C "$SCRATCH" push -q origin HEAD:refs/heads/main
+git -C "$SCRATCH" fetch -q origin
+
 commit_file() {  # <message>
   git -C "$SCRATCH" commit -q --no-verify -m "$1" file.txt
 }
@@ -99,6 +109,11 @@ else
 fi
 
 # ── The control: a clean commit must PASS ───────────────────────────────────
+# From a base that is actually on the remote. The two refusal fixtures above are
+# still on this branch and are NOT pushed, so a range measured from here would
+# legitimately include them: the gate would be right to refuse, and the control
+# would be testing the wrong thing. Throw them away first.
+git -C "$SCRATCH" reset -q --hard origin/main
 echo "an entirely ordinary line" >> "$SCRATCH/file.txt"
 commit_file "chore: an ordinary change"
 GOOD_SHA="$(git -C "$SCRATCH" rev-parse HEAD)"
@@ -125,6 +140,48 @@ else
   ok "the denylist file is excluded from the scan"
 fi
 git -C "$SCRATCH" reset -q
+
+# ── An already-public commit arriving via a merge must NOT be rescanned ──────
+# The regression that produced this case: merging `main` into a feature branch to
+# bring it up to date makes main's commits new to THAT ref, so a plain
+# `remote..local` range handed them to the scan even though every one of them was
+# already pushed and world-readable. The hook refused its own author's push on
+# 2026-09-12 over two addresses in a dependabot commit message already on `main`.
+# A gate that refuses the ordinary act of updating a branch gets turned off.
+# A commit on "main" whose MESSAGE would trip the scan, pushed and therefore public.
+# The two sides touch DIFFERENT files on purpose: appending to one file from both
+# makes the merge below conflict, and a conflicted merge leaves HEAD where it was,
+# so the range under test is trivially clean and the case passes for the wrong
+# reason. That is not hypothetical either — the first version of this case did
+# exactly that and a mutant survived it.
+echo "upstream work" > "$SCRATCH/upstream.txt"
+git -C "$SCRATCH" add upstream.txt
+git -C "$SCRATCH" commit -q --no-verify -m "chore: a message naming AcmeCorp-Private, already public"
+PUBLIC_SHA="$(git -C "$SCRATCH" rev-parse HEAD)"
+git -C "$SCRATCH" push -q origin HEAD:refs/heads/main
+git -C "$SCRATCH" fetch -q origin
+
+# A feature branch that merges it in, then pushes. Nothing of ITS own discloses.
+git -C "$SCRATCH" checkout -q -b feature "$PUBLIC_SHA~1"
+echo "my own clean work" > "$SCRATCH/mine.txt"
+git -C "$SCRATCH" add mine.txt
+git -C "$SCRATCH" commit -q --no-verify -m "chore: an ordinary change of my own"
+FEATURE_BASE="$(git -C "$SCRATCH" rev-parse HEAD)"
+git -C "$SCRATCH" merge -q --no-ff --no-verify -m "merge: origin/main" "$PUBLIC_SHA"
+if [ "$(git -C "$SCRATCH" rev-parse HEAD)" = "$FEATURE_BASE" ]; then
+  fail "the fixture's merge did not move HEAD, so this case would pass for the wrong reason"
+fi
+if ! git -C "$SCRATCH" merge-base --is-ancestor "$PUBLIC_SHA" HEAD; then
+  fail "the fixture's merge did not bring the public commit in; the case proves nothing"
+fi
+out="$(printf 'refs/heads/feature %s refs/heads/feature %s\n' "$(git -C "$SCRATCH" rev-parse HEAD)" "$FEATURE_BASE" | "$SCRATCH/.githooks/pre-push" 2>&1)"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  ok "a commit already on a remote is not rescanned when merged in"
+else
+  fail "merging public history into a branch was refused (rc=$rc): $(printf '%s' "$out" | head -3)"
+fi
+git -C "$SCRATCH" checkout -q -
 
 # ── The gate cannot silently degrade ────────────────────────────────────────
 rm "$SCRATCH/.githooks/lib/disclosure-scan.sh"


### PR DESCRIPTION
🍄 The push gate I added in #212 refused its own author's push, and it was right by its rules and wrong in substance.

It scanned `remote..local`, which for an existing branch means everything new to that ref. Merging `main` into a feature branch to bring it up to date makes main's commits new to the ref, so the gate handed already-published history to the scan and blocked on two addresses in a dependabot commit message that was already on `main` and already world-readable.

That happened at the exact moment a branch was being updated in order to merge it. A gate that refuses the ordinary act of updating a branch is a gate somebody turns off.

## The fix

`--not --remotes` for every push, not only for a new branch. What no remote ref carries is exactly what this push would publish. The remote sha is not needed at all: a deletion is told apart by its all-zero local sha.

Measured on a scratch repo where a feature branch merges a pushed commit:

```
old  BASE..HEAD            -> merge commit + the already-public commit
new  HEAD --not --remotes  -> merge commit + my own clean commit
```

## Two mutants, and the second one is the lesson

Reverting the range left the new case green. The fixture appended to one file from both sides, so the merge conflicted, HEAD never moved, and the range under test was trivially clean. A case that passes because its own setup failed is worse than no case.

The two sides now touch different files, and the case asserts its own premise before asserting anything else: that HEAD moved, and that the public commit is an ancestor of it. With those in place the old range fails the case, as it must.

The control case also needed fixing: it sat downstream of two deliberately-bad fixtures that were never pushed, so under the corrected range the gate was right to refuse it. It resets to a pushed base first.

Suite is 16 assertions, exit 0.

https://claude.ai/code/session_01SKUTn6SXT7NvVrihufNoPm