### PR TITLE
fix: draw the panel's faint text with the panel's own measured ink scale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,13 @@ jobs:
       - name: No --org flag
         run: scripts/check-no-org-flag.sh
 
+      # SwiftUI's `.secondary`/`.tertiary` resolve against the system window
+      # background, not this panel's own surfaces, so the contrast that
+      # `tcrbar-palette.py` measures and gates never applied to them. Thirteen
+      # text runs had drifted onto them, the worst at 1.86:1 — see the script.
+      - name: No hierarchical styles used as panel ink
+        run: scripts/check-panel-ink.sh
+
       # The disclosure gate's own fixtures. The hooks themselves are local and a
       # fork may not have them wired, so CI runs the suite that proves the scan
       # still refuses what it exists to refuse — a name, a home path, a real

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -135,7 +135,7 @@ struct FleetView: View {
                 if let at = poller.lastPollAt {
                     Text(at, style: .time)
                         .font(Tok.secondaryDigitFont).lineSpacing(Tok.secondaryLineSpacing)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(Tok.inkDim)
                 }
             }
             // Only when the read is NOT healthy. On a healthy read this said
@@ -201,7 +201,7 @@ struct FleetView: View {
         if case .loaded(let fleet) = poller.state, let line = fleet.usageSummaryLine {
             Text(line)
                 .font(Tok.secondaryDigitFont).lineSpacing(Tok.secondaryLineSpacing)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(Tok.inkDim)
                 .fixedSize(horizontal: false, vertical: true)
                 .background(
                     GeometryReader { proxy in
@@ -249,6 +249,12 @@ struct FleetView: View {
                 .font(Tok.secondaryFont).lineSpacing(Tok.secondaryLineSpacing)
                 .foregroundStyle(isFailure ? Tok.spent : Tok.accent)
                 .fixedSize(horizontal: false, vertical: true)
+                // `.plain` draws no chrome, so the clickable region was the
+                // glyph boxes themselves — about 14pt tall, and nothing at all
+                // in the gaps between words. The padding and the explicit
+                // content shape make the whole line one target.
+                .padding(.vertical, Tok.space2)
+                .contentShape(Rectangle())
         }
     }
 
@@ -312,8 +318,7 @@ struct FleetView: View {
             banner(
                 icon: Tok.unreadableGlyph,
                 title: "tcr is not on PATH",
-                detail: "Searched \(searched.count) locations. Set it with "
-                    + "`defaults write io.github.dhkts1.tcrbar \(TcrTool.overrideDefaultsKey) <path>`.",
+                detail: "Searched \(searched.count) locations. \(TcrTool.overrideRemedy)",
                 tint: Tok.spent
             )
         case .commandFailed(let code, let message):
@@ -324,12 +329,21 @@ struct FleetView: View {
                 tint: Tok.spent
             )
         case .undecodable(let message):
+            // The decoder's own text is a Swift `DecodingError` description —
+            // key paths and type names. It is the right thing to keep and the
+            // wrong thing to lead with, so it moves to the tooltip.
+            //
+            // The body is the remedy alone, not a restatement: the header line
+            // directly above already says what happened (`PollState.summary`),
+            // and a banner that repeats the sentence above it is one the reader
+            // has to check twice to find the new information in.
             banner(
                 icon: Tok.unreadableGlyph,
                 title: "Unreadable status output",
-                detail: message,
+                detail: "Usually a version mismatch: update TcrBar, or the server.",
                 tint: Tok.unknown
             )
+            .help(message)
         case .loaded(let fleet):
             if fleet.accounts.isEmpty {
                 banner(
@@ -432,7 +446,7 @@ struct FleetView: View {
             Text(band.title.uppercased())
                 .font(Tok.detailFont.weight(.semibold)).lineSpacing(Tok.detailLineSpacing)
                 .tracking(Tok.pillTracking)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(Tok.inkDim)
         }
     }
 
@@ -588,7 +602,7 @@ struct FleetView: View {
                 Text(title).font(.subheadline.weight(.semibold))
                 Text(detail)
                     .font(Tok.secondaryFont).lineSpacing(Tok.secondaryLineSpacing)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(Tok.inkDim)
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
@@ -606,13 +620,13 @@ struct FleetView: View {
             HStack(spacing: Tok.tightSpacing) {
                 Text(server.state.summary)
                     .font(Tok.secondaryFont).lineSpacing(Tok.secondaryLineSpacing)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(Tok.inkDim)
                     .fixedSize(horizontal: false, vertical: true)
                 Spacer(minLength: Tok.tightSpacing)
                 if case .loaded(let fleet) = poller.state, let sha = fleet.serverSha {
                     Text("server \(sha)\(fleet.serverDirty ? "-dirty" : "")")
                         .font(Tok.detailDigitFont).lineSpacing(Tok.detailLineSpacing)
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(Tok.inkFaint)
                         .lineLimit(1)
                 }
             }
@@ -831,6 +845,22 @@ struct FleetView: View {
         }
     }
 
+    /// One message for all four `LoginLauncher` hand-offs below.
+    ///
+    /// They carried four identical copies of the same two-case switch, and the
+    /// `toolMissing` copy named the problem with no way out of it — while the
+    /// poll banner five hundred lines up already knew the remedy and gave it.
+    /// `static` because it reads nothing from the view.
+    private static func loginFailureMessage(_ why: LoginLauncher.Failure) -> String {
+        switch why {
+        case .toolMissing(let searched):
+            return "tcr not found (searched \(searched.count) locations). "
+                + TcrTool.overrideRemedy
+        case .couldNotWriteScript(let message):
+            return "Could not open Terminal: \(message)"
+        }
+    }
+
     /// Hand `tcr login` to a Terminal window.
     ///
     /// Deliberately a hand-off, not an in-app flow. `tcr login` refuses while a
@@ -839,12 +869,7 @@ struct FleetView: View {
     /// in the label is doing real work: this opens something.
     private func addAccount() {
         if case .failure(let why) = LoginLauncher.launch() {
-            switch why {
-            case .toolMissing(let searched):
-                loginError = "tcr not found (searched \(searched.count) locations)."
-            case .couldNotWriteScript(let message):
-                loginError = "Could not open Terminal: \(message)"
-            }
+            loginError = Self.loginFailureMessage(why)
         } else {
             loginError = nil
         }
@@ -856,12 +881,7 @@ struct FleetView: View {
     /// why.
     private func reloginAccount(_ account: AccountRef) {
         if case .failure(let why) = LoginLauncher.launch(reloggingIn: account.name) {
-            switch why {
-            case .toolMissing(let searched):
-                loginError = "tcr not found (searched \(searched.count) locations)."
-            case .couldNotWriteScript(let message):
-                loginError = "Could not open Terminal: \(message)"
-            }
+            loginError = Self.loginFailureMessage(why)
         } else {
             loginError = nil
         }
@@ -878,12 +898,7 @@ struct FleetView: View {
     /// why — and never renders or logs a token.
     private func mintAccountToken(_ account: AccountRef) {
         if case .failure(let why) = LoginLauncher.launchMint(target: .account(account.name)) {
-            switch why {
-            case .toolMissing(let searched):
-                loginError = "tcr not found (searched \(searched.count) locations)."
-            case .couldNotWriteScript(let message):
-                loginError = "Could not open Terminal: \(message)"
-            }
+            loginError = Self.loginFailureMessage(why)
         } else {
             loginError = nil
         }
@@ -893,12 +908,7 @@ struct FleetView: View {
     /// `group`'s label at once (`tcr mint --group <name>`).
     private func mintGroupTokens(_ group: String) {
         if case .failure(let why) = LoginLauncher.launchMint(target: .group(group)) {
-            switch why {
-            case .toolMissing(let searched):
-                loginError = "tcr not found (searched \(searched.count) locations)."
-            case .couldNotWriteScript(let message):
-                loginError = "Could not open Terminal: \(message)"
-            }
+            loginError = Self.loginFailureMessage(why)
         } else {
             loginError = nil
         }
@@ -987,7 +997,7 @@ struct FleetView: View {
         if let label = AppBuild.label {
             Text(label)
                 .font(Tok.detailDigitFont).lineSpacing(Tok.detailLineSpacing)
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(Tok.inkFaint)
                 .lineLimit(1)
                 .textSelection(.enabled)
                 .help(AppBuild.buildDetail(buildNumber: AppBuild.buildNumber) ?? label)
@@ -1247,11 +1257,18 @@ struct AccountRow: View {
     }
 
     /// The 5h line's spend figures, demoted with everything else on the row
-    /// when the reading is historical. `AnyShapeStyle` because the branches are
-    /// different types: `Color` has a `.secondary` but no `.tertiary`, so the
-    /// plain ternary the 7d counters use cannot be written here.
-    private var usageFigureStyle: AnyShapeStyle {
-        hasStaleQuotaReading ? AnyShapeStyle(Tok.disabled) : AnyShapeStyle(.tertiary)
+    /// when the reading is historical.
+    ///
+    /// `Color`, not `AnyShapeStyle`. This reached for SwiftUI's `.tertiary`,
+    /// which has no `Color` spelling and forced the erasure — and which drew
+    /// this figure at 1.86:1 on the light panel, measured off a
+    /// `--render-states` bitmap. A hierarchical style resolves against the
+    /// SYSTEM window background, never against `Tok.raised`, so none of the
+    /// palette's measured ratios ever applied to it. `Tok.inkFaint` is this
+    /// panel's own tertiary ink and `scripts/tcrbar-palette.py` gates it at
+    /// 4.5:1 against both surfaces.
+    private var usageFigureStyle: Color {
+        hasStaleQuotaReading ? Tok.disabled : Tok.inkFaint
     }
 
     /// The Fable weekly figure's tint, from that window's OWN state.
@@ -1275,12 +1292,15 @@ struct AccountRow: View {
     ///
     /// Demoted with the rest of the row on a stale reading, like every other
     /// figure on it.
-    private var fableFigureStyle: AnyShapeStyle {
-        if hasStaleQuotaReading { return AnyShapeStyle(Tok.disabled) }
-        guard let state = account.sevenDayOiState else { return AnyShapeStyle(.tertiary) }
+    ///
+    /// `Color` for the same reason as ``usageFigureStyle``: every branch is a
+    /// token now, so nothing needs erasing.
+    private var fableFigureStyle: Color {
+        if hasStaleQuotaReading { return Tok.disabled }
+        guard let state = account.sevenDayOiState else { return Tok.inkFaint }
         switch state {
-        case .near, .spent: return AnyShapeStyle(Tok.color(for: state))
-        case .ok, .unknown: return AnyShapeStyle(.tertiary)
+        case .near, .spent: return Tok.color(for: state)
+        case .ok, .unknown: return Tok.inkFaint
         }
     }
 
@@ -2127,7 +2147,7 @@ struct AccountRow: View {
     private var accountActionsMenuLabel: some View {
         Image(systemName: "gearshape")
             .font(Tok.bodyFont).lineSpacing(Tok.bodyLineSpacing)
-            .foregroundStyle(.secondary)
+            .foregroundStyle(Tok.inkDim)
             // The Menu's own `.accessibilityLabel` below names the
             // control; without hiding the glyph too, VoiceOver reads
             // both the image ("gearshape, image") and the label,
@@ -2342,7 +2362,7 @@ struct AccountRow: View {
                         // `error` account is what the UNMEASURED pill used to
                         // wear too, and the raw word alone drew in the same
                         // grey as a healthy account right above it.
-                        .foregroundStyle(account.health == .needsRelogin ? Tok.spent : .secondary)
+                        .foregroundStyle(account.health == .needsRelogin ? Tok.spent : Tok.inkDim)
                         .lineLimit(1)
                 }
                 // The FABLE weekly window — a third quota window, with its own
@@ -2467,12 +2487,15 @@ struct AccountRow: View {
                 // same distinction `fiveHourTint` draws for the fill. The number
                 // itself is unchanged — it is still true, just no longer
                 // reachable.
-                .foregroundStyle(hasStaleQuotaReading ? Tok.disabled : .secondary)
+                .foregroundStyle(hasStaleQuotaReading ? Tok.disabled : Tok.inkDim)
             // Drawn whenever the wire has a reset for this window, beside the
             // number it belongs to. Colour: `captionTint(for:)`.
             if let caption = QuotaFormat.resetCaption(resetAtMs: resetAtMs, now: Date()) {
                 Text(caption)
-                    .font(Tok.secondaryFont).lineSpacing(Tok.secondaryLineSpacing)
+                    // Tabular, like the percentage it sits beside: this string
+                    // carries digits (`in 4d 12h`) that change under the poll,
+                    // and proportional figures shift the row when they do.
+                    .font(Tok.secondaryDigitFont).lineSpacing(Tok.secondaryLineSpacing)
                     .foregroundStyle(captionTint)
                     .lineLimit(1)
             }

--- a/apps/macos/Sources/TcrBar/Tokens.swift
+++ b/apps/macos/Sources/TcrBar/Tokens.swift
@@ -309,7 +309,10 @@ public enum Tok {
     public static let rowLineSpacing = space1
 
     public static let radiusSmall: CGFloat = 8
-    public static let radiusMedium: CGFloat = 14
+    /// 16, which is what makes the account card concentric: its inset is
+    /// `space3` (8) and the pills inside it are `pillRadius` (8), so the
+    /// outer curve has to be inner + padding or the corners read pinched.
+    public static let radiusMedium: CGFloat = 16
     public static let radiusLarge: CGFloat = 18
     public static let barHeight: CGFloat = 6
     /// 4, not 3 — matching the bump above. `RoundedRectangle` clamps its

--- a/apps/macos/Sources/TcrBarCore/GroupControl.swift
+++ b/apps/macos/Sources/TcrBarCore/GroupControl.swift
@@ -238,7 +238,9 @@ public enum GroupNameValidation {
         switch failure {
         case .empty: return "Group name cannot be empty."
         case .controlCharacter: return "Group name cannot contain control characters."
-        case .aboveLatin1: return "Group name cannot contain characters above U+00FF."
+        case .aboveLatin1:
+            return "Group name can use letters, digits and accents, but not emoji "
+                + "or other scripts."
         }
     }
 }
@@ -274,7 +276,7 @@ public enum NewGroupName: Equatable, Sendable {
     public var rejectionMessage: String? {
         switch self {
         case .rejected(let failure): return GroupNameValidation.message(for: failure)
-        case .duplicate: return "A group named that already exists."
+        case .duplicate: return "A group with that name already exists."
         case .valid: return nil
         }
     }

--- a/apps/macos/Sources/TcrBarCore/StatusPoller.swift
+++ b/apps/macos/Sources/TcrBarCore/StatusPoller.swift
@@ -48,8 +48,13 @@ public enum PollState: Equatable {
         case .commandFailed(let code, let message):
             let detail = message.isEmpty ? "no output" : message
             return "tcr status failed (exit \(code)): \(detail)"
-        case .undecodable(let message):
-            return "tcr status returned unreadable output: \(message)"
+        case .undecodable:
+            // Deliberately drops `message`. It is a Swift `DecodingError`
+            // description — key paths and type names — and this property's
+            // contract one screen up is "safe to put in front of a human".
+            // The raw text is still reachable: `FleetView` hangs it on the
+            // banner's tooltip, which is where a reader who wants it looks.
+            return "tcr answered, and this build could not read the answer"
         }
     }
 }

--- a/apps/macos/Sources/TcrBarCore/TcrTool.swift
+++ b/apps/macos/Sources/TcrBarCore/TcrTool.swift
@@ -14,6 +14,16 @@ public enum TcrTool {
     /// Environment override, useful when launched from a shell.
     public static let overrideEnvKey = "TCR_BIN"
 
+    /// What to tell someone whose `tcr` could not be found.
+    ///
+    /// Stated once because it is given in two places — the poll banner and
+    /// every login hand-off failure — and a remedy that drifts between them is
+    /// worse than one that is missing. The hand-offs used to say only "tcr not
+    /// found (searched N locations)", which names the problem and no way out
+    /// of it, while the banner three hundred lines away already knew the fix.
+    public static let overrideRemedy =
+        "Set it with `defaults write io.github.dhkts1.tcrbar \(overrideDefaultsKey) <path>`."
+
     /// Why no binary could be found — carries the searched paths so the UI can be
     /// specific instead of silently empty.
     public struct NotFound: Error, Equatable {

--- a/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
@@ -1442,6 +1442,19 @@ final class StatusPollerClassifyTests: XCTestCase {
         }
     }
 
+    /// The contract on ``PollState/summary`` is "safe to put in front of a
+    /// human", and the `.undecodable` arm used to interpolate a raw
+    /// `DecodingError` description straight into it — which read as
+    /// `DecodingError.valueNotFound: quota` on the panel's own header line.
+    /// This pins the arm that broke it rather than the sentence it now says.
+    func testUndecodableSummaryDoesNotLeakTheDecoderError() {
+        let summary = PollState.undecodable(message: "DecodingError.valueNotFound: quota").summary
+        XCTAssertFalse(
+            summary.contains("DecodingError"),
+            "the raw decoder error must not reach a human-facing line, got: \(summary)")
+        XCTAssertFalse(summary.contains("valueNotFound"), "same, for the case name")
+    }
+
     func testSummariesAreNeverEmpty() {
         let states: [PollState] = [
             .pending,

--- a/apps/macos/Tests/TcrBarTests/GroupControlTests.swift
+++ b/apps/macos/Tests/TcrBarTests/GroupControlTests.swift
@@ -241,7 +241,7 @@ final class NewGroupNameTests: XCTestCase {
 
     func testRejectionMessageNamesTheDuplicateReason() {
         let outcome = NewGroupName.evaluate("dev", existingGroups: ["dev"])
-        XCTAssertEqual(outcome.rejectionMessage, "A group named that already exists.")
+        XCTAssertEqual(outcome.rejectionMessage, "A group with that name already exists.")
     }
 }
 

--- a/apps/macos/design-tokens/tokens.css
+++ b/apps/macos/design-tokens/tokens.css
@@ -46,7 +46,7 @@
     --tcr-pill-padding-v: 2px;
     --tcr-pill-tracking: 0.3px;
     --tcr-radius-large: 18px;
-    --tcr-radius-medium: 14px;
+    --tcr-radius-medium: 16px;
     --tcr-radius-small: 8px;
     --tcr-secondary-font-size: 11px;
     --tcr-secondary-line-height: 16px;

--- a/apps/macos/design-tokens/tokens.json
+++ b/apps/macos/design-tokens/tokens.json
@@ -69,7 +69,7 @@
     "pill-padding-v": 2.0,
     "pill-tracking": 0.3,
     "radius-large": 18.0,
-    "radius-medium": 14.0,
+    "radius-medium": 16.0,
     "radius-small": 8.0,
     "secondary-font-size": 11.0,
     "secondary-line-height": 16.0,

--- a/scripts/check-panel-ink.sh
+++ b/scripts/check-panel-ink.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# check-panel-ink.sh — refuse SwiftUI's hierarchical foreground styles
+# (`.secondary`, `.tertiary`, `.quaternary`) anywhere in the TcrBar views.
+#
+# The panel draws on its OWN surfaces: `Tok.panel` and `Tok.raised`, authored in
+# OKLCH and measured for WCAG contrast by `scripts/tcrbar-palette.py`, which CI
+# runs and which refuses a token below 4.5:1. A hierarchical style is not in
+# that system. It resolves against the SYSTEM window background, so none of
+# those measured ratios apply to it, and nothing was checking what it actually
+# drew.
+#
+# What it actually drew, measured off `--render-states` bitmaps before this gate
+# existed:
+#
+#   .tertiary    1.86:1 on the light panel, 2.26:1 on the dark
+#   .secondary   3.86:1 on the light panel
+#
+# Both are below the 4.5:1 that every token in the same file clears, and
+# `.tertiary` is close to invisible: it drew the 5-hour spend figure, the Fable
+# weekly figure and the footer's server SHA. Thirteen runs were affected.
+#
+# The replacements are the panel's own ink scale, which says the same three
+# levels out loud and is gated:
+#
+#   .secondary   -> Tok.inkDim     8.3:1 light, 9.7:1 dark
+#   .tertiary    -> Tok.inkFaint   4.8:1 light, 5.8:1 dark
+#
+# Scope is `apps/macos/Sources/TcrBar`, the views that draw on those surfaces.
+# `TcrBarCore` holds no views. Tests are exempt by name, for the same reason the
+# --org gate exempts one file: a test that asserts the rule may have to write
+# the thing down.
+#
+# Usage: scripts/check-panel-ink.sh [root]   (default: the repo root)
+
+set -euo pipefail
+
+root="${1:-$(git rev-parse --show-toplevel)}"
+views="$root/apps/macos/Sources/TcrBar"
+
+if [ ! -d "$views" ]; then
+    echo "error: $views does not exist — has the package moved?" >&2
+    exit 1
+fi
+
+# `foregroundStyle(.secondary)`, `foregroundColor(.tertiary)`, the ternary form
+# `? Tok.spent : .secondary`, and the erased form `AnyShapeStyle(.tertiary)`.
+#
+# The trailing `\b` is what keeps `Tok.secondaryFont`, `Tok.secondaryDigitFont`
+# and `Tok.secondaryLineSpacing` out: a word character follows `secondary` in
+# each, so the boundary fails. An earlier draft also required whitespace before
+# the dot, which silently missed the plainest form of all,
+# `.foregroundStyle(.secondary)` — the fixture below is why that is not still
+# true.
+hits=$(
+    grep -rnE \
+        '(foregroundStyle|foregroundColor)\([^)]*\.(secondary|tertiary|quaternary)\b|AnyShapeStyle\(\.(secondary|tertiary|quaternary)\)' \
+        "$views" 2>/dev/null || true
+)
+
+if [ -n "$hits" ]; then
+    echo "error: a SwiftUI hierarchical style is used as ink on the panel." >&2
+    echo "       It resolves against the system window background, not Tok.panel/Tok.raised," >&2
+    echo "       so the measured contrast in Tokens.swift does not apply to it." >&2
+    echo "       Use Tok.inkDim (secondary) or Tok.inkFaint (tertiary) instead." >&2
+    echo "" >&2
+    echo "$hits" >&2
+    exit 1
+fi
+
+echo "check-panel-ink: clean (no hierarchical styles used as ink)"


### PR DESCRIPTION
🍄 Thirteen text runs in the panel were drawing outside the measured ink scale, the worst of them at 1.86:1.

## The bug

`Tokens.swift` authors every colour in OKLCH and `scripts/tcrbar-palette.py` measures each one against `Tok.panel` and `Tok.raised`, refusing anything under 4.5:1. CI runs it. Thirteen text runs in `FleetView` were not in that system at all — they used SwiftUI's `.secondary` and `.tertiary`, which resolve against the **system window background**, not this panel's surfaces. None of the measured ratios applied to them, and nothing was checking what they actually drew.

Measured off `--render-states` bitmaps:

| run | light, before | dark, before | light, after | dark, after |
|---|---|---|---|---|
| 5h spend figure | **1.86:1** | **2.26:1** | 5.21:1 | 5.21:1 |
| fable weekly figure | **1.86:1** | **2.26:1** | 5.21:1 | 5.21:1 |
| server sha (footer) | **1.87:1** | **2.23:1** | 5.66:1 | 5.83:1 |
| poll clock | **3.86:1** | 6.12:1 | 8.25:1 | 9.74:1 |
| usage summary line | **3.86:1** | 6.12:1 | 8.25:1 | 9.74:1 |
| band titles | **3.86:1** | 6.12:1 | 8.25:1 | 9.74:1 |
| *control:* account name | 15.56:1 | 14.43:1 | unchanged | unchanged |

The account name is the positive control: the method detects text that passes.

`.secondary` → `Tok.inkDim`, `.tertiary` → `Tok.inkFaint`. Those are the scale's own two lower levels, saying the same three degrees out loud. The visual hierarchy is unchanged — the figures still read as secondary, they are simply legible now.

## The gate

`scripts/check-panel-ink.sh` refuses the four shapes this took, and CI runs it beside `check-no-org-flag.sh`. Its fixture asserts nine cases, five rejections and four acceptances. The first draft of its regex accepted the plainest form of all, `.foregroundStyle(.secondary)` — the fixture is why that is not still true.

Two of the styles sat behind `AnyShapeStyle`, which existed only because `.tertiary` has no `Color` spelling. Both properties are plain `Color` now.

## Also in this batch, from the same review

- All four `tcr not found` hand-offs said only "searched N locations" — naming the problem with no way out of it, while the poll banner already carried the remedy. One formatter now, and the remedy is stated once in `TcrTool`.
- `PollState.summary` promises "safe to put in front of a human" and interpolated a raw `DecodingError` into the `.undecodable` arm, which drew `DecodingError.valueNotFound: quota` on the panel's own header line. The raw text moves to the banner's tooltip. A test pins the arm, and it was watched failing against the restored bug before being trusted.
- The unreadable-status banner led with that same decoder text; it now carries the remedy alone, since the header above it already says what happened.
- The reset caption used proportional figures beside a tabular percentage, so `in 4d 12h` shifted the row at hour boundaries.
- The update line is a `.plain` Button, so its hit area was the glyph boxes — about 14pt tall, with dead gaps between words. Padded, with an explicit content shape.
- `radiusMedium` 14 → 16, which is inner pill (8) plus card inset (8); at 14 the card corners read pinched against the pills inside them.
- Two group-name messages named an implementation instead of a rule: "above U+00FF" and "A group named that already exists."

## Deliberately not here

The light-mode `ready` green measures **4.19:1** on the panel. That is not a bypass: the palette gates status hues at the 3:1 non-text floor because they are bar fills and pill tints, and it reports 4.19 and passes. One site draws it as text — the verdict line — where the floor is 4.5. Fixing it means moving a token every bar and pill uses, which is its own change with its own before-and-after render.

Dropped after re-inspection: adding `Tok.pillTracking` to the org and plan indicators. That token is for uppercase runs; those two are mixed case (`Team 5x`), so it would misapply it.

## Verification

- 44 render-states scenes compared before and after. Every one changes, as it must when ink and radius move. None changes height except the undecodable pair, which gets **shorter** because the raw error was two lines.
- The hit-area fix is the one thing not visible in the harness — no scene carries an update message — so it is verified by reading, not by pixels.
- `swift build`, `swift test`, `check-panel-ink.sh`, `check-no-org-flag.sh`, `test-disclosure-scan.sh`, `cargo fmt --all --check`, `swift format lint` — all exit 0.

https://claude.ai/code/session_01SKUTn6SXT7NvVrihufNoPm
