### PR TITLE
chore: take the one real checkout bump dependabot bundled with four dead ones

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,16 @@ updates:
   # `ignore: dependency-name: actions/checkout` is repo-wide and would also freeze
   # ci.yml, which IS hand-maintained and is correctly on @v7 already.
   #
+  # CLOSING IT IS NOT THE WHOLE ACTION, and this is the part that was missed the
+  # second time round. `groups: patterns: ["*"]` puts every workflow in ONE pull
+  # request, so the unmergeable generated-file bump arrives bundled with bumps to
+  # hand-written files that are perfectly correct. PR #176 (2026-09-12) carried
+  # five dead `release.yml` bumps AND a live one for appcast-guard.yml:94, which
+  # really was still on @v6; closing the PR wholesale would have dropped it
+  # silently, and nothing would have said so. So: before closing, diff the PR per
+  # file, take any bump that is NOT in release.yml into its own commit, and say in
+  # the close comment which files you took and which you dropped.
+  #
   # Deliberately NOT setting `allow-dirty = ["ci"]` in dist-workspace.toml: that
   # would let the bump merge, but only by switching off the check that caught it.
   - package-ecosystem: github-actions

--- a/.github/workflows/appcast-guard.yml
+++ b/.github/workflows/appcast-guard.yml
@@ -91,7 +91,7 @@ jobs:
   ensure-appcast:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Ensure the release carries appcast.xml
         env:


### PR DESCRIPTION
🍄 Takes the one real `actions/checkout` bump that dependabot #176 bundled with four dead ones, so #176 can be closed without silently dropping it.

## Why #176 cannot be merged

`.github/workflows/release.yml` is **generated by cargo-dist**, which re-verifies on every run that the file still matches what it would emit. dist 0.32.0 pins `actions/checkout@v6`, so dependabot's bump to `@v7` makes `dist plan` refuse:

```
× release.yml has out of date contents and needs to be regenerated
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
help: run 'dist init' to update the file
```

exit 255. `ci`, `audit`, `macos`, `miri` and `tsan` all stay green; only `plan` goes red, and it is the one that decides whether a tag produces a release at all. This is the recurrence `.github/dependabot.yml` predicts in its own header, and the second of its kind after #30.

## What is real

Five of #176's six bumps are in that generated file. The sixth is not: `appcast-guard.yml:94` is hand-written and was still on `@v6`, while `ci.yml` and `release-app.yml` have been on `@v7` since an earlier bump. That one is taken here.

## The note that was missing

dependabot.yml already said to close the recurring PR rather than re-diagnose it, which is correct and saved the diagnosis. What it did not say is that closing is only half the action. `groups: patterns: ["*"]` bundles every workflow into one PR, so the unmergeable generated-file bump arrives wrapped around bumps that are perfectly correct — and closing wholesale drops them with nothing reporting it. The note now says to diff per file first, take anything outside `release.yml`, and record in the close comment what was taken and what was dropped.

## Verified

- `dist plan --output-format=json` in this tree exits **0** and emits a real manifest, `announcement_tag: v0.2.46`.
- Positive control: the five bumps were re-applied to `release.yml`, `dist plan` exited **255** with the message above, then reverted. `git status` reports `release.yml` unchanged.

https://claude.ai/code/session_01SKUTn6SXT7NvVrihufNoPm
