### PR TITLE
chore: add the 0.2.46 appcast entry

### DIFF
--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.46</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.46</link>
+      <sparkle:version>513</sparkle:version>
+      <sparkle:shortVersionString>0.2.46</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Sat, 12 Sep 2026 11:34:33 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.46/TcrBar-0.2.46.dmg" type="application/octet-stream" sparkle:edSignature="X1ip4hnOYWaQLnuGTvun0VBgpaDEG9EirhTc1Fzur7ogwePl0TI43hmdah36uIHVAPVV93Fv6pFFxUqM0lSGDA==" length="6722859" />
+    </item>
+    <item>
       <title>TcrBar 0.2.45</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.45</link>
       <sparkle:version>501</sparkle:version>


### PR DESCRIPTION
🍄 The `<item>` `release-tcrbar.sh` stage 8 wrote when v0.2.46 was cut, landed in the same pass as the release instead of being left for the next cut to trip over.

That is not hypothetical: `release-local.sh` check 5 refuses to start a release while this file is dirty, which is exactly how the 0.2.45 entry sat uncommitted and blocked this release until it was landed separately as #222.

`publish-appcast-feed.sh` reads the **committed** file to push the `gh-pages` feed, so until this merges `SUFeedURL` serves a feed with no 0.2.46 in it. Nine added lines, one file, no behaviour change.