### PR TITLE
feat: offer Re-login on every account row, not just broken ones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.46"
+version = "0.2.47"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "teamclaude-rs"
-version = "0.2.46"
+version = "0.2.47"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -1124,8 +1124,9 @@ struct AccountRow: View {
     /// computed against — reading the poller's published `state` afterwards could
     /// pick up a different, later poll.
     let onChanged: () async -> PollState
-    /// Hands `tcr login` to a Terminal window for THIS account. Only drawn on a
-    /// `.needsRelogin` row.
+    /// Hands `tcr login` to a Terminal window for THIS account. Drawn on
+    /// every row's context menu, and additionally as the standalone
+    /// ``AccountRow/reloginButton`` on a `.needsRelogin` row.
     let onRelogin: () -> Void
     /// Hands `tcr mint --account <this row's name>` to a Terminal window. See
     /// ``FleetView/mintAccountToken(_:)``.
@@ -1809,9 +1810,14 @@ struct AccountRow: View {
             Task { await performToggle(enabling: enabling) }
         }
         .disabled(accounts.isPending(account.ref))
-        if account.health == .needsRelogin {
-            Button("Re-login…") { onRelogin() }
-        }
+        Button("Re-login…") { onRelogin() }
+            .help(
+                "Opens `tcr login --account` in a Terminal window, requesting "
+                    + "this exact account. `tcr` refuses to save if the browser "
+                    + "hands back a different one. The login it starts now mints "
+                    + "a credential good for a year, so running it on a healthy "
+                    + "row is a safe way to get ahead of the old one expiring."
+            )
         Divider()
         // Hidden entirely while `control` cannot answer the question at all
         // (``ControlAccountController/unavailable``) — an older `tcr` has no

--- a/apps/macos/Tests/TcrBarTests/FleetViewContextMenuTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetViewContextMenuTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+
+/// `AccountRow`'s `contextMenuItems` is a `@ViewBuilder` built from live
+/// `AccountController`/`ControlAccountController`/`GroupController`/
+/// `RemoveAccountController` dependencies with no lightweight test doubles in
+/// this target, and ViewInspector is not a dependency here — so this reads
+/// the source directly, the same technique `FleetStatusTests` already uses
+/// (`testAccountStatusErrorTokenStillExistsInRustSource`) for an assertion a
+/// runtime test can't reach cheaply.
+final class ContextMenuReloginAvailabilityTests: XCTestCase {
+    /// The bug this test guards: "Re-login…" used to disappear from the
+    /// context menu the moment an account came back healthy, which made it
+    /// useless as the migration path off the eight-hour credentials PR #214
+    /// replaced with year-long ones — a healthy row is exactly the row an
+    /// operator would want to migrate ahead of its old token's own expiry.
+    func testReloginItemHasNoHealthGateInContextMenu() throws {
+        let body = try contextMenuItemsBody()
+        XCTAssertFalse(
+            body.contains("account.health == .needsRelogin"),
+            "contextMenuItems still gates \"Re-login…\" on .needsRelogin — "
+                + "the item is hidden on every healthy row, so an account "
+                + "that logged in before PR #214 has no way to pick up its "
+                + "one-year credential without first breaking"
+        )
+        XCTAssertTrue(
+            body.contains(#"Button("Re-login…") { onRelogin() }"#),
+            "the \"Re-login…\" button itself has moved or been renamed in "
+                + "contextMenuItems — update this test's anchor to match"
+        )
+    }
+
+    /// Isolates the `contextMenuItems` computed property's source text so
+    /// the assertion above cannot accidentally match some other `.needsRelogin`
+    /// check elsewhere in the file (e.g. the standalone `reloginButton`'s own
+    /// gate, which is deliberately left alone).
+    private func contextMenuItemsBody() throws -> String {
+        let thisFile = URL(fileURLWithPath: #filePath)
+        let repoRoot =
+            thisFile
+            .deletingLastPathComponent()  // FleetViewContextMenuTests.swift -> TcrBarTests
+            .deletingLastPathComponent()  // TcrBarTests -> Tests
+            .deletingLastPathComponent()  // Tests -> apps/macos
+            .deletingLastPathComponent()  // apps/macos -> apps
+            .deletingLastPathComponent()  // apps -> repo root
+        let fleetView = repoRoot.appendingPathComponent(
+            "apps/macos/Sources/TcrBar/FleetView.swift")
+        let contents = try String(contentsOf: fleetView, encoding: .utf8)
+        guard
+            let start = contents.range(
+                of: "private var contextMenuItems: some View {"),
+            let end = contents.range(
+                of: "private var groupMenuItems: some View {",
+                range: start.upperBound..<contents.endIndex)
+        else {
+            XCTFail(
+                "contextMenuItems or groupMenuItems has moved or been renamed "
+                    + "in \(fleetView.path) — update this test's anchors")
+            return ""
+        }
+        return String(contents[start.upperBound..<end.lowerBound])
+    }
+}


### PR DESCRIPTION
🍄

## What

`AccountRow`'s context-menu "Re-login…" item is no longer gated on `account.health == .needsRelogin`. It's present on every row now. The standalone bordered `reloginButton` drawn on broken rows is untouched — still gated, still the visible repair affordance.

## Why

PR #214 made `exchange_code` mint a one-year access token from any login instead of an eight-hour one. `tcr` only refreshes when the access token is expired or inside its 5-minute buffer, so a row already holding a one-year token never touches its refresh token again — which matters because the refresh token itself dies on an absolute ~29-day clock refreshing doesn't extend. The 18 existing accounts predate #214 and still hold short-lived credentials; this context-menu item is now how each one gets migrated, one click, without needing to be broken first.

The identity guard (`tcr login --account <name>` refuses to save a mismatched account) is what makes exposing this on every row safe — an untargeted login could otherwise authenticate as whichever account the browser happens to hold.

Added a `.help` on the context-menu item explaining why a reader would click it on a healthy row.

## Test

`contextMenuItems` composes live `AccountController`/`ControlAccountController`/`GroupController`/`RemoveAccountController` state with no lightweight test seam and this target has no ViewInspector, so the test reads `FleetView.swift`'s own source — the same technique `FleetStatusTests.testAccountStatusErrorTokenStillExistsInRustSource` already uses for an assertion a runtime test can't reach cheaply. It isolates the `contextMenuItems` property's body text and asserts it no longer contains the `.needsRelogin` gate.

Watched it fail first against the unmodified condition:

```
XCTAssertFalse failed - contextMenuItems still gates "Re-login…" on .needsRelogin — the item is hidden on every healthy row, so an account that logged in before PR #214 has no way to pick up its one-year credential without first breaking
```

A context-menu item doesn't show up in a rendered PNG, so no `--render-states` re-render is included or claimed as proof here — this diff has no visible layout change.

## Gates

- `swift build` — exit 0
- `swift test` — exit 0 (499 tests)
- `swift-format lint --strict --recursive` — exit 0
- `scripts/check-panel-ink.sh` — exit 0

https://claude.ai/code/session_01SthzJbCpAHAF8AtNkVyksa
