### PR TITLE
chore: add the 0.2.47 appcast entry

### DIFF
--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.47</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.47</link>
+      <sparkle:version>515</sparkle:version>
+      <sparkle:shortVersionString>0.2.47</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Sat, 12 Sep 2026 12:07:52 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.47/TcrBar-0.2.47.dmg" type="application/octet-stream" sparkle:edSignature="XIwrzZGh5ussCEUdadh2vN3jQ0FGCVWcCRcFu3WOWmZ/1mqeFTbmXIYu6kBgSaDRFtOEkpW0smom2eW+FybjCw==" length="6723177" />
+    </item>
+    <item>
       <title>TcrBar 0.2.46</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.46</link>
       <sparkle:version>513</sparkle:version>


### PR DESCRIPTION
🍄 The `<item>` stage 8 wrote when v0.2.47 was cut. `publish-appcast-feed.sh` reads the committed file to push the `gh-pages` feed, so until this merges `SUFeedURL` has no 0.2.47 in it. Nine lines, one file, no behaviour change.