### PR TITLE
Outline each group's section in its own group colour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.47"
+version = "0.2.48"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "teamclaude-rs"
-version = "0.2.47"
+version = "0.2.48"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -426,8 +426,9 @@ struct FleetView: View {
     }
 
     /// One section's heading and rows, outlined in the group's colour when
-    /// ``FleetSection/isOutlined`` says to (never for `.ungrouped` — its
-    /// bare absence of a box is the signal, per the bridge's decision #1).
+    /// ``FleetSection/outlineColor`` resolves one (never for `.ungrouped`,
+    /// and never for a named group with no resolved colour either — see
+    /// that property's own doc-comment for why the two draw identically).
     ///
     /// `drawsHeading` is threaded through rather than recomputed, and
     /// `listChildKeys` below gates on the SAME call `accountList` made: a
@@ -470,28 +471,35 @@ struct FleetView: View {
     /// itself short of its own content. Growing the background instead
     /// changes nothing SwiftUI's layout pass measures.
     ///
-    /// A named group with no resolved colour (``FleetSection/outlineColor``
-    /// `nil`) still draws — in ``Tok/hairlineStrong``, the same neutral the
-    /// account card's own border already uses — because it IS a real group,
-    /// just one this build cannot colour; only ``FleetGroupKey/ungrouped``
-    /// draws nothing at all.
+    /// Draws NOTHING when ``FleetSection/outlineColor`` is `nil` — an
+    /// earlier version of this drew a neutral ``Tok/hairlineStrong`` box for
+    /// a named group with no resolved colour, mirroring ``GroupChip``'s own
+    /// colourless-but-still-legible fallback. That does not transfer here: a
+    /// chip stays informative without colour because it has text inside it;
+    /// an outline IS the colour, so stripping it leaves a box that groups
+    /// nothing while still competing for the eye — measured at 2.56:1 dark /
+    /// 2.23:1 light against the panel, visible enough to be clutter and not
+    /// visible enough to read as a boundary. An absent box beats an
+    /// invisible one, so an unresolved colour now draws exactly like
+    /// `.ungrouped`.
+    ///
+    /// The resolved colour itself is drawn at full strength, undimmed, even
+    /// where its own measured contrast is low (`henry-team`'s green is
+    /// 1.73:1 on the light panel) — that is reported, not silently
+    /// corrected, because the group heading already names the group in
+    /// text: the outline's colour is redundant decoration here, not
+    /// information the reader has no other way to get, so it does not need
+    /// to clear a text-legibility bar to be worth drawing.
     @ViewBuilder
     private func groupOutline(for section: FleetSection) -> some View {
-        if section.isOutlined {
+        if let rgb = section.outlineColor {
             RoundedRectangle(cornerRadius: Tok.groupOutlineRadius)
-                .strokeBorder(outlineTint(for: section), lineWidth: Tok.groupOutlineWidth)
+                .strokeBorder(
+                    Color(red: rgb.red, green: rgb.green, blue: rgb.blue),
+                    lineWidth: Tok.groupOutlineWidth
+                )
                 .padding(-Tok.groupOutlineInset)
         }
-    }
-
-    /// The colour to stroke a section's outline in: the server-resolved
-    /// group colour at full strength when one exists, else the same neutral
-    /// ``Tok/hairlineStrong`` the account card's own border already draws —
-    /// never a dimmed or invented hue (see ``FleetSection/outlineColor``'s
-    /// doc-comment for why).
-    private func outlineTint(for section: FleetSection) -> Color {
-        guard let rgb = section.outlineColor else { return Tok.hairlineStrong }
-        return Color(red: rgb.red, green: rgb.green, blue: rgb.blue)
     }
 
     /// The outer heading: what these accounts can do for you right now.

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -419,22 +419,79 @@ struct FleetView: View {
                 if sections.isFirstOfBand(index) {
                     bandHeading(section.band)
                 }
-                // Gated, and `listChildKeys` below gates on the SAME call. The
-                // two must agree exactly: a heading drawn but unkeyed is a row
-                // the viewport never charges for, and a heading keyed but not
-                // drawn charges for a row that is not there. Both clip.
-                if sections.drawsGroupHeading(at: index) {
-                    groupHeading(section)
-                }
-                // `FleetSectionRow` is `Identifiable` on the composite
-                // (group, account) id, which is why this can be a plain
-                // `ForEach` over the rows: the duplicated account's two rows
-                // carry different identities.
-                ForEach(section.rows) { row in
-                    accountRow(row, fleet: fleet)
-                }
+                sectionBody(
+                    section, drawsHeading: sections.drawsGroupHeading(at: index), fleet: fleet)
             }
         }
+    }
+
+    /// One section's heading and rows, outlined in the group's colour when
+    /// ``FleetSection/isOutlined`` says to (never for `.ungrouped` — its
+    /// bare absence of a box is the signal, per the bridge's decision #1).
+    ///
+    /// `drawsHeading` is threaded through rather than recomputed, and
+    /// `listChildKeys` below gates on the SAME call `accountList` made: a
+    /// heading drawn but unkeyed is a row the viewport never charges for,
+    /// and a heading keyed but not drawn charges for a row that is not
+    /// there. Both clip.
+    ///
+    /// `FleetSectionRow` is `Identifiable` on the composite (group, account)
+    /// id, which is why the inner `ForEach` can iterate `section.rows`
+    /// directly: the duplicated account's two rows carry different
+    /// identities.
+    private func sectionBody(_ section: FleetSection, drawsHeading: Bool, fleet: Fleet)
+        -> some View
+    {
+        VStack(alignment: .leading, spacing: Tok.rowSpacing) {
+            if drawsHeading {
+                groupHeading(section)
+            }
+            ForEach(section.rows) { row in
+                accountRow(row, fleet: fleet)
+            }
+        }
+        .background(groupOutline(for: section))
+    }
+
+    /// The section's outline, drawn OUTSIDE its content's own bounds via
+    /// negative padding rather than by padding the content inward.
+    ///
+    /// A `.background` is sized to match the view it is attached to — the
+    /// `VStack` above never grows to accommodate it — so expanding the
+    /// stroked shape past that size with `.padding(-Tok.groupOutlineInset)`
+    /// draws it bleeding outward into the surrounding `rowSpacing` gap
+    /// without asking the `VStack` for one extra point of height. That
+    /// matters here specifically: every row and heading in this list
+    /// publishes its own measured height (`FleetView/rowHeights`,
+    /// `measured(_:content:)`) and `PanelHeight.visibleRowsHeight` sums
+    /// those keyed heights independently of whatever SwiftUI actually lays
+    /// out — a real padding here would grow the rendered list without
+    /// growing any of those published numbers, and the panel would size
+    /// itself short of its own content. Growing the background instead
+    /// changes nothing SwiftUI's layout pass measures.
+    ///
+    /// A named group with no resolved colour (``FleetSection/outlineColor``
+    /// `nil`) still draws — in ``Tok/hairlineStrong``, the same neutral the
+    /// account card's own border already uses — because it IS a real group,
+    /// just one this build cannot colour; only ``FleetGroupKey/ungrouped``
+    /// draws nothing at all.
+    @ViewBuilder
+    private func groupOutline(for section: FleetSection) -> some View {
+        if section.isOutlined {
+            RoundedRectangle(cornerRadius: Tok.groupOutlineRadius)
+                .strokeBorder(outlineTint(for: section), lineWidth: Tok.groupOutlineWidth)
+                .padding(-Tok.groupOutlineInset)
+        }
+    }
+
+    /// The colour to stroke a section's outline in: the server-resolved
+    /// group colour at full strength when one exists, else the same neutral
+    /// ``Tok/hairlineStrong`` the account card's own border already draws —
+    /// never a dimmed or invented hue (see ``FleetSection/outlineColor``'s
+    /// doc-comment for why).
+    private func outlineTint(for section: FleetSection) -> Color {
+        guard let rgb = section.outlineColor else { return Tok.hairlineStrong }
+        return Color(red: rgb.red, green: rgb.green, blue: rgb.blue)
     }
 
     /// The outer heading: what these accounts can do for you right now.

--- a/apps/macos/Sources/TcrBar/RenderStates.swift
+++ b/apps/macos/Sources/TcrBar/RenderStates.swift
@@ -585,11 +585,25 @@ enum RenderStates {
     /// clipped and the name is still readable. A second, ordinary row is
     /// included as the control: if the panel is over-wide for a structural
     /// reason, both rows show it, and the bug is not the one this scene names.
+    ///
+    /// Carries `groupColors` (`widestRowSceneColors`), which every earlier
+    /// version of this fixture omitted. This is also the one scene that puts
+    /// ONE account in TWO group sections at once (`docs/plans/
+    /// group-outline-bridge.md`, decision #4) — the case the group-outline
+    /// feature most needs a real render of, and a fixture with no colours
+    /// draws the section-outline feature's neutral FALLBACK stroke in both
+    /// sections, which reads as identical grey regardless of whether the two
+    /// sections are wired to two different colours or none at all. Without
+    /// this, the scene cannot tell "outline colour is broken" apart from
+    /// "outline colour was never given one to draw" — the exact ambiguity
+    /// that made a rendered PNG of this scene, by itself, prove nothing about
+    /// the feature it was chosen to demonstrate.
     private static var widestRowJSON: String {
         let worst = account(
             "henry.fitzgerald@example.com", quota: "0.62", state: "ok",
             groups: ["gil", "henry-team-parked"],
             reservedGroups: ["gil"],
+            groupColors: widestRowSceneColors,
             plan: "Team Standard",
             orgUuid: "22222222-2222-2222-2222-222222222222")
         let ordinary = account(
@@ -642,6 +656,17 @@ enum RenderStates {
     /// `groupColors` the server actually sends.
     private static let parkedSceneColors: [String: String] = [
         "henry-team": "#32d74b", "dev": "#0a84ff",
+    ]
+
+    /// Real colours for the widest-row scene, deliberately DIFFERENT hues
+    /// from `parkedSceneColors` (orange, purple, rather than green, blue) —
+    /// two scenes both carrying blue/green would leave a swapped-colour bug
+    /// invisible if the swap happened to land the same pair back on the same
+    /// two sections. `henry.fitzgerald@example.com` sits in BOTH `gil` and
+    /// `henry-team-parked` at once, so this is the fixture that shows the
+    /// group-outline feature's account-in-two-groups case in colour.
+    private static let widestRowSceneColors: [String: String] = [
+        "gil": "#ff9f0a", "henry-team-parked": "#bf5af2",
     ]
 
     /// ONE PERSON, TWO ORGS — the shape that broke the panel, and the names it

--- a/apps/macos/Sources/TcrBar/Tokens.swift
+++ b/apps/macos/Sources/TcrBar/Tokens.swift
@@ -345,6 +345,28 @@ public enum Tok {
     public static let pillPaddingV: CGFloat = 2
     public static let hairlineWidth: CGFloat = 0.5
 
+    /// Group outline: the section-level border wrapped around a named
+    /// group's heading and rows (`docs/plans/group-outline-bridge.md`).
+    /// Heavier than the card's own ``hairlineWidth`` (0.5) on purpose — a
+    /// structural grouping cue drawn at arm's length needs to read at a
+    /// glance, where a hairline disappears — and it is drawn OUTSIDE the
+    /// section's own layout box (`FleetView.groupOutline(for:)`, via
+    /// negative padding) rather than by adding real padding around the
+    /// content, so it never changes any ``rowHeights``-measured row or
+    /// heading height. See that function's own doc-comment for why that
+    /// distinction matters here.
+    public static let groupOutlineWidth: CGFloat = 1.0
+    /// How far outside its section's own bounds the outline sits. Kept
+    /// under `rowSpacing` (8) so two adjacent sections' outlines never
+    /// touch in the gap between them.
+    public static let groupOutlineInset: CGFloat = 6
+    /// Bigger than `radiusMedium` (the cards' own radius) by roughly
+    /// `groupOutlineInset` — the same outer-equals-inner-plus-padding rule
+    /// `radiusMedium`'s own doc-comment uses for the cards, applied one
+    /// level up so the outline reads as a looser box AROUND same-radius
+    /// cards rather than a same-size sibling beside them.
+    public static let groupOutlineRadius: CGFloat = radiusMedium + groupOutlineInset
+
     // MARK: - Motion
     //
     // One duration and one curve for the whole app. A status panel that animates

--- a/apps/macos/Sources/TcrBarCore/FleetSections.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetSections.swift
@@ -221,32 +221,28 @@ public struct FleetSection: Identifiable, Equatable, Sendable {
     /// the heading without walking `rows` itself.
     public var containsControl: Bool { rows.contains(where: \.isControl) }
 
-    /// Whether the view should draw a group outline around this section at
-    /// all — every named group, never ``FleetGroupKey/ungrouped``
-    /// (`docs/plans/group-outline-bridge.md`, decision #1: the absence of an
-    /// outline on an ungrouped section IS the signal, so nothing here
-    /// invents a neutral one for it). A named group still answers `true`
-    /// even when ``outlineColor`` is `nil` — that is a real group with an
-    /// unresolved colour, not the absence of a group, and the view falls
-    /// back to a neutral stroke the same way ``GroupTag/background``'s own
-    /// fallback keeps drawing a (colourless) chip rather than no chip.
-    public var isOutlined: Bool {
-        if case .named = group { return true }
-        return false
-    }
-
     /// The server-resolved colour to stroke this section's outline in, or
-    /// `nil` when no row in it carries a colour for this group (an older
-    /// server, or the field genuinely absent). Never invented client-side —
-    /// the same rule ``Account/groupTags`` already follows for the per-row
-    /// chip — so a `nil` here means the view must fall back to a neutral
-    /// stroke, not guess a hue.
+    /// `nil` when there is nothing to draw: `.ungrouped`
+    /// (`docs/plans/group-outline-bridge.md`, decision #1 — the absence of
+    /// an outline there IS the signal), OR a named group whose colour has
+    /// not resolved (an older server, or the field genuinely absent).
     ///
-    /// Reads from the first row that has an answer rather than requiring
-    /// every row to agree: `groupColors` is fleet-wide (every row of every
-    /// account carries the same map, per its own doc-comment), so in
-    /// practice they always agree, and this only guards against a
-    /// pathological wire payload where they do not.
+    /// Both `nil` cases draw NOTHING, on purpose — this does NOT mirror
+    /// ``GroupTag/background``'s neutral fallback, even though an earlier
+    /// version of this property did. A chip stays informative without
+    /// colour because it has legible text inside it; an outline is only the
+    /// stroke, so a colourless one is a box that groups nothing while still
+    /// competing for the eye. A neutral fallback here measured 2.56:1 dark /
+    /// 2.23:1 light against the panel — visible enough to be clutter, not
+    /// visible enough to read as a boundary — which is why an unresolved
+    /// colour now answers the same as no group at all.
+    ///
+    /// Never invents a colour client-side — the same rule ``Account/groupTags``
+    /// already follows for the per-row chip. Reads from the first row that
+    /// has an answer rather than requiring every row to agree: `groupColors`
+    /// is fleet-wide (every row of every account carries the same map, per
+    /// its own doc-comment), so in practice they always agree, and this only
+    /// guards against a pathological wire payload where they do not.
     public var outlineColor: GroupTagColor.RGB? {
         guard case .named(let name) = group else { return nil }
         for row in rows {
@@ -256,6 +252,13 @@ public struct FleetSection: Identifiable, Equatable, Sendable {
         }
         return nil
     }
+
+    /// Whether the view should draw a group outline around this section at
+    /// all — exactly when ``outlineColor`` resolves to a real colour. Kept
+    /// as its own named property, rather than inlined at every call site, so
+    /// the "draw or not" decision reads as one word and is unit-testable on
+    /// its own: see the drawing rule's full reasoning on ``outlineColor``.
+    public var isOutlined: Bool { outlineColor != nil }
 }
 
 extension Array where Element == FleetSection {

--- a/apps/macos/Sources/TcrBarCore/FleetSections.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetSections.swift
@@ -220,6 +220,42 @@ public struct FleetSection: Identifiable, Equatable, Sendable {
     /// True when any row here is the control account — so a view can decorate
     /// the heading without walking `rows` itself.
     public var containsControl: Bool { rows.contains(where: \.isControl) }
+
+    /// Whether the view should draw a group outline around this section at
+    /// all — every named group, never ``FleetGroupKey/ungrouped``
+    /// (`docs/plans/group-outline-bridge.md`, decision #1: the absence of an
+    /// outline on an ungrouped section IS the signal, so nothing here
+    /// invents a neutral one for it). A named group still answers `true`
+    /// even when ``outlineColor`` is `nil` — that is a real group with an
+    /// unresolved colour, not the absence of a group, and the view falls
+    /// back to a neutral stroke the same way ``GroupTag/background``'s own
+    /// fallback keeps drawing a (colourless) chip rather than no chip.
+    public var isOutlined: Bool {
+        if case .named = group { return true }
+        return false
+    }
+
+    /// The server-resolved colour to stroke this section's outline in, or
+    /// `nil` when no row in it carries a colour for this group (an older
+    /// server, or the field genuinely absent). Never invented client-side —
+    /// the same rule ``Account/groupTags`` already follows for the per-row
+    /// chip — so a `nil` here means the view must fall back to a neutral
+    /// stroke, not guess a hue.
+    ///
+    /// Reads from the first row that has an answer rather than requiring
+    /// every row to agree: `groupColors` is fleet-wide (every row of every
+    /// account carries the same map, per its own doc-comment), so in
+    /// practice they always agree, and this only guards against a
+    /// pathological wire payload where they do not.
+    public var outlineColor: GroupTagColor.RGB? {
+        guard case .named(let name) = group else { return nil }
+        for row in rows {
+            if let hex = row.account.groupColors?[name], let rgb = GroupTagColor.parse(hex) {
+                return rgb
+            }
+        }
+        return nil
+    }
 }
 
 extension Array where Element == FleetSection {

--- a/apps/macos/Tests/TcrBarTests/FleetSectionsTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetSectionsTests.swift
@@ -260,6 +260,45 @@ final class FleetSectionsTests: XCTestCase {
                 .rows.map(\.account.name), ["a@example.com", "z@example.com"])
     }
 
+    // MARK: - Group outline (docs/plans/group-outline-bridge.md)
+
+    /// A named group's section carries its own server-resolved colour, and
+    /// `isOutlined` says the view should draw it. Decision #1: `.ungrouped`
+    /// carries neither — no colour AND no outline at all, not merely an
+    /// unresolved one, which is the distinction the next test locks down.
+    func testNamedGroupSectionCarriesItsColorAndUngroupedCarriesNone() {
+        let fleet = Fleet(accounts: [
+            sectionAccount(
+                "a@example.com", groups: ["dev"], groupColors: ["dev": "#0a84ff"]),
+            sectionAccount("b@example.com", groups: nil),
+        ])
+        let sections = fleet.sectionsInDisplayOrder()
+
+        let dev = try? XCTUnwrap(sections.first { $0.group == .named("dev") })
+        XCTAssertTrue(dev?.isOutlined ?? false)
+        let devColor = dev?.outlineColor
+        XCTAssertEqual(devColor?.red ?? -1, 0x0a / 255.0, accuracy: 0.001)
+        XCTAssertEqual(devColor?.green ?? -1, 0x84 / 255.0, accuracy: 0.001)
+        XCTAssertEqual(devColor?.blue ?? -1, 0xff / 255.0, accuracy: 0.001)
+
+        let ungrouped = try? XCTUnwrap(sections.first { $0.group == .ungrouped })
+        XCTAssertFalse(ungrouped?.isOutlined ?? true)
+        XCTAssertNil(ungrouped?.outlineColor)
+    }
+
+    /// A named group with no `groupColors` entry — an older server, or the
+    /// field genuinely absent — still answers `isOutlined == true` (it is a
+    /// real group), but `outlineColor` is `nil` rather than an invented hue.
+    /// The view is the one that falls back to a neutral stroke; this layer
+    /// never guesses a colour.
+    func testNamedGroupWithNoResolvedColorIsStillOutlinedButHasNoColor() {
+        let fleet = Fleet(accounts: [sectionAccount("a@example.com", groups: ["dev"])])
+        let section = try? XCTUnwrap(fleet.sectionsInDisplayOrder().first)
+
+        XCTAssertTrue(section?.isOutlined ?? false)
+        XCTAssertNil(section?.outlineColor)
+    }
+
     // MARK: - What the row and the view need
 
     /// A row's band matches the section it is in — the carried copy cannot
@@ -349,7 +388,8 @@ private func sectionAccount(
     quotaState: QuotaState = .ok,
     quota: Double? = 0,
     status: String = "active",
-    disabled: Bool = false
+    disabled: Bool = false,
+    groupColors: [String: String]? = nil
 ) -> Account {
     Account(
         name: name,
@@ -377,6 +417,6 @@ private func sectionAccount(
         groups: groups,
         reservedGroups: nil,
         parkedGroups: parkedGroups,
-        groupColors: nil
+        groupColors: groupColors
     )
 }

--- a/apps/macos/Tests/TcrBarTests/FleetSectionsTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetSectionsTests.swift
@@ -262,10 +262,10 @@ final class FleetSectionsTests: XCTestCase {
 
     // MARK: - Group outline (docs/plans/group-outline-bridge.md)
 
-    /// A named group's section carries its own server-resolved colour, and
-    /// `isOutlined` says the view should draw it. Decision #1: `.ungrouped`
-    /// carries neither — no colour AND no outline at all, not merely an
-    /// unresolved one, which is the distinction the next test locks down.
+    /// A named group's section carries its own server-resolved colour.
+    /// `.ungrouped` carries none — decision #1, its absent outline IS the
+    /// signal — which is the same `nil` the next test locks down for a
+    /// DIFFERENT reason (a real group whose colour never resolved).
     func testNamedGroupSectionCarriesItsColorAndUngroupedCarriesNone() {
         let fleet = Fleet(accounts: [
             sectionAccount(
@@ -287,15 +287,18 @@ final class FleetSectionsTests: XCTestCase {
     }
 
     /// A named group with no `groupColors` entry — an older server, or the
-    /// field genuinely absent — still answers `isOutlined == true` (it is a
-    /// real group), but `outlineColor` is `nil` rather than an invented hue.
-    /// The view is the one that falls back to a neutral stroke; this layer
-    /// never guesses a colour.
-    func testNamedGroupWithNoResolvedColorIsStillOutlinedButHasNoColor() {
+    /// field genuinely absent — answers `isOutlined == false`, exactly like
+    /// `.ungrouped` does, and the view draws NO outline for either. An
+    /// earlier version of this answered `true` here and had the view fall
+    /// back to a neutral box, mirroring `GroupTag`'s own colourless-chip
+    /// fallback; that was reverted because an outline that is only ever a
+    /// stroke has nothing left to say once its colour is gone — a chip
+    /// still has its text. An absent box beats an invisible one.
+    func testNamedGroupWithNoResolvedColorDrawsNoOutlineEitherJustLikeUngrouped() {
         let fleet = Fleet(accounts: [sectionAccount("a@example.com", groups: ["dev"])])
         let section = try? XCTUnwrap(fleet.sectionsInDisplayOrder().first)
 
-        XCTAssertTrue(section?.isOutlined ?? false)
+        XCTAssertFalse(section?.isOutlined ?? true)
         XCTAssertNil(section?.outlineColor)
     }
 

--- a/apps/macos/design-tokens/tokens.css
+++ b/apps/macos/design-tokens/tokens.css
@@ -37,6 +37,8 @@
     --tcr-body-size: 13px;
     --tcr-detail-font-size: 10px;
     --tcr-detail-line-height: 14px;
+    --tcr-group-outline-inset: 6px;
+    --tcr-group-outline-width: 1.0px;
     --tcr-hairline-width: 0.5px;
     --tcr-measurement-grain: 0.5px;
     --tcr-panel-max-height: 520px;

--- a/apps/macos/design-tokens/tokens.json
+++ b/apps/macos/design-tokens/tokens.json
@@ -60,6 +60,8 @@
     "body-size": 13.0,
     "detail-font-size": 10.0,
     "detail-line-height": 14.0,
+    "group-outline-inset": 6.0,
+    "group-outline-width": 1.0,
     "hairline-width": 0.5,
     "measurement-grain": 0.5,
     "panel-max-height": 520.0,


### PR DESCRIPTION
🍄

## What

Wraps a named group's heading and rows in a stroked, rounded rectangle
tinted with the group's server-resolved colour — `derive_group_color`
(`src/config.rs`) end-to-end through the `group_colors` wire map to
`FleetSection.outlineColor` (new). Drawing rule, after review:

- `.ungrouped` never gets an outline — its absence is the signal.
- A named group with an UNRESOLVED colour (older server, or the field
  genuinely absent) draws no outline either. An earlier revision mirrored
  `GroupChip`'s own colourless-but-legible chip fallback here; that does
  not transfer — a chip stays informative without colour because it has
  text inside it, an outline IS the colour, so a colourless outline is a
  box that groups nothing while still competing for the eye (measured
  2.56:1 dark / 2.23:1 light against the panel — visible enough to be
  clutter, not visible enough to read as a boundary). An absent box beats
  an invisible one.
- A named group WITH a resolved colour always draws it at full strength,
  even where its own contrast against the panel is low (see below) — the
  section heading already names the group in text, so the outline's
  colour is redundant decoration, not information the reader has no other
  way to get.

The outline is drawn OUTSIDE the section's own layout box, via negative
padding on the background shape, so it never changes the per-row/
per-heading measured heights `PanelHeight` sums to size the scroll view —
confirmed by pixel-diffing the before/after renders and finding the change
confined to exactly the outline's own bounding box, nothing shifted below
it.

## Render verdict

Rendered `--render-states` before/after for all 44 PNGs (light + dark).
The full outline reads cleanly, not as clutter — the outer box is clearly
bigger and more rounded than the account cards inside it, with enough
breathing room that it doesn't read as boxes-in-boxes, in both the neutral
and the coloured cases. Kept the full outline rather than falling back to
a left-edge colour bar.

The render fixtures needed a fix along the way: `01g-widest-row` carried
`groups: ["gil", "henry-team-parked"]` but no `groupColors`, so its render
could not tell "the wiring is broken" apart from "this fixture never gave
it a colour to draw" — both sections drew the same grey
(`(161,165,170)`/`(180,184,188)` sampled off the PNG, exact match to
`Tok.hairlineStrong`). Added `widestRowSceneColors` (orange `#ff9f0a` for
`gil`, purple `#bf5af2` for `henry-team-parked` — deliberately different
hues from `15-parked-group`'s green/blue so a colour-swap bug can't hide).
Confirmed the wiring was never broken: `15-parked-group` already had real
colours and already rendered two genuinely different hues before this fix;
`01g-widest-row` now does too, exact-pixel-matched (`gil` 5458px
saturation 1.0, `henry-team-parked` 10059px saturation 0.854, in both
appearances).

Checked specifically:
- `15-parked-group`: real colours (`dev` blue, `henry-team` green) — clean,
  unchanged across every revision of this PR.
- `01g-widest-row`: the account-in-two-groups case (decision #4) — now
  shows two genuinely different hues on the SAME account's two sections.
- `01-healthy`: the neutral-fallback case — after the drawing-rule fix,
  its `research` section (no `groupColors` on that fixture, an
  older-server payload) now shows NO outline at all; pixel-diffed against
  the prior revision and the change is confined exactly to the former
  outline's bounding box.
- `02-mixed-thirteen` / `07-empty-fleet`: negative controls, no groups —
  zero outlines throughout every revision.

## Contrast (measured off the rendered PNGs, WCAG formula, floor is 3:1)

| stroke | dark panel | light panel |
|---|---|---|
| `dev` `#0a84ff` | 4.97:1 | 3.29:1 |
| `henry-team` `#32d74b` | 9.46:1 | **1.73:1 — below floor, drawn anyway (see above)** |
| `gil` `#ff9f0a` | 8.82:1 | **1.85:1 — below floor, drawn anyway** |
| `henry-team-parked` `#bf5af2` | 5.15:1 | 3.17:1 |

Not silently darkened. A real server-derived group colour can fail the
3:1 non-text floor on the light panel, and it's drawn at full strength
anyway, because the group heading's TEXT is the information-bearing
channel and the outline is decoration on top of it, per the drawing rule
above.

## Gates

- `swift build`: exit 0
- `swift test` (501 tests): exit 0 — three tests added/revised in
  `FleetSectionsTests`, each watched failing against the wrong
  implementation before being confirmed green against the real one.
- `swift-format lint --strict --recursive`: exit 0
- `scripts/check-panel-ink.sh`: exit 0
- `check-release-version.sh` blocked on 0.2.47 already being a tagged
  release — bumped `Cargo.toml`/`Cargo.lock` to 0.2.48 and regenerated
  `apps/macos/design-tokens/` from the two new `Tokens.swift` constants.

Public repo: no real emails, org names or UUIDs added — the fixture's
`gil`/`henry-team-parked` group-name strings and `@example.com` addresses
all pre-date this branch.