### PR TITLE
chore: add the 0.2.48 appcast entry

### DIFF
--- a/apps/macos/appcast.xml
+++ b/apps/macos/appcast.xml
@@ -6,6 +6,15 @@
     <language>en</language>
     <!-- release-tcrbar.sh inserts new items directly below this line -->
     <item>
+      <title>TcrBar 0.2.48</title>
+      <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.48</link>
+      <sparkle:version>517</sparkle:version>
+      <sparkle:shortVersionString>0.2.48</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <pubDate>Sat, 12 Sep 2026 12:50:28 +0000</pubDate>
+      <enclosure url="https://github.com/dhkts1/teamclaude-rs/releases/download/v0.2.48/TcrBar-0.2.48.dmg" type="application/octet-stream" sparkle:edSignature="aeUIyFCTZty/QAWDl2kh5zRlOWIh2CoD5m0PiK6LK5dHAknsXFOyVxKWYhapQGYCQAa8t0KfdV5c+GUyx3EVDQ==" length="6728732" />
+    </item>
+    <item>
       <title>TcrBar 0.2.47</title>
       <link>https://github.com/dhkts1/teamclaude-rs/releases/tag/v0.2.47</link>
       <sparkle:version>515</sparkle:version>


### PR DESCRIPTION
🍄 The `<item>` stage 8 wrote when v0.2.48 was cut. `publish-appcast-feed.sh` reads the committed file, so until this merges `SUFeedURL` has no 0.2.48 in it.