### PR TITLE
fix: tell the operator what to do when the fleet is empty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.48"
+version = "0.2.49"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "teamclaude-rs"
-version = "0.2.48"
+version = "0.2.49"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -349,7 +349,7 @@ struct FleetView: View {
                 banner(
                     icon: Tok.unreadableGlyph,
                     title: "No accounts configured",
-                    detail: "tcr answered, and the fleet is empty.",
+                    detail: "tcr answered, and the fleet is empty. Run `tcr login` in a terminal to add one.",
                     tint: Tok.unknown
                 )
             } else {


### PR DESCRIPTION
🍄

The empty-fleet banner (`FleetView.swift:351`) said "tcr answered, and the
fleet is empty." and stopped there. It now adds the actual next step: run
`tcr login` in a terminal.

No button that launches a login flow — that's a separate design, per the
harvest bridge item A12.

## Verification

- `TCRBAR_DEV_BUILD=1 apps/macos/scripts/build-tcrbar.sh` — exit 0 (swift
  build + cargo build release, both succeeded; dev bundle id used so it
  never touches the shipping identity).
- Rendered the `07-empty-fleet` fixture with the built dev bundle's
  `--render-states` flag (`TcrBar.app/Contents/MacOS/TcrBar --render-states
  /tmp/tcrbar-states-a12`), 44/44 images written, exit 0. The panel now
  reads:

  > No accounts configured
  > tcr answered, and the fleet is empty. Run `tcr login` in a terminal to
  > add one.

  (checked visually against `07-empty-fleet-light.png` / `-dark.png` in
  that output directory — not committed, since it's a local build artifact).

Bumps `Cargo.toml`/`Cargo.lock` from 0.2.48 to 0.2.49 because the
release-version pre-commit gate blocks a shippable change against an
already-tagged version.

https://claude.ai/code/session_01WyxK6BTWQoYSZyQAehjgCE