### PR TITLE
test: bind TCRBAR_BUNDLE_ID to the shipped build script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.48"
+version = "0.2.49"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "teamclaude-rs"
-version = "0.2.48"
+version = "0.2.49"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/src/update.rs
+++ b/src/update.rs
@@ -1339,6 +1339,41 @@ mod tests {
         assert_eq!(open_handoff_argv(), ["-g", "tcrbar://check-for-updates"]);
     }
 
+    /// The literal assert above pins the constant against itself — it would
+    /// pass even if the app shipped under a different id. Bind it to the
+    /// actual shipped identity instead: the build script's unconditional
+    /// `bundle_id="..."` assignment (`apps/macos/scripts/build-tcrbar.sh`),
+    /// which is what lands in `Info.plist` (the plist itself only ever writes
+    /// `$bundle_id`, a shell variable, so the assignment is the one place the
+    /// real string lives).
+    #[test]
+    fn the_bundle_id_constant_matches_the_shipped_build_script() {
+        let script_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("apps")
+            .join("macos")
+            .join("scripts")
+            .join("build-tcrbar.sh");
+        let script = fs::read_to_string(&script_path)
+            .unwrap_or_else(|e| panic!("reading {}: {e}", script_path.display()));
+        let shipped_id = script
+            .lines()
+            .find_map(|line| {
+                let line = line.trim();
+                line.strip_prefix("bundle_id=\"")
+                    .and_then(|rest| rest.strip_suffix('"'))
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "no `bundle_id=\"...\"` assignment found in {}",
+                    script_path.display()
+                )
+            });
+        assert_eq!(
+            shipped_id, TCRBAR_BUNDLE_ID,
+            "the build script's shipped bundle id has drifted from TCRBAR_BUNDLE_ID"
+        );
+    }
+
     /// If we print a command, the binary it names has to be there — the same
     /// rule `the_recommended_app_installer_script_exists` enforces for the
     /// installer path.


### PR DESCRIPTION
🍄

`the_handoff_contract_matches_the_app` asserted `TCRBAR_BUNDLE_ID` equals its
own literal — vacuous, since it would pass even if the app shipped under a
different id. Adds a second test,
`the_bundle_id_constant_matches_the_shipped_build_script`, that reads
`apps/macos/scripts/build-tcrbar.sh`'s `bundle_id="..."` assignment (the one
place the real string lives — `Info.plist` itself only ever writes the shell
variable `$bundle_id`, never the literal) and asserts it matches the
constant. Kept the existing literal assert too, per the harvest bridge item
A7.

## Verification

- Watched it fail first: mutated the script's `bundle_id` to
  `io.github.dhkts1.mutated` in-tree, ran the new test alone, confirmed it
  failed with `left: "io.github.dhkts1.mutated" right:
  "io.github.dhkts1.tcrbar"`, restored with `git checkout --`, confirmed
  `git status` clean on the script.
- `cargo test update::` — exit 0 (see below).

```
$ cargo test update:: > /tmp/a7-test.log 2>&1; echo exit=$?
exit=0
```

Bumps `Cargo.toml`/`Cargo.lock` from 0.2.48 to 0.2.49 because the
release-version pre-commit gate blocks a shippable change against an
already-tagged version.

https://claude.ai/code/session_01WyxK6BTWQoYSZyQAehjgCE