### PR TITLE
feat: put per-session tool-call timing on the status wire (F1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.48"
+version = "0.2.49"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "teamclaude-rs"
-version = "0.2.48"
+version = "0.2.49"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/crates/tcr-status-wire/src/lib.rs
+++ b/crates/tcr-status-wire/src/lib.rs
@@ -119,6 +119,78 @@ pub struct HeldWindowRow {
     pub minutes_until_reset: i64,
 }
 
+/// One tool call still awaiting its `tool_result`, on the wire.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunningToolRow {
+    pub tool: String,
+    pub started_ms: i64,
+    /// First 120 characters of a Bash tool's `input.command` — `None` for any other tool, or
+    /// when the running call carries no command. Held in memory only on the server; never
+    /// written to a log (see `src/session_wire.rs`'s module doc in the main crate).
+    pub command_head: Option<String>,
+}
+
+/// One completed tool call, for a session's "ten slowest" list.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlowToolRow {
+    pub tool: String,
+    pub seconds: f64,
+    pub command_head: Option<String>,
+    pub ended_ms: i64,
+}
+
+/// A session's tool-call aggregates.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionToolsRow {
+    #[serde(default)]
+    pub calls: u64,
+    #[serde(default)]
+    pub errors: u64,
+    #[serde(default)]
+    pub timeouts: u64,
+    /// Tool calls still awaiting a `tool_result`, capped at 64 per session.
+    #[serde(default)]
+    pub running: Vec<RunningToolRow>,
+    /// The ten slowest completed tool calls, descending by `seconds`.
+    #[serde(default)]
+    pub slowest: Vec<SlowToolRow>,
+}
+
+/// One live session on the `tcr status --json` wire's `sessions` array (F1,
+/// `docs/design/panel-tabs.md`). One entry per session the proxy has seen in the last hour —
+/// see `src/session_wire.rs` in the main crate for how it is built and bounded.
+///
+/// `#[serde(default)]` on every field but `sessionId` so a payload from a server built before
+/// this row existed simply omits `sessions` entirely (the array field itself is
+/// `#[serde(default)]` on the enclosing status payload, in `status.rs`) — never a hard parse
+/// failure that drops a client back to a fabricated all-zeros offline snapshot.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionRow {
+    pub session_id: String,
+    /// The account this session's most recent request served against, or `None` when it has
+    /// never been attributed to one (e.g. the request carried no stable identity).
+    #[serde(default)]
+    pub account: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+    pub first_seen_ms: i64,
+    pub last_seen_ms: i64,
+    #[serde(default)]
+    pub requests: u64,
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+    #[serde(default)]
+    pub cache_read_tokens: u64,
+    #[serde(default)]
+    pub tools: SessionToolsRow,
+}
+
 /// One account's row on the `tcr status --json` wire.
 ///
 /// Field-for-field mirror of what `render_accounts_json` emits today — see that

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6011,6 +6011,7 @@ mod tests {
                 current: Some(0),
                 recent: Vec::new(),
                 sessions: Vec::new(),
+                wire_sessions: Vec::new(),
             },
             thresholds,
         )
@@ -6585,6 +6586,7 @@ mod tests {
                 current: None,
                 recent: Vec::new(),
                 sessions: Vec::new(),
+                wire_sessions: Vec::new(),
             },
             vec![0.90, 0.90],
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub mod proxy;
 pub mod quota;
 pub mod schedule;
 pub mod server;
+pub mod session_wire;
 pub mod singleton;
 pub mod stats;
 pub mod status;

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -54,6 +54,7 @@ mod state;
 mod throttle;
 mod usage;
 mod warm;
+mod wire_sessions;
 
 // Re-exported so unit F's replay harness (`tests/`) can call the SAME
 // production predicate rather than a reimplementation — see
@@ -1076,6 +1077,12 @@ pub struct Manager {
     /// live per-session visibility in the TUI. Separate from `affinity` so the
     /// routing pin stays byte-for-byte unchanged; bounded in `record_served`.
     sessions: Mutex<HashMap<u64, SessionStat>>,
+    /// The Claude Code `session_id`-keyed table with tool-call timing (F1,
+    /// `docs/design/panel-tabs.md`), on a different grain from [`Self::sessions`] above — see
+    /// [`crate::session_wire`] for the tracker itself and [`crate::stats::StatsSnapshot::wire_sessions`]
+    /// for where it surfaces. A separate lock from every other field here: nothing on the
+    /// routing path reads it, so it is never held together with `accounts` or `affinity`.
+    wire_sessions: Mutex<crate::session_wire::WireSessionTracker>,
     /// Monotonic session-key source handed out by [`Manager::next_session_key`],
     /// one per connection. Starts at 1 so the first key is a nonzero, unique u64.
     session_seq: AtomicU64,
@@ -1389,6 +1396,7 @@ impl Manager {
             affinity_extended: Mutex::new(HashSet::new()),
             affinity_dirty: AtomicBool::new(false),
             sessions: Mutex::new(HashMap::new()),
+            wire_sessions: Mutex::new(crate::session_wire::WireSessionTracker::new()),
             session_seq: AtomicU64::new(1),
             next_revalidation_at_ms: std::sync::atomic::AtomicI64::new(0),
             conn_affinity: Mutex::new(HashMap::new()),

--- a/src/manager/snapshot.rs
+++ b/src/manager/snapshot.rs
@@ -326,6 +326,7 @@ impl Manager {
             current: *self.current.lock().expect("current lock poisoned"),
             recent,
             sessions,
+            wire_sessions: self.wire_sessions_snapshot(now),
         }
     }
 }

--- a/src/manager/wire_sessions.rs
+++ b/src/manager/wire_sessions.rs
@@ -1,0 +1,159 @@
+//! `Manager` glue for [`crate::session_wire::WireSessionTracker`] — split verbatim from
+//! `mod.rs`, mirroring `usage.rs`/`snapshot.rs`'s split.
+
+use super::*;
+use crate::session_wire::{ToolResultEvent, ToolUseEvent};
+
+impl Manager {
+    /// Fold one request's session identity, model and parsed tool events into the wire-session
+    /// table. A no-op when `session_id` is `None` — a request with no recognizable Claude Code
+    /// identity has nothing for this table to key on.
+    ///
+    /// Called once per client request at the terminal outcome, alongside [`Self::record_served`]
+    /// (same call site in `proxy.rs`) — not per upstream retry, for the same reason
+    /// `record_served` isn't: a request rotated across accounts must count once, not once per
+    /// account tried.
+    pub fn record_wire_session(
+        &self,
+        session_id: Option<&str>,
+        account: Option<String>,
+        model: Option<String>,
+        now: OffsetDateTime,
+        tool_uses: &[ToolUseEvent],
+        tool_results: &[ToolResultEvent],
+    ) {
+        let Some(session_id) = session_id else {
+            return;
+        };
+        let now_ms = odt_to_ms(now);
+        let mut tracker = self
+            .wire_sessions
+            .lock()
+            .expect("wire sessions lock poisoned");
+        tracker.record_request(session_id, account, model, now_ms, tool_uses, tool_results);
+    }
+
+    /// Add token counts learned from a response's usage to the wire-session table. Called
+    /// beside [`Self::record_usage`] (the per-account ledger) at both of its call sites in
+    /// `proxy.rs` — streamed and non-streamed — with the SAME parsed totals, so the two never
+    /// disagree about how much a response cost.
+    pub fn record_wire_session_usage(
+        &self,
+        session_id: Option<&str>,
+        input_tokens: u64,
+        output_tokens: u64,
+        cache_read_tokens: u64,
+    ) {
+        let Some(session_id) = session_id else {
+            return;
+        };
+        let mut tracker = self
+            .wire_sessions
+            .lock()
+            .expect("wire sessions lock poisoned");
+        tracker.record_usage(session_id, input_tokens, output_tokens, cache_read_tokens);
+    }
+
+    /// The live wire-session table, projected onto [`tcr_status_wire::SessionRow`] — what
+    /// [`Self::snapshot`] hangs onto [`crate::stats::StatsSnapshot::wire_sessions`].
+    pub(super) fn wire_sessions_snapshot(
+        &self,
+        now: OffsetDateTime,
+    ) -> Vec<tcr_status_wire::SessionRow> {
+        let now_ms = odt_to_ms(now);
+        let tracker = self
+            .wire_sessions
+            .lock()
+            .expect("wire sessions lock poisoned");
+        tracker
+            .snapshot(now_ms)
+            .into_iter()
+            .map(|(session_id, s)| tcr_status_wire::SessionRow {
+                session_id,
+                account: s.account,
+                model: s.model,
+                first_seen_ms: s.first_seen_ms,
+                last_seen_ms: s.last_seen_ms,
+                requests: s.requests,
+                input_tokens: s.input_tokens,
+                output_tokens: s.output_tokens,
+                cache_read_tokens: s.cache_read_tokens,
+                tools: tcr_status_wire::SessionToolsRow {
+                    calls: s.tools.calls,
+                    errors: s.tools.errors,
+                    timeouts: s.tools.timeouts,
+                    running: s
+                        .tools
+                        .running
+                        .into_values()
+                        .map(|r| tcr_status_wire::RunningToolRow {
+                            tool: r.tool,
+                            started_ms: r.started_ms,
+                            command_head: r.command_head,
+                        })
+                        .collect(),
+                    slowest: s
+                        .tools
+                        .slowest
+                        .into_iter()
+                        .map(|t| tcr_status_wire::SlowToolRow {
+                            tool: t.tool,
+                            seconds: t.seconds,
+                            command_head: t.command_head,
+                            ended_ms: t.ended_ms,
+                        })
+                        .collect(),
+                },
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `WireSessionTracker` itself is unit-tested in `session_wire.rs` with canned bodies;
+    /// these tests prove the `Manager` GLUE — the lock, the projection to `SessionRow`, and
+    /// that an absent session id is a clean no-op rather than a panic. [`Manager::from_runtimes`]
+    /// (also used by `pins.rs`'s tests) never touches the network.
+    #[test]
+    fn record_wire_session_round_trips_through_the_manager_snapshot() {
+        let manager = Manager::from_runtimes(vec![]);
+        let now = OffsetDateTime::now_utc();
+        manager.record_wire_session(
+            Some("sess-glue"),
+            Some("alice@example.com".to_string()),
+            Some("claude-fable-5".to_string()),
+            now,
+            &[],
+            &[],
+        );
+        manager.record_wire_session_usage(Some("sess-glue"), 10, 20, 5);
+
+        let snap = manager.snapshot(now);
+        assert_eq!(snap.wire_sessions.len(), 1);
+        let row = &snap.wire_sessions[0];
+        assert_eq!(row.session_id, "sess-glue");
+        assert_eq!(row.account.as_deref(), Some("alice@example.com"));
+        assert_eq!(row.input_tokens, 10);
+        assert_eq!(row.output_tokens, 20);
+        assert_eq!(row.cache_read_tokens, 5);
+    }
+
+    #[test]
+    fn record_wire_session_with_no_session_id_is_a_no_op() {
+        let manager = Manager::from_runtimes(vec![]);
+        let now = OffsetDateTime::now_utc();
+        manager.record_wire_session(
+            None,
+            Some("alice@example.com".to_string()),
+            None,
+            now,
+            &[],
+            &[],
+        );
+        manager.record_wire_session_usage(None, 10, 20, 5);
+        assert!(manager.snapshot(now).wire_sessions.is_empty());
+    }
+}

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -2016,6 +2016,41 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
     // Parse the request's target model ONCE — it is constant across the rotation
     // loop, and drives per-model (Fable-aware) account selection below.
     let request_model = crate::model::parse_request_model(&body_bytes);
+
+    // F1 (`docs/design/panel-tabs.md`, `data/plans/sessions-wire-bridge.md`): the Claude Code
+    // session id embedded in `metadata.user_id`, plus any `tool_use`/`tool_result` blocks in
+    // the LAST TWO messages — parsed ONCE per request, independent of whether session
+    // affinity is on (unlike `stable_session_key`'s peek below, which only runs when the
+    // `SessionKey` extension is present). `RequestSessionPeek` borrows `messages` as a
+    // `RawValue` rather than materializing the whole conversation — see `session_wire.rs`'s
+    // module doc. A body that fails to parse here yields "no session, no tool events" rather
+    // than rejecting the request: this is an observability peek, never a validation gate.
+    let (wire_session_id, wire_tool_uses, wire_tool_results) = {
+        #[derive(serde::Deserialize)]
+        struct RequestSessionPeek<'a> {
+            metadata: Option<RequestSessionMeta>,
+            #[serde(borrow)]
+            messages: Option<&'a serde_json::value::RawValue>,
+        }
+        #[derive(serde::Deserialize)]
+        struct RequestSessionMeta {
+            user_id: Option<String>,
+        }
+        match serde_json::from_slice::<RequestSessionPeek>(&body_bytes) {
+            Ok(peek) => {
+                let session_id = peek
+                    .metadata
+                    .and_then(|m| m.user_id)
+                    .and_then(|blob| crate::session_wire::extract_session_id(&blob));
+                let (uses, results) = peek
+                    .messages
+                    .map(crate::session_wire::extract_tool_events)
+                    .unwrap_or_default();
+                (session_id, uses, results)
+            }
+            Err(_) => (None, Vec::new(), Vec::new()),
+        }
+    };
     // Whether THIS request targets a Fable model — the same classification
     // selection uses (`select.rs`). Threaded into every fleet-exhausted 429 so the
     // `retry-after` hint reflects the Fable-scoped weekly gate for a Fable request
@@ -2885,6 +2920,18 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
         // request once against the true serving account and log it.
         let served_at = OffsetDateTime::now_utc();
         manager.record_served(idx, served_at, session_key, session_kind);
+        // F1: fold this request's session id, model and tool events into the wire-session
+        // table (`tcr status --json`'s `sessions` array) — a no-op when `wire_session_id` is
+        // `None`. Cloned, not moved: the usage-recording arms below (streamed and
+        // non-streamed) still need `account_name`/`request_model`/`wire_session_id`.
+        manager.record_wire_session(
+            wire_session_id.as_deref(),
+            account_name.clone(),
+            request_model.clone(),
+            served_at,
+            &wire_tool_uses,
+            &wire_tool_results,
+        );
         manager.push_log(RequestLogEntry {
             time: served_at,
             method: method.to_string(),
@@ -2944,6 +2991,9 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
             // task below outlives this iteration. A `String` clone per streamed
             // request, so the ledger can attribute tokens to a model at all.
             let request_model_for_usage = request_model.clone();
+            // Same reasoning, for F1's wire-session token counts: the spawned parser task
+            // outlives this iteration, so it needs its own clone of the session id.
+            let wire_session_id_for_usage = wire_session_id.clone();
             // The ANSWER, not the cell and not the body. Resolving it here costs
             // one structural deserialize per streamed request — the same one the
             // pin's TTL above already pays whenever session affinity is on,
@@ -2989,6 +3039,12 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
                         "request usage"
                     );
                     manager_side.record_usage(idx, record);
+                    manager_side.record_wire_session_usage(
+                        wire_session_id_for_usage.as_deref(),
+                        parsed.input_total,
+                        parsed.output,
+                        parsed.cache_read,
+                    );
                 }
                 // Sibling of the usage guard above, not nested in it: an error
                 // event with NO message_start leaves input_total == output == 0,
@@ -3187,6 +3243,12 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
                     "request usage"
                 );
                 manager.record_usage(idx, record);
+                manager.record_wire_session_usage(
+                    wire_session_id.as_deref(),
+                    parsed.input_total,
+                    parsed.output,
+                    parsed.cache_read,
+                );
             }
         } else {
             // The "upstream response" line above (:2587) has never carried a

--- a/src/session_wire.rs
+++ b/src/session_wire.rs
@@ -1,0 +1,626 @@
+//! F1: session + tool-call tracking for `tcr status --json`'s `sessions` array.
+//!
+//! Design and measurements: `docs/design/panel-tabs.md`; the bridge that specced this is
+//! `data/plans/sessions-wire-bridge.md`.
+//!
+//! Two halves, deliberately separate:
+//!
+//! - Pure parsing (this module): given a request body already read into memory, pull out the
+//!   `metadata.user_id`-embedded `session_id` and, from the LAST TWO entries of `messages`
+//!   only, any `tool_use` (assistant) and `tool_result` (user) blocks. Never deserializes the
+//!   whole conversation history into owned [`serde_json::Value`]s — `messages` is read
+//!   borrowed as [`RawValue`] and only its tail two elements are turned into owned values.
+//! - [`WireSessionTracker`]: the bounded, in-memory table one request's parsed events get
+//!   folded into. No I/O, no locking — [`crate::manager::Manager`] wraps one in a `Mutex`.
+//!
+//! `command_head` (a Bash tool's `input.command`, capped to 120 chars) is held ONLY in this
+//! in-memory table — never written to `~/.cache/teamclaude/logs` or any other file. That is
+//! the same body-content-never-hits-disk rule `src/proxy.rs` states for the request log.
+
+use serde_json::value::RawValue;
+use serde_json::Value;
+
+/// A `tool_use` block found in an assistant message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolUseEvent {
+    pub id: String,
+    pub name: Option<String>,
+    /// First 120 characters of `input.command`, only for a `Bash` tool call. Held in memory
+    /// only — see the module doc's no-body-content-on-disk rule.
+    pub command_head: Option<String>,
+}
+
+/// A `tool_result` block found in a user message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolResultEvent {
+    pub id: String,
+    pub is_error: bool,
+    /// `is_error` and the result's own content text contains "timed out" — the same string a
+    /// Bash-tool timeout error carries.
+    pub timed_out: bool,
+}
+
+/// Max characters kept from a Bash tool's `input.command` — see [`ToolUseEvent::command_head`].
+const COMMAND_HEAD_MAX: usize = 120;
+
+/// Parse `metadata.user_id`'s stringified JSON blob for its `session_id` — see
+/// `src/proxy.rs`'s `stable_session_key` doc-comment for the blob's shape and lineage
+/// guarantees. `None` on absence or a parse failure; never a panic on a hand-shaped or
+/// truncated blob.
+pub fn extract_session_id(user_id_json: &str) -> Option<String> {
+    #[derive(serde::Deserialize)]
+    struct SessionIdPeek {
+        #[serde(default)]
+        session_id: Option<String>,
+    }
+    serde_json::from_str::<SessionIdPeek>(user_id_json)
+        .ok()
+        .and_then(|p| p.session_id)
+}
+
+/// The minimal shape read from `messages`: only `role` and `content`, and only for the last
+/// two elements of the array — see the module doc for why the rest of the history is never
+/// materialized.
+#[derive(serde::Deserialize)]
+struct MessagePeek {
+    #[serde(default)]
+    role: String,
+    #[serde(default)]
+    content: Option<Value>,
+}
+
+/// The minimal shape read from one content block.
+#[derive(serde::Deserialize)]
+struct BlockPeek {
+    #[serde(rename = "type", default)]
+    kind: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    input: Option<Value>,
+    #[serde(default)]
+    tool_use_id: Option<String>,
+    #[serde(default)]
+    is_error: Option<bool>,
+    #[serde(default)]
+    content: Option<Value>,
+}
+
+fn content_mentions_timeout(content: &Option<Value>) -> bool {
+    match content {
+        Some(Value::String(s)) => s.to_lowercase().contains("timed out"),
+        Some(Value::Array(items)) => items.iter().any(|item| {
+            item.get("text")
+                .and_then(Value::as_str)
+                .is_some_and(|s| s.to_lowercase().contains("timed out"))
+        }),
+        _ => false,
+    }
+}
+
+/// Extract `tool_use` / `tool_result` blocks from the LAST TWO elements of a request's
+/// `messages` array, given as a borrowed [`RawValue`] (see [`crate::proxy::SessionKeyPeek`]-
+/// style peeks for the same borrowing technique). A body with no `messages`, a non-array
+/// `messages`, or malformed elements yields two empty vectors rather than an error — this is
+/// a best-effort observability peek, never a request-rejection path.
+pub fn extract_tool_events(messages: &RawValue) -> (Vec<ToolUseEvent>, Vec<ToolResultEvent>) {
+    let mut tool_uses = Vec::new();
+    let mut tool_results = Vec::new();
+
+    let Ok(all) = serde_json::from_str::<Vec<&RawValue>>(messages.get()) else {
+        return (tool_uses, tool_results);
+    };
+    let tail_start = all.len().saturating_sub(2);
+    for raw in &all[tail_start..] {
+        let Ok(msg) = serde_json::from_str::<MessagePeek>(raw.get()) else {
+            continue;
+        };
+        let Some(Value::Array(blocks)) = msg.content else {
+            continue;
+        };
+        for block in blocks {
+            let Ok(b) = serde_json::from_value::<BlockPeek>(block) else {
+                continue;
+            };
+            match (msg.role.as_str(), b.kind.as_str()) {
+                ("assistant", "tool_use") => {
+                    if let Some(id) = b.id {
+                        let command_head = if b.name.as_deref() == Some("Bash") {
+                            b.input
+                                .as_ref()
+                                .and_then(|v| v.get("command"))
+                                .and_then(Value::as_str)
+                                .map(|s| s.chars().take(COMMAND_HEAD_MAX).collect())
+                        } else {
+                            None
+                        };
+                        tool_uses.push(ToolUseEvent {
+                            id,
+                            name: b.name,
+                            command_head,
+                        });
+                    }
+                }
+                ("user", "tool_result") => {
+                    if let Some(id) = b.tool_use_id {
+                        let is_error = b.is_error.unwrap_or(false);
+                        let timed_out = is_error && content_mentions_timeout(&b.content);
+                        tool_results.push(ToolResultEvent {
+                            id,
+                            is_error,
+                            timed_out,
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    (tool_uses, tool_results)
+}
+
+/// One tool call still awaiting its `tool_result`.
+#[derive(Debug, Clone)]
+pub struct RunningTool {
+    pub tool: String,
+    pub started_ms: i64,
+    pub command_head: Option<String>,
+}
+
+/// One completed tool call, for the "ten slowest" list.
+#[derive(Debug, Clone)]
+pub struct SlowTool {
+    pub tool: String,
+    pub seconds: f64,
+    pub command_head: Option<String>,
+    pub ended_ms: i64,
+}
+
+/// Per-session tool aggregates.
+#[derive(Debug, Clone, Default)]
+pub struct ToolStats {
+    pub calls: u64,
+    pub errors: u64,
+    pub timeouts: u64,
+    /// Keyed by `tool_use_id`. Capped at [`PENDING_TOOL_CAP`] per session.
+    pub running: std::collections::HashMap<String, RunningTool>,
+    /// Sorted by `seconds` descending, capped at [`SLOWEST_CAP`].
+    pub slowest: Vec<SlowTool>,
+}
+
+/// One session's row.
+#[derive(Debug, Clone, Default)]
+pub struct WireSession {
+    pub account: Option<String>,
+    pub model: Option<String>,
+    pub first_seen_ms: i64,
+    pub last_seen_ms: i64,
+    pub requests: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub tools: ToolStats,
+}
+
+/// Cap on pending (running) tool-use ids per session — see the bridge.
+pub const PENDING_TOOL_CAP: usize = 64;
+/// Cap on tracked sessions — see the bridge.
+pub const SESSION_CAP: usize = 512;
+/// How many of the slowest completed tool calls each session keeps.
+pub const SLOWEST_CAP: usize = 10;
+/// A session unseen for this long is evicted — see the bridge ("an hour").
+pub const SESSION_TTL_MS: i64 = 60 * 60 * 1000;
+
+/// The bounded, in-memory table `tcr status --json`'s `sessions` array is read from. No I/O; a
+/// caller (`Manager`) is responsible for locking.
+#[derive(Debug, Default)]
+pub struct WireSessionTracker {
+    sessions: std::collections::HashMap<String, WireSession>,
+}
+
+impl WireSessionTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Fold one request's parsed events into the table. `account`/`model` overwrite the
+    /// session's last-known value when `Some`, and are left untouched when `None` (a request
+    /// that could not be attributed to an account, or carried no `model` field, must not
+    /// blank out a value a previous request already established).
+    pub fn record_request(
+        &mut self,
+        session_id: &str,
+        account: Option<String>,
+        model: Option<String>,
+        now_ms: i64,
+        tool_uses: &[ToolUseEvent],
+        tool_results: &[ToolResultEvent],
+    ) {
+        self.evict_stale(now_ms);
+
+        let is_new = !self.sessions.contains_key(session_id);
+        let entry = self
+            .sessions
+            .entry(session_id.to_string())
+            .or_insert_with(|| WireSession {
+                first_seen_ms: now_ms,
+                ..Default::default()
+            });
+        // The instant this session's previous response finished streaming — the "running"
+        // start time for any tool_use first seen THIS request (see the bridge: "the moment
+        // the proxy finished streaming the response that produced it"). A brand-new session
+        // has no such instant, so its first tool_use starts "now" rather than at a fabricated
+        // past time.
+        let previous_response_end_ms = if is_new { now_ms } else { entry.last_seen_ms };
+
+        entry.requests += 1;
+        entry.last_seen_ms = now_ms;
+        if account.is_some() {
+            entry.account = account;
+        }
+        if model.is_some() {
+            entry.model = model;
+        }
+
+        for tu in tool_uses {
+            if entry.tools.running.contains_key(&tu.id) {
+                continue;
+            }
+            if entry.tools.running.len() >= PENDING_TOOL_CAP {
+                if let Some(oldest) = entry
+                    .tools
+                    .running
+                    .iter()
+                    .min_by_key(|(_, r)| r.started_ms)
+                    .map(|(k, _)| k.clone())
+                {
+                    entry.tools.running.remove(&oldest);
+                }
+            }
+            entry.tools.running.insert(
+                tu.id.clone(),
+                RunningTool {
+                    tool: tu.name.clone().unwrap_or_default(),
+                    started_ms: previous_response_end_ms,
+                    command_head: tu.command_head.clone(),
+                },
+            );
+        }
+
+        for tr in tool_results {
+            if let Some(running) = entry.tools.running.remove(&tr.id) {
+                let seconds = (now_ms - running.started_ms).max(0) as f64 / 1000.0;
+                entry.tools.calls += 1;
+                if tr.is_error {
+                    entry.tools.errors += 1;
+                }
+                if tr.timed_out {
+                    entry.tools.timeouts += 1;
+                }
+                Self::insert_slowest(
+                    &mut entry.tools.slowest,
+                    SlowTool {
+                        tool: running.tool,
+                        seconds,
+                        command_head: running.command_head,
+                        ended_ms: now_ms,
+                    },
+                );
+            }
+        }
+
+        self.evict_over_cap();
+    }
+
+    /// Add token counts learned from a response's usage — a separate call because usage is
+    /// resolved later than the request (after the upstream response, sometimes after an SSE
+    /// stream finishes), on a session that [`Self::record_request`] has already created. A
+    /// session not (yet, or no longer) present is silently ignored — there is nothing to
+    /// attribute the tokens to.
+    pub fn record_usage(&mut self, session_id: &str, input: u64, output: u64, cache_read: u64) {
+        if let Some(entry) = self.sessions.get_mut(session_id) {
+            entry.input_tokens += input;
+            entry.output_tokens += output;
+            entry.cache_read_tokens += cache_read;
+        }
+    }
+
+    fn insert_slowest(slowest: &mut Vec<SlowTool>, tool: SlowTool) {
+        slowest.push(tool);
+        slowest.sort_by(|a, b| {
+            b.seconds
+                .partial_cmp(&a.seconds)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        slowest.truncate(SLOWEST_CAP);
+    }
+
+    fn evict_stale(&mut self, now_ms: i64) {
+        self.sessions
+            .retain(|_, s| now_ms.saturating_sub(s.last_seen_ms) <= SESSION_TTL_MS);
+    }
+
+    fn evict_over_cap(&mut self) {
+        if self.sessions.len() > SESSION_CAP {
+            if let Some(oldest) = self
+                .sessions
+                .iter()
+                .min_by_key(|(_, s)| s.last_seen_ms)
+                .map(|(k, _)| k.clone())
+            {
+                self.sessions.remove(&oldest);
+            }
+        }
+    }
+
+    /// Every currently-live session, unordered. `now_ms` evicts stale entries first, so a
+    /// session that crossed the one-hour idle line since its last write never surfaces.
+    pub fn snapshot(&self, now_ms: i64) -> Vec<(String, WireSession)> {
+        self.sessions
+            .iter()
+            .filter(|(_, s)| now_ms.saturating_sub(s.last_seen_ms) <= SESSION_TTL_MS)
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tool_use(id: &str, name: &str, command: Option<&str>) -> Value {
+        serde_json::json!({
+            "type": "tool_use",
+            "id": id,
+            "name": name,
+            "input": command.map_or(Value::Null, |c| serde_json::json!({"command": c})),
+        })
+    }
+
+    fn tool_result(id: &str, is_error: bool, text: &str) -> Value {
+        serde_json::json!({
+            "type": "tool_result",
+            "tool_use_id": id,
+            "is_error": is_error,
+            "content": text,
+        })
+    }
+
+    fn messages_raw(msgs: Value) -> Box<RawValue> {
+        RawValue::from_string(msgs.to_string()).expect("valid json")
+    }
+
+    #[test]
+    fn extract_session_id_reads_the_embedded_field() {
+        let blob = r#"{"device_id":"d1","account_uuid":"a1","session_id":"sess-123"}"#;
+        assert_eq!(extract_session_id(blob), Some("sess-123".to_string()));
+    }
+
+    #[test]
+    fn extract_session_id_none_on_absence_or_garbage() {
+        assert_eq!(extract_session_id(r#"{"device_id":"d1"}"#), None);
+        assert_eq!(extract_session_id("not json"), None);
+    }
+
+    #[test]
+    fn extract_tool_events_pairs_use_and_result_in_the_last_two_messages() {
+        let messages = serde_json::json!([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": [tool_use("tu_1", "Bash", Some("ls -la"))]},
+            {"role": "user", "content": [tool_result("tu_1", false, "ok")]},
+        ]);
+        let raw = messages_raw(messages);
+        let (uses, results) = extract_tool_events(&raw);
+        // Only the LAST TWO messages are read, so the assistant tool_use message is seen
+        // (it's second-to-last) and the tool_result message (last) is seen too.
+        assert_eq!(uses.len(), 1);
+        assert_eq!(uses[0].id, "tu_1");
+        assert_eq!(uses[0].command_head.as_deref(), Some("ls -la"));
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, "tu_1");
+        assert!(!results[0].is_error);
+    }
+
+    #[test]
+    fn extract_tool_events_ignores_history_before_the_last_two() {
+        let messages = serde_json::json!([
+            {"role": "assistant", "content": [tool_use("stale", "Bash", Some("rm -rf /"))]},
+            {"role": "user", "content": [tool_result("stale", false, "ok")]},
+            {"role": "assistant", "content": "just text"},
+            {"role": "user", "content": "another turn"},
+        ]);
+        let raw = messages_raw(messages);
+        let (uses, results) = extract_tool_events(&raw);
+        assert!(
+            uses.is_empty(),
+            "the stale tool_use is outside the last two messages"
+        );
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn a_tool_use_then_its_tool_result_yields_one_call_with_the_right_seconds() {
+        let mut tracker = WireSessionTracker::new();
+        let uses = vec![ToolUseEvent {
+            id: "tu_1".into(),
+            name: Some("Bash".into()),
+            command_head: Some("sleep 5".into()),
+        }];
+        // First request: the tool_use appears, no result yet.
+        tracker.record_request(
+            "sess-a",
+            Some("alice@example.com".into()),
+            Some("claude-x".into()),
+            1_000,
+            &uses,
+            &[],
+        );
+        // Second request, 5500ms later: the tool_result arrives.
+        let results = vec![ToolResultEvent {
+            id: "tu_1".into(),
+            is_error: false,
+            timed_out: false,
+        }];
+        tracker.record_request(
+            "sess-a",
+            Some("alice@example.com".into()),
+            Some("claude-x".into()),
+            6_500,
+            &[],
+            &results,
+        );
+
+        let snap = tracker.snapshot(6_500);
+        assert_eq!(snap.len(), 1);
+        let (_, session) = &snap[0];
+        assert_eq!(session.tools.calls, 1);
+        assert_eq!(session.tools.errors, 0);
+        assert!(session.tools.running.is_empty());
+        assert_eq!(session.tools.slowest.len(), 1);
+        // Started at the PREVIOUS request's time (1_000, this session's first-ever request,
+        // so "previous response end" is that request's own arrival), resolved at 6_500.
+        assert_eq!(session.tools.slowest[0].seconds, 5.5);
+        assert_eq!(session.tools.slowest[0].tool, "Bash");
+    }
+
+    #[test]
+    fn an_unmatched_tool_use_id_stays_in_running() {
+        let mut tracker = WireSessionTracker::new();
+        let uses = vec![ToolUseEvent {
+            id: "tu_orphan".into(),
+            name: Some("Read".into()),
+            command_head: None,
+        }];
+        tracker.record_request("sess-b", None, None, 1_000, &uses, &[]);
+        let snap = tracker.snapshot(2_000);
+        let (_, session) = &snap[0];
+        assert_eq!(session.tools.calls, 0);
+        assert_eq!(session.tools.running.len(), 1);
+        assert!(session.tools.running.contains_key("tu_orphan"));
+    }
+
+    #[test]
+    fn a_65th_pending_tool_use_evicts_the_oldest() {
+        let mut tracker = WireSessionTracker::new();
+        // Establish the session with a plain touch first (no tool_use), at a time distinctly
+        // earlier than every subsequent one — a brand-new session's OWN first tool_use starts
+        // at its own arrival time (see `record_request`'s doc), which would otherwise tie with
+        // the second tool_use's start (the first request's own arrival time) and make "the
+        // oldest" ambiguous between them.
+        tracker.record_request("sess-c", None, None, 0, &[], &[]);
+        for i in 0..PENDING_TOOL_CAP {
+            let uses = vec![ToolUseEvent {
+                id: format!("tu_{i}"),
+                name: Some("Bash".into()),
+                command_head: None,
+            }];
+            tracker.record_request("sess-c", None, None, 1_000 + i as i64, &uses, &[]);
+        }
+        let snap = tracker.snapshot(2_000);
+        let (_, session) = &snap[0];
+        // Exactly at the cap (64 pending ids): nothing evicted yet.
+        assert_eq!(session.tools.running.len(), PENDING_TOOL_CAP);
+        assert!(session.tools.running.contains_key("tu_0"));
+
+        // The 65th distinct pending id.
+        let uses = vec![ToolUseEvent {
+            id: "tu_overflow".into(),
+            name: Some("Bash".into()),
+            command_head: None,
+        }];
+        tracker.record_request("sess-c", None, None, 2_000, &uses, &[]);
+        let snap = tracker.snapshot(3_000);
+        let (_, session) = &snap[0];
+        assert_eq!(session.tools.running.len(), PENDING_TOOL_CAP);
+        assert!(session.tools.running.contains_key("tu_overflow"));
+        assert!(
+            !session.tools.running.contains_key("tu_0"),
+            "the oldest pending id (tu_0, started at 0) must have been evicted to make room"
+        );
+        assert!(
+            session.tools.running.contains_key("tu_1"),
+            "the next-oldest survives"
+        );
+    }
+
+    #[test]
+    fn a_session_unseen_for_an_hour_disappears() {
+        let mut tracker = WireSessionTracker::new();
+        tracker.record_request(
+            "sess-d",
+            Some("alice@example.com".into()),
+            None,
+            0,
+            &[],
+            &[],
+        );
+        assert_eq!(
+            tracker.snapshot(SESSION_TTL_MS).len(),
+            1,
+            "exactly at the TTL boundary it is still live"
+        );
+        assert_eq!(
+            tracker.snapshot(SESSION_TTL_MS + 1).len(),
+            0,
+            "one ms past the TTL it is gone"
+        );
+    }
+
+    #[test]
+    fn a_body_with_no_messages_changes_nothing() {
+        // Modeled as: the caller found no `messages` field at all and so never calls
+        // `extract_tool_events`; `record_request` with empty event slices must still update
+        // request/account/model bookkeeping and touch nothing tool-related.
+        let mut tracker = WireSessionTracker::new();
+        tracker.record_request(
+            "sess-e",
+            Some("alice@example.com".into()),
+            Some("claude-x".into()),
+            1_000,
+            &[],
+            &[],
+        );
+        let snap = tracker.snapshot(1_000);
+        let (_, session) = &snap[0];
+        assert_eq!(session.requests, 1);
+        assert_eq!(session.tools.calls, 0);
+        assert!(session.tools.running.is_empty());
+    }
+
+    #[test]
+    fn extract_tool_events_empty_on_absent_or_malformed_messages() {
+        let raw = RawValue::from_string("null".to_string()).unwrap();
+        let (uses, results) = extract_tool_events(&raw);
+        assert!(uses.is_empty());
+        assert!(results.is_empty());
+
+        let raw = RawValue::from_string("\"not an array\"".to_string()).unwrap();
+        let (uses, results) = extract_tool_events(&raw);
+        assert!(uses.is_empty());
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn a_timeout_error_is_counted_as_both_error_and_timeout() {
+        let mut tracker = WireSessionTracker::new();
+        let uses = vec![ToolUseEvent {
+            id: "tu_timeout".into(),
+            name: Some("Bash".into()),
+            command_head: Some("sleep 700".into()),
+        }];
+        tracker.record_request("sess-f", None, None, 1_000, &uses, &[]);
+        let results = vec![ToolResultEvent {
+            id: "tu_timeout".into(),
+            is_error: true,
+            timed_out: true,
+        }];
+        tracker.record_request("sess-f", None, None, 601_000, &[], &results);
+        let snap = tracker.snapshot(601_000);
+        let (_, session) = &snap[0];
+        assert_eq!(session.tools.calls, 1);
+        assert_eq!(session.tools.errors, 1);
+        assert_eq!(session.tools.timeouts, 1);
+    }
+}

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -307,4 +307,11 @@ pub struct StatsSnapshot {
     /// session id) — deliberately NOT recency, so a row holds its place instead of
     /// jumping to the top of the pane on every request.
     pub sessions: Vec<SessionSnapshot>,
+    /// Live sessions keyed on the Claude Code `session_id` embedded in
+    /// `metadata.user_id` (F1, `docs/design/panel-tabs.md`) — a different grain from
+    /// [`Self::sessions`] above, which is keyed on the proxy's own affinity hash and exists
+    /// for the TUI's pin display. This one carries tool-call timing and is what
+    /// `tcr status --json`'s `sessions` array (via [`crate::status::StatusPayload`]) is built
+    /// from. Reusing the wire type directly here, same as [`AccountSnapshot::usage`] beside it.
+    pub wire_sessions: Vec<tcr_status_wire::SessionRow>,
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -28,9 +28,13 @@
 //!    test rather than a code review.
 //!
 //! Deliberately NOT on the wire: the recent-request ring buffer (it carries the
-//! request paths a client sent) and the live session table. `tcr status` prints
-//! neither, so neither is exposed — the endpoint ships the smallest thing that
-//! renders the fleet view.
+//! request paths a client sent) and the affinity-hash session table
+//! ([`StatsSnapshot::sessions`], which exists for the TUI's pin display). `tcr status` prints
+//! neither, so neither is exposed.
+//!
+//! [`StatsSnapshot::wire_sessions`] — the Claude Code `session_id`-keyed table with tool-call
+//! timing (F1, `docs/design/panel-tabs.md`) — IS on the wire, as [`StatusPayload::sessions`]:
+//! it carries no credential material either, and it is the whole point of the feature.
 
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
@@ -149,6 +153,18 @@ pub struct StatusPayload {
     /// this must NOT bump [`STATUS_KIND`] — same reasoning as `control`.
     #[serde(default)]
     pub group_colors: std::collections::BTreeMap<String, String>,
+    /// One row per Claude Code session the proxy has seen in the last hour (F1,
+    /// `docs/design/panel-tabs.md`) — see [`crate::stats::StatsSnapshot::wire_sessions`] for
+    /// where this comes from and [`tcr_status_wire::SessionRow`] for the shape.
+    ///
+    /// `#[serde(default)]` for the same forward/back-compat reason as `group_colors` above: an
+    /// OLD server's payload has no such key, and a NEW client reads an empty array — the
+    /// truth, "this server never reported any sessions" — rather than failing the parse and
+    /// dropping to the all-zeros offline snapshot. An OLD client reading a NEW server simply
+    /// never looks at the extra key. Neither direction is MISREAD, so this must NOT bump
+    /// [`STATUS_KIND`], per this struct's `build` doc-comment.
+    #[serde(default)]
+    pub sessions: Vec<tcr_status_wire::SessionRow>,
 }
 
 /// One account's live row. Field-for-field the serializable half of
@@ -379,16 +395,20 @@ impl StatusPayload {
             http1_only,
             control,
             group_colors,
+            sessions: snapshot.wire_sessions.clone(),
         }
     }
 
     /// Rebuild the snapshot the CLI renderers take, plus the server's thresholds.
     ///
-    /// The `recent` log and `sessions` table come back EMPTY and `current` `None`:
-    /// they are not on the wire (see the module docs) and no `tcr status` renderer
-    /// reads them. Every `AccountSnapshot` field, by contrast, is reconstructed —
-    /// the struct literal below names all of them, so a new field forces an
-    /// explicit decision here instead of silently rendering a default.
+    /// The `recent` log and the affinity-hash `sessions` table (`StatsSnapshot::sessions`,
+    /// the TUI pin display) come back EMPTY and `current` `None`: they are not on the wire
+    /// (see the module docs) and no `tcr status` renderer reads them.
+    /// `StatsSnapshot::wire_sessions`, by contrast, IS reconstructed from
+    /// [`Self::sessions`] — it genuinely round-trips.
+    /// Every `AccountSnapshot` field is reconstructed too — the struct literal below names
+    /// all of them, so a new field forces an explicit decision here instead of silently
+    /// rendering a default.
     pub fn into_snapshot(self) -> (StatsSnapshot, Vec<f64>) {
         let mut thresholds = Vec::with_capacity(self.accounts.len());
         let accounts = self
@@ -441,6 +461,7 @@ impl StatusPayload {
                 current: None,
                 recent: Vec::new(),
                 sessions: Vec::new(),
+                wire_sessions: self.sessions,
             },
             thresholds,
         )
@@ -493,6 +514,33 @@ mod tests {
             current: Some(0),
             recent: Vec::new(),
             sessions: Vec::new(),
+            wire_sessions: vec![tcr_status_wire::SessionRow {
+                session_id: "sess-1".to_string(),
+                account: Some("alice@example.com".to_string()),
+                model: Some("claude-fable-5".to_string()),
+                first_seen_ms: crate::now_ms() - 60_000,
+                last_seen_ms: crate::now_ms(),
+                requests: 3,
+                input_tokens: 400,
+                output_tokens: 100,
+                cache_read_tokens: 200,
+                tools: tcr_status_wire::SessionToolsRow {
+                    calls: 2,
+                    errors: 0,
+                    timeouts: 0,
+                    running: vec![tcr_status_wire::RunningToolRow {
+                        tool: "Bash".to_string(),
+                        started_ms: crate::now_ms() - 5_000,
+                        command_head: Some("ls -la".to_string()),
+                    }],
+                    slowest: vec![tcr_status_wire::SlowToolRow {
+                        tool: "Bash".to_string(),
+                        seconds: 3.5,
+                        command_head: Some("sleep 3".to_string()),
+                        ended_ms: crate::now_ms(),
+                    }],
+                },
+            }],
         }
     }
 
@@ -537,6 +585,10 @@ mod tests {
         assert_eq!(after.quota_state, before.quota_state);
         assert_eq!(after.gate, before.gate);
         assert_eq!(after.groups, before.groups, "groups rides the wire intact");
+        assert_eq!(
+            rebuilt.wire_sessions, snapshot.wire_sessions,
+            "the sessions array rides the wire intact"
+        );
         assert_eq!(
             after.reserved_groups, before.reserved_groups,
             "reservedGroups rides the wire intact"
@@ -634,6 +686,33 @@ mod tests {
         assert_eq!(
             back.accounts[0].seven_day_oi_reset_ms, None,
             "missing sevenDayOiResetMs field on the wire defaults to None, not a decode error"
+        );
+    }
+
+    /// A payload from an older server that predates the `sessions` array (F1) still
+    /// deserializes, defaulting to empty — same forward-compat contract as `groupColors`.
+    #[test]
+    fn payload_without_sessions_field_still_deserializes() {
+        let wire = serde_json::to_string(&StatusPayload::from_snapshot(
+            &snapshot_with_counters(),
+            &[0.85],
+            false,
+            None,
+            Default::default(),
+        ))
+        .expect("serialize");
+        let mut value: serde_json::Value = serde_json::from_str(&wire).expect("parse");
+        value
+            .as_object_mut()
+            .expect("payload object")
+            .remove("sessions");
+        let stripped = serde_json::to_string(&value).expect("re-serialize");
+        let back: StatusPayload =
+            serde_json::from_str(&stripped).expect("deserialize without a sessions field");
+        assert_eq!(
+            back.sessions,
+            Vec::new(),
+            "missing sessions field on the wire defaults to empty, not a decode error"
         );
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1660,6 +1660,7 @@ mod tests {
             current: Some(0),
             recent: vec![],
             sessions: vec![],
+            wire_sessions: vec![],
         }
     }
 
@@ -2001,6 +2002,7 @@ mod tests {
             current: None,
             recent: vec![],
             sessions: vec![diverted("a1f3", "alice", "bob", 24, Some(100))],
+            wire_sessions: vec![],
         };
         let backend = TestBackend::new(48, 8);
         let mut terminal = Terminal::new(backend).expect("test backend builds a terminal");


### PR DESCRIPTION
🍄

## Summary

F1 from `docs/design/panel-tabs.md` / `data/plans/sessions-wire-bridge.md`: the proxy now
tracks, per Claude Code session, tool-call timing and token counts, and exposes it as a new
`sessions` array on the `GET /_tcr/status` wire (`StatusPayload`).

- `src/session_wire.rs` (new): pure parsing + `WireSessionTracker`. Reads `metadata.user_id`'s
  embedded `session_id`, and pairs `tool_use`/`tool_result` blocks from the LAST TWO messages
  of the request body only — never the whole conversation history. Bounded: 64 pending
  tool-use ids per session, 512 sessions, evicted after an hour idle.
- `src/manager/wire_sessions.rs` (new): `Manager` glue — a `Mutex<WireSessionTracker>`,
  folded into every served request beside the existing `record_served`/`record_usage` calls.
- `crates/tcr-status-wire`: new `SessionRow`/`SessionToolsRow`/`RunningToolRow`/`SlowToolRow`
  wire types.
- `src/status.rs`: `StatusPayload` grows a `sessions: Vec<SessionRow>` field,
  `#[serde(default)]` like every other optional field there — an old client reading a new
  server sees the extra key skipped; a new client reading an old server sees an empty array.
  Does NOT bump `STATUS_KIND`, by that struct's own documented rule for additive fields.

**One deliberate deviation from the bridge's literal gate command.** The bridge's gate step 4
reads `tcr status --json --port <p> | jq .sessions`, but `render_accounts_json`'s own
doc-comment states a HARD, tested invariant: `tcr status --json`'s CLI output is, and must
stay, a bare JSON array (`FleetStatus.swift` decodes it row-by-row; a top-level object would
break every existing `jq '.[].name']` script and, per `panel-tabs.md`'s own back-compat
constraint, an older TcrBar reading it). So the new `sessions` table is NOT added there.
It lives on `GET /_tcr/status`'s object payload (`StatusPayload`) instead, which already has
sibling top-level fields (`build`, `http1Only`, `groupColors`) for exactly this shape of
addition, and is what `tcr status` (the CLI) already fetches under the hood. Verified live
against that endpoint directly — see the report below. `status` also has no `--port` flag
(only `server` does); the live check below uses `--config` with the port baked into the temp
config instead.

Command text (a Bash tool's `input.command`, capped to 120 chars) is held in memory only —
never written to `~/.cache/teamclaude/logs` or any other file, matching this repo's public
rule.

## Test plan

- [x] `cargo test` — 1046 passed (session_wire's own canned-body unit tests cover: a
      tool_use paired with its tool_result yields one call with the right seconds; an
      unmatched id stays in `running`; a 65th pending id evicts the oldest; a session unseen
      for an hour disappears; a body with no `messages` changes nothing) — exit 0
- [x] `cargo clippy --all-targets` — exit 0
- [x] `cargo fmt --check` — exit 0
- [x] Watched a mutation: flipped the eviction's `min_by_key` to `max_by_key`, confirmed the
      65th-id test failed on the intended assertion, restored it, re-ran green
- [x] Live wire check on a throwaway `tcr server --port 34567` against a canned local
      upstream (never touched the real proxy on :3456): two `POST /v1/messages` for one
      session — the second carrying a matching `tool_result` — then
      `curl 127.0.0.1:34567/_tcr/status | jq .sessions` showed one session row with
      `tools.calls: 1`, the paired duration, and accumulated token counts

Claude-Session: https://claude.ai/code/session_01WyxK6BTWQoYSZyQAehjgCE