### PR TITLE
fix: outline the whole group, legend its heading, smoosh parked groups, drop 0x truncated

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -417,7 +417,7 @@ struct FleetView: View {
             // one section's rows into the other's slot.
             ForEach(Array(sections.enumerated()), id: \.element.id) { index, section in
                 if sections.isFirstOfBand(index) {
-                    bandHeading(section.band)
+                    bandHeading(section.band, soleGroupInBand: sections.soleGroupInBand(at: index))
                 }
                 sectionBody(
                     section, drawsHeading: sections.drawsGroupHeading(at: index), fleet: fleet)
@@ -443,34 +443,93 @@ struct FleetView: View {
     private func sectionBody(_ section: FleetSection, drawsHeading: Bool, fleet: Fleet)
         -> some View
     {
-        VStack(alignment: .leading, spacing: Tok.rowSpacing) {
-            if drawsHeading {
+        // "maybe smoush the group" (Gil, 2026-09-12): a wholly-parked NAMED
+        // group renders one line per account — no quota bars, no cost line —
+        // until its own legend is clicked. Remembered per group name across
+        // launches (`expandedParkedGroups`), never for a live group: there is
+        // nothing here worth hiding from an operator who can act on it right
+        // now.
+        let collapsed = section.isWhollyParked && !expandedParkedGroups.contains(section.group.token)
+        return VStack(alignment: .leading, spacing: Tok.rowSpacing) {
+            // The plain-text heading is for a section with no stroke to carry
+            // a legend on — the unlabelled pile, or a named group whose
+            // colour never resolved. An outlined section draws its name as
+            // the legend in the `.overlay` below instead of here, never both.
+            if drawsHeading && section.outlineColor == nil {
                 groupHeading(section)
             }
-            ForEach(section.rows) { row in
-                accountRow(row, fleet: fleet)
+            if collapsed {
+                ForEach(section.rows) { row in
+                    smooshedAccountRow(row)
+                }
+            } else {
+                ForEach(section.rows) { row in
+                    accountRow(row, fleet: fleet)
+                }
             }
         }
+        // Real padding now, not the old negative one — see `groupOutline`'s
+        // own doc-comment for why. Zero for a section with nothing to
+        // outline, so an unoutlined section's layout is byte-for-byte what
+        // it was before this round.
+        .padding(section.outlineColor == nil ? 0 : Tok.groupOutlineInset)
         .background(groupOutline(for: section))
+        .overlay(alignment: .topLeading) {
+            if section.outlineColor != nil {
+                groupHeading(section)
+                    .padding(.leading, Tok.space3)
+                    .offset(y: -Tok.groupLegendHeight / 2)
+            }
+        }
     }
 
-    /// The section's outline, drawn OUTSIDE its content's own bounds via
-    /// negative padding rather than by padding the content inward.
-    ///
-    /// A `.background` is sized to match the view it is attached to — the
-    /// `VStack` above never grows to accommodate it — so expanding the
-    /// stroked shape past that size with `.padding(-Tok.groupOutlineInset)`
-    /// draws it bleeding outward into the surrounding `rowSpacing` gap
-    /// without asking the `VStack` for one extra point of height. That
-    /// matters here specifically: every row and heading in this list
-    /// publishes its own measured height (`FleetView/rowHeights`,
-    /// `measured(_:content:)`) and `PanelHeight.visibleRowsHeight` sums
-    /// those keyed heights independently of whatever SwiftUI actually lays
-    /// out — a real padding here would grow the rendered list without
-    /// growing any of those published numbers, and the panel would size
-    /// itself short of its own content. Growing the background instead
-    /// changes nothing SwiftUI's layout pass measures.
-    ///
+    /// One line per account inside a collapsed, wholly-parked group: the
+    /// name, its plan in dim text, and the SAME quota-state pill
+    /// `AccountRow.information` draws — never its rotation pill, since every
+    /// row here is parked by construction and the group's own legend already
+    /// says so once for all of them. No quota bars and no cost line, on
+    /// purpose: those are the two things this state exists to hide until the
+    /// legend is clicked.
+    private func smooshedAccountRow(_ row: FleetSectionRow) -> some View {
+        let account = row.account
+        return HStack(spacing: Tok.tightSpacing) {
+            Text(account.name)
+                .font(Tok.bodyFont).lineSpacing(Tok.bodyLineSpacing)
+                .foregroundStyle(account.disabled ? Tok.disabled : Tok.ink)
+                .lineLimit(1)
+                .help(account.name)
+            if let plan = account.plan, !plan.isEmpty {
+                Text(plan)
+                    .font(Tok.detailFont).lineSpacing(Tok.detailLineSpacing)
+                    .foregroundStyle(Tok.inkFaint)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: Tok.tightSpacing)
+            smooshedStatePill(account)
+        }
+        .padding(.vertical, Tok.space1)
+    }
+
+    /// The quota-state pill for a smooshed row — the same five cases
+    /// `AccountRow.information` draws its own quota pill from, mirrored here
+    /// rather than shared because that property also reads `AccountRow`'s
+    /// private `quotaTint` (which demotes a stale reading this collapsed
+    /// view never shows a bar for in the first place).
+    @ViewBuilder
+    private func smooshedStatePill(_ account: Account) -> some View {
+        if account.health == .needsRelogin {
+            StatusPill("needs re-login", tint: Tok.spent)
+        } else if account.isRejected {
+            StatusPill("rejected", tint: Tok.spent)
+        } else if account.hasQuotaEvidence {
+            StatusPill(account.quotaState.token, tint: Tok.color(for: account.quotaState))
+        } else if account.probeStatus.isFailure {
+            StatusPill(account.probeStatus.token, tint: Tok.unmeasured)
+        } else {
+            StatusPill("unmeasured", tint: Tok.unmeasured)
+        }
+    }
+
     /// Draws NOTHING when ``FleetSection/outlineColor`` is `nil` — an
     /// earlier version of this drew a neutral ``Tok/hairlineStrong`` box for
     /// a named group with no resolved colour, mirroring ``GroupChip``'s own
@@ -490,6 +549,22 @@ struct FleetView: View {
     /// text: the outline's colour is redundant decoration here, not
     /// information the reader has no other way to get, so it does not need
     /// to clear a text-legibility bar to be worth drawing.
+    /// **Draws at the section's OWN bounds now, not past them.** The
+    /// negative-padding version of this function bled the stroke outward
+    /// into the surrounding `rowSpacing` gap so no real padding was ever
+    /// added — cheap for `PanelHeight`, since nothing it measures grew, but
+    /// the outward bleed only had room to survive vertically, where the gap
+    /// between sections gave it somewhere to go. Horizontally there is no
+    /// such gap: the account list sits in a fixed-width column, so the same
+    /// bleed ran straight into that column's edge and was clipped —
+    /// Gil, 2026-09-12: "the group doesnt do outline around all the group
+    /// its just on top and under". `sectionBody` now insets its CONTENT by
+    /// `Tok.groupOutlineInset` on all four sides instead, so this stroke —
+    /// drawn unpadded, as a plain background — sits fully inside the padded
+    /// box and is never asked to bleed past anything. The outer-equals-
+    /// inner-plus-inset relationship `Tok.groupOutlineRadius`'s own doc
+    /// comment describes still holds; only which side carries the inset
+    /// changed.
     @ViewBuilder
     private func groupOutline(for section: FleetSection) -> some View {
         if let rgb = section.outlineColor {
@@ -498,7 +573,6 @@ struct FleetView: View {
                     Color(red: rgb.red, green: rgb.green, blue: rgb.blue),
                     lineWidth: Tok.groupOutlineWidth
                 )
-                .padding(-Tok.groupOutlineInset)
         }
     }
 
@@ -506,24 +580,124 @@ struct FleetView: View {
     /// ``FleetBand/title`` supplies the words — "Live", "Out of tokens",
     /// "Parked" — so the panel and any future caller cannot name a band two
     /// different ways.
-    private func bandHeading(_ band: FleetBand) -> some View {
-        measured(bandHeightKey(band)) {
-            Text(band.title.uppercased())
-                .font(Tok.detailFont.weight(.semibold)).lineSpacing(Tok.detailLineSpacing)
-                .tracking(Tok.pillTracking)
-                .foregroundStyle(Tok.inkDim)
+    ///
+    /// Drawn NOTHING when `soleGroupInBand` — see
+    /// ``Array/soleGroupInBand(at:)``'s own doc-comment for why a band
+    /// holding exactly one group section does not also get a band heading
+    /// over it. Skipped rather than drawn-and-hidden, the same discipline
+    /// ``groupHeading(_:)`` already follows: an unkeyed, undrawn heading
+    /// charges the viewport nothing, and a keyed-but-undrawn one would
+    /// charge for a row that is not there.
+    @ViewBuilder
+    private func bandHeading(_ band: FleetBand, soleGroupInBand: Bool) -> some View {
+        if !soleGroupInBand {
+            measured(bandHeightKey(band)) {
+                Text(band.title.uppercased())
+                    .font(Tok.detailFont.weight(.semibold)).lineSpacing(Tok.detailLineSpacing)
+                    .tracking(Tok.pillTracking)
+                    .foregroundStyle(Tok.inkDim)
+            }
         }
     }
 
-    /// The inner heading: one group, or the unlabelled pile. Set apart from the
-    /// band heading by case and weight rather than by an indent, so a row and
-    /// its heading keep the same left edge and the eye reads one column.
+    /// The inner heading: one group, or the unlabelled pile. Two shapes now:
+    ///
+    /// - Plain text, set apart from the band heading by case and weight
+    ///   rather than by an indent (so a row and its heading keep the same
+    ///   left edge), for a section with no outline to carry a legend on —
+    ///   unchanged from before this round.
+    /// - A LEGEND when ``FleetSection/outlineColor`` resolves one: the
+    ///   group's name sitting ON its own stroke, in its own colour, small
+    ///   caps with tracking — "why parked ontop of it and henry token group
+    ///   name so on the side not some header" (Gil, 2026-09-12). This is
+    ///   what replaces the old stacked band-heading-over-group-heading pair;
+    ///   `sectionBody` draws it in an `.overlay`, never alongside the plain
+    ///   text form. Reads " · PARKED" for a wholly-parked group — the one
+    ///   place that word still survives once the per-row pill is dropped
+    ///   (see `AccountRow.suppressParkedPill`) — and always " · N" for the
+    ///   row count.
+    ///
+    ///   A wholly-parked group's legend is a real `Button`, not decorative
+    ///   text with a tap gesture bolted on — `docs/design/panel-tabs-
+    ///   review.md` finding 9 caught exactly that shape ("2 more · click to
+    ///   expand", styled identically to the static text beside it) on the
+    ///   sibling tabs mockup, and a `Text.onTapGesture` here would be the
+    ///   same defect: no keyboard path, no announced role beyond whatever
+    ///   `.accessibilityAddTraits` bolts on by hand. A live group's legend
+    ///   stays plain `Text` — it has nothing to activate, and a control that
+    ///   does nothing on activation is worse than no control (same review,
+    ///   finding 1's whole premise).
+    @ViewBuilder
     private func groupHeading(_ section: FleetSection) -> some View {
-        measured(groupHeightKey(section)) {
-            Text(section.title)
-                .font(Tok.secondaryFont.weight(.semibold)).lineSpacing(Tok.secondaryLineSpacing)
-                .foregroundStyle(.primary)
+        if let rgb = section.outlineColor {
+            let color = Color(red: rgb.red, green: rgb.green, blue: rgb.blue)
+            let legend = Text(section.legendText)
+                .font(Tok.detailFont.weight(.bold)).lineSpacing(Tok.detailLineSpacing)
+                .tracking(Tok.pillTracking)
+                .foregroundStyle(color)
+                .padding(.horizontal, Tok.space1)
+                .padding(.vertical, Tok.space1)
+                // Matches the panel body behind it, so the stroke line reads
+                // as broken by the legend rather than running behind it.
+                //
+                // `Tok.panel` is a flat, fully opaque `Color` — this panel is
+                // NOT a real translucent material (no `NSVisualEffectView`
+                // anywhere in this target; `FleetView`'s own root is
+                // `.background(Tok.panel)`, a plain fill). The tabs-mockup
+                // review's finding 11 (an opaque legend patch reads as a
+                // black bar over a backdrop-filter panel) is a defect in that
+                // CSS approximation and does not reproduce here — checked
+                // against both appearances in `--render-states`, scene
+                // `15-parked-group`: the legend's background is pixel-
+                // identical to the panel around it in both. Revisit this
+                // comment the day this panel ever gains real vibrancy.
+                .background(Tok.panel)
+            if section.isWhollyParked {
+                Button {
+                    toggleParkedGroupExpansion(section.group.token)
+                } label: {
+                    legend
+                }
+                .buttonStyle(.plain)
+                .accessibilityHint(
+                    expandedParkedGroups.contains(section.group.token)
+                        ? "Collapses this parked group."
+                        : "Expands this parked group."
+                )
+            } else {
+                legend
+            }
+        } else {
+            measured(groupHeightKey(section)) {
+                Text(section.title)
+                    .font(Tok.secondaryFont.weight(.semibold)).lineSpacing(Tok.secondaryLineSpacing)
+                    .foregroundStyle(.primary)
+            }
         }
+    }
+
+    /// Persisted across launches under ``expandedParkedGroupsKey`` — a
+    /// wholly-parked group an operator has already looked at once should
+    /// stay open, not re-collapse on the next poll or the next time the
+    /// panel opens. Keyed on ``FleetGroupKey/token`` rather than the bare
+    /// name for the same collision reason `FleetSectionRow.id` uses it: a
+    /// group literally named `Ungrouped` cannot borrow the sentinel's key.
+    @State private var expandedParkedGroups: Set<String> = Set(
+        UserDefaults.standard.stringArray(forKey: FleetView.expandedParkedGroupsKey) ?? [])
+
+    /// Internal, not `private`, so ``RenderStates`` — this file's `--render-
+    /// states` harness, same target — can seed and clear it around one scene
+    /// (`15b-parked-group-expanded`) without a second copy of the literal.
+    static let expandedParkedGroupsKey = "expandedParkedGroupNames"
+
+    private func toggleParkedGroupExpansion(_ groupToken: String) {
+        if expandedParkedGroups.contains(groupToken) {
+            expandedParkedGroups.remove(groupToken)
+        } else {
+            expandedParkedGroups.insert(groupToken)
+        }
+        UserDefaults.standard.set(
+            Array(expandedParkedGroups), forKey: Self.expandedParkedGroupsKey)
     }
 
     /// Height key for a band heading. The `b:` prefix cannot collide with a row
@@ -576,6 +750,13 @@ struct FleetView: View {
             removeController: removeController,
             allAccounts: fleet.accounts,
             enclosingGroupName: enclosingGroupName,
+            // Every row reaching this section is parked BECAUSE this named
+            // group is parked (`FleetSection.isWhollyParked`) — the group's
+            // own legend already says so once, in text that survives without
+            // colour, so restating it on every card under it is the same
+            // fact twice in one glance. `false` (unchanged) for the
+            // ungrouped pile and every live section.
+            suppressParkedPill: row.band == .parked && row.group != .ungrouped,
             snapshotMode: snapshotMode
         )
         .background(
@@ -1218,6 +1399,12 @@ struct AccountRow: View {
     /// ``Account/groupTags`` itself, which still lists every group this
     /// account belongs to.
     var enclosingGroupName: String?
+    /// True when this row sits inside a wholly-parked NAMED group section
+    /// (``FleetSection/isWhollyParked``) — every row there is parked for the
+    /// same reason the group heading now names as a legend, so
+    /// ``rotationPill`` drops the per-row "parked" pill it would otherwise
+    /// draw. Defaults to `false`, unchanged for every other call site.
+    var suppressParkedPill: Bool = false
     /// Mirrors ``FleetView/snapshotMode``. `ImageRenderer` cannot draw a
     /// `Menu` — it rasterises the yellow "unsupported control" placeholder
     /// the README hero used to ship — so a snapshot draws
@@ -1609,7 +1796,9 @@ struct AccountRow: View {
     /// height even on the two branches that go empty.
     @ViewBuilder
     private var rotationPill: some View {
-        if account.disabled {
+        if suppressParkedPill && (account.disabled || account.isParkedByGroup) {
+            EmptyView()
+        } else if account.disabled {
             StatusPill("parked", tint: Tok.disabled)
                 .help("Out of the rotation — `tcr` sends this account no traffic.")
                 .transition(.opacity)
@@ -2531,17 +2720,21 @@ struct AccountRow: View {
             // the slot. Absent — no tooltip at all — on a structurally zero
             // offline read, the same rule the printed line followed.
             .help(account.countersTooltip(countersAreStructural: countersAreStructural) ?? "")
-            if let error = account.lastStreamError, !error.isEmpty {
-                // A nil count here is not a quantity with an unknown value —
-                // unlike `account.requests` above, this number is a MODIFIER
-                // on the error string that is already being displayed, and
-                // the error alone is the actionable fact regardless of how
-                // many times it happened. See
-                // `QuotaFormat.streamErrorLabel(count:error:)`'s doc comment
-                // for why this suppresses the multiplier on `nil` instead of
-                // following `QuotaFormat.count`'s "n/a" the way the line
-                // above does.
-                Text(QuotaFormat.streamErrorLabel(count: account.streamErrorCount, error: error))
+            // A nil count here is not a quantity with an unknown value —
+            // unlike `account.requests` above, this number is a MODIFIER
+            // on the error string that is already being displayed, and
+            // the error alone is the actionable fact regardless of how
+            // many times it happened. See
+            // `QuotaFormat.streamErrorLabel(count:error:)`'s doc comment
+            // for why this suppresses the multiplier on `nil` instead of
+            // following `QuotaFormat.count`'s "n/a" the way the line
+            // above does, and returns `nil` outright on a MEASURED zero —
+            // a count of 0 means the error has not recurred, and the line
+            // must not render at all.
+            if let error = account.lastStreamError, !error.isEmpty,
+                let label = QuotaFormat.streamErrorLabel(count: account.streamErrorCount, error: error)
+            {
+                Text(label)
                     .font(Tok.detailFont).lineSpacing(Tok.detailLineSpacing)
                     .foregroundStyle(Tok.spent)
                     .lineLimit(2)

--- a/apps/macos/Sources/TcrBar/RenderStates.swift
+++ b/apps/macos/Sources/TcrBar/RenderStates.swift
@@ -101,6 +101,10 @@ enum RenderStates {
             ("14-usage-stats", .loaded(fleet(usageStatsJSON)), false, nil),
             // A parked group beside a live one — see `parkedGroupJSON`.
             ("15-parked-group", .loaded(fleet(parkedGroupJSON)), false, nil),
+            // The SAME fleet, expanded — see `render(_:appearance:into:)`'s
+            // own seeding of `FleetView.expandedParkedGroupsKey` for
+            // `henry-team`, the wholly-parked group `parkedGroupJSON` builds.
+            ("15b-parked-group-expanded", .loaded(fleet(parkedGroupJSON)), false, nil),
         ]
     }
 
@@ -165,6 +169,23 @@ enum RenderStates {
         // `.harness()` is inert on both halves.
         let awake = AwakeController.harness()
         awake.setOn(scene.awake)
+
+        // `expandedParkedGroups` reads `UserDefaults.standard` at construction
+        // — real for the shipping app, but this harness only ever runs under
+        // `TCRBAR_DEV_BUILD=1`'s OWN bundle id (`build-tcrbar.sh`'s own
+        // comment: "gives a non-shipping build its own identity"), a
+        // `UserDefaults` domain the shipping app never reads or writes.
+        // Seeded here, for exactly one scene, rather than threading a new
+        // constructor parameter through `FleetView` for a harness-only need:
+        // every OTHER scene explicitly clears the key first, so construction
+        // order across scenes cannot leak one render's expansion into the
+        // next.
+        if scene.name == "15b-parked-group-expanded" {
+            UserDefaults.standard.set(
+                ["g:henry-team"], forKey: FleetView.expandedParkedGroupsKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: FleetView.expandedParkedGroupsKey)
+        }
 
         let view =
             FleetView(

--- a/apps/macos/Sources/TcrBar/Tokens.swift
+++ b/apps/macos/Sources/TcrBar/Tokens.swift
@@ -349,16 +349,22 @@ public enum Tok {
     /// group's heading and rows (`docs/plans/group-outline-bridge.md`).
     /// Heavier than the card's own ``hairlineWidth`` (0.5) on purpose — a
     /// structural grouping cue drawn at arm's length needs to read at a
-    /// glance, where a hairline disappears — and it is drawn OUTSIDE the
-    /// section's own layout box (`FleetView.groupOutline(for:)`, via
-    /// negative padding) rather than by adding real padding around the
-    /// content, so it never changes any ``rowHeights``-measured row or
-    /// heading height. See that function's own doc-comment for why that
-    /// distinction matters here.
+    /// glance, where a hairline disappears. Drawn at the section's OWN
+    /// bounds (`FleetView.groupOutline(for:)`) with the section's CONTENT
+    /// inset inward by `groupOutlineInset` on all four sides
+    /// (`FleetView.sectionBody`) — an earlier version bled the stroke
+    /// outward via negative padding instead, which only had room to survive
+    /// vertically (inside the gap `rowSpacing` leaves between sections) and
+    /// was clipped on the left and right, where the account list has no
+    /// such gap. See `groupOutline(for:)`'s own doc-comment for the full
+    /// account.
     public static let groupOutlineWidth: CGFloat = 1.0
-    /// How far outside its section's own bounds the outline sits. Kept
-    /// under `rowSpacing` (8) so two adjacent sections' outlines never
-    /// touch in the gap between them.
+    /// How far the section's content is inset from the stroke on every side.
+    /// Kept under `rowSpacing` (8) for the same reason it always was — this
+    /// used to bound how far the OLD outward bleed could travel before
+    /// touching a neighbour; now it bounds how much the section visibly
+    /// shrinks inside its own border, which reads better at a value smaller
+    /// than the gap between two sections.
     public static let groupOutlineInset: CGFloat = 6
     /// Bigger than `radiusMedium` (the cards' own radius) by roughly
     /// `groupOutlineInset` — the same outer-equals-inner-plus-padding rule
@@ -366,6 +372,13 @@ public enum Tok {
     /// level up so the outline reads as a looser box AROUND same-radius
     /// cards rather than a same-size sibling beside them.
     public static let groupOutlineRadius: CGFloat = radiusMedium + groupOutlineInset
+    /// The legend's own height, in points — `detailFontSize` (10) plus its
+    /// line-spacing plus the `space1` vertical breathing room the pill-style
+    /// background around the text effectively adds. `FleetView.sectionBody`
+    /// offsets the legend upward by half of this so it sits centred ON the
+    /// stroke's top edge, the same way `HENRY-TOKEN · PARKED · 5` sits on
+    /// the mockup's border rather than above or below it.
+    public static let groupLegendHeight: CGFloat = detailFontSize + detailLineSpacing + space1
 
     // MARK: - Motion
     //

--- a/apps/macos/Sources/TcrBarCore/FleetSections.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetSections.swift
@@ -259,6 +259,37 @@ public struct FleetSection: Identifiable, Equatable, Sendable {
     /// the "draw or not" decision reads as one word and is unit-testable on
     /// its own: see the drawing rule's full reasoning on ``outlineColor``.
     public var isOutlined: Bool { outlineColor != nil }
+
+    /// True for a NAMED group every one of whose rows landed in
+    /// ``FleetBand/parked`` — which, by ``FleetBand/init(_:)``, means every
+    /// row here is either `disabled` or ``Account/isParkedByGroup``. A
+    /// section is per-(band, group), so this needs no per-row check: the
+    /// section's own `band` already speaks for all of them.
+    ///
+    /// `.ungrouped` is never wholly parked, even when every row in it
+    /// happens to be — there is no group name to legend it with and nothing
+    /// for an operator to unpark by name, so the panel draws it exactly like
+    /// any other ungrouped section.
+    public var isWhollyParked: Bool { band == .parked && group != .ungrouped }
+
+    /// "HENRY-TOKEN · PARKED · 5" — the legend `FleetView.groupHeading(_:)`
+    /// draws on an outlined section's own stroke, top-left, in place of the
+    /// old stacked band-heading-over-group-heading pair. The group name,
+    /// uppercased; `· PARKED` exactly when ``isWhollyParked`` — the one place
+    /// that word still survives once the per-row pill is dropped inside such
+    /// a group (`AccountRow.suppressParkedPill`); then always `· <row
+    /// count>`. Lives here, not in the view, for the same reason every other
+    /// formatter in this codebase does: a live section's legend and a
+    /// wholly-parked one's are a fact about the model, testable without
+    /// SwiftUI.
+    public var legendText: String {
+        var text = title.uppercased()
+        if isWhollyParked {
+            text += " · PARKED"
+        }
+        text += " · \(rows.count)"
+        return text
+    }
 }
 
 extension Array where Element == FleetSection {
@@ -295,6 +326,24 @@ extension Array where Element == FleetSection {
         let section = self[index]
         guard section.group == .ungrouped else { return true }
         return filter { $0.band == section.band }.count > 1
+    }
+
+    /// Whether the band containing the section at `index` holds exactly one
+    /// group section — the cue to skip the band heading entirely.
+    ///
+    /// "why parked ontop of it and henry token group name so on the side not
+    /// some header" (Gil, 2026-09-12): a band heading stacked directly over
+    /// a single group's own heading says the same thing twice — "PARKED"
+    /// over "HENRY-TOKEN · PARKED · 5" restates the word the legend already
+    /// carries. This mirrors ``drawsGroupHeading(at:)``'s single-ungrouped-
+    /// section case one level up, and — unlike that one — applies to a
+    /// single NAMED section too: a lone group's own heading (or legend)
+    /// already says which group, which is everything the band heading over
+    /// it would have said.
+    public func soleGroupInBand(at index: Int) -> Bool {
+        guard indices.contains(index) else { return false }
+        let band = self[index].band
+        return filter { $0.band == band }.count == 1
     }
 }
 

--- a/apps/macos/Sources/TcrBarCore/FleetStatus.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetStatus.swift
@@ -483,7 +483,8 @@ public enum QuotaFormat {
     }
 
     /// `(3, "overloaded_error")` → `"3× overloaded_error"`;
-    /// `(nil, "overloaded_error")` → `"overloaded_error"`.
+    /// `(nil, "overloaded_error")` → `"overloaded_error"`;
+    /// `(0, "overloaded_error")` → `nil` — nothing to render.
     ///
     /// Deliberately NOT ``count(_:)`` plus a literal `"×"`: a stream-error
     /// count is a MODIFIER on the error string already being displayed, not
@@ -496,8 +497,16 @@ public enum QuotaFormat {
     /// view, for the same reason every formatter in this enum does: so the
     /// rendered string is a property of the model a test can assert on
     /// directly.
-    public static func streamErrorLabel(count: Int?, error: String) -> String {
+    ///
+    /// `Int?` return, not `String`: a MEASURED zero is not a modifier on
+    /// anything, it is proof the error has not recurred, and a `"0×
+    /// overloaded_error"` line told an operator the opposite of the truth —
+    /// the string reads as "this just happened", not "this stopped
+    /// happening". The caller drops the whole line on `nil`, exactly the way
+    /// it already drops the line when `lastStreamError` itself is absent.
+    public static func streamErrorLabel(count: Int?, error: String) -> String? {
         guard let count else { return error }
+        guard count > 0 else { return nil }
         return "\(count)× \(error)"
     }
 

--- a/apps/macos/Tests/TcrBarTests/FleetSectionsTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetSectionsTests.swift
@@ -380,6 +380,83 @@ final class FleetSectionsTests: XCTestCase {
                 "two sections in one band — both headings separate something")
         }
     }
+
+    // MARK: - Group legend (data/plans/panel-groups-bridge.md)
+
+    /// A wholly-parked named group's legend carries both the group name and
+    /// " · PARKED" — the one place that word survives once the per-row pill
+    /// is dropped inside it.
+    func testLegendTextForWhollyParkedGroupCarriesParkedAndCount() {
+        let fleet = Fleet(accounts: [
+            sectionAccount(
+                "p1@example.com", groups: ["henry-token"], parkedGroups: ["henry-token"]),
+            sectionAccount(
+                "p2@example.com", groups: ["henry-token"], parkedGroups: ["henry-token"]),
+        ])
+        let section = try! XCTUnwrap(fleet.sectionsInDisplayOrder().first)
+
+        XCTAssertTrue(section.isWhollyParked)
+        XCTAssertEqual(section.legendText, "HENRY-TOKEN · PARKED · 2")
+    }
+
+    /// A live (mixed, not wholly parked) named group's legend carries the
+    /// name and the count, but never the word "PARKED" — that word is a
+    /// claim about the group's own state, not decoration every legend wears.
+    func testLegendTextForLiveGroupOmitsParked() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("a@example.com", groups: ["dev"]),
+            sectionAccount("b@example.com", groups: ["dev"]),
+        ])
+        let section = try! XCTUnwrap(fleet.sectionsInDisplayOrder().first)
+
+        XCTAssertFalse(section.isWhollyParked)
+        XCTAssertEqual(section.legendText, "DEV · 2")
+    }
+
+    /// A group split across bands (some rows parked, some not) is wholly
+    /// parked only in the section that actually landed in the parked band —
+    /// the live half of the same group must not borrow the word.
+    func testLegendTextForSplitGroupDiffersPerBand() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("live@example.com", groups: ["dev"]),
+            sectionAccount("off@example.com", groups: ["dev"], disabled: true),
+        ])
+        let sections = fleet.sectionsInDisplayOrder()
+        let live = try! XCTUnwrap(sections.first { $0.band == .live })
+        let parked = try! XCTUnwrap(sections.first { $0.band == .parked })
+
+        XCTAssertEqual(live.legendText, "DEV · 1")
+        XCTAssertEqual(parked.legendText, "DEV · PARKED · 1")
+    }
+
+    // MARK: - Sole group in band (data/plans/panel-groups-bridge.md, item 2)
+
+    /// A band holding exactly one group section — named or ungrouped — draws
+    /// no band heading: the group's own heading (or legend) already says
+    /// everything the band heading over it would have said.
+    func testSoleGroupInBandIsTrueForALoneNamedSection() {
+        let fleet = Fleet(accounts: [
+            sectionAccount(
+                "p1@example.com", groups: ["henry-token"], parkedGroups: ["henry-token"])
+        ])
+        let sections = fleet.sectionsInDisplayOrder()
+        XCTAssertEqual(sections.count, 1)
+        XCTAssertTrue(sections.soleGroupInBand(at: 0))
+    }
+
+    /// Two groups sharing one band are each NOT sole — the band heading still
+    /// draws to separate them.
+    func testSoleGroupInBandIsFalseWhenTwoGroupsShareABand() {
+        let fleet = Fleet(accounts: [
+            sectionAccount("a@example.com", groups: ["dev"]),
+            sectionAccount("b@example.com", groups: ["ops"]),
+        ])
+        let sections = fleet.sectionsInDisplayOrder()
+        XCTAssertEqual(sections.count, 2)
+        for index in sections.indices {
+            XCTAssertFalse(sections.soleGroupInBand(at: index))
+        }
+    }
 }
 
 /// A row with everything but the group/state fields fixed — the same shape

--- a/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
@@ -278,9 +278,26 @@ final class FleetStatusTests: XCTestCase {
             "overloaded_error"
         )
         XCTAssertFalse(
-            QuotaFormat.streamErrorLabel(count: finn.streamErrorCount, error: "overloaded_error")
+            QuotaFormat.streamErrorLabel(count: finn.streamErrorCount, error: "overloaded_error")!
                 .hasPrefix("n/a"),
             "a nil stream-error count must never render as the broken-English \"n/a×\""
+        )
+    }
+
+    /// `streamErrorCount: 0` is a MEASURED zero — the error has not
+    /// recurred — and `alice` (`liveFixture`) carries exactly that shape:
+    /// `streamErrorCount: 0` beside a `lastStreamError` of `nil`. The panel's
+    /// only gate against rendering the line at all is `lastStreamError`
+    /// being non-nil, so this test pins the label itself: a caller that
+    /// somehow reaches this function with a real error string and a
+    /// measured zero count must get `nil` back, never `"0× …"`, which read
+    /// as the opposite of what a zero count means.
+    func testZeroStreamErrorCountRendersNoLine() throws {
+        let alice = try fleet(liveFixture).accounts[0]
+        XCTAssertEqual(alice.streamErrorCount, 0)
+        XCTAssertNil(
+            QuotaFormat.streamErrorLabel(count: 0, error: "overloaded_error"),
+            "a measured zero stream-error count must render no line at all"
         )
     }
 }


### PR DESCRIPTION
🍄 fix: outline the whole group, legend its heading, smoosh parked groups, drop 0x truncated

## What

Four defects Gil found in the live 0.2.48 panel, all in `FleetView`'s group rendering
(`data/plans/panel-groups-bridge.md`):

1. **Group outline clipped on the sides.** It bled outward via negative padding and got
   clipped by the account list's fixed-width column — only top/bottom survived. Fixed by
   insetting the section's own content inward instead (`Tok.groupOutlineInset`, all four
   sides), so the stroke sits fully inside the section's bounds.
2. **Stacked band-heading-over-group-heading.** "PARKED" over "henry-team" restated the
   same word twice. The group name is now a legend drawn ON the stroke
   ("HENRY-TOKEN · PARKED · 5"), and the band heading is skipped entirely when its band
   holds only one group section — named or ungrouped.
3. **Smoosh.** A wholly-parked named group now renders collapsed: one line per account, no
   quota bars, no cost line, no per-row PARKED pill (the legend already says it once for
   the whole group). The legend is a real `Button` that expands/collapses it, remembered
   per group name in `UserDefaults`.
4. **`0× truncated`.** `QuotaFormat.streamErrorLabel` returned `"0× overloaded_error"` for
   a MEASURED zero stream-error count — the opposite of what a zero means. It now returns
   `nil` on a measured zero and the row renders no line at all.

Fixture: added `15b-parked-group-expanded` beside the existing `15-parked-group`.

## Screenshots

Collapsed (dark) — outline now visible on all four sides, legend on the stroke, no
per-row PARKED pill:

`/tmp/tcrbar-states-groups/15-parked-group-dark.png`

Collapsed (light):

`/tmp/tcrbar-states-groups/15-parked-group-light.png`

Expanded, via the legend button (dark):

`/tmp/tcrbar-states-groups/15b-parked-group-expanded-dark.png`

Expanded (light):

`/tmp/tcrbar-states-groups/15b-parked-group-expanded-light.png`

## Findings (from `docs/design/panel-tabs-review.md`, relayed for this lane)

Three findings from the sibling tabs lane's interface review generalize to this lane's new
UI. Addressed two in code, and am reporting rather than fixing the third per that message's
own instruction:

- **Finding 9** ("2 more · click to expand" — decorative text with a tap gesture bolted
  on, no keyboard path). Fixed: the group legend is a real SwiftUI `Button`
  (`.buttonStyle(.plain)`), not `Text.onTapGesture` — real keyboard/VoiceOver operability
  for the one case that's interactive (a wholly-parked group); a live group's legend stays
  plain `Text`, since it has nothing to activate.
- **Finding 11** (an opaque legend patch reads as a black bar over a translucent,
  `backdrop-filter` panel). **Checked, does not reproduce here.** TcrBar's panel is a flat,
  fully opaque `Tok.panel` fill — no `NSVisualEffectView`/real material anywhere in this
  target (`FleetView.swift:125`, `.background(Tok.panel)`). The legend's own
  `.background(Tok.panel)` patch is pixel-identical to its surroundings in every rendered
  scene above; the defect the review caught is specific to the mockup's CSS
  `backdrop-filter` approximation of a translucent panel this app does not have.
- **Finding 12** (a group's identity colour can collide with a status colour — the same
  concern the mockup raised about `--ok` green vs `--grp` green). **Not fixed, flagged**:
  `parkedGroupJSON`'s own fixture colours `henry-team` `#32d74b`, which sits close to
  `Tok.ok`'s green (`#66d081` dark / `#00873c` light) — visible in the screenshots above,
  where the outline and the `OK` pills read as near-identical greens. Group colours are
  server-resolved (`groupColors` on the wire) and this build never recolours them — the
  parked *state* is carried by the legend's `· PARKED` text, never by the outline hue, so
  the two facts stay distinct even when their colours are close. Whether to constrain which
  hues a group can pick (client-side or server-side) is a product decision outside this
  fix's scope.
- **Finding 4** (contrast floor on dim/plan text). Checked, not touched: this lane's
  collapsed-row plan text uses `Tok.inkFaint`, documented and gated at 5.8:1 dark / 4.8:1
  light against the panel (`Tokens.swift`) — already above the 4.5:1 floor the review
  applies to the sibling mockup's own `--mute` token. `Tokens.swift` is shared with the
  tabs lane; not editing it here per that message's own instruction.

## Gates

- `swift test --package-path apps/macos` — exit 0, 507 tests, 0 failures.
- Watched the zero-count fix fail: flipped `guard count > 0` to `guard count >= 0`, re-ran
  `--filter FleetStatusTests`, confirmed `testZeroStreamErrorCountRendersNoLine` failed with
  the `"0× overloaded_error"` string, restored, re-ran full suite green.
- `TCRBAR_DEV_BUILD=1 apps/macos/scripts/build-tcrbar.sh` — exit 0.
- `--render-states` — 46/46 images written; read `15-parked-group-{dark,light}.png` and
  `15b-parked-group-expanded-{dark,light}.png` myself and confirmed the stroke is visible
  on all four sides.

https://claude.ai/code/session_01WyxK6BTWQoYSZyQAehjgCE
