### PR TITLE
feat: show ready/enabled counts in the menu bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "teamclaude-rs"
-version = "0.2.48"
+version = "0.2.49"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "teamclaude-rs"
-version = "0.2.48"
+version = "0.2.49"
 edition = "2021"
 license = "PolyForm-Noncommercial-1.0.0"
 # Noncommercial license, so this crate must never reach crates.io, whose terms

--- a/apps/macos/Sources/TcrBar/MenuBarShell.swift
+++ b/apps/macos/Sources/TcrBar/MenuBarShell.swift
@@ -36,6 +36,11 @@ final class MenuBarShell {
     /// control that keeps nothing awake.
     let awake: AwakeController
     let preference: LaunchPreference
+    /// "Show counts in the menu bar" — whether ``updateMark`` draws the
+    /// `ready/enabled` label. Owned here for the same reason as `preference`:
+    /// the mark it gates is composed on every poll tick, not just while the
+    /// panel is open.
+    let countsPreference: MenuBarCountsPreference
     /// Group-membership mutations for the Groups view, owned here for the
     /// same reason as `accounts`: an in-flight/failure/restart-notice state
     /// that reset every time the panel opened would lose the "restart the
@@ -75,6 +80,7 @@ final class MenuBarShell {
         control: ControlAccountController? = nil,
         awake: AwakeController? = nil,
         preference: LaunchPreference? = nil,
+        countsPreference: MenuBarCountsPreference? = nil,
         updater: Updater? = nil,
         groupController: GroupController? = nil,
         removeController: RemoveAccountController? = nil,
@@ -87,6 +93,7 @@ final class MenuBarShell {
         self.control = control ?? ControlAccountController()
         self.awake = awake ?? AwakeController()
         self.preference = preference ?? LaunchPreference()
+        self.countsPreference = countsPreference ?? MenuBarCountsPreference()
         self.updater = updater ?? Updater()
         self.groupController = groupController ?? GroupController()
         self.removeController = removeController ?? RemoveAccountController()
@@ -135,7 +142,8 @@ final class MenuBarShell {
             rootView: FleetPanel(
                 poller: self.poller, server: self.server, loginItem: self.loginItem,
                 accounts: self.accounts, control: self.control, awake: self.awake,
-                preference: self.preference, updater: self.updater,
+                preference: self.preference, countsPreference: self.countsPreference,
+                updater: self.updater,
                 groupController: self.groupController, removeController: self.removeController,
                 onWhatsNew: { [weak self] in self?.openWhatsNew() }))
         // Without this the popover takes a default size and the panel is clipped.
@@ -203,19 +211,22 @@ final class MenuBarShell {
             button.sendAction(on: [.leftMouseUp, .rightMouseUp])
         }
 
-        // Both publishers, combined, so the image is recomposed whenever either
-        // half of it changes.
+        // All three publishers, combined, so the image and label are
+        // recomposed whenever any of them changes.
         //
         // The values come from the publisher, never from re-reading the
         // controllers. `@Published` fires in `willSet`, so `awake.isOn` inside
         // this sink is still the OLD value — a mark composed from it would
         // disagree with `AwakeController.isOn` for one edge in each direction,
         // which is the same "three representations of one fact" failure that
-        // controller's own doc-comment is built to prevent.
+        // controller's own doc-comment is built to prevent. `showCounts`
+        // follows the identical rule for the same reason: toggling it and
+        // reading `countsPreference.showCounts` back inside this sink would
+        // race the very publisher this sink exists to trust.
         self.poller.$state
-            .combineLatest(self.awake.$isOn)
-            .sink { [weak self] state, isOn in
-                self?.updateMark(state: state, awake: isOn)
+            .combineLatest(self.awake.$isOn, self.countsPreference.$showCounts)
+            .sink { [weak self] state, isOn, showCounts in
+                self?.updateMark(state: state, awake: isOn, showCounts: showCounts)
             }
             .store(in: &marks)
 
@@ -257,19 +268,41 @@ final class MenuBarShell {
 
     /// One line for the tooltip. The menu bar has room for a glyph and nothing
     /// else, so this is where the poll's own summary is reachable by a human who
-    /// has not opened the panel.
+    /// has not opened the panel. ``PollState/tooltipSentence`` is the fuller
+    /// capacity sentence when a healthy read has one to give, and
+    /// ``PollState/summary`` unchanged for every other case.
     static func toolTip(state: PollState, awake: Bool) -> String {
-        awake ? "\(state.summary) · \(KeepAwakeGlyph.accessibilityDescription)" : state.summary
+        awake
+            ? "\(state.tooltipSentence) · \(KeepAwakeGlyph.accessibilityDescription)"
+            : state.tooltipSentence
     }
 
-    private func updateMark(state: PollState, awake isOn: Bool) {
+    /// `PollState.countsLabel`, rendered with tabular figures so the status
+    /// item does not jitter in width as the digits change between polls.
+    private static func countsAttributedTitle(_ label: String) -> NSAttributedString {
+        let font = NSFont.monospacedDigitSystemFont(
+            ofSize: NSFont.menuBarFont(ofSize: 0).pointSize, weight: .regular)
+        return NSAttributedString(
+            string: label,
+            attributes: [.font: font, .foregroundColor: NSColor.labelColor])
+    }
+
+    private func updateMark(state: PollState, awake isOn: Bool, showCounts: Bool) {
         guard let button = statusItem.button else { return }
         if let mark = MenuBarMark.image(
             gaugeSymbol: Self.gaugeSymbol(for: state), awake: isOn,
             awakeTint: Tok.awakeNSColor)
         {
             button.image = mark
-            button.title = ""
+            // `state.countsLabel` (`TcrBarCore/StatusPoller.swift`) is `nil`
+            // for the same cases the glyph alone already carries — pending, a
+            // failed read, an all-disabled fleet — so the guard below is
+            // purely `showCounts`; the state check already happened.
+            if showCounts, let label = state.countsLabel {
+                button.attributedTitle = Self.countsAttributedTitle(label)
+            } else {
+                button.title = ""
+            }
         } else if button.image == nil {
             // Only reachable if an SF Symbol this build names has gone missing.
             // A status item with neither image nor title is zero points wide and
@@ -459,24 +492,45 @@ struct FleetPanel: View {
     @ObservedObject var control: ControlAccountController
     @ObservedObject var awake: AwakeController
     @ObservedObject var preference: LaunchPreference
+    @ObservedObject var countsPreference: MenuBarCountsPreference
     @ObservedObject var updater: Updater
     @ObservedObject var groupController: GroupController
     @ObservedObject var removeController: RemoveAccountController
     var onWhatsNew: () -> Void = {}
 
     var body: some View {
-        FleetView(
-            poller: poller,
-            server: server,
-            loginItem: loginItem,
-            accounts: accounts,
-            control: control,
-            awake: awake,
-            updater: updater,
-            groupController: groupController,
-            removeController: removeController,
-            startServerAtLaunch: $preference.startServerAtLaunch,
-            onWhatsNew: onWhatsNew
-        )
+        VStack(spacing: 0) {
+            FleetView(
+                poller: poller,
+                server: server,
+                loginItem: loginItem,
+                accounts: accounts,
+                control: control,
+                awake: awake,
+                updater: updater,
+                groupController: groupController,
+                removeController: removeController,
+                startServerAtLaunch: $preference.startServerAtLaunch,
+                onWhatsNew: onWhatsNew
+            )
+            // Kept OUTSIDE `FleetView` rather than folded into its own
+            // preferences footer: this feature's bridge (F5,
+            // `data/plans/menubar-counts-bridge.md`) is scoped away from
+            // `FleetView.swift`, which a separate lane owns concurrently — an
+            // edit there risks the exact collision DNA's "you are not alone"
+            // rule exists to prevent. A one-row toggle appended below the
+            // existing panel is the whole cost of keeping this feature inside
+            // its own files.
+            Divider()
+            Toggle("Show counts in the menu bar", isOn: $countsPreference.showCounts)
+                .toggleStyle(.checkbox)
+                .font(Tok.secondaryFont)
+                .help(
+                    "Shows the ready/enabled fraction (e.g. \u{201c}9/13\u{201d}) "
+                        + "beside the gauge glyph in the menu bar."
+                )
+                .padding(.horizontal, Tok.space4)
+                .padding(.vertical, Tok.space3)
+        }
     }
 }

--- a/apps/macos/Sources/TcrBar/RenderMark.swift
+++ b/apps/macos/Sources/TcrBar/RenderMark.swift
@@ -1,0 +1,186 @@
+import AppKit
+import TcrBarCore
+
+/// Rasterise the menu-bar mark itself — the composed `NSImage`
+/// ``MenuBarMark/image(gaugeSymbol:awake:awakeTint:)`` builds, plus the
+/// `ready/enabled` label this feature (F5, `data/plans/menubar-counts-bridge.md`)
+/// adds beside it — to PNG, in-process, then exit.
+///
+/// ## Why this exists, separate from `--render-states`
+///
+/// `RenderStates` draws `FleetView` with `ImageRenderer`, which never touches the
+/// real `NSStatusItem` — the mark is composed straight onto `button.image`/
+/// `button.attributedTitle` (`MenuBarShell.updateMark`), a path `ImageRenderer`
+/// cannot reach because it is not a SwiftUI view at all. `MenuBarMark.image` IS
+/// rasterisable headless, though: it is a plain `NSImage(size:flipped:drawingHandler:)`,
+/// the same shape `AppIcon.image(size:)` already rasterises for `--render-icon`. So
+/// this composes gauge + label the same way `updateMark` does, onto a canvas sized
+/// like a real `NSStatusBarButton`, instead of adding a `--render-mark` scene to
+/// `RenderStates` — a file this feature's own bridge keeps out of, matching the
+/// concurrent lane already working there.
+///
+/// ## Usage
+///
+///     TcrBar.app/Contents/MacOS/TcrBar --render-mark /tmp/tcrbar-mark
+///
+/// Writes one PNG per scene and exits without ever showing a menu-bar item,
+/// polling `tcr`, or touching a server.
+enum RenderMark {
+    static let flag = "--render-mark"
+
+    static func requestedDirectory(_ arguments: [String] = CommandLine.arguments) -> URL? {
+        guard let i = arguments.firstIndex(of: flag), i + 1 < arguments.count else { return nil }
+        return URL(fileURLWithPath: arguments[i + 1])
+    }
+
+    /// A handful of states worth looking at: a mixed fleet (label visible), an
+    /// empty fleet and a failed poll (label hidden — the exact two conditions
+    /// ``PollState/countsLabel`` documents), and the mixed fleet again with
+    /// `showCounts` off, so the "hidden by preference" branch is also on
+    /// disk to look at rather than only unit-tested.
+    private static var scenes: [(name: String, state: PollState, showCounts: Bool)] {
+        [
+            ("01-mixed-fleet-counts-on", .loaded(mixedFleet), true),
+            ("02-mixed-fleet-counts-off", .loaded(mixedFleet), false),
+            ("03-empty-fleet", .loaded(Fleet(accounts: [])), true),
+            (
+                "04-poll-failed", .commandFailed(exitCode: 1, message: "connection refused"), true
+            ),
+        ]
+    }
+
+    @MainActor
+    static func run(into directory: URL) -> Never {
+        do {
+            try FileManager.default.createDirectory(
+                at: directory, withIntermediateDirectories: true)
+        } catch {
+            FileHandle.standardError.write(
+                Data("cannot create \(directory.path): \(error)\n".utf8))
+            exit(1)
+        }
+
+        var written = 0
+        for scene in scenes {
+            if render(scene, into: directory) { written += 1 }
+        }
+        print("\nrendered \(written)/\(scenes.count) images into \(directory.path)")
+        exit(written == scenes.count ? 0 : 1)
+    }
+
+    /// The width `NSFont.menuBarFont(ofSize: 0)`'s tallest glyph plus the label
+    /// text needs, at 2x — wide enough that a two-digit `"12/13"` is never
+    /// clipped, generous rather than measured, since this is a review artifact
+    /// and not a layout contract.
+    private static let canvasSize = NSSize(width: 160, height: 44)
+
+    @MainActor
+    private static func render(
+        _ scene: (name: String, state: PollState, showCounts: Bool),
+        into directory: URL
+    ) -> Bool {
+        let gauge = MenuBarShell.gaugeSymbol(for: scene.state)
+        guard let mark = MenuBarMark.image(gaugeSymbol: gauge, awake: false, awakeTint: .systemCyan)
+        else {
+            FileHandle.standardError.write(Data("no such SF Symbol: \(gauge)\n".utf8))
+            return false
+        }
+
+        let label = scene.showCounts ? scene.state.countsLabel : nil
+        let font = NSFont.monospacedDigitSystemFont(
+            ofSize: NSFont.menuBarFont(ofSize: 0).pointSize, weight: .regular)
+
+        let composed = NSImage(size: canvasSize, flipped: false) { rect in
+            NSColor.windowBackgroundColor.setFill()
+            rect.fill()
+            let markRect = NSRect(
+                x: 8, y: (rect.height - mark.size.height) / 2,
+                width: mark.size.width, height: mark.size.height)
+            mark.draw(in: markRect, from: .zero, operation: .sourceOver, fraction: 1)
+            if let label {
+                let attributed = NSAttributedString(
+                    string: label,
+                    attributes: [.font: font, .foregroundColor: NSColor.labelColor])
+                let labelOrigin = NSPoint(
+                    x: markRect.maxX + 4, y: (rect.height - attributed.size().height) / 2)
+                attributed.draw(at: labelOrigin)
+            }
+            return true
+        }
+
+        let name = "\(scene.name).png"
+        guard let tiff = composed.tiffRepresentation,
+            let rep = NSBitmapImageRep(data: tiff),
+            let png = rep.representation(using: .png, properties: [:])
+        else {
+            FileHandle.standardError.write(Data("render failed: \(name)\n".utf8))
+            return false
+        }
+
+        let url = directory.appendingPathComponent(name)
+        do {
+            try png.write(to: url)
+            print("  \(name)  label=\(label ?? "(hidden)")")
+            return true
+        } catch {
+            FileHandle.standardError.write(Data("write failed \(name): \(error)\n".utf8))
+            return false
+        }
+    }
+
+    /// Obviously-fake names only — this repository is public.
+    private static let mixedFleetJSON = """
+        [
+          {
+            "source": "live", "serverSha": "abc1234", "serverDirty": false,
+            "name": "alice@example.com", "priority": 1, "status": "active",
+            "disabled": false, "quota": 0.1, "quotaState": "ok",
+            "fiveHour": 0.1, "sevenDay": 0.1, "sevenDayOi": 0.0,
+            "held": [], "requests": 10, "inputTokens": 100, "outputTokens": 10,
+            "cacheReadTokens": 0, "cacheHitRatio": 0.5, "probeStatus": "ok",
+            "probeError": null, "lastStreamError": null, "streamErrorCount": 0
+          },
+          {
+            "source": "live", "serverSha": "abc1234", "serverDirty": false,
+            "name": "bob@example.com", "priority": 2, "status": "active",
+            "disabled": false, "quota": 0.2, "quotaState": "ok",
+            "fiveHour": 0.2, "sevenDay": 0.2, "sevenDayOi": 0.0,
+            "held": [], "requests": 20, "inputTokens": 200, "outputTokens": 20,
+            "cacheReadTokens": 0, "cacheHitRatio": 0.5, "probeStatus": "ok",
+            "probeError": null, "lastStreamError": null, "streamErrorCount": 0
+          },
+          {
+            "source": "live", "serverSha": "abc1234", "serverDirty": false,
+            "name": "carol@example.com", "priority": 3, "status": "held",
+            "disabled": false, "quota": 0.85, "quotaState": "near",
+            "fiveHour": 0.3, "sevenDay": 0.85, "sevenDayOi": 0.1,
+            "held": [{"window": "5h", "minutesUntilReset": 93, "resetAtMs": 999000000000}],
+            "requests": 5, "inputTokens": 50, "outputTokens": 5,
+            "cacheReadTokens": 0, "cacheHitRatio": 0.4, "probeStatus": "ok",
+            "probeError": null, "lastStreamError": null, "streamErrorCount": 0
+          },
+          {
+            "source": "live", "serverSha": "abc1234", "serverDirty": false,
+            "name": "dave@example.com", "priority": 4, "status": "active",
+            "disabled": false, "quota": null, "quotaState": "ok",
+            "fiveHour": null, "sevenDay": null, "sevenDayOi": null,
+            "held": [], "requests": 0, "inputTokens": 0, "outputTokens": 0,
+            "cacheReadTokens": 0, "cacheHitRatio": null, "probeStatus": "never",
+            "probeError": null, "lastStreamError": null, "streamErrorCount": 0
+          },
+          {
+            "source": "live", "serverSha": "abc1234", "serverDirty": false,
+            "name": "erin@example.com", "priority": 5, "status": "active",
+            "disabled": true, "quota": 0.1, "quotaState": "ok",
+            "fiveHour": 0.1, "sevenDay": 0.1, "sevenDayOi": 0.0,
+            "held": [], "requests": 0, "inputTokens": 0, "outputTokens": 0,
+            "cacheReadTokens": 0, "cacheHitRatio": null, "probeStatus": "ok",
+            "probeError": null, "lastStreamError": null, "streamErrorCount": 0
+          }
+        ]
+        """
+
+    private static var mixedFleet: Fleet {
+        (try? Fleet.decode(Data(mixedFleetJSON.utf8))) ?? Fleet(accounts: [])
+    }
+}

--- a/apps/macos/Sources/TcrBar/TcrBarApp.swift
+++ b/apps/macos/Sources/TcrBar/TcrBarApp.swift
@@ -83,6 +83,10 @@ enum TcrBarEntry {
             _ = NSApplication.shared
             RenderStates.run(into: directory)  // exits
         }
+        if let directory = RenderMark.requestedDirectory() {
+            _ = NSApplication.shared
+            RenderMark.run(into: directory)  // exits
+        }
         if let directory = AppIcon.requestedDirectory() {
             _ = NSApplication.shared
             AppIcon.writeIconSet(to: directory)  // exits

--- a/apps/macos/Sources/TcrBarCore/FleetStatus.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetStatus.swift
@@ -2021,6 +2021,56 @@ public struct Fleet: Equatable, Sendable {
         return .spent
     }
 
+    /// One sentence for the menu-bar tooltip: `"9 of 13 accounts ready · 3 near
+    /// their limit · 1 unmeasured · 2 parked"`. Every clause names both a unit
+    /// and its subject — never a bare number — and a clause with a zero count
+    /// is dropped rather than printed as `"0 parked"`, which would read as
+    /// news about a fleet with nothing to report (`docs/design/panel-tabs-
+    /// review.md` finding 7, which flagged exactly this on the sibling tabs
+    /// mockup: a summary that states a population without breaking down who
+    /// is in each part of it).
+    ///
+    /// `nil` when there are no enabled accounts — the same condition that hides
+    /// the menu-bar `ready/enabled` label — so the caller falls back to
+    /// ``PollState/summary`` instead of a sentence with nothing to build on.
+    ///
+    /// "Near their limit" and "unmeasured" reuse this file's own existing
+    /// severity predicates rather than inventing new ones: the near count is
+    /// exactly ``capacityGlyphState``'s own `.near` test (`hasQuotaEvidence &&
+    /// quotaState == .near && health != .needsRelogin` — the `health` clause
+    /// matters here too, for the identical reason its doc-comment gives: a
+    /// credential that died after being probed keeps its last-learned `.near`
+    /// state), and the unmeasured count is ``unmeasuredCount`` unchanged.
+    /// "Parked" is every account — enabled or not — that the panel itself
+    /// already draws a `"parked"` pill for: disabled outright, or held out of
+    /// general rotation by a parked group (``Account/isParkedByGroup``). A
+    /// `sessions`/tools-running clause is deliberately absent: nothing on the
+    /// wire carries that count yet, and a sentence must not print a number
+    /// nobody measured.
+    public var countsSentence: String? {
+        guard !enabledAccounts.isEmpty else { return nil }
+        let readyNoun = enabledCount == 1 ? "account" : "accounts"
+        var clauses = ["\(readyCount) of \(enabledCount) \(readyNoun) ready"]
+
+        let nearLimitCount = enabledAccounts.filter {
+            $0.hasQuotaEvidence && $0.quotaState == .near && $0.health != .needsRelogin
+        }.count
+        if nearLimitCount > 0 {
+            clauses.append("\(nearLimitCount) near their limit")
+        }
+
+        if unmeasuredCount > 0 {
+            clauses.append("\(unmeasuredCount) unmeasured")
+        }
+
+        let parkedCount = accounts.filter { $0.disabled || $0.isParkedByGroup }.count
+        if parkedCount > 0 {
+            clauses.append("\(parkedCount) parked")
+        }
+
+        return clauses.joined(separator: " · ")
+    }
+
     /// Per-bucket counts in fixed severity order, with empty buckets omitted so
     /// a healthy fleet reads just `"12 ok"`.
     ///

--- a/apps/macos/Sources/TcrBarCore/MenuBarCountsPreference.swift
+++ b/apps/macos/Sources/TcrBarCore/MenuBarCountsPreference.swift
@@ -1,0 +1,46 @@
+import Combine
+import Foundation
+
+/// "Show counts in the menu bar" — whether the `ready/enabled` label is drawn
+/// beside the gauge glyph. Persisted in `UserDefaults`, same shape as
+/// ``LaunchPreference``, for the same reason: there is no `App`/`View` to hang
+/// an `@AppStorage` off, and a plain read would not publish the change back to
+/// the checkbox that set it.
+///
+/// ## Default is ON, unlike ``LaunchPreference``
+///
+/// `UserDefaults.bool(forKey:)` answers `false` for an absent key, which is
+/// exactly wrong here: the feature this preference gates should be visible the
+/// first time TcrBar runs with it, not opt-in. So the stored value is only
+/// trusted when the key has actually been written — `object(forKey:) != nil`
+/// — and an absent key reads as `true` instead of falling through to the
+/// framework's own `false`.
+@MainActor
+public final class MenuBarCountsPreference: ObservableObject {
+
+    /// The `UserDefaults` key. Do not change it — the same trap
+    /// ``LaunchPreference/startServerAtLaunchKey`` documents: renaming it
+    /// fails nothing and silently resets an operator's choice.
+    /// `MenuBarCountsPreferenceTests` pins the literal.
+    public static let showCountsKey = "showCountsInMenuBar"
+
+    private let defaults: UserDefaults
+
+    /// Written through to `UserDefaults` on every change, so the value the
+    /// panel shows and the value the next launch reads cannot disagree.
+    @Published public var showCounts: Bool {
+        didSet { defaults.set(showCounts, forKey: Self.showCountsKey) }
+    }
+
+    /// - Parameter defaults: injected so a test can use a scratch suite rather
+    ///   than writing to the operator's real preferences.
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        // Property initialisation in `init` does not fire `didSet`, so reading
+        // the stored value here cannot write it straight back.
+        self.showCounts =
+            defaults.object(forKey: Self.showCountsKey) == nil
+            ? true
+            : defaults.bool(forKey: Self.showCountsKey)
+    }
+}

--- a/apps/macos/Sources/TcrBarCore/StatusPoller.swift
+++ b/apps/macos/Sources/TcrBarCore/StatusPoller.swift
@@ -57,6 +57,37 @@ public enum PollState: Equatable {
             return "tcr answered, and this build could not read the answer"
         }
     }
+
+    /// The `ready/enabled` label drawn beside the gauge glyph, e.g. `"9/13"`.
+    ///
+    /// `nil` for anything but a healthy read of a fleet with at least one
+    /// enabled account: the glyph alone already carries "pending", "tool
+    /// missing" and "poll failed" (``MenuBarShell/gaugeSymbol(for:)``), and an
+    /// all-disabled fleet has no numerator/denominator worth showing — `0/0`
+    /// would read as a fault, not a fact, the same reasoning
+    /// ``Fleet/countsSentence`` gives for returning `nil` in the identical
+    /// case.
+    public var countsLabel: String? {
+        guard case .loaded(let fleet) = self, !fleet.enabledAccounts.isEmpty else { return nil }
+        return "\(fleet.readyCount)/\(fleet.enabledCount)"
+    }
+
+    /// The menu-bar tooltip's own line: ``Fleet/countsSentence`` when there is
+    /// one to give, else ``summary`` unchanged.
+    ///
+    /// `countsSentence` is `nil` for every case but a healthy read with at
+    /// least one enabled account — a pending poll, a missing `tcr`, a failed
+    /// command, an undecodable payload, and a healthy read of an all-disabled
+    /// fleet all fall through to the same `summary` a reader already knows,
+    /// rather than growing a second empty-fleet sentence to keep in sync with
+    /// the first.
+    public var tooltipSentence: String {
+        guard case .loaded(let fleet) = self, let sentence = fleet.countsSentence else {
+            return summary
+        }
+        guard let unreadable = fleet.unreadableNotice else { return sentence }
+        return "\(sentence) · \(unreadable)"
+    }
 }
 
 /// Runs `tcr status --json` on a timer and publishes the result.

--- a/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
@@ -560,7 +560,9 @@ private func account(
     state: QuotaState,
     disabled: Bool = false,
     held: [HeldWindow] = [],
-    groups: [String]? = nil
+    groups: [String]? = nil,
+    parkedGroups: [String]? = nil,
+    gate: GateReason? = nil
 ) -> Account {
     Account(
         name: name,
@@ -585,7 +587,9 @@ private func account(
         source: .live,
         serverSha: "abc1234",
         serverDirty: false,
-        groups: groups
+        groups: groups,
+        parkedGroups: parkedGroups,
+        gate: gate
     )
 }
 
@@ -1140,6 +1144,94 @@ final class FleetCapacitySummaryTests: XCTestCase {
     }
 }
 
+/// `Fleet.countsSentence` — the menu-bar tooltip's capacity sentence (F5,
+/// `data/plans/menubar-counts-bridge.md`).
+final class FleetCountsSentenceTests: XCTestCase {
+    /// A genuinely never-probed account — `quota: nil`, `probeStatus: .never`,
+    /// `status: "active"` — the same shape `testGlyphIsSpentNotUnknownWhenOnlyBrokenAccountsAreNotReady`
+    /// uses to pin `unmeasuredCount`, not `brokenAccount` (`status: "error"`,
+    /// which is `.needsRelogin` and explicitly excluded from this count).
+    private func unmeasuredAccount(_ name: String) -> Account {
+        Account(
+            name: name, priority: 1, status: "active", disabled: false,
+            quota: nil, quotaState: .ok, fiveHour: nil, sevenDay: nil, sevenDayOi: nil,
+            held: [], requests: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0,
+            cacheHitRatio: nil, probeStatus: .never, probeError: nil, lastStreamError: nil,
+            streamErrorCount: 0, source: .live, serverSha: nil, serverDirty: nil
+        )
+    }
+
+    func testMixedFleetJoinsAllFourClauses() {
+        var accounts = (1...4).map { account("ok\($0)@example.com", state: .ok) }
+        accounts += (1...3).map { account("near\($0)@example.com", state: .near) }
+        accounts.append(unmeasuredAccount("unmeasured1@example.com"))
+        accounts.append(account("parked1@example.com", state: .ok, disabled: true))
+        let fleet = Fleet(accounts: accounts)
+
+        XCTAssertEqual(
+            fleet.countsSentence,
+            "4 of 8 accounts ready · 3 near their limit · 1 unmeasured · 1 parked"
+        )
+    }
+
+    func testEmptyFleetHasNoSentence() {
+        XCTAssertNil(Fleet(accounts: []).countsSentence)
+    }
+
+    func testAllDisabledFleetHasNoSentence() {
+        // No enabled accounts at all — nothing for a ready/enabled fraction to
+        // say, same condition that hides the menu-bar label.
+        let fleet = Fleet(accounts: [account("off1@example.com", state: .ok, disabled: true)])
+        XCTAssertNil(fleet.countsSentence)
+    }
+
+    func testZeroCountClausesAreOmittedNotPrintedAsZero() {
+        let fleet = Fleet(accounts: [account("ok1@example.com", state: .ok)])
+        XCTAssertEqual(fleet.countsSentence, "1 of 1 account ready")
+    }
+
+    func testGroupParkedAccountCountsAsParkedEvenThoughIsReadyDoesNotExcludeIt() {
+        // `isParkedByGroup` is a `disabled: false` account held out of GENERAL
+        // rotation by its own `parkedGroups` — it must count toward "parked"
+        // even though it is not disabled and stays in `enabledCount`.
+        //
+        // It also stays in `readyCount`: ``Account/isReady`` does not check
+        // `isParkedByGroup` (only `disabled`, `health` and `quotaState` gate
+        // it), so a quota-ok group-parked account is BOTH "ready" and
+        // "parked" here — that is this codebase's own existing behaviour
+        // (verified: flip `parkedGroups` to `nil` above and `readyCount`
+        // does not change), not something this sentence invents.
+        let fleet = Fleet(accounts: [
+            account("ok1@example.com", state: .ok),
+            account(
+                "parked1@example.com", state: .ok,
+                groups: ["team-a"], parkedGroups: ["team-a"]
+            ),
+        ])
+        XCTAssertEqual(fleet.countsSentence, "2 of 2 accounts ready · 1 parked")
+    }
+
+    func testNeedsReloginNearAccountIsNotDoubleCountedAsNearItsLimit() {
+        // A credential that died AFTER being probed keeps its last-learned
+        // `.near` quotaState (`Account/isReady`'s own doc-comment). It must
+        // not also read as "near their limit" — it is a broken credential,
+        // not a quota concern, and counting it in both would overstate the
+        // fleet's near-limit population by exactly the accounts this sentence
+        // has no separate clause for.
+        let broken = brokenAccount("broken1@example.com")
+        XCTAssertEqual(broken.health, .needsRelogin)
+        let fleet = Fleet(accounts: [
+            account("ok1@example.com", state: .ok),
+            broken,
+        ])
+        // `brokenAccount` is never-probed, so it also does not count as
+        // "near" — it falls through to neither the near nor the unmeasured
+        // clause (`unmeasuredCount` explicitly excludes `.needsRelogin` too),
+        // leaving a sentence with only the ready clause.
+        XCTAssertEqual(fleet.countsSentence, "1 of 2 accounts ready")
+    }
+}
+
 /// Reset-time rendering. Every assertion injects a fixed reference date, a fixed
 /// calendar and a fixed locale — nothing here reads the wall clock or the
 /// machine's region, so the suite means the same thing on any machine at any
@@ -1423,6 +1515,92 @@ final class AccountCommandTests: XCTestCase {
         else { return XCTFail("a non-zero exit must classify as failed") }
         XCTAssertEqual(failure.summary, "enable failed (exit 2): no output")
         XCTAssertFalse(failure.summary.isEmpty)
+    }
+}
+
+/// `PollState.countsLabel` — the `ready/enabled` label beside the gauge glyph
+/// (F5, `data/plans/menubar-counts-bridge.md`).
+final class PollStateCountsLabelTests: XCTestCase {
+    func testMixedFleetLabel() {
+        let fleet = Fleet(accounts: [
+            account("a1@example.com", state: .ok),
+            account("a2@example.com", state: .ok),
+            account("a3@example.com", state: .spent),
+        ])
+        XCTAssertEqual(PollState.loaded(fleet).countsLabel, "2/3")
+    }
+
+    func testReadyCountZeroStillShowsTheFraction() {
+        let fleet = Fleet(accounts: [account("a1@example.com", state: .spent)])
+        XCTAssertEqual(PollState.loaded(fleet).countsLabel, "0/1")
+    }
+
+    func testEmptyFleetHidesTheLabel() {
+        XCTAssertNil(PollState.loaded(Fleet(accounts: [])).countsLabel)
+    }
+
+    func testAllDisabledFleetHidesTheLabel() {
+        let fleet = Fleet(accounts: [account("off1@example.com", state: .ok, disabled: true)])
+        XCTAssertNil(PollState.loaded(fleet).countsLabel)
+    }
+
+    func testFailedPollHidesTheLabel() {
+        XCTAssertNil(PollState.pending.countsLabel)
+        XCTAssertNil(PollState.toolMissing(searched: []).countsLabel)
+        XCTAssertNil(PollState.commandFailed(exitCode: 1, message: "").countsLabel)
+        XCTAssertNil(PollState.undecodable(message: "boom").countsLabel)
+    }
+}
+
+/// `PollState.tooltipSentence` (F5, `data/plans/menubar-counts-bridge.md`) —
+/// the capacity sentence for a healthy read, `summary` unchanged otherwise.
+final class PollStateTooltipSentenceTests: XCTestCase {
+    func testLoadedFleetUsesTheCountsSentence() {
+        let fleet = Fleet(accounts: [
+            account("a1@example.com", state: .ok),
+            account("a2@example.com", state: .spent, disabled: true),
+        ])
+        XCTAssertEqual(PollState.loaded(fleet).tooltipSentence, fleet.countsSentence)
+        XCTAssertEqual(PollState.loaded(fleet).tooltipSentence, "1 of 1 account ready · 1 parked")
+    }
+
+    func testEmptyFleetFallsBackToSummary() {
+        let state = PollState.loaded(Fleet(accounts: []))
+        XCTAssertEqual(state.tooltipSentence, state.summary)
+        XCTAssertEqual(
+            state.tooltipSentence, "0 accounts — offline read, counters are structurally zero")
+    }
+
+    func testAllDisabledFleetFallsBackToSummary() {
+        // No enabled accounts — `countsSentence` is `nil`, same condition
+        // that hides the menu-bar `ready/enabled` label.
+        let fleet = Fleet(accounts: [account("off1@example.com", state: .ok, disabled: true)])
+        let state = PollState.loaded(fleet)
+        XCTAssertEqual(state.tooltipSentence, state.summary)
+    }
+
+    func testPendingToolMissingCommandFailedAndUndecodableUseSummaryUnchanged() {
+        let states: [PollState] = [
+            .pending,
+            .toolMissing(searched: ["/usr/local/bin/tcr"]),
+            .commandFailed(exitCode: 1, message: "connection refused"),
+            .undecodable(message: "boom"),
+        ]
+        for state in states {
+            XCTAssertEqual(state.tooltipSentence, state.summary, "\(state) must fall through unchanged")
+        }
+    }
+
+    func testUnreadableNoticeIsAppendedAfterTheSentence() {
+        let good = Fleet(accounts: [account("a1@example.com", state: .ok)])
+        let withUnreadable = Fleet(
+            accounts: good.accounts,
+            unreadable: [Fleet.UnreadableRow(index: 1, message: "boom")]
+        )
+        XCTAssertEqual(
+            PollState.loaded(withUnreadable).tooltipSentence,
+            "1 of 1 account ready · 1 account unreadable"
+        )
     }
 }
 

--- a/apps/macos/Tests/TcrBarTests/MenuBarCountsPreferenceTests.swift
+++ b/apps/macos/Tests/TcrBarTests/MenuBarCountsPreferenceTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+
+@testable import TcrBarCore
+
+/// "Show counts in the menu bar" (F5, `data/plans/menubar-counts-bridge.md`).
+/// Same storage shape as `LaunchPreferenceTests`, with the one deliberate
+/// difference this type exists for: the default is ON.
+@MainActor
+final class MenuBarCountsPreferenceTests: XCTestCase {
+
+    private var suiteName = ""
+    private var defaults = UserDefaults.standard
+
+    override func setUp() {
+        super.setUp()
+        // A scratch suite, never `.standard`: a test that writes the real key
+        // would silently flip the operator's own menu-bar preference.
+        suiteName = "tcrbar.tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName) ?? .standard
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    /// The literal, pinned — the same trap `LaunchPreference.startServerAtLaunchKey`
+    /// documents: renaming it silently resets an operator's choice.
+    func testTheDefaultsKeyIsPinned() {
+        XCTAssertEqual(MenuBarCountsPreference.showCountsKey, "showCountsInMenuBar")
+    }
+
+    /// The one place this type disagrees with `LaunchPreference`: an absent
+    /// key reads as ON, not off. `UserDefaults.bool(forKey:)` alone would say
+    /// `false` here, which is exactly the wrong default for a feature meant to
+    /// be visible from the first launch that carries it.
+    func testAnAbsentKeyReadsAsOn() {
+        XCTAssertNil(defaults.object(forKey: MenuBarCountsPreference.showCountsKey))
+        XCTAssertTrue(MenuBarCountsPreference(defaults: defaults).showCounts)
+    }
+
+    func testAStoredFalseValueIsRead() {
+        defaults.set(false, forKey: MenuBarCountsPreference.showCountsKey)
+        XCTAssertFalse(MenuBarCountsPreference(defaults: defaults).showCounts)
+    }
+
+    func testAStoredTrueValueIsRead() {
+        defaults.set(true, forKey: MenuBarCountsPreference.showCountsKey)
+        XCTAssertTrue(MenuBarCountsPreference(defaults: defaults).showCounts)
+    }
+
+    /// Written through immediately, not on quit — the toggle and the next
+    /// launch read the same fact, so they cannot disagree about it.
+    func testSettingItWritesThroughAndSurvivesANewInstance() {
+        let preference = MenuBarCountsPreference(defaults: defaults)
+        preference.showCounts = false
+
+        XCTAssertFalse(defaults.bool(forKey: MenuBarCountsPreference.showCountsKey))
+        XCTAssertFalse(MenuBarCountsPreference(defaults: defaults).showCounts)
+
+        preference.showCounts = true
+        XCTAssertTrue(defaults.bool(forKey: MenuBarCountsPreference.showCountsKey))
+        XCTAssertTrue(MenuBarCountsPreference(defaults: defaults).showCounts)
+    }
+
+    /// Reading the stored value in `init` must not write it back — a property
+    /// initialised in `init` does not fire `didSet`, same as `LaunchPreference`.
+    func testConstructingItDoesNotWriteTheKey() {
+        _ = MenuBarCountsPreference(defaults: defaults)
+        XCTAssertNil(defaults.object(forKey: MenuBarCountsPreference.showCountsKey))
+    }
+}


### PR DESCRIPTION
🍄

## Summary

F5, `data/plans/menubar-counts-bridge.md`.

- Beside the gauge glyph, the menu-bar mark draws a `ready/enabled` label (e.g. `9/13`), tabular figures, hidden for a pending poll, a failed read, or a fleet with no enabled accounts.
- A "Show counts in the menu bar" toggle, default ON (`MenuBarCountsPreference`, mirrors `LaunchPreference`'s storage shape). It lives in `FleetPanel` rather than `FleetView`'s own preferences footer — `FleetView.swift` is excluded from this bridge because a concurrent lane owns it, and adding a UI toggle to the file a sibling PR is actively editing risked exactly the collision that exclusion exists to prevent.
- The tooltip becomes a fuller sentence — `9 of 13 accounts ready · 3 near their limit · 1 unmeasured · 2 parked` — built as `Fleet.countsSentence` / `PollState.tooltipSentence` in `TcrBarCore` so it is unit-tested rather than assembled in the view. Every clause names a unit and a subject, never a bare number, per a delta from `docs/design/panel-tabs-review.md` finding 7 (the sibling tabs-mockup review, which flagged the identical defect on a population summary). "Near their limit" and "unmeasured" reuse this file's own existing severity predicates — the same `.near` test `capacityGlyphState` already makes, and `unmeasuredCount` unchanged. "Parked" matches every account the panel already draws a parked pill for. A `sessions`/tools-running clause is omitted — nothing on the wire carries that count yet.
- Adds `--render-mark`, a headless PNG harness for the composed `NSImage` `MenuBarMark.image` builds plus the new label — `--render-states` draws `FleetView` through `ImageRenderer` and never touches the real `NSStatusItem` the mark is set on, so it could not show this feature.
- `Cargo.toml`/`Cargo.lock`: 0.2.48 → 0.2.49, per the repo's own pre-commit release-version gate (0.2.48 is already a released tag).

## Test plan

- [x] `swift test --package-path apps/macos` — 523 tests, 0 failures.
- [x] Watched the new tests fail: broke `countsSentence`'s weekly-gate/near clause and `countsLabel`'s fraction, confirmed the expected failure, restored, re-ran green.
- [x] `TCRBAR_DEV_BUILD=1 apps/macos/scripts/build-tcrbar.sh` — exit 0.
- [x] `TcrBar.app/Contents/MacOS/TcrBar --render-mark <dir>` — rendered and read all 4 PNGs (mixed fleet with the label on, the same fleet with the toggle off, an empty fleet, a failed poll) — label present/absent exactly where expected in each.