### PR TITLE
feat: add Sessions and Tools tabs to the TcrBar panel (F2 + F3)

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -112,6 +112,53 @@ struct FleetView: View {
     @State private var usageLineHeight: CGFloat = 0
     @State private var usageLineBaseline: CGFloat = 0
 
+    /// Accounts / Sessions / Tools (F2 + F3, `panel-tabs-bridge.md`).
+    /// `.accounts` selected by default, per the bridge.
+    @State private var selectedTab: PanelTab = .accounts
+
+    /// The Claude Code session files joined to the wire's `Session`s for the
+    /// Sessions tab — see ``SessionFiles``. Read once on appear and again
+    /// every poll; never on every render, since ``SessionFiles/read(directory:)``
+    /// touches disk.
+    @State private var sessionFiles: [String: SessionFile] = [:]
+
+    /// Every stored property above still gets its usual default — this exists
+    /// only so ``RenderStates`` can seed ``selectedTab`` deterministically.
+    /// `@State`'s wrapped value can only be seeded through
+    /// `State(initialValue:)` in an initializer; a plain assignment in
+    /// `.onAppear` would work for the live app but leaves the render
+    /// harness's very first (and only) frame racing SwiftUI's own appearance
+    /// timing, which `ImageRenderer` does not document.
+    init(
+        poller: StatusPoller,
+        server: ServerController,
+        loginItem: LoginItem,
+        accounts: AccountController,
+        control: ControlAccountController,
+        awake: AwakeController,
+        updater: Updater,
+        groupController: GroupController,
+        removeController: RemoveAccountController,
+        startServerAtLaunch: Binding<Bool>,
+        snapshotMode: Bool = false,
+        onWhatsNew: @escaping () -> Void = {},
+        initialTab: PanelTab = .accounts
+    ) {
+        self.poller = poller
+        self.server = server
+        self.loginItem = loginItem
+        self.accounts = accounts
+        self.control = control
+        self.awake = awake
+        self.updater = updater
+        self.groupController = groupController
+        self.removeController = removeController
+        self._startServerAtLaunch = startServerAtLaunch
+        self.snapshotMode = snapshotMode
+        self.onWhatsNew = onWhatsNew
+        self._selectedTab = State(initialValue: initialTab)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: Tok.rowSpacing) {
             header
@@ -123,6 +170,14 @@ struct FleetView: View {
         .padding(Tok.gutter)
         .frame(width: Tok.panelWidth)
         .background(Tok.panel)
+        // `snapshotMode` never touches disk here: the render harness's session
+        // ids are fixture strings that join to nothing real, so the read
+        // would only ever populate an unused dictionary — see
+        // `RenderStates.swift`'s sessions-tab fixtures.
+        .onAppear { if !snapshotMode { sessionFiles = SessionFiles.read() } }
+        .onChange(of: poller.lastPollAt) { _ in
+            if !snapshotMode { sessionFiles = SessionFiles.read() }
+        }
     }
 
     // MARK: Header
@@ -360,19 +415,349 @@ struct FleetView: View {
 
     private func fleetRows(_ fleet: Fleet) -> some View {
         VStack(alignment: .leading, spacing: Tok.rowSpacing) {
-            if fleet.source.countersAreStructural {
-                offlineNotice(fleet.source)
-            }
-            if snapshotMode {
-                accountList(fleet)
-            } else {
-                ScrollView {
-                    accountList(fleet)
+            panelTabBar(fleet)
+            switch selectedTab {
+            case .accounts:
+                if fleet.source.countersAreStructural {
+                    offlineNotice(fleet.source)
                 }
-                .frame(height: visibleRowsHeight(for: fleet))
-                .onPreferenceChange(RowHeightsKey.self) { rowHeights = PanelHeight.settled(rowHeights, $0) }
+                if snapshotMode {
+                    accountList(fleet)
+                } else {
+                    ScrollView {
+                        accountList(fleet)
+                    }
+                    .frame(height: visibleRowsHeight(for: fleet))
+                    .onPreferenceChange(RowHeightsKey.self) {
+                        rowHeights = PanelHeight.settled(rowHeights, $0)
+                    }
+                }
+            case .sessions:
+                sessionsTab(fleet)
+            case .tools:
+                toolsTab(fleet)
             }
         }
+    }
+
+    // MARK: Tabs (F2 + F3)
+    //
+    // Only the Accounts tab measures its own rows (`RowHeightsKey`, above) —
+    // Sessions and Tools deliberately do not. `visibleRowsHeight(for:)` is
+    // driven entirely by `rowHeights`, which the Accounts tab keeps populated
+    // the instant it is on screen (the default tab), so switching to either
+    // new tab reuses that same number as a FIXED height budget rather than
+    // measuring its own content. That is `panel-tabs-bridge.md`'s rule made
+    // concrete: "Each tab gets a FIXED height budget through the same
+    // functions; no tab's height may depend on content it renders" — the
+    // popover's layout-cycle crash (`ffe8a86`) is exactly what a
+    // content-dependent height on a tab switch would risk reopening.
+
+    /// The segmented control at the top of the panel — SF Symbols
+    /// `gauge`/`person.2`/`terminal`, a count badge on the two new tabs,
+    /// mirroring `docs/design/panel-tabs-mockup.html`.
+    private func panelTabBar(_ fleet: Fleet) -> some View {
+        HStack(spacing: 3) {
+            ForEach(PanelTab.allCases, id: \.self) { tab in
+                tabButton(tab, badge: badge(for: tab, fleet: fleet))
+            }
+        }
+        .padding(3)
+        .background(RoundedRectangle(cornerRadius: Tok.radiusSmall + 2).fill(Tok.raised))
+    }
+
+    /// `nil` on `.accounts` (the mockup carries no badge on it either); a
+    /// live session count on `.sessions`; the RUNNING count on `.tools` — the
+    /// one figure a glance at the closed tab cannot otherwise see. Both zero
+    /// out to `nil` rather than drawing a `0` badge, the same "a zero count
+    /// should never render" rule `panel-tabs-bridge.md` names for the account
+    /// cards.
+    private func badge(for tab: PanelTab, fleet: Fleet) -> Int? {
+        switch tab {
+        case .accounts: return nil
+        case .sessions: return fleet.sessions.isEmpty ? nil : fleet.sessions.count
+        case .tools: return fleet.toolsRunning.isEmpty ? nil : fleet.toolsRunning.count
+        }
+    }
+
+    private func tabButton(_ tab: PanelTab, badge: Int?) -> some View {
+        let isOn = tab == selectedTab
+        return Button {
+            if reduceMotion {
+                selectedTab = tab
+            } else {
+                withAnimation(Tok.standardAnimation) { selectedTab = tab }
+            }
+        } label: {
+            HStack(spacing: Tok.space2) {
+                Image(systemName: tab.systemImage)
+                Text(tab.title)
+                if let badge {
+                    Text("\(badge)")
+                        .font(.caption2.weight(.semibold))
+                        .padding(.horizontal, Tok.space2)
+                        .background(Capsule().fill(Tok.hover))
+                }
+            }
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(isOn ? Tok.ink : Tok.inkDim)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, Tok.space2)
+            .background(RoundedRectangle(cornerRadius: Tok.radiusSmall).fill(isOn ? Tok.hover : Color.clear))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(badge.map { "\(tab.title), \($0)" } ?? tab.title)
+    }
+
+    /// One row per session, grouped by the account it is pinned to — an
+    /// unpinned session (``Session/account`` `nil`) groups under
+    /// "Unassigned", listed last.
+    @ViewBuilder
+    private func sessionsTab(_ fleet: Fleet) -> some View {
+        if !fleet.sessionsSupported {
+            banner(
+                icon: "person.2",
+                title: "No sessions yet",
+                detail: "This server predates sessions — update tcr.",
+                tint: Tok.unknown)
+        } else if fleet.sessions.isEmpty {
+            banner(
+                icon: "person.2",
+                title: "No live sessions",
+                detail: "Nothing has spoken to the proxy in the last hour.",
+                tint: Tok.inkDim)
+        } else {
+            let joined = SessionJoin.join(sessions: fleet.sessions, files: sessionFiles)
+            if snapshotMode {
+                sessionsList(joined)
+            } else {
+                ScrollView { sessionsList(joined) }
+                    .frame(height: visibleRowsHeight(for: fleet))
+            }
+        }
+    }
+
+    private func sessionsList(_ sessions: [JoinedSession]) -> some View {
+        let byAccount = Dictionary(grouping: sessions) { $0.session.account ?? "" }
+        // Unassigned (`""`) sorts last; named accounts sort by name so the
+        // list order does not reshuffle between two polls that carry
+        // identical data.
+        let order = byAccount.keys.sorted { lhs, rhs in
+            if lhs.isEmpty != rhs.isEmpty { return rhs.isEmpty }
+            return lhs < rhs
+        }
+        return VStack(alignment: .leading, spacing: Tok.rowSpacing) {
+            ForEach(order, id: \.self) { key in
+                VStack(alignment: .leading, spacing: Tok.tightSpacing) {
+                    Text(key.isEmpty ? "Unassigned" : key)
+                        .font(.subheadline.weight(.semibold))
+                    ForEach(byAccount[key] ?? []) { row in
+                        sessionRow(row)
+                    }
+                }
+            }
+        }
+    }
+
+    private func sessionRow(_ row: JoinedSession) -> some View {
+        VStack(alignment: .leading, spacing: Tok.space1) {
+            HStack(spacing: Tok.tightSpacing) {
+                Circle()
+                    .fill(activityColor(row.activity))
+                    .frame(width: 8, height: 8)
+                Text(row.displayName).font(.subheadline.weight(.semibold))
+                if let project = row.project {
+                    Text(project).font(Tok.secondaryFont).foregroundStyle(Tok.inkDim)
+                }
+                Spacer()
+            }
+            HStack(spacing: Tok.tightSpacing) {
+                Text("\(row.session.requests) req").monospacedDigit()
+                if let model = row.session.model { Text(model) }
+                Spacer()
+                Text(trailingStatus(row, now: Date())).monospacedDigit()
+            }
+            .font(Tok.secondaryDigitFont)
+            .foregroundStyle(Tok.inkDim)
+        }
+        .padding(.vertical, Tok.space1)
+    }
+
+    /// `docs/design/panel-tabs-review.md` finding 2: a session with a tool
+    /// running shows the age of its OLDEST running tool, not its own
+    /// `lastSeenMs` — a session cannot be "busy 3m" while a tool it owns has
+    /// run for 9. This is also the fix for the finding's other half: reading
+    /// `row.session.tools.running` here is the exact array
+    /// ``Fleet/toolsRunning`` pools for the Tools tab, so the two tabs can no
+    /// longer derive two different counts for the same session.
+    private func trailingStatus(_ row: JoinedSession, now: Date) -> String {
+        let running = row.session.tools.running
+        guard !running.isEmpty, let oldestStartedMs = running.compactMap(\.startedMs).min() else {
+            return row.ageLabel(now: now)
+        }
+        let elapsed = max(
+            0, now.timeIntervalSince(Date(timeIntervalSince1970: Double(oldestStartedMs) / 1000)))
+        return "\(running.count) running · oldest \(durationLabel(elapsed))"
+    }
+
+    private func activityColor(_ activity: SessionActivity) -> Color {
+        switch activity {
+        case .busy: return Tok.ok
+        case .waiting: return Tok.near
+        case .idle, .unknown: return Tok.inkFaint
+        }
+    }
+
+    /// The ten slowest calls across every session, then running now, then
+    /// fleet-wide totals — `panel-tabs-bridge.md`'s order for this tab.
+    @ViewBuilder
+    private func toolsTab(_ fleet: Fleet) -> some View {
+        if !fleet.sessionsSupported {
+            banner(
+                icon: "terminal",
+                title: "No tool data yet",
+                detail: "This server predates sessions — update tcr.",
+                tint: Tok.unknown)
+        } else if snapshotMode {
+            toolsList(fleet)
+        } else {
+            ScrollView { toolsList(fleet) }
+                .frame(height: visibleRowsHeight(for: fleet))
+        }
+    }
+
+    private func toolsList(_ fleet: Fleet) -> some View {
+        VStack(alignment: .leading, spacing: Tok.rowSpacing) {
+            // `docs/design/panel-tabs-review.md` finding 3: the sum over
+            // EVERY tool, never one category standing in for the total —
+            // `toolsTotalCalls` already sums across every session's
+            // `tools.calls`, whatever tool made each call.
+            Text(
+                "\(fleet.toolsTotalCalls) calls · \(fleet.toolsTotalErrors) errors"
+                    + " · \(fleet.toolsTotalTimeouts) timeouts"
+            )
+            .font(Tok.secondaryDigitFont)
+            .foregroundStyle(Tok.inkDim)
+
+            if !fleet.toolsRunning.isEmpty {
+                VStack(alignment: .leading, spacing: Tok.space1) {
+                    sectionHeading("RUNNING NOW")
+                    // Finding 5: state the denominator a ring fills toward,
+                    // rather than drawing a fraction with no stated whole.
+                    Text("Ring fills toward the 600s Bash timeout")
+                        .font(Tok.detailFont)
+                        .foregroundStyle(Tok.inkFaint)
+                }
+                ForEach(fleet.toolsRunning) { entry in runningToolRow(entry) }
+            }
+            if !fleet.toolsSlowest.isEmpty {
+                sectionHeading("SLOWEST TODAY")
+                ForEach(fleet.toolsSlowest) { entry in slowestToolRow(entry) }
+            }
+            if fleet.toolsRunning.isEmpty && fleet.toolsSlowest.isEmpty {
+                Text("No tool calls recorded yet.")
+                    .font(Tok.secondaryFont)
+                    .foregroundStyle(Tok.inkDim)
+            }
+        }
+    }
+
+    private func sectionHeading(_ text: String) -> some View {
+        Text(text)
+            .font(.caption2.weight(.bold))
+            .foregroundStyle(Tok.inkFaint)
+            .tracking(Tok.pillTracking)
+    }
+
+    /// `commandHead` in monospace, truncated to one line — `panel-tabs-bridge.md`:
+    /// "`command_head` shown in monospace, truncated to one line." Shared by
+    /// ``runningToolRow(_:)`` and ``slowestToolRow(_:)`` so the two rows never
+    /// drift on how a call names itself.
+    private func toolCallLabel(_ entry: SessionToolEntry) -> some View {
+        VStack(alignment: .leading, spacing: Tok.space1) {
+            Text(entry.call.commandHead ?? entry.call.tool)
+                .font(.system(size: Tok.detailFontSize, design: .monospaced))
+                .lineLimit(1)
+                .truncationMode(.tail)
+            Text("\(entry.call.tool) · \(String(entry.sessionId.prefix(8)))")
+                .font(Tok.detailFont)
+                .foregroundStyle(Tok.inkDim)
+        }
+    }
+
+    /// The Bash tool's own timeout — the one denominator this build knows,
+    /// and the reason `docs/design/panel-tabs.md` names 600s specifically:
+    /// "The ten slowest calls today all sit at 600s: the Bash tool's own
+    /// timeout." A non-Bash running call has no known denominator and draws
+    /// no ring, per finding 5's own fix ("state the denominator … set to the
+    /// third ring") — inventing one for a tool this build has no timeout
+    /// figure for would be the same overclaim finding 5 exists to remove.
+    private let bashTimeoutSeconds: Double = 600
+
+    /// A running call: its ring (Bash only, filling toward
+    /// ``bashTimeoutSeconds``) and its elapsed time since `startedMs`, turning
+    /// `--bad`/`Tok.spent` and naming the seconds left inside the last 20s —
+    /// finding 5's fix, verbatim: "20s to timeout" beside the reddened ring.
+    private func runningToolRow(_ entry: SessionToolEntry) -> some View {
+        let now = Date()
+        let elapsed = entry.call.startedMs.map { started in
+            max(0, now.timeIntervalSince(Date(timeIntervalSince1970: Double(started) / 1000)))
+        }
+        let isBash = entry.call.tool == "Bash"
+        let remaining = elapsed.map { bashTimeoutSeconds - $0 }
+        let isNearTimeout = isBash && (remaining ?? .infinity) <= 20
+        return HStack(spacing: Tok.tightSpacing) {
+            toolCallLabel(entry)
+            Spacer()
+            VStack(alignment: .trailing, spacing: Tok.space1) {
+                if isBash, let elapsed {
+                    ZStack {
+                        Circle().stroke(Tok.hairline, lineWidth: 3)
+                        Circle()
+                            .trim(from: 0, to: min(elapsed / bashTimeoutSeconds, 1))
+                            .stroke(
+                                isNearTimeout ? Tok.spent : Tok.ok,
+                                style: StrokeStyle(lineWidth: 3, lineCap: .round)
+                            )
+                            .rotationEffect(.degrees(-90))
+                    }
+                    .frame(width: 18, height: 18)
+                }
+                if let elapsed {
+                    Text(
+                        isNearTimeout
+                            ? "\(Int(max(0, remaining ?? 0)))s to timeout" : durationLabel(elapsed)
+                    )
+                    .font(Tok.secondaryDigitFont)
+                    .monospacedDigit()
+                    .foregroundStyle(isNearTimeout ? Tok.spent : Tok.inkDim)
+                }
+            }
+        }
+        .padding(.vertical, Tok.space1)
+    }
+
+    private func slowestToolRow(_ entry: SessionToolEntry) -> some View {
+        HStack(spacing: Tok.tightSpacing) {
+            toolCallLabel(entry)
+            Spacer()
+            if let seconds = entry.call.seconds {
+                Text(durationLabel(seconds))
+                    .font(Tok.secondaryDigitFont)
+                    .monospacedDigit()
+                    .foregroundStyle(seconds >= bashTimeoutSeconds ? Tok.spent : Tok.inkDim)
+            }
+        }
+        .padding(.vertical, Tok.space1)
+    }
+
+    /// `"45s"`, `"4m 12s"` — no day tier: the longest call this tab shows is
+    /// the Bash tool's own timeout, six orders of magnitude under a day.
+    private func durationLabel(_ seconds: Double) -> String {
+        let total = Int(seconds.rounded())
+        let minutes = total / 60
+        let rest = total % 60
+        return minutes > 0 ? "\(minutes)m \(rest)s" : "\(rest)s"
     }
 
     /// The account list, cut into sections: a state band heading, then a group
@@ -1312,6 +1697,29 @@ struct FleetView: View {
 /// A dictionary rather than one summed scalar because rows are not uniform
 /// height — `visibleRowsHeight(for:)` needs the first N individually, in
 /// display order, not just their total.
+/// The panel's three tabs (F2 + F3, `data/plans/panel-tabs-bridge.md`).
+/// `CaseIterable` so `panelTabBar` draws them in one declared order rather
+/// than a second list a reviewer has to keep in sync with this one.
+enum PanelTab: Equatable, CaseIterable {
+    case accounts, sessions, tools
+
+    var title: String {
+        switch self {
+        case .accounts: return "Accounts"
+        case .sessions: return "Sessions"
+        case .tools: return "Tools"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .accounts: return "gauge"
+        case .sessions: return "person.2"
+        case .tools: return "terminal"
+        }
+    }
+}
+
 struct RowHeightsKey: PreferenceKey {
     static let defaultValue: [String: CGFloat] = [:]
     static func reduce(value: inout [String: CGFloat], nextValue: () -> [String: CGFloat]) {

--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -480,13 +480,26 @@ struct FleetView: View {
         }
     }
 
+    /// Damping 1.0 (critically damped — settles without overshoot, i.e. "no
+    /// bounce"), response ~0.3s. Local to the tab switch rather than
+    /// `Tok.standardAnimation` (`.easeOut(duration: 0.15)`, tuned for a
+    /// tint/parked-state crossfade elsewhere in this file and not owned by
+    /// this lane) — a tab switch and a colour fade are different motions and
+    /// sharing one token would make the next edit to either fight the other.
+    /// `response`/`dampingFraction` rather than the newer `Spring` type: this
+    /// package's deployment target is macOS 13 (`Package.swift`), and `Spring`
+    /// needs macOS 14.
+    private var tabSwitchAnimation: Animation {
+        .spring(response: 0.3, dampingFraction: 1.0)
+    }
+
     private func tabButton(_ tab: PanelTab, badge: Int?) -> some View {
         let isOn = tab == selectedTab
         return Button {
             if reduceMotion {
                 selectedTab = tab
             } else {
-                withAnimation(Tok.standardAnimation) { selectedTab = tab }
+                withAnimation(tabSwitchAnimation) { selectedTab = tab }
             }
         } label: {
             HStack(spacing: Tok.space2) {
@@ -495,6 +508,8 @@ struct FleetView: View {
                 if let badge {
                     Text("\(badge)")
                         .font(.caption2.weight(.semibold))
+                        .contentTransition(.numericText())
+                        .animation(reduceMotion ? nil : .easeOut(duration: 0.2), value: badge)
                         .padding(.horizontal, Tok.space2)
                         .background(Capsule().fill(Tok.hover))
                 }
@@ -572,9 +587,17 @@ struct FleetView: View {
                 Spacer()
             }
             HStack(spacing: Tok.tightSpacing) {
-                Text("\(row.session.requests) req").monospacedDigit()
+                Text("\(row.session.requests) req")
+                    .monospacedDigit()
+                    .contentTransition(.numericText())
+                    .animation(reduceMotion ? nil : .easeOut(duration: 0.2), value: row.session.requests)
                 if let model = row.session.model { Text(model) }
                 Spacer()
+                // A rolling digit transition here would need this string's
+                // VALUE, not its rendered text, to drive `.animation(value:)`
+                // — it is age-since-oldest-running-tool, recomputed from
+                // `Date()` on every render, so a state-driven transition has
+                // no discrete value to key off. Left as a plain `Text`.
                 Text(trailingStatus(row, now: Date())).monospacedDigit()
             }
             .font(Tok.secondaryDigitFont)

--- a/apps/macos/Sources/TcrBar/RenderStates.swift
+++ b/apps/macos/Sources/TcrBar/RenderStates.swift
@@ -105,7 +105,30 @@ enum RenderStates {
             // own seeding of `FleetView.expandedParkedGroupsKey` for
             // `henry-team`, the wholly-parked group `parkedGroupJSON` builds.
             ("15b-parked-group-expanded", .loaded(fleet(parkedGroupJSON)), false, nil),
+            // F2 — the Sessions tab, grouped by account, one row with a
+            // tool running and one waiting, plus an unassigned session with
+            // no matching Claude Code session file (`sessionsFixture`'s
+            // third entry) to review the id-head fallback.
+            ("16-sessions-tab", .loaded(sessionsTabFleet), false, nil),
+            // F3 — the Tools tab: running now, slowest today (one at the
+            // Bash timeout), and the fleet-wide totals line.
+            ("17-tools-tab", .loaded(sessionsTabFleet), false, nil),
+            // The forward-compat case both tabs must show as one sentence,
+            // never an empty list: `healthyJSON` carries no `sessions` key at
+            // all, the shape every server shipped before F1.
+            ("18-sessions-tab-old-server", .loaded(fleet(healthyJSON)), false, nil),
         ]
+    }
+
+    /// Which tab a scene opens on — `.accounts` for every scene above scene
+    /// 16, so this stays a lookup by name rather than a fifth tuple element
+    /// every existing scene would have to grow.
+    private static func initialTab(for sceneName: String) -> PanelTab {
+        switch sceneName {
+        case "16-sessions-tab", "18-sessions-tab-old-server": return .sessions
+        case "17-tools-tab": return .tools
+        default: return .accounts
+        }
     }
 
     @MainActor
@@ -202,7 +225,8 @@ enum RenderStates {
                 groupController: GroupController(),
                 removeController: RemoveAccountController(),
                 startServerAtLaunch: .constant(false),
-                snapshotMode: true
+                snapshotMode: true,
+                initialTab: initialTab(for: scene.name)
             )
             .environment(\.colorScheme, appearance == .dark ? .dark : .light)
             // A FIXED height, not the measured one.
@@ -569,6 +593,80 @@ enum RenderStates {
     private static var healthyJSON: String {
         "[\(account("alice@example.com", quota: "0.12", state: "ok", fiveHourResetInMinutes: 130, sevenDayResetInMinutes: 4_320, sevenDayOi: "0.21", sevenDayOiState: "ok", sevenDayOiResetInMinutes: 6_498, plan: "Max 20x", orgUuid: "11111111-1111-1111-1111-111111111111")),"
             + "\(account("bob@example.com", quota: "0.31", state: "ok", sevenDayOi: "0.44", sevenDayOiState: "ok", groups: ["research"], reservedGroups: ["research"], plan: "Team 5x", orgUuid: "22222222-2222-2222-2222-222222222222"))]"
+    }
+
+    /// F1's wire shape (`data/plans/sessions-wire-bridge.md`), attached to
+    /// `alice`'s row the way the server sends it — see ``Account/sessions``'s
+    /// doc-comment for why nothing here is wired to a live fetch yet: this
+    /// build has no safe channel for real session data, so the review
+    /// fixture builds ``Session`` values directly rather than decoding them
+    /// off `tcr status --json`'s bare account array, the same way
+    /// `FleetStatusTests` now does. Scenes 16 and 17 both use this Fleet;
+    /// only ``initialTab(for:)`` decides which tab opens.
+    ///
+    /// Three sessions cover the join's three cases: `alice-c1` has a live
+    /// Bash call running (Sessions tab's "N running · oldest …" line, Tools
+    /// tab's RUNNING NOW ring); `alice-c2` has one already at the Bash
+    /// tool's own 600-second timeout (`panel-tabs.md`: "The ten slowest
+    /// calls today all sit at 600s"); `unassigned-c3` has no `account`,
+    /// exercising the Sessions tab's "Unassigned" group and, having no
+    /// matching session file in this harness, the id-head fallback
+    /// (`panel-tabs-bridge.md`: "no file shows its id's first 8 chars").
+    private static var sessionsFixture: [Session] {
+        // `lastSeenMs`/`firstSeenMs` are epoch milliseconds, and the age
+        // label reads real wall-clock `Date()` (`FleetView.trailingStatus`,
+        // the same "views re-render often enough" idiom
+        // `HeldWindow.countdownLabel` already uses) — not this file's fixed
+        // `referenceDate`, which only pins the POLL timestamp shown in the
+        // header. These are minutes-ago offsets from the real clock so the
+        // rendered age reads like a live fleet's.
+        func msAgo(_ seconds: TimeInterval) -> Int64 {
+            Int64(Date().addingTimeInterval(-seconds).timeIntervalSince1970 * 1000)
+        }
+        return [
+            Session(
+                sessionId: "aaaaaaaa-1111-2222-3333-444444444444", account: "alice@example.com",
+                model: "claude-opus-5", firstSeenMs: msAgo(3 * 3600), lastSeenMs: msAgo(3 * 60),
+                requests: 412, inputTokens: 812_000, outputTokens: 41_000, cacheReadTokens: 790_000,
+                tools: SessionTools(
+                    calls: 38, errors: 1, timeouts: 0,
+                    running: [
+                        ToolCall(
+                            tool: "Bash", commandHead: "cargo test --release > /tmp/f1-test.log",
+                            startedMs: msAgo(4 * 60))
+                    ],
+                    slowest: [
+                        ToolCall(
+                            tool: "Bash",
+                            commandHead: "git -C ~/git/henry-plugin push > /tmp/push.log",
+                            endedMs: msAgo(5 * 60), seconds: 47.5)
+                    ])),
+            Session(
+                sessionId: "bbbbbbbb-1111-2222-3333-444444444444", account: "alice@example.com",
+                model: "claude-sonnet-5", firstSeenMs: msAgo(6 * 3600), lastSeenMs: msAgo(12 * 60),
+                requests: 5756, inputTokens: 940_000, outputTokens: 88_000, cacheReadTokens: 905_000,
+                tools: SessionTools(
+                    calls: 210, errors: 4, timeouts: 1,
+                    slowest: [
+                        ToolCall(
+                            tool: "Bash",
+                            commandHead: "/opt/homebrew/bin/bash /tmp/disk-scan.sh 2>&1 | tee",
+                            endedMs: msAgo(11 * 60), seconds: 600.0)
+                    ])),
+            Session(
+                sessionId: "cccccccc-1111-2222-3333-444444444444", account: nil,
+                model: "claude-sonnet-5", firstSeenMs: msAgo(45 * 60), lastSeenMs: msAgo(40 * 60),
+                requests: 12, inputTokens: 9000, outputTokens: 800, cacheReadTokens: 6000),
+        ]
+    }
+
+    private static var sessionsTabFleet: Fleet {
+        let base = fleet(
+            "[\(account("alice@example.com", quota: "0.12", state: "ok", plan: "Max 20x", orgUuid: "11111111-1111-1111-1111-111111111111"))]"
+        )
+        return Fleet(
+            accounts: base.accounts, unreadable: base.unreadable, sessions: sessionsFixture,
+            sessionsSupported: true)
     }
 
     /// The three plan labels a real fleet produces, side by side — `Max 20x`,

--- a/apps/macos/Sources/TcrBarCore/FleetStatus.swift
+++ b/apps/macos/Sources/TcrBarCore/FleetStatus.swift
@@ -868,6 +868,132 @@ public struct UsageRow: Decodable, Equatable, Sendable {
 }
 
 /// One account row of `tcr status --json`.
+/// One tool call the proxy has observed on the wire — either still
+/// `running` or one of a session's `slowest` (F1, `data/plans/
+/// sessions-wire-bridge.md`). The two arrays carry different halves of the
+/// same fact: a running call has ``startedMs`` and no ``seconds`` yet, a
+/// slowest call has ``seconds``/``endedMs`` and no ``startedMs`` — never
+/// both, but modelled as one `Optional`-heavy type rather than two so the
+/// Tools tab can pool them without a cast.
+public struct ToolCall: Decodable, Equatable, Sendable {
+    public let tool: String
+    /// The first 120 characters of a Bash `input.command`, held in memory
+    /// only (`panel-tabs.md` "Constraints"). `nil` for a non-Bash tool.
+    public let commandHead: String?
+    public let startedMs: Int64?
+    public let endedMs: Int64?
+    public let seconds: Double?
+
+    public init(
+        tool: String,
+        commandHead: String? = nil,
+        startedMs: Int64? = nil,
+        endedMs: Int64? = nil,
+        seconds: Double? = nil
+    ) {
+        self.tool = tool
+        self.commandHead = commandHead
+        self.startedMs = startedMs
+        self.endedMs = endedMs
+        self.seconds = seconds
+    }
+}
+
+/// A session's tool aggregate — the wire's `tools` object.
+public struct SessionTools: Decodable, Equatable, Sendable {
+    public let calls: Int
+    public let errors: Int
+    public let timeouts: Int
+    public let running: [ToolCall]
+    /// The ten slowest calls this session made today, longest first per the
+    /// server (`sessions-wire-bridge.md`); this build does not re-sort a
+    /// single session's own list.
+    public let slowest: [ToolCall]
+
+    public init(
+        calls: Int = 0,
+        errors: Int = 0,
+        timeouts: Int = 0,
+        running: [ToolCall] = [],
+        slowest: [ToolCall] = []
+    ) {
+        self.calls = calls
+        self.errors = errors
+        self.timeouts = timeouts
+        self.running = running
+        self.slowest = slowest
+    }
+}
+
+/// One entry of ``Fleet/sessions`` — a session the proxy has seen in the
+/// last hour, field-for-field the merged F1 wire's `SessionRow`
+/// (`crates/tcr-status-wire/src/lib.rs` on `teamclaude-rs#232`).
+///
+/// Lives on the proxy's `/_tcr/status` HTTP response (`StatusPayload.sessions`),
+/// not on `tcr status --json`'s bare account array — see ``Fleet/sessions``'s
+/// own doc-comment for why nothing here is wired to a live fetch yet.
+/// `Decodable` so a future safe channel (or a test fixture) can build one from
+/// JSON shaped exactly like that endpoint's.
+public struct Session: Decodable, Equatable, Identifiable, Sendable {
+    public let sessionId: String
+    /// The row name this session is pinned to, or `nil` when the proxy has
+    /// not attributed it to an account yet.
+    public let account: String?
+    public let model: String?
+    public let firstSeenMs: Int64
+    public let lastSeenMs: Int64
+    public let requests: Int
+    public let inputTokens: Int
+    public let outputTokens: Int
+    public let cacheReadTokens: Int
+    public let tools: SessionTools
+
+    public var id: String { sessionId }
+
+    public init(
+        sessionId: String,
+        account: String? = nil,
+        model: String? = nil,
+        firstSeenMs: Int64,
+        lastSeenMs: Int64,
+        requests: Int = 0,
+        inputTokens: Int = 0,
+        outputTokens: Int = 0,
+        cacheReadTokens: Int = 0,
+        tools: SessionTools = SessionTools()
+    ) {
+        self.sessionId = sessionId
+        self.account = account
+        self.model = model
+        self.firstSeenMs = firstSeenMs
+        self.lastSeenMs = lastSeenMs
+        self.requests = requests
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+        self.cacheReadTokens = cacheReadTokens
+        self.tools = tools
+    }
+}
+
+/// One ``ToolCall`` paired with the session that made it, for the Tools tab's
+/// pooled-across-every-session views. Not on ``ToolCall`` itself: a call has
+/// no notion of its own session, and duplicating the id onto every element of
+/// ``SessionTools/running``/``SessionTools/slowest`` would be a second place
+/// for the two to drift.
+public struct SessionToolEntry: Identifiable, Equatable, Sendable {
+    public let sessionId: String
+    public let call: ToolCall
+
+    public var id: String {
+        "\(sessionId)|\(call.tool)|\(call.startedMs ?? 0)|\(call.endedMs ?? 0)|\(call.commandHead ?? "")"
+    }
+
+    public init(sessionId: String, call: ToolCall) {
+        self.sessionId = sessionId
+        self.call = call
+    }
+}
+
 public struct Account: Decodable, Equatable, Identifiable, Sendable {
     public let name: String
     public let priority: Int
@@ -1773,9 +1899,45 @@ public struct Fleet: Equatable, Sendable {
     /// Rows that failed to decode. Never dropped silently — see ``unreadableNotice``.
     public let unreadable: [UnreadableRow]
 
-    public init(accounts: [Account], unreadable: [UnreadableRow] = []) {
+    /// Every session the proxy has seen in the last hour (F2 + F3,
+    /// `data/plans/panel-tabs-bridge.md`). **Never populated by
+    /// ``decode(_:)``** — see this property's own placement, a stored field
+    /// rather than something read off ``accounts``.
+    ///
+    /// The bridge this build was written against said the wire would grow a
+    /// top-level `sessions` array on `tcr status --json`'s existing bare
+    /// array. The merged F1 work (`teamclaude-rs#232`) put it somewhere else
+    /// instead: `SessionRow`/`StatusPayload.sessions` live on the PROXY's own
+    /// `/_tcr/status` HTTP response, which `fetch_live_status` (`src/cli.rs`)
+    /// reads with the proxy's api-key — and `tcr status --json` (`status()`,
+    /// same file) discards `sessions` entirely when it turns that payload
+    /// back into the bare array `Fleet.decode` reads. This app never touches
+    /// `~/.config/teamclaude.json` or the proxy's api-key from Swift — see
+    /// `CLAUDE.md`'s "No credentials, ever" and every `TcrBarCore` file that
+    /// says "this app never writes/reads the tcr config" — so there is
+    /// currently no channel this build may safely use to populate this field
+    /// against a live server. It exists, tested, so the Sessions and Tools
+    /// tabs are ready the moment a safe one exists (a `tcr` CLI subcommand
+    /// that shells out the way every other fact in this app already does),
+    /// and so ``RenderStates``'s fixtures can review the tabs' design today.
+    public let sessions: [Session]
+
+    /// Whether the CURRENT read populated ``sessions`` at all — distinct from
+    /// an empty ``sessions``, which is also true of a server with nothing
+    /// live right now. `false` from every call to ``decode(_:)``, for the
+    /// reason ``sessions`` documents; a future safe channel sets it `true`.
+    public let sessionsSupported: Bool
+
+    public init(
+        accounts: [Account],
+        unreadable: [UnreadableRow] = [],
+        sessions: [Session] = [],
+        sessionsSupported: Bool = false
+    ) {
         self.accounts = accounts
         self.unreadable = unreadable
+        self.sessions = sessions
+        self.sessionsSupported = sessionsSupported
     }
 
     /// Decode the array **one row at a time**.
@@ -1843,6 +2005,29 @@ public struct Fleet: Equatable, Sendable {
 
     public var serverSha: String? { accounts.first?.serverSha }
     public var serverDirty: Bool { accounts.first?.serverDirty ?? false }
+
+    public var toolsTotalCalls: Int { sessions.reduce(0) { $0 + $1.tools.calls } }
+    public var toolsTotalErrors: Int { sessions.reduce(0) { $0 + $1.tools.errors } }
+    public var toolsTotalTimeouts: Int { sessions.reduce(0) { $0 + $1.tools.timeouts } }
+
+    /// Every tool call currently running, pooled across every session.
+    public var toolsRunning: [SessionToolEntry] {
+        sessions.flatMap { session in
+            session.tools.running.map { SessionToolEntry(sessionId: session.sessionId, call: $0) }
+        }
+    }
+
+    /// The ten slowest calls across every session, longest first. Each
+    /// session already reports its own ten slowest (`sessions-wire-bridge.md`
+    /// "ten"), so pooling `N` sessions' lists and re-sorting before taking the
+    /// top ten is correct without asking the server for more than ten per
+    /// session.
+    public var toolsSlowest: [SessionToolEntry] {
+        let pooled = sessions.flatMap { session in
+            session.tools.slowest.map { SessionToolEntry(sessionId: session.sessionId, call: $0) }
+        }
+        return Array(pooled.sorted { ($0.call.seconds ?? 0) > ($1.call.seconds ?? 0) }.prefix(10))
+    }
 
     /// The account in the worst shape. Reporting only — the menu-bar glyph is
     /// driven by ``capacityGlyphState``, which is a fleet property, not a

--- a/apps/macos/Sources/TcrBarCore/SessionFiles.swift
+++ b/apps/macos/Sources/TcrBarCore/SessionFiles.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+/// The join for the Sessions tab: `~/.claude/sessions/*.json`, one file per
+/// live Claude Code process, keyed by `sessionId` to line up with
+/// ``Session/sessionId`` from the proxy's own wire (`panel-tabs-bridge.md`
+/// "The join for the Sessions tab").
+///
+/// One field of this file (`bridgeSessionId`) is read by the sessions-wire
+/// lane server-side, not by this build — see `panel-tabs.md`'s "Not
+/// verified" note on a resumed session's id. Nothing here re-derives that.
+public struct SessionFile: Decodable, Equatable, Sendable {
+    public let sessionId: String
+    public let cwd: String?
+    public let name: String?
+    /// `"busy"`, `"idle"` or `"waiting"`, verbatim from the file — never
+    /// pattern-matched here beyond ``SessionActivity``'s own mapping.
+    public let status: String?
+    public let updatedAt: Int64?
+
+    public init(
+        sessionId: String,
+        cwd: String? = nil,
+        name: String? = nil,
+        status: String? = nil,
+        updatedAt: Int64? = nil
+    ) {
+        self.sessionId = sessionId
+        self.cwd = cwd
+        self.name = name
+        self.status = status
+        self.updatedAt = updatedAt
+    }
+}
+
+/// Reads every session file on disk, keyed by ``SessionFile/sessionId``.
+public enum SessionFiles {
+    /// `~/.claude/sessions`.
+    public static var defaultDirectory: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude", isDirectory: true)
+            .appendingPathComponent("sessions", isDirectory: true)
+    }
+
+    /// One poll's worth of session files, tolerant of everything that can go
+    /// wrong reading them — a missing directory (most machines running
+    /// `tcr` have never run Claude Code's CLI at all) and a file that is not
+    /// valid JSON or does not carry ``SessionFile``'s shape (a partial write
+    /// mid-save is routine for a file another process rewrites continuously).
+    /// Both skip rather than fail the whole read, per `panel-tabs-bridge.md`:
+    /// "Tolerate a missing directory and unparsable files: skip, never fail
+    /// the poll."
+    public static func read(directory: URL = defaultDirectory) -> [String: SessionFile] {
+        guard
+            let urls = try? FileManager.default.contentsOfDirectory(
+                at: directory, includingPropertiesForKeys: nil)
+        else { return [:] }
+
+        let decoder = JSONDecoder()
+        var out: [String: SessionFile] = [:]
+        for url in urls where url.pathExtension == "json" {
+            guard
+                let data = try? Data(contentsOf: url),
+                let file = try? decoder.decode(SessionFile.self, from: data)
+            else { continue }
+            out[file.sessionId] = file
+        }
+        return out
+    }
+}
+
+/// A live/idle/waiting reading for a joined session — the file side of
+/// ``JoinedSession/activity``, kept as its own type rather than a raw string
+/// the same way ``Account/AccountHealth`` keeps `status` from leaking its raw
+/// spelling into every call site. `.unknown` is the join-has-no-file case,
+/// not a fourth server-reported state.
+public enum SessionActivity: Equatable, Sendable {
+    case busy, idle, waiting, unknown
+
+    init(rawStatus: String?) {
+        switch rawStatus?.lowercased() {
+        case "busy": self = .busy
+        case "idle": self = .idle
+        case "waiting": self = .waiting
+        default: self = .unknown
+        }
+    }
+}
+
+/// A wire ``Session`` joined to its ``SessionFile``, if any — the row the
+/// Sessions and Tools tabs actually draw.
+///
+/// `file == nil` is routine, not an error: `panel-tabs-bridge.md` names it
+/// directly ("A wire session with no file shows its id's first 8 chars and no
+/// project") for the case where the harness on the other end of the proxy is
+/// not Claude Code at all, or its session file has already aged out.
+public struct JoinedSession: Identifiable, Equatable, Sendable {
+    public let session: Session
+    public let file: SessionFile?
+
+    public init(session: Session, file: SessionFile?) {
+        self.session = session
+        self.file = file
+    }
+
+    public var id: String { session.sessionId }
+
+    /// The file's `name`, else the session id's first 8 characters — never
+    /// the bare full id, which is wider than this panel and no more readable.
+    public var displayName: String {
+        if let name = file?.name, !name.isEmpty { return name }
+        return String(session.sessionId.prefix(8))
+    }
+
+    /// `cwd`'s last path component, `nil` when there is no file to read a
+    /// `cwd` from at all. Never guessed from the session id.
+    public var project: String? {
+        guard let cwd = file?.cwd, !cwd.isEmpty else { return nil }
+        return (cwd as NSString).lastPathComponent
+    }
+
+    public var activity: SessionActivity { SessionActivity(rawStatus: file?.status) }
+
+    public var lastSeenAt: Date { Date(timeIntervalSince1970: Double(session.lastSeenMs) / 1000) }
+
+    /// `"3m"`, `"2h"`, `"4d"` — the same tiering ``HeldWindow/duration(minutes:)``
+    /// already gives a countdown, read backwards for an elapsed span instead.
+    /// `now` is a required parameter, not a default, so a test stays
+    /// deterministic the way every other clock-reading function here is.
+    public func ageLabel(now: Date) -> String {
+        let elapsedSeconds = max(0, now.timeIntervalSince(lastSeenAt))
+        let minutes = Int((elapsedSeconds / 60).rounded())
+        return minutes < 1 ? "now" : HeldWindow.duration(minutes: minutes)
+    }
+}
+
+/// Joins the wire's sessions to the files on disk. A file with no matching
+/// wire session is dropped — `panel-tabs-bridge.md`: "it never went through
+/// the proxy" — so this always returns exactly `sessions.count` rows.
+public enum SessionJoin {
+    public static func join(sessions: [Session], files: [String: SessionFile]) -> [JoinedSession] {
+        sessions.map { JoinedSession(session: $0, file: files[$0.sessionId]) }
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
+++ b/apps/macos/Tests/TcrBarTests/FleetStatusTests.swift
@@ -300,6 +300,105 @@ final class FleetStatusTests: XCTestCase {
             "a measured zero stream-error count must render no line at all"
         )
     }
+
+    // MARK: F2/F3 — sessions (`data/plans/panel-tabs-bridge.md`)
+    //
+    // `Fleet.decode` decodes ONLY the bare account array `tcr status
+    // --json` sends — confirmed against the merged F1 work
+    // (`teamclaude-rs#232`, `crates/tcr-status-wire/src/lib.rs`): the wire's
+    // `SessionRow`/`StatusPayload.sessions` live on the proxy's own
+    // `/_tcr/status` HTTP response, gated by the proxy's api-key
+    // (`fetch_live_status`, `src/cli.rs`), and `tcr status --json` discards
+    // them before printing. This app never touches that endpoint or that key
+    // from Swift (`CLAUDE.md` "No credentials, ever"), so ``Fleet/sessions``
+    // is a plain stored field with no live producer yet — these tests
+    // construct it directly rather than decoding it off the account array,
+    // which is also the proof that `Fleet.decode` never sets it.
+
+    private func session(
+        id: String,
+        account: String? = "alice@example.com",
+        model: String? = "claude-opus-5",
+        requests: Int = 0,
+        tools: SessionTools = SessionTools()
+    ) -> Session {
+        Session(
+            sessionId: id, account: account, model: model, firstSeenMs: 0, lastSeenMs: 1000,
+            requests: requests, tools: tools)
+    }
+
+    /// `Fleet.decode` never populates `sessions`/`sessionsSupported`, on any
+    /// input — including a row that happens to carry a `"sessions"` key,
+    /// which a synthesized `Decodable` simply ignores as an unknown key
+    /// rather than reading it onto ``Account``.
+    func testDecodeNeverPopulatesSessions() throws {
+        let decoded = try fleet(liveFixture)
+        XCTAssertFalse(decoded.sessionsSupported)
+        XCTAssertTrue(decoded.sessions.isEmpty)
+    }
+
+    /// A fleet with zero accounts still reports empty/unsupported rather than
+    /// crashing — there is no `accounts.first` to read at all any more,
+    /// since ``Fleet/sessions`` is now its own stored field.
+    func testEmptyFleetHasNoSessionsAndIsUnsupported() throws {
+        let decoded = try fleet("[]")
+        XCTAssertTrue(decoded.sessions.isEmpty)
+        XCTAssertFalse(decoded.sessionsSupported)
+    }
+
+    /// A `Fleet` built with sessions directly (the shape a future safe
+    /// channel — or a render-states fixture — hands this build) reports them
+    /// and marks itself supported.
+    func testFleetConstructedWithSessionsReportsThemAsSupported() throws {
+        let oneSession = session(
+            id: "11111111-aaaa-bbbb-cccc-111111111111", requests: 40,
+            tools: SessionTools(
+                calls: 12, errors: 1, timeouts: 0,
+                running: [ToolCall(tool: "Bash", commandHead: "cargo test", startedMs: 1500)],
+                slowest: [
+                    ToolCall(tool: "Bash", commandHead: "swift build", endedMs: 1900, seconds: 90.5)
+                ]))
+        let decoded = try fleet(liveFixture)
+        let withSessions = Fleet(
+            accounts: decoded.accounts, sessions: [oneSession], sessionsSupported: true)
+        XCTAssertTrue(withSessions.sessionsSupported)
+        XCTAssertEqual(withSessions.sessions.count, 1)
+        let readBack = withSessions.sessions[0]
+        XCTAssertEqual(readBack.sessionId, "11111111-aaaa-bbbb-cccc-111111111111")
+        XCTAssertEqual(readBack.requests, 40)
+        XCTAssertEqual(readBack.tools.calls, 12)
+        XCTAssertEqual(readBack.tools.running.count, 1)
+        XCTAssertEqual(readBack.tools.running[0].commandHead, "cargo test")
+        XCTAssertEqual(readBack.tools.slowest.count, 1)
+        XCTAssertEqual(readBack.tools.slowest[0].seconds, 90.5)
+    }
+
+    /// `Fleet.toolsRunning`/`toolsSlowest` pool across every session and
+    /// `toolsSlowest` re-sorts rather than trusting per-session order.
+    func testToolsPoolAcrossSessionsAndSlowestSortsDescending() throws {
+        let s1 = session(
+            id: "s1", model: "claude-opus-5",
+            tools: SessionTools(
+                calls: 3, errors: 0, timeouts: 1, slowest: [ToolCall(tool: "Bash", seconds: 12.0)]))
+        let s2 = session(
+            id: "s2", model: "claude-sonnet-5",
+            tools: SessionTools(
+                calls: 5, errors: 2, timeouts: 0,
+                running: [ToolCall(tool: "Read", startedMs: 10)],
+                slowest: [ToolCall(tool: "Bash", seconds: 600.0)]))
+        let decoded = try fleet(liveFixture)
+        let withSessions = Fleet(
+            accounts: decoded.accounts, sessions: [s1, s2], sessionsSupported: true)
+        XCTAssertEqual(withSessions.toolsTotalCalls, 8)
+        XCTAssertEqual(withSessions.toolsTotalErrors, 2)
+        XCTAssertEqual(withSessions.toolsTotalTimeouts, 1)
+        XCTAssertEqual(withSessions.toolsRunning.count, 1)
+        XCTAssertEqual(withSessions.toolsRunning[0].sessionId, "s2")
+        // s2's 600s call sorts ahead of s1's 12s call, even though s1 is
+        // first in the array.
+        XCTAssertEqual(withSessions.toolsSlowest.map(\.sessionId), ["s2", "s1"])
+        XCTAssertEqual(withSessions.toolsSlowest.map { $0.call.seconds }, [600.0, 12.0])
+    }
 }
 
 /// ``Account/effectiveQuotaState(for:)`` is the pure selection

--- a/apps/macos/Tests/TcrBarTests/SessionFilesTests.swift
+++ b/apps/macos/Tests/TcrBarTests/SessionFilesTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+
+@testable import TcrBarCore
+
+final class SessionFilesTests: XCTestCase {
+    private func makeTempDirectory() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tcrbar-session-files-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// A missing directory reads as no files at all, never a thrown error —
+    /// `panel-tabs-bridge.md`: "Tolerate a missing directory … skip, never
+    /// fail the poll." Most machines running `tcr` have never run Claude
+    /// Code's own CLI, so this is the routine case, not the edge one.
+    func testMissingDirectoryReadsAsEmpty() {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tcrbar-does-not-exist-\(UUID().uuidString)")
+        XCTAssertTrue(SessionFiles.read(directory: missing).isEmpty)
+    }
+
+    /// A file that does not parse is skipped, not fatal — the sibling files
+    /// in the same directory still decode.
+    func testUnparsableFileIsSkippedWithoutFailingTheRead() throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        try "not json at all".write(
+            to: dir.appendingPathComponent("broken.json"), atomically: true, encoding: .utf8)
+        let goodJSON = """
+            {"sessionId":"good-session","cwd":"/Users/alice/git/example",
+             "name":"example-c1","status":"busy"}
+            """
+        try goodJSON.write(
+            to: dir.appendingPathComponent("good.json"), atomically: true, encoding: .utf8)
+
+        let files = SessionFiles.read(directory: dir)
+        XCTAssertEqual(files.count, 1)
+        XCTAssertEqual(files["good-session"]?.name, "example-c1")
+    }
+
+    /// A non-`.json` file in the same directory is ignored outright, not
+    /// attempted and skipped — it never counts against the read.
+    func testNonJsonFilesAreIgnored() throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try "hello".write(to: dir.appendingPathComponent("notes.txt"), atomically: true, encoding: .utf8)
+        XCTAssertTrue(SessionFiles.read(directory: dir).isEmpty)
+    }
+
+    // MARK: JoinedSession
+
+    private func session(id: String, account: String? = nil, lastSeenMs: Int64 = 0) -> Session {
+        Session(
+            sessionId: id, account: account, model: "claude-opus-5", firstSeenMs: 0, lastSeenMs: lastSeenMs)
+    }
+
+    /// `panel-tabs-bridge.md`: "A wire session with no file shows its id's
+    /// first 8 chars and no project."
+    func testWireSessionWithNoFileShowsIdHeadAndNoProject() {
+        let joined = JoinedSession(session: session(id: "11111111-aaaa-bbbb"), file: nil)
+        XCTAssertEqual(joined.displayName, "11111111")
+        XCTAssertNil(joined.project)
+        XCTAssertEqual(joined.activity, .unknown)
+    }
+
+    /// A joined session reads its name and project from the file, and its
+    /// activity from the file's `status`.
+    func testJoinedSessionReadsNameProjectAndActivityFromTheFile() {
+        let file = SessionFile(
+            sessionId: "11111111-aaaa-bbbb", cwd: "/Users/alice/git/teamclaude-rs",
+            name: "teamclaude-rs-c7", status: "busy")
+        let joined = JoinedSession(session: session(id: "11111111-aaaa-bbbb"), file: file)
+        XCTAssertEqual(joined.displayName, "teamclaude-rs-c7")
+        XCTAssertEqual(joined.project, "teamclaude-rs")
+        XCTAssertEqual(joined.activity, .busy)
+    }
+
+    /// A file with no matching wire session is dropped — `panel-tabs-bridge.md`:
+    /// "it never went through the proxy" — so the join always returns exactly
+    /// `sessions.count` rows, never `files.count`.
+    func testAFileWithNoMatchingWireSessionIsDropped() {
+        let sessions = [session(id: "s1")]
+        let files = [
+            "s1": SessionFile(sessionId: "s1", name: "kept"),
+            "orphan": SessionFile(sessionId: "orphan", name: "never went through the proxy"),
+        ]
+        let joined = SessionJoin.join(sessions: sessions, files: files)
+        XCTAssertEqual(joined.count, 1)
+        XCTAssertEqual(joined[0].displayName, "kept")
+    }
+
+    func testAgeLabelTiers() {
+        let joined = JoinedSession(session: session(id: "s1", lastSeenMs: 0), file: nil)
+        let now = Date(timeIntervalSince1970: 5 * 60)  // 5 minutes later
+        XCTAssertEqual(joined.ageLabel(now: now), "5m")
+    }
+}


### PR DESCRIPTION
🍄

Segmented Accounts/Sessions/Tools control at the top of the panel, matching `docs/design/panel-tabs-mockup.html`: SF Symbols `gauge`/`person.2`/`terminal`, a count badge per tab, and a shared height budget so switching tabs never resizes the popover mid-cycle (the `ffe8a86` layout crash this panel already guards against).

## The wire gap this PR surfaces

`Session`/`SessionTools`/`ToolCall`/`SessionToolEntry` live on `Fleet` as plain stored fields rather than being decoded off `tcr status --json`'s bare account array. The bridge this was written against (`data/plans/panel-tabs-bridge.md`) said the wire would grow a top-level `sessions` array on that existing array. The merged F1 work (#232) put it somewhere else instead: `SessionRow`/`StatusPayload.sessions` live on the proxy's own `/_tcr/status` HTTP response, which `fetch_live_status` (`src/cli.rs`) reads with the proxy's api-key — and `tcr status --json` discards `sessions` entirely when it turns that payload back into the bare array this app decodes.

This app never touches `~/.config/teamclaude.json` or the proxy's api-key from Swift (`CLAUDE.md` "No credentials, ever", and every `TcrBarCore` file that says this app never reads/writes the tcr config), so there is currently **no safe channel** for a live poll to populate `Fleet.sessions`. It ships anyway: the types are tested, and both tabs render correctly against directly-constructed data (`RenderStates.swift`'s fixtures, PNGs below) — they are ready the moment a safe channel exists, most likely a new `tcr` CLI subcommand that shells out the way every other fact in this app already does. Flagging this loudly rather than routing the proxy's api-key through Swift to close the gap myself.

## Design review deltas applied

`docs/design/panel-tabs-review.md` (full-suite review of the v2 mockup, verdict: Block, 5 HIGH findings) named several defects that map onto this build:
- **Finding 2**: a running session's trailing figure is the age of its OLDEST running tool, read from the same `tools.running` array the Tools tab pools from — the two tabs can no longer derive two different counts for the same session.
- **Finding 5**: a running Bash call draws a ring toward its 600s timeout (stated in the section caption), reddening with "Ns to timeout" in the last 20 seconds.
- **Finding 13**: tabular figures on the tab badges and the running/slowest rows.

Findings 8, 9, 14 and 15 are Accounts-tab/general-panel scope (quota grid, disclosure buttons, header clock, a BY-TOOL bar chart this build never added) and are out of this PR's F2+F3 scope.

## Gates

- `swift test --package-path apps/macos` — exit 0, 512 tests (11 new: decoder/session-file/join tests plus a mutation ("watch one fail") proving `Fleet.decode` never populates `sessions`, run and restored twice — once for the original bridge shape, once for the corrected one).
- `apps/macos/scripts/build-tcrbar.sh` — exit 0, `version=0.2.50 build=519 sha=40d4949`.
- `--render-states` — 50/50 PNGs, including three new: `16-sessions-tab`, `17-tools-tab`, `18-sessions-tab-old-server` (dark + light).

PNG paths (local, not committed): `/tmp/tcrbar-states-tabs/16-sessions-tab-{dark,light}.png`, `17-tools-tab-{dark,light}.png`, `18-sessions-tab-old-server-{dark,light}.png`.

Cargo.toml/Cargo.lock bumped 0.2.48 → 0.2.50: this branch's base was still 0.2.48 and `origin/main` has since advanced to 0.2.49 via another merged PR, so 0.2.49 would collide.

https://claude.ai/code/session_01WyxK6BTWQoYSZyQAehjgCE