### PR TITLE
feat: label subagents on the session tools wire (F4)

### DIFF
--- a/crates/tcr-status-wire/src/lib.rs
+++ b/crates/tcr-status-wire/src/lib.rs
@@ -125,9 +125,10 @@ pub struct HeldWindowRow {
 pub struct RunningToolRow {
     pub tool: String,
     pub started_ms: i64,
-    /// First 120 characters of a Bash tool's `input.command` — `None` for any other tool, or
-    /// when the running call carries no command. Held in memory only on the server; never
-    /// written to a log (see `src/session_wire.rs`'s module doc in the main crate).
+    /// A Bash tool's `input.command`, or an `Agent`/`Task` tool's `input.subagent_type:
+    /// input.description` — `None` for any other tool, or when the running call carries
+    /// neither. Held in memory only on the server; never written to a log (see
+    /// `src/session_wire.rs`'s module doc in the main crate).
     pub command_head: Option<String>,
 }
 
@@ -154,6 +155,12 @@ pub struct SessionToolsRow {
     /// Tool calls still awaiting a `tool_result`, capped at 64 per session.
     #[serde(default)]
     pub running: Vec<RunningToolRow>,
+    /// The count of [`Self::running`] entries whose `tool` is `Agent` or `Task` — a running
+    /// subagent — so a panel can print "2 subagents" without scanning the list. `#[serde(default)]`
+    /// so a payload from a server built before this field existed decodes as "no subagents known"
+    /// rather than a parse failure.
+    #[serde(default)]
+    pub subagents_running: u64,
     /// The ten slowest completed tool calls, descending by `seconds`.
     #[serde(default)]
     pub slowest: Vec<SlowToolRow>,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -564,6 +564,15 @@ row says which.
 Totals survive a restart: each served request is appended to `~/.cache/teamclaude/usage/`, and boot
 replays the day back in. Fleet-wide totals are not a field — sum the rows.
 
+### The `sessions` array on `GET /_tcr/status`
+
+Reachable via the raw `/_tcr/status` endpoint, not the CLI's own array output: one entry per Claude
+Code session seen in the last hour, each carrying its tool-call stats (`tools.running`, the pending
+calls; `tools.slowest`, the ten slowest completed ones). `tools.running` entries for an `Agent` or
+`Task` tool call carry the subagent's description in `commandHead` (prefixed with its type when
+Claude Code sent one), and `tools.subagentsRunning` is that count precomputed, so a panel can show
+"2 subagents" without scanning the list itself.
+
 ---
 
 ## `tcr wrap`

--- a/src/manager/wire_sessions.rs
+++ b/src/manager/wire_sessions.rs
@@ -82,6 +82,12 @@ impl Manager {
                     calls: s.tools.calls,
                     errors: s.tools.errors,
                     timeouts: s.tools.timeouts,
+                    subagents_running: s
+                        .tools
+                        .running
+                        .values()
+                        .filter(|r| r.tool == "Agent" || r.tool == "Task")
+                        .count() as u64,
                     running: s
                         .tools
                         .running
@@ -139,6 +145,42 @@ mod tests {
         assert_eq!(row.input_tokens, 10);
         assert_eq!(row.output_tokens, 20);
         assert_eq!(row.cache_read_tokens, 5);
+    }
+
+    /// `subagents_running` counts only `Agent`/`Task` entries among the running tools — a plain
+    /// `Bash` call sitting alongside two subagents must not be counted, and a caller must be
+    /// able to print "2 subagents" without scanning `running` itself.
+    #[test]
+    fn subagents_running_counts_agent_and_task_but_not_bash() {
+        let manager = Manager::from_runtimes(vec![]);
+        let now = OffsetDateTime::now_utc();
+        let uses = vec![
+            ToolUseEvent {
+                id: "tu_bash".to_string(),
+                name: Some("Bash".to_string()),
+                command_head: Some("ls".to_string()),
+            },
+            ToolUseEvent {
+                id: "tu_agent".to_string(),
+                name: Some("Agent".to_string()),
+                command_head: Some("henry:coder: F4 subagents on the wire".to_string()),
+            },
+            ToolUseEvent {
+                id: "tu_task".to_string(),
+                name: Some("Task".to_string()),
+                command_head: Some("review the diff".to_string()),
+            },
+        ];
+        manager.record_wire_session(Some("sess-sub"), None, None, now, &uses, &[]);
+
+        let snap = manager.snapshot(now);
+        assert_eq!(snap.wire_sessions.len(), 1);
+        let row = &snap.wire_sessions[0];
+        assert_eq!(row.tools.running.len(), 3, "all three tools stay pending");
+        assert_eq!(
+            row.tools.subagents_running, 2,
+            "only the Agent and Task entries count, not the Bash call"
+        );
     }
 
     #[test]

--- a/src/session_wire.rs
+++ b/src/session_wire.rs
@@ -13,7 +13,8 @@
 //! - [`WireSessionTracker`]: the bounded, in-memory table one request's parsed events get
 //!   folded into. No I/O, no locking — [`crate::manager::Manager`] wraps one in a `Mutex`.
 //!
-//! `command_head` (a Bash tool's `input.command`, capped to 120 chars) is held ONLY in this
+//! `command_head` (a Bash tool's `input.command`, or an `Agent`/`Task` tool's
+//! `input.subagent_type: input.description`, capped to 120 chars) is held ONLY in this
 //! in-memory table — never written to `~/.cache/teamclaude/logs` or any other file. That is
 //! the same body-content-never-hits-disk rule `src/proxy.rs` states for the request log.
 
@@ -25,8 +26,11 @@ use serde_json::Value;
 pub struct ToolUseEvent {
     pub id: String,
     pub name: Option<String>,
-    /// First 120 characters of `input.command`, only for a `Bash` tool call. Held in memory
-    /// only — see the module doc's no-body-content-on-disk rule.
+    /// For a `Bash` tool call, the first 120 characters of `input.command`. For an `Agent` or
+    /// `Task` tool call (a running subagent), `input.description` (Claude Code's 3-5 word
+    /// summary), prefixed with `input.subagent_type` when present (`"henry:coder: F4 subagents
+    /// on the wire"`), same 120-char cap. `None` for any other tool. Held in memory only — see
+    /// the module doc's no-body-content-on-disk rule.
     pub command_head: Option<String>,
 }
 
@@ -127,14 +131,26 @@ pub fn extract_tool_events(messages: &RawValue) -> (Vec<ToolUseEvent>, Vec<ToolR
             match (msg.role.as_str(), b.kind.as_str()) {
                 ("assistant", "tool_use") => {
                     if let Some(id) = b.id {
-                        let command_head = if b.name.as_deref() == Some("Bash") {
-                            b.input
+                        let command_head = match b.name.as_deref() {
+                            Some("Bash") => b
+                                .input
                                 .as_ref()
                                 .and_then(|v| v.get("command"))
                                 .and_then(Value::as_str)
-                                .map(|s| s.chars().take(COMMAND_HEAD_MAX).collect())
-                        } else {
-                            None
+                                .map(|s| s.chars().take(COMMAND_HEAD_MAX).collect()),
+                            Some("Agent") | Some("Task") => b.input.as_ref().and_then(|input| {
+                                let description =
+                                    input.get("description").and_then(Value::as_str)?;
+                                let head = match input.get("subagent_type").and_then(Value::as_str)
+                                {
+                                    Some(subagent_type) => {
+                                        format!("{subagent_type}: {description}")
+                                    }
+                                    None => description.to_string(),
+                                };
+                                Some(head.chars().take(COMMAND_HEAD_MAX).collect())
+                            }),
+                            _ => None,
                         };
                         tool_uses.push(ToolUseEvent {
                             id,
@@ -379,6 +395,24 @@ mod tests {
         })
     }
 
+    fn agent_tool_use(
+        id: &str,
+        name: &str,
+        description: &str,
+        subagent_type: Option<&str>,
+    ) -> Value {
+        let mut input = serde_json::json!({"description": description});
+        if let Some(st) = subagent_type {
+            input["subagent_type"] = Value::String(st.to_string());
+        }
+        serde_json::json!({
+            "type": "tool_use",
+            "id": id,
+            "name": name,
+            "input": input,
+        })
+    }
+
     fn tool_result(id: &str, is_error: bool, text: &str) -> Value {
         serde_json::json!({
             "type": "tool_result",
@@ -421,6 +455,43 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id, "tu_1");
         assert!(!results[0].is_error);
+    }
+
+    #[test]
+    fn extract_tool_events_fills_command_head_for_an_agent_tool_with_subagent_type() {
+        let messages = serde_json::json!([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": [agent_tool_use(
+                "tu_agent",
+                "Agent",
+                "F4 subagents on the wire",
+                Some("henry:coder"),
+            )]},
+        ]);
+        let raw = messages_raw(messages);
+        let (uses, _results) = extract_tool_events(&raw);
+        assert_eq!(uses.len(), 1);
+        assert_eq!(
+            uses[0].command_head.as_deref(),
+            Some("henry:coder: F4 subagents on the wire")
+        );
+    }
+
+    #[test]
+    fn extract_tool_events_fills_command_head_for_a_task_tool_without_subagent_type() {
+        let messages = serde_json::json!([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": [agent_tool_use(
+                "tu_task",
+                "Task",
+                "review the diff",
+                None,
+            )]},
+        ]);
+        let raw = messages_raw(messages);
+        let (uses, _results) = extract_tool_events(&raw);
+        assert_eq!(uses.len(), 1);
+        assert_eq!(uses[0].command_head.as_deref(), Some("review the diff"));
     }
 
     #[test]

--- a/src/status.rs
+++ b/src/status.rs
@@ -533,6 +533,7 @@ mod tests {
                         started_ms: crate::now_ms() - 5_000,
                         command_head: Some("ls -la".to_string()),
                     }],
+                    subagents_running: 0,
                     slowest: vec![tcr_status_wire::SlowToolRow {
                         tool: "Bash".to_string(),
                         seconds: 3.5,
@@ -713,6 +714,34 @@ mod tests {
             back.sessions,
             Vec::new(),
             "missing sessions field on the wire defaults to empty, not a decode error"
+        );
+    }
+
+    /// A payload from an older server that predates `subagentsRunning` (F4) still
+    /// deserializes, defaulting to zero — same forward-compat contract as `sessions` itself.
+    #[test]
+    fn payload_without_subagents_running_field_still_deserializes() {
+        let wire = serde_json::to_string(&StatusPayload::from_snapshot(
+            &snapshot_with_counters(),
+            &[0.85],
+            false,
+            None,
+            Default::default(),
+        ))
+        .expect("serialize");
+        let mut value: serde_json::Value = serde_json::from_str(&wire).expect("parse");
+        for session in value["sessions"].as_array_mut().expect("sessions array") {
+            session["tools"]
+                .as_object_mut()
+                .expect("tools object")
+                .remove("subagentsRunning");
+        }
+        let stripped = serde_json::to_string(&value).expect("re-serialize");
+        let back: StatusPayload =
+            serde_json::from_str(&stripped).expect("deserialize without subagentsRunning field");
+        assert_eq!(
+            back.sessions[0].tools.subagents_running, 0,
+            "missing subagentsRunning field on the wire defaults to 0, not a decode error"
         );
     }
 


### PR DESCRIPTION
🍄 F4 from `docs/ROADMAP-product.md`: labels a running subagent on the already-tracked `sessions` wire from F1.

## What ships
- `extract_tool_events` fills `command_head` for `Agent`/`Task` tool calls from `input.description`, prefixed with `input.subagent_type` when present, same 120-char cap as the existing `Bash` handling. Field stays named `command_head` on the wire.
- `SessionToolsRow.subagents_running: u64` (`#[serde(default)]`) — the count of `running` entries whose tool is `Agent` or `Task`.
- `docs/cli.md` gets a short `sessions` array subsection describing both.

## Test plan
- [x] `cargo test` — 1055 passed, 0 failed, exit 0
- [x] Watched `subagents_running_counts_agent_and_task_but_not_bash` fail with a mutation that also counted `Bash` (`left: 3, right: 2`), then restored to green
- [x] `cargo clippy --all-targets` — exit 0, no warnings
- [x] `cargo fmt --check` — exit 0

https://claude.ai/code/session_01WyxK6BTWQoYSZyQAehjgCE