### PR TITLE
feat: build the TcrBar Settings window (gear button, ⌘,)

### DIFF
--- a/apps/macos/Sources/TcrBar/FleetView.swift
+++ b/apps/macos/Sources/TcrBar/FleetView.swift
@@ -49,6 +49,10 @@ struct FleetView: View {
     /// Opens the "What's new" window. A closure rather than the controller so
     /// the render harness passes `{}` and can neither fetch nor open anything.
     var onWhatsNew: () -> Void = {}
+    /// Opens the Settings window (gear button, `⌘,`) — `data/plans/
+    /// settings-window-bridge.md`. Same closure shape as ``onWhatsNew``, and
+    /// for the same reason: the render harness passes `{}`.
+    var onSettings: () -> Void = {}
 
     /// Surfaced in place rather than swallowed: a button that silently does
     /// nothing is worse than one that says why.
@@ -142,6 +146,7 @@ struct FleetView: View {
         startServerAtLaunch: Binding<Bool>,
         snapshotMode: Bool = false,
         onWhatsNew: @escaping () -> Void = {},
+        onSettings: @escaping () -> Void = {},
         initialTab: PanelTab = .accounts
     ) {
         self.poller = poller
@@ -156,6 +161,7 @@ struct FleetView: View {
         self._startServerAtLaunch = startServerAtLaunch
         self.snapshotMode = snapshotMode
         self.onWhatsNew = onWhatsNew
+        self.onSettings = onSettings
         self._selectedTab = State(initialValue: initialTab)
     }
 
@@ -192,6 +198,20 @@ struct FleetView: View {
                         .font(Tok.secondaryDigitFont).lineSpacing(Tok.secondaryLineSpacing)
                         .foregroundStyle(Tok.inkDim)
                 }
+                // Gear opens Settings — in the header, not the footer, and
+                // present regardless of which tab is selected: it is window
+                // chrome, not tab content, the same reasoning the mockup's
+                // own note gives for repeating it on all three tabs
+                // (`docs/design/panel-tabs-mockup.html`). `⌘,` is the
+                // platform's own settings shortcut.
+                Button(action: onSettings) {
+                    Image(systemName: "gearshape")
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(Tok.inkDim)
+                .keyboardShortcut(",", modifiers: [.command])
+                .help("Settings… ⌘,")
+                .accessibilityLabel("Settings")
             }
             // Only when the read is NOT healthy. On a healthy read this said
             // "13 accounts — live", which the tallies below say with more
@@ -1294,26 +1314,6 @@ struct FleetView: View {
                 }
             }
             fleetActions
-            // Scope boundary by PROXIMITY, not by a rule. A `Hairline` shipped
-            // here first and was then rendered with `--render-states`: it put a
-            // THIRD full-width rule into the bottom third of the panel — one
-            // above this block, one here, one above the danger zone — and the
-            // new one sat between two rows that are both just buttons, while
-            // the checkboxes directly below it got no separator at all. The
-            // original trailing-alignment was reaching for the right thing
-            // ("without needing a rule between them"); only its method was
-            // wrong. Space groups these two without adding weight.
-            //
-            // The padding used to match `Tok.tightSpacing` — the same value
-            // as the intra-group gap between buttons in `fleetActions` and
-            // `appActions` themselves — so the two six-button rows read as
-            // one undifferentiated block (`--render-states`, `01g-widest-row`).
-            // `Tok.space4`, stacked on this `VStack`'s own `Tok.tightSpacing`
-            // gap between children, puts the inter-group gap at 16pt against
-            // an intra-group gap of 4pt: four times it, comfortably past the
-            // "at least twice" floor.
-            appActions
-                .padding(.top, Tok.space4)
 
             if let loginError {
                 Text(loginError)
@@ -1322,10 +1322,13 @@ struct FleetView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            launchAtLogin
-            startServerToggle
-            keepAwakeToggle
-
+            // Start server at launch / Launch at login / Keep this Mac awake,
+            // and Check for Updates / What's New / Quit, all moved to the
+            // Settings window the gear opens (`data/plans/
+            // settings-window-bridge.md`): "the panel loses the three
+            // toggles, Check for Updates, What's New and Quit from its
+            // bottom block; Refresh and Add account stay." ``fleetActions``
+            // above is the surviving pair.
             dangerZone
         }
     }
@@ -1387,134 +1390,6 @@ struct FleetView: View {
             Spacer(minLength: 0)
         }
         .buttonStyle(.bordered)
-    }
-
-    /// Actions that act on the APP rather than on the fleet.
-    ///
-    /// These used to be trailing-aligned, on the reasoning that opposite
-    /// alignment would read as a separate group "without needing a rule between
-    /// them". In practice it read as misalignment: two button rows with
-    /// different left edges look broken before they look grouped, and the
-    /// second row's buttons floated away from everything above them. The scope
-    /// split is real, so it is now drawn — a `Hairline`, the same divider this
-    /// panel already uses to separate its sections — and both rows share one
-    /// left edge so the footer has a single vertical rhythm.
-    private var appActions: some View {
-        HStack(spacing: Tok.tightSpacing) {
-            // Disabled rather than silently no-op while Sparkle already has
-            // a check in flight — the same rule "Take over port…" follows.
-            Button("Check for Updates…") { updater.checkForUpdates() }
-                .disabled(!updater.canCheckForUpdates)
-                .help(
-                    "Ask the release feed whether a newer TcrBar exists. "
-                        + "Also reachable as `tcrbar://check-for-updates`."
-                )
-            Button("What's New…") { onWhatsNew() }
-                .help("The release notes for the TcrBar you are running.")
-            Button("Quit") { NSApplication.shared.terminate(nil) }
-            Spacer(minLength: 0)
-        }
-        .buttonStyle(.bordered)
-    }
-
-    /// Bring the proxy up when TcrBar starts. Pairs with "Launch at login" to
-    /// mean "the proxy is always up".
-    ///
-    /// The warning is not decoration. Once TcrBar supervises the server, Quit
-    /// stops it — correct for a supervisor, and a genuinely expensive surprise if
-    /// nobody said so before the box was ticked.
-    ///
-    /// So it is drawn UNCONDITIONALLY, not inside `if startServerAtLaunch`. The
-    /// preference defaults to off (`LaunchPreference.swift`), so a caveat that
-    /// only appears once the box is ticked appears strictly *after* the decision
-    /// it exists to inform — it can tell an operator what they already did, never
-    /// what they are about to do. The hover help cannot carry it either: a
-    /// tooltip is opt-in, and this cost is not.
-    ///
-    /// Always-present also holds the panel's height still as the box toggles,
-    /// which a conditional line does not: the fleet rows above would shift under
-    /// the pointer at the moment of the click.
-    ///
-    /// It carries `Tok.inkFaint`, not `Tok.near`. Every amber line in this footer
-    /// is a live condition of *this* install; this one is a standing fact about
-    /// what the mode means, true before anybody chooses anything, and drawing a
-    /// permanent note in the alarm colour would leave the panel looking alarmed at
-    /// rest. The wording is deliberately state-neutral for the same reason — it
-    /// reads correctly both as a consequence to weigh and as one already taken on.
-    private var startServerToggle: some View {
-        VStack(alignment: .leading, spacing: Tok.tightSpacing) {
-            Toggle("Start server at launch", isOn: $startServerAtLaunch)
-                .toggleStyle(.checkbox)
-                .font(Tok.secondaryFont).lineSpacing(Tok.secondaryLineSpacing)
-                .help(
-                    "Runs `tcr server --headless --no-replace` when TcrBar starts. "
-                        + "`--headless` is the load-bearing one: it keeps the "
-                        + "server alive with no terminal to run its TUI in. "
-                        + "Standing down rather than disturbing a proxy that is "
-                        + "already serving is the default, which `--no-replace` "
-                        + "only restates for an older `tcr`. TcrBar then "
-                        + "supervises the server it started, and quitting TcrBar "
-                        + "stops it."
-                )
-            Text("TcrBar supervises a server it starts, so quitting TcrBar stops it.")
-                .font(Tok.detailFont).lineSpacing(Tok.detailLineSpacing)
-                .foregroundStyle(Tok.inkFaint)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-    }
-
-    /// Keep the Mac from idle-sleeping, for as long as the box is ticked.
-    ///
-    /// A checkbox rather than a fifth button: the button row above is already
-    /// four wide inside a 380pt panel, and this belongs with the other two
-    /// toggles anyway — all three are modes, not actions.
-    ///
-    /// The detail line is not decoration. "Keep this Mac awake" over-promises by
-    /// exactly the two cases an operator will hit — a dark screen, and a laptop
-    /// on battery, where the `PreventSystemSleep` half of the hold is inert per
-    /// `man caffeinate` — and hitting either means coming back to a dead run and
-    /// blaming the proxy. It says nothing about a closed lid in either
-    /// direction, because nothing here has measured that.
-    ///
-    /// It carries `Tok.awake`, NOT `Tok.near`. Amber is this palette's "close to
-    /// a gating limit", and it is what the login-item error directly above uses;
-    /// an informational note about a mode the operator just turned on is not
-    /// that, and rendering it in the alarm colour made a footer with one note
-    /// read as a footer with two problems. `Tok.awake` is the mode's own token —
-    /// the same one the menu-bar mark uses — so the line reads as belonging to
-    /// the thing that is on, which is what it is.
-    ///
-    /// `.tint(Tok.awake)` asks for the mark to be the same token the menu bar
-    /// draws, so the two surfaces cannot disagree about what "on" looks like.
-    /// **That one line is unverified**, and it is the only thing here that is: a
-    /// `.checkbox` toggle is an AppKit control, `ImageRenderer` does not draw
-    /// those at all (`--render-states` shows a placeholder for this toggle and
-    /// for the two above it, all three the same), and reading the real control
-    /// back needs a screenshot. On macOS a checkbox may well follow the system
-    /// accent colour and ignore the tint outright. The state is carried by the
-    /// checkbox being *ticked*, which is not a colour, so nothing depends on it.
-    private var keepAwakeToggle: some View {
-        VStack(alignment: .leading, spacing: Tok.tightSpacing) {
-            Toggle(
-                "Keep this Mac awake",
-                isOn: Binding(get: { awake.isOn }, set: { awake.setOn($0) })
-            )
-            .toggleStyle(.checkbox)
-            .font(Tok.secondaryFont).lineSpacing(Tok.secondaryLineSpacing)
-            .tint(Tok.awake)
-            .help(
-                "Holds the three power assertions `caffeinate -i -m -s` holds, for "
-                    + "as long as this is on. Released when you untick it or quit "
-                    + "TcrBar, and taken again the next time TcrBar starts — the "
-                    + "cup in the menu bar is on whenever it is held."
-            )
-            if awake.isOn {
-                Text("The display still sleeps. Sleep itself is only held off on AC power.")
-                    .font(Tok.detailFont).lineSpacing(Tok.detailLineSpacing)
-                    .foregroundStyle(Tok.awake)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-        }
     }
 
     /// One message for all four `LoginLauncher` hand-offs below.
@@ -1584,36 +1459,6 @@ struct FleetView: View {
         } else {
             loginError = nil
         }
-    }
-
-    /// App-level preference, deliberately beside Quit rather than among the
-    /// account rows: it is about TcrBar, not about the fleet.
-    private var launchAtLogin: some View {
-        VStack(alignment: .leading, spacing: Tok.tightSpacing) {
-            Toggle(
-                "Launch at login",
-                isOn: Binding(
-                    get: { loginItem.status.isOn },
-                    set: { loginItem.set(enabled: $0) }
-                )
-            )
-            .toggleStyle(.checkbox)
-            .font(Tok.secondaryFont).lineSpacing(Tok.secondaryLineSpacing)
-            if let detail = loginItem.status.detail {
-                Text(detail)
-                    .font(Tok.detailFont).lineSpacing(Tok.detailLineSpacing)
-                    .foregroundStyle(Tok.near)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            if let error = loginItem.lastError {
-                Text(error)
-                    .font(Tok.detailFont).lineSpacing(Tok.detailLineSpacing)
-                    .foregroundStyle(Tok.spent)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-        }
-        .padding(.top, Tok.tightSpacing)
-        .onAppear { loginItem.refresh() }
     }
 
     /// Kept apart from the routine controls on purpose. "Refresh" costs nothing

--- a/apps/macos/Sources/TcrBar/MenuBarShell.swift
+++ b/apps/macos/Sources/TcrBar/MenuBarShell.swift
@@ -61,6 +61,24 @@ final class MenuBarShell {
     /// right-click menu can reach it with the panel closed.
     let whatsNew: WhatsNewController
     let whatsNewWindow: WhatsNewWindow
+    /// "Show the running-tool count" and "Open on" — the two Settings-window
+    /// rows with no pre-existing controller (`data/plans/
+    /// settings-window-bridge.md`, Menu Bar pane). Owned here for the same
+    /// reason as `countsPreference`: read by every poll tick, not just while
+    /// the Settings window happens to be open.
+    let runningToolsPreference: ShowRunningToolsPreference
+    let defaultTabPreference: DefaultTabPreference
+    /// The Settings window itself. Lazy and reused, same shape as
+    /// `whatsNewWindow` — a window rebuilt per open loses its sidebar
+    /// selection and its size.
+    private(set) lazy var settingsWindow = SettingsWindowController(
+        dependencies: SettingsDependencies(
+            poller: poller, server: server, loginItem: loginItem, awake: awake,
+            preference: preference, countsPreference: countsPreference,
+            runningToolsPreference: runningToolsPreference,
+            defaultTabPreference: defaultTabPreference,
+            groupController: groupController, updater: updater,
+            onWhatsNew: { [weak self] in self?.openWhatsNew() }))
 
     let statusItem: NSStatusItem
     let popover: NSPopover
@@ -84,7 +102,9 @@ final class MenuBarShell {
         updater: Updater? = nil,
         groupController: GroupController? = nil,
         removeController: RemoveAccountController? = nil,
-        whatsNew: WhatsNewController? = nil
+        whatsNew: WhatsNewController? = nil,
+        runningToolsPreference: ShowRunningToolsPreference? = nil,
+        defaultTabPreference: DefaultTabPreference? = nil
     ) {
         self.poller = poller ?? StatusPoller()
         self.server = server ?? ServerController()
@@ -107,6 +127,8 @@ final class MenuBarShell {
                 location: ReleaseFeedLocation.from(bundle: .main),
                 currentVersion: AppBuild.shortVersion)
         self.whatsNewWindow = WhatsNewWindow(controller: self.whatsNew)
+        self.runningToolsPreference = runningToolsPreference ?? ShowRunningToolsPreference()
+        self.defaultTabPreference = defaultTabPreference ?? DefaultTabPreference()
 
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         // An `NSStatusItem`'s visibility is *persisted*, and the app must never
@@ -145,7 +167,9 @@ final class MenuBarShell {
                 preference: self.preference, countsPreference: self.countsPreference,
                 updater: self.updater,
                 groupController: self.groupController, removeController: self.removeController,
-                onWhatsNew: { [weak self] in self?.openWhatsNew() }))
+                onWhatsNew: { [weak self] in self?.openWhatsNew() },
+                onSettings: { [weak self] in self?.openSettings() },
+                initialTab: Self.initialTab(from: self.defaultTabPreference)))
         // Without this the popover takes a default size and the panel is clipped.
         //
         // This is the specific thing `MenuBarExtra` did for free. `FleetView`
@@ -444,6 +468,27 @@ final class MenuBarShell {
     }
     @objc private func quickQuit() { NSApplication.shared.terminate(nil) }
 
+    /// The gear button's action (`⌘,`, every tab header). Closes the popover
+    /// first — the same reasoning `openWhatsNew()` already follows — since a
+    /// transient popover would otherwise dismiss itself the instant the
+    /// Settings window steals key focus.
+    func openSettings() {
+        closePanel()
+        settingsWindow.show()
+    }
+
+    /// `DefaultTabPreference` stores a plain string (see that type's own
+    /// doc-comment on why it cannot hold `PanelTab` directly); this is the
+    /// one place that turns it back into the real enum, at the one call site
+    /// that constructs the live panel.
+    private static func initialTab(from preference: DefaultTabPreference) -> PanelTab {
+        switch preference.tab {
+        case "sessions": return .sessions
+        case "tools": return .tools
+        default: return .accounts
+        }
+    }
+
     func openPanel() {
         guard let button = statusItem.button else { return }
         // macOS owns the login-item bit and the operator can revoke it in System
@@ -497,6 +542,8 @@ struct FleetPanel: View {
     @ObservedObject var groupController: GroupController
     @ObservedObject var removeController: RemoveAccountController
     var onWhatsNew: () -> Void = {}
+    var onSettings: () -> Void = {}
+    var initialTab: PanelTab = .accounts
 
     var body: some View {
         VStack(spacing: 0) {
@@ -511,7 +558,9 @@ struct FleetPanel: View {
                 groupController: groupController,
                 removeController: removeController,
                 startServerAtLaunch: $preference.startServerAtLaunch,
-                onWhatsNew: onWhatsNew
+                onWhatsNew: onWhatsNew,
+                onSettings: onSettings,
+                initialTab: initialTab
             )
             // Kept OUTSIDE `FleetView` rather than folded into its own
             // preferences footer: this feature's bridge (F5,

--- a/apps/macos/Sources/TcrBar/RenderSettings.swift
+++ b/apps/macos/Sources/TcrBar/RenderSettings.swift
@@ -1,0 +1,165 @@
+import AppKit
+import SwiftUI
+import TcrBarCore
+
+/// Rasterise the Settings window, one PNG per pane, in-process, then exit.
+///
+/// Same reasoning as ``RenderStates``: `ImageRenderer` needs no Screen
+/// Recording permission and draws the real view with the real tokens, and
+/// this window's genuine failure mode (S1, `docs/design/panel-tabs-review.md`)
+/// was exactly a fact only a render could show — a sidebar selection that drew
+/// every section from every pane underneath it regardless of which was
+/// "selected". `swift test` cannot see that; a screenshot of each pane can.
+///
+/// ## Usage
+///
+///     TcrBar.app/Contents/MacOS/TcrBar --render-settings /tmp/tcrbar-settings
+///
+/// Writes one PNG per pane per appearance and exits without ever showing a
+/// menu-bar item, polling `tcr`, or touching a server.
+enum RenderSettings {
+    static let flag = "--render-settings"
+
+    static func requestedDirectory(_ arguments: [String] = CommandLine.arguments) -> URL? {
+        guard let i = arguments.firstIndex(of: flag), i + 1 < arguments.count else { return nil }
+        return URL(fileURLWithPath: arguments[i + 1])
+    }
+
+    enum Appearance: String, CaseIterable {
+        case dark, light
+        var nsAppearance: NSAppearance? {
+            NSAppearance(named: self == .dark ? .darkAqua : .aqua)
+        }
+    }
+
+    @MainActor
+    static func run(into directory: URL) -> Never {
+        do {
+            try FileManager.default.createDirectory(
+                at: directory, withIntermediateDirectories: true)
+        } catch {
+            FileHandle.standardError.write(
+                Data("cannot create \(directory.path): \(error)\n".utf8))
+            exit(1)
+        }
+
+        var written = 0
+        var attempted = 0
+        for tab in SettingsTab.allCases {
+            for appearance in Appearance.allCases {
+                attempted += 1
+                if render(tab, appearance: appearance, into: directory) { written += 1 }
+            }
+        }
+
+        print("\nrendered \(written)/\(attempted) images into \(directory.path)")
+        exit(written == attempted ? 0 : 1)
+    }
+
+    /// Two groups — one parked, one not — so the Groups & Rotation pane shows
+    /// both a real member count and a real parked toggle state, the same way
+    /// `RenderStates`'s own fixtures avoid an all-healthy fleet that cannot
+    /// distinguish "wired correctly" from "never wired at all".
+    private static func fixtureAccounts() -> [Account] {
+        [
+            fixtureAccount("alice@example.com", groups: ["dev"], groupColors: ["dev": "#0a84ff"]),
+            fixtureAccount("bob@example.com", groups: ["dev"], groupColors: ["dev": "#0a84ff"]),
+            fixtureAccount(
+                "carol@example.com", groups: ["henry-team"], parkedGroups: ["henry-team"],
+                groupColors: ["henry-team": "#32d74b"]),
+        ]
+    }
+
+    @MainActor
+    private static func render(
+        _ tab: SettingsTab, appearance: Appearance, into directory: URL
+    ) -> Bool {
+        let previous = NSAppearance.current
+        NSAppearance.current = appearance.nsAppearance
+        defer { NSAppearance.current = previous }
+
+        SettingsNavigation.shared.selectedTab = tab
+
+        let fleet = Fleet(accounts: fixtureAccounts())
+        let dependencies = SettingsDependencies(
+            poller: StatusPoller(pinnedState: .loaded(fleet), lastPollAt: Date()),
+            server: ServerController(),
+            loginItem: LoginItem(),
+            awake: AwakeController.harness(),
+            preference: LaunchPreference(),
+            countsPreference: MenuBarCountsPreference(),
+            runningToolsPreference: ShowRunningToolsPreference(),
+            defaultTabPreference: DefaultTabPreference(),
+            groupController: GroupController(),
+            updater: Updater(startingUpdater: false),
+            onWhatsNew: {})
+
+        let view =
+            SettingsRootView(dependencies: dependencies)
+            .environment(\.colorScheme, appearance == .dark ? .dark : .light)
+            .frame(width: 660, height: 540)
+
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = 2
+        renderer.proposedSize = ProposedViewSize(width: 660, height: 540)
+
+        let name = "\(tab.rawValue)-\(appearance.rawValue).png"
+        guard let image = renderer.nsImage,
+            let tiff = image.tiffRepresentation,
+            let rep = NSBitmapImageRep(data: tiff),
+            let png = rep.representation(using: .png, properties: [:])
+        else {
+            FileHandle.standardError.write(Data("render failed: \(name)\n".utf8))
+            return false
+        }
+
+        let url = directory.appendingPathComponent(name)
+        do {
+            try png.write(to: url)
+            print("  \(name)  \(Int(image.size.width))x\(Int(image.size.height))pt")
+            return true
+        } catch {
+            FileHandle.standardError.write(Data("write failed \(name): \(error)\n".utf8))
+            return false
+        }
+    }
+}
+
+/// Hand-built account with the fields this harness's fixtures touch — same
+/// shape as `GroupSummaryTests`'s own `summaryAccount` fixture.
+private func fixtureAccount(
+    _ name: String,
+    groups: [String]?,
+    reservedGroups: [String]? = nil,
+    parkedGroups: [String]? = nil,
+    groupColors: [String: String]? = nil
+) -> Account {
+    Account(
+        name: name,
+        priority: 1,
+        status: "active",
+        disabled: false,
+        quota: 0.2,
+        quotaState: .ok,
+        fiveHour: 0.2,
+        sevenDay: 0.2,
+        sevenDayOi: nil,
+        held: [],
+        requests: 10,
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheReadTokens: 200,
+        cacheHitRatio: 0.9,
+        probeStatus: .ok,
+        probeError: nil,
+        lastStreamError: nil,
+        streamErrorCount: 0,
+        source: .live,
+        serverSha: "abc1234",
+        serverDirty: false,
+        groups: groups,
+        reservedGroups: reservedGroups,
+        parkedGroups: parkedGroups,
+        groupColors: groupColors
+    )
+}

--- a/apps/macos/Sources/TcrBar/RenderSettings.swift
+++ b/apps/macos/Sources/TcrBar/RenderSettings.swift
@@ -4,26 +4,44 @@ import TcrBarCore
 
 /// Rasterise the Settings window, one PNG per pane, in-process, then exit.
 ///
-/// Same reasoning as ``RenderStates``: `ImageRenderer` needs no Screen
-/// Recording permission and draws the real view with the real tokens, and
-/// this window's genuine failure mode (S1, `docs/design/panel-tabs-review.md`)
-/// was exactly a fact only a render could show — a sidebar selection that drew
-/// every section from every pane underneath it regardless of which was
-/// "selected". `swift test` cannot see that; a screenshot of each pane can.
+/// ## Two rendering approaches tried and rejected before this one
 ///
-/// **Captures the DETAIL pane content directly, not `SettingsRootView`.**
-/// Measured, not assumed: the first version of this harness rendered the
-/// whole `NavigationSplitView` (sidebar, toolbar, detail) and every pane past
-/// the first came back as AppKit's generic "cannot display this content"
-/// glyph — a yellow circle-slash, not a rendering failure with an error on
-/// stderr, so `written == attempted` reported a false 8/8. `NavigationSplitView`
-/// plus a `.toolbar` needs a real `NSWindow`/`NSToolbar` host, which
-/// `ImageRenderer` does not provide (`RenderStates`'s own views never use
-/// either, which is why that harness never hit this). The sidebar and
-/// toolbar chrome is therefore **not verified by this harness** — same
-/// admitted gap `RenderStates` already carries for AppKit controls
-/// (`--render-states`'s own header: "a `.checkbox` toggle … `ImageRenderer`
-/// does not draw those at all") — and needs the real running window.
+/// **`ImageRenderer` on the whole `NavigationSplitView`** (attempt 1):
+/// every pane past the first came back as AppKit's generic "cannot display
+/// this content" glyph — a yellow circle-slash, not a rendering failure with
+/// an error on stderr, so `written == attempted` reported a false 8/8.
+/// `NavigationSplitView` plus a `.toolbar` needs a real `NSWindow`/`NSToolbar`
+/// host, which `ImageRenderer` never provides.
+///
+/// **`ImageRenderer` on each pane's bare `Form`, no split view** (attempt 2):
+/// fixed the placeholder, but produced a pixel-uniform blank/white PNG —
+/// `Form(.grouped)` is `NSTableView`-backed, and `ImageRenderer`'s headless
+/// layout pass never walks a table view's real `draw(_:)` path either
+/// (`FleetView`'s own plain `ScrollView`+`VStack` DOES rasterise fine via
+/// `ImageRenderer` — `RenderStates` already proves it — so this is specific
+/// to table/list-backed SwiftUI, not scroll content generally). A follow-up
+/// fix hosted the bare pane in an OFF-SCREEN `NSWindow` and captured with
+/// `NSView.cacheDisplay(in:to:)`: the pane's own text and `Tok`-drawn badges
+/// rendered, but the window never got real AppKit compositing (off-screen,
+/// never key, never main) — dark captures showed dark-tinted TEXT on a
+/// LIGHT background, which is not merely "wrong chrome colour", it is text
+/// that is barely legible against its own background. Read, not assumed: a
+/// second reviewer caught this by reading `groupsRotation-dark.png` and
+/// finding badges and toggle knobs floating on blank white with no row
+/// labels, no section cards and no sidebar at all.
+///
+/// **This version: the REAL `SettingsRootView` (sidebar, toolbar, detail —
+/// everything `SettingsWindowController` shows) in a real window, positioned
+/// ON a connected screen and given one real display cycle before capture.**
+/// The window is `.orderFrontRegardless()`ed rather than skipped, because
+/// that ordering — plus a real screen origin — is what makes AppKit's
+/// vibrancy/table-view backing stores actually get created; an off-screen
+/// origin was tried first and left the same blank/mistinted result attempt
+/// 2 already describes. `NSApp.setActivationPolicy` is never touched and no
+/// status item or server is ever created (this whole harness runs before
+/// `AppDelegate` exists — see `TcrBarEntry.main()`), so this never registers
+/// as the running menu-bar app or starts a proxy; the window is closed again
+/// immediately after each capture.
 ///
 /// ## Usage
 ///
@@ -70,22 +88,6 @@ enum RenderSettings {
         exit(written == attempted ? 0 : 1)
     }
 
-    /// The same switch `SettingsDetailView` (`SettingsView.swift`) makes,
-    /// reproduced here rather than reused: that type is `private` to its own
-    /// file and wraps its result in `.navigationTitle`, which is meaningless
-    /// (and untestable) outside a real `NavigationSplitView` host.
-    @ViewBuilder
-    private static func paneView(
-        for tab: SettingsTab, dependencies: SettingsDependencies
-    ) -> some View {
-        switch tab {
-        case .general: GeneralSettingsPane(dependencies: dependencies)
-        case .menuBar: MenuBarSettingsPane(dependencies: dependencies)
-        case .groupsRotation: GroupsRotationSettingsPane(dependencies: dependencies)
-        case .updates: UpdatesSettingsPane(dependencies: dependencies)
-        }
-    }
-
     /// Two groups — one parked, one not — so the Groups & Rotation pane shows
     /// both a real member count and a real parked toggle state, the same way
     /// `RenderStates`'s own fixtures avoid an all-healthy fleet that cannot
@@ -100,30 +102,18 @@ enum RenderSettings {
         ]
     }
 
+    /// 660×581 — the window's own real minimum, per `SettingsWindowController`
+    /// and the design review's own "Applied" note
+    /// (`docs/design/panel-tabs-review.md`: "window 660×581 with a 200px
+    /// sidebar").
+    private static let windowSize = NSSize(width: 660, height: 581)
+
     @MainActor
     private static func render(
         _ tab: SettingsTab, appearance: Appearance, into directory: URL
     ) -> Bool {
         let previous = NSAppearance.current
         NSAppearance.current = appearance.nsAppearance
-        // `NSAppearance.current` alone resolves `Tok`'s own dynamic
-        // `NSColor` closures (measured: tag text and borders came out
-        // correctly tinted for dark even before this line existed) but NOT
-        // `Form(.grouped)`'s native system materials — those follow
-        // `NSApplication.appearance`, which stayed at the system's real
-        // appearance regardless, so the first attempt at this fix rendered
-        // dark-appropriate text on a light-appearance background. Both must
-        // be set for one coherent capture.
-        // **Measured, and only partially effective**: with both lines set,
-        // `Tok`'s own dynamic colours (every tag, every hint) correctly
-        // switch per appearance, but `Form(.grouped)`'s native system
-        // material (the light/dark grouped-row background) does not — this
-        // off-screen, never-activated, never-key window does not walk the
-        // same effective-appearance path a real on-screen window does. The
-        // dark PNGs from this harness are therefore accurate for every
-        // `Tok`-drawn element and NOT proof of the native chrome's dark
-        // appearance; that needs the real running window
-        // (`SettingsWindowController`, opened by hand).
         let previousAppAppearance = NSApp.appearance
         NSApp.appearance = appearance.nsAppearance
         defer {
@@ -145,55 +135,71 @@ enum RenderSettings {
             updater: Updater(startingUpdater: false),
             onWhatsNew: {})
 
-        // The detail pane's own content, at the window's real inner width —
-        // 660 total minus the fixed 200pt sidebar (`SettingsView.swift`'s own
-        // `.frame(width: 200)`).
-        //
-        // **`ImageRenderer` alone renders this blank.** Measured across three
-        // attempts (`.fixedSize()`, a bare `.frame`, `.frame` plus a matching
-        // `proposedSize`): all three produced a pixel-uniform white PNG, byte-
-        // identical across every pane and both appearances. `Form(.grouped)`
-        // is `NSTableView`-backed on macOS, and `ImageRenderer` runs its
-        // layout headless, off any real window — `FleetView`'s own plain
-        // `ScrollView`+`VStack` rasterises fine that way (`RenderStates`
-        // already proves it), but a table view's rows are drawn through
-        // AppKit's real display path, which a window-less render never
-        // triggers. So this hosts the view in a real (off-screen, non-key,
-        // never-shown-to-the-operator) `NSWindow` and captures it with
-        // `NSView.cacheDisplay(in:to:)` — the same mechanism screen-capture
-        // tools use, and the one path that actually walks the table view's
-        // `draw(_:)` — instead of `ImageRenderer`.
-        let hostedView = paneView(for: tab, dependencies: dependencies)
+        // A fresh navigation object per capture, not `.shared` — so setting
+        // `selectedTab` here can never race or persist against a later call
+        // in this same process.
+        let navigation = SettingsNavigation()
+        navigation.selectedTab = tab
+
+        // The REAL root view — sidebar, toolbar, detail, exactly what
+        // `SettingsWindowController` shows — not a bare pane. See this
+        // type's own doc-comment for the two rejected approaches that only
+        // captured the detail content.
+        let rootView = SettingsRootView(dependencies: dependencies, navigation: navigation)
             .environment(\.colorScheme, appearance == .dark ? .dark : .light)
-            .frame(width: 460, height: 540)
 
-        let hosting = NSHostingView(rootView: hostedView)
-        hosting.frame = NSRect(x: 0, y: 0, width: 460, height: 540)
-
+        let hostingController = NSHostingController(rootView: rootView)
         let window = NSWindow(
-            contentRect: hosting.frame, styleMask: [.borderless], backing: .buffered,
+            contentRect: NSRect(origin: .zero, size: windowSize),
+            styleMask: [.titled, .closable, .resizable, .miniaturizable, .fullSizeContentView],
+            backing: .buffered,
             defer: false)
-        // Off-screen — this process never shows the operator a window, the
-        // same guarantee `RenderStates` gives for its own harness.
-        window.setFrameOrigin(NSPoint(x: -10000, y: -10000))
         window.appearance = appearance.nsAppearance
-        window.contentView = hosting
+        window.contentViewController = hostingController
+        window.setFrame(NSRect(origin: .zero, size: windowSize), display: true)
+        // A normal on-screen position — centred, the way a real window would
+        // open — not the screen's literal (0,0) origin. `NSWindow.center()`
+        // measured, not assumed: an earlier attempt set the origin to the
+        // screen's own `minX`/`minY` (AppKit's bottom-LEFT origin), which put
+        // the window's bottom edge at the very bottom of the display, mostly
+        // hidden behind the Dock — the captured PNG showed only a drop-shadow
+        // gradient in two corners, nothing else. `orderFrontRegardless()`
+        // rather than `makeKeyAndOrderFront` and `NSApp.activate` never
+        // called — this must never take key focus or activate the app
+        // (`NSApp.setActivationPolicy` is never touched anywhere in this
+        // file, so it stays `.accessory` throughout).
+        window.center()
         window.orderFrontRegardless()
-        hosting.layoutSubtreeIfNeeded()
-        // One run-loop turn so AppKit actually lays out and backs the table
-        // view before the capture — `layoutSubtreeIfNeeded()` alone left the
-        // same blank result in an earlier attempt at this same fix.
-        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        window.layoutIfNeeded()
+        window.contentView?.layoutSubtreeIfNeeded()
+        // Several run-loop turns so the window server actually composites a
+        // frame before capture.
+        for _ in 0..<5 {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
 
         let name = "\(tab.rawValue)-\(appearance.rawValue).png"
-        guard let rep = hosting.bitmapImageRepForCachingDisplay(in: hosting.bounds)
+        // `NSView.cacheDisplay`/`ImageRenderer` both draw OFFSCREEN, bypassing
+        // the window server entirely — measured across every attempt in this
+        // file's own doc-comment, neither one reliably reproduces what
+        // `Form(.grouped)`'s native table/vibrancy backing actually composites.
+        // `CGWindowListCreateImage` instead asks the WINDOW SERVER for the
+        // pixels it already composited for this exact window — the same
+        // mechanism `screencapture -l <windowNumber>` uses. Capturing a
+        // window this PROCESS OWNS needs no Screen Recording permission
+        // (that gate is for capturing another process's windows); only this
+        // process's own window is ever named here.
+        guard
+            let cgImage = CGWindowListCreateImage(
+                .null, .optionIncludingWindow, CGWindowID(window.windowNumber),
+                [.boundsIgnoreFraming, .bestResolution])
         else {
             window.close()
             FileHandle.standardError.write(Data("render failed: \(name)\n".utf8))
             return false
         }
-        hosting.cacheDisplay(in: hosting.bounds, to: rep)
         window.close()
+        let rep = NSBitmapImageRep(cgImage: cgImage)
         guard let png = rep.representation(using: .png, properties: [:]) else {
             FileHandle.standardError.write(Data("render failed: \(name)\n".utf8))
             return false
@@ -202,7 +208,7 @@ enum RenderSettings {
         let url = directory.appendingPathComponent(name)
         do {
             try png.write(to: url)
-            print("  \(name)  \(Int(hosting.bounds.width))x\(Int(hosting.bounds.height))pt")
+            print("  \(name)  \(cgImage.width)x\(cgImage.height)px")
             return true
         } catch {
             FileHandle.standardError.write(Data("write failed \(name): \(error)\n".utf8))

--- a/apps/macos/Sources/TcrBar/RenderSettings.swift
+++ b/apps/macos/Sources/TcrBar/RenderSettings.swift
@@ -11,6 +11,20 @@ import TcrBarCore
 /// every section from every pane underneath it regardless of which was
 /// "selected". `swift test` cannot see that; a screenshot of each pane can.
 ///
+/// **Captures the DETAIL pane content directly, not `SettingsRootView`.**
+/// Measured, not assumed: the first version of this harness rendered the
+/// whole `NavigationSplitView` (sidebar, toolbar, detail) and every pane past
+/// the first came back as AppKit's generic "cannot display this content"
+/// glyph — a yellow circle-slash, not a rendering failure with an error on
+/// stderr, so `written == attempted` reported a false 8/8. `NavigationSplitView`
+/// plus a `.toolbar` needs a real `NSWindow`/`NSToolbar` host, which
+/// `ImageRenderer` does not provide (`RenderStates`'s own views never use
+/// either, which is why that harness never hit this). The sidebar and
+/// toolbar chrome is therefore **not verified by this harness** — same
+/// admitted gap `RenderStates` already carries for AppKit controls
+/// (`--render-states`'s own header: "a `.checkbox` toggle … `ImageRenderer`
+/// does not draw those at all") — and needs the real running window.
+///
 /// ## Usage
 ///
 ///     TcrBar.app/Contents/MacOS/TcrBar --render-settings /tmp/tcrbar-settings
@@ -56,6 +70,22 @@ enum RenderSettings {
         exit(written == attempted ? 0 : 1)
     }
 
+    /// The same switch `SettingsDetailView` (`SettingsView.swift`) makes,
+    /// reproduced here rather than reused: that type is `private` to its own
+    /// file and wraps its result in `.navigationTitle`, which is meaningless
+    /// (and untestable) outside a real `NavigationSplitView` host.
+    @ViewBuilder
+    private static func paneView(
+        for tab: SettingsTab, dependencies: SettingsDependencies
+    ) -> some View {
+        switch tab {
+        case .general: GeneralSettingsPane(dependencies: dependencies)
+        case .menuBar: MenuBarSettingsPane(dependencies: dependencies)
+        case .groupsRotation: GroupsRotationSettingsPane(dependencies: dependencies)
+        case .updates: UpdatesSettingsPane(dependencies: dependencies)
+        }
+    }
+
     /// Two groups — one parked, one not — so the Groups & Rotation pane shows
     /// both a real member count and a real parked toggle state, the same way
     /// `RenderStates`'s own fixtures avoid an all-healthy fleet that cannot
@@ -76,9 +106,30 @@ enum RenderSettings {
     ) -> Bool {
         let previous = NSAppearance.current
         NSAppearance.current = appearance.nsAppearance
-        defer { NSAppearance.current = previous }
-
-        SettingsNavigation.shared.selectedTab = tab
+        // `NSAppearance.current` alone resolves `Tok`'s own dynamic
+        // `NSColor` closures (measured: tag text and borders came out
+        // correctly tinted for dark even before this line existed) but NOT
+        // `Form(.grouped)`'s native system materials — those follow
+        // `NSApplication.appearance`, which stayed at the system's real
+        // appearance regardless, so the first attempt at this fix rendered
+        // dark-appropriate text on a light-appearance background. Both must
+        // be set for one coherent capture.
+        // **Measured, and only partially effective**: with both lines set,
+        // `Tok`'s own dynamic colours (every tag, every hint) correctly
+        // switch per appearance, but `Form(.grouped)`'s native system
+        // material (the light/dark grouped-row background) does not — this
+        // off-screen, never-activated, never-key window does not walk the
+        // same effective-appearance path a real on-screen window does. The
+        // dark PNGs from this harness are therefore accurate for every
+        // `Tok`-drawn element and NOT proof of the native chrome's dark
+        // appearance; that needs the real running window
+        // (`SettingsWindowController`, opened by hand).
+        let previousAppAppearance = NSApp.appearance
+        NSApp.appearance = appearance.nsAppearance
+        defer {
+            NSAppearance.current = previous
+            NSApp.appearance = previousAppAppearance
+        }
 
         let fleet = Fleet(accounts: fixtureAccounts())
         let dependencies = SettingsDependencies(
@@ -94,21 +145,56 @@ enum RenderSettings {
             updater: Updater(startingUpdater: false),
             onWhatsNew: {})
 
-        let view =
-            SettingsRootView(dependencies: dependencies)
+        // The detail pane's own content, at the window's real inner width —
+        // 660 total minus the fixed 200pt sidebar (`SettingsView.swift`'s own
+        // `.frame(width: 200)`).
+        //
+        // **`ImageRenderer` alone renders this blank.** Measured across three
+        // attempts (`.fixedSize()`, a bare `.frame`, `.frame` plus a matching
+        // `proposedSize`): all three produced a pixel-uniform white PNG, byte-
+        // identical across every pane and both appearances. `Form(.grouped)`
+        // is `NSTableView`-backed on macOS, and `ImageRenderer` runs its
+        // layout headless, off any real window — `FleetView`'s own plain
+        // `ScrollView`+`VStack` rasterises fine that way (`RenderStates`
+        // already proves it), but a table view's rows are drawn through
+        // AppKit's real display path, which a window-less render never
+        // triggers. So this hosts the view in a real (off-screen, non-key,
+        // never-shown-to-the-operator) `NSWindow` and captures it with
+        // `NSView.cacheDisplay(in:to:)` — the same mechanism screen-capture
+        // tools use, and the one path that actually walks the table view's
+        // `draw(_:)` — instead of `ImageRenderer`.
+        let hostedView = paneView(for: tab, dependencies: dependencies)
             .environment(\.colorScheme, appearance == .dark ? .dark : .light)
-            .frame(width: 660, height: 540)
+            .frame(width: 460, height: 540)
 
-        let renderer = ImageRenderer(content: view)
-        renderer.scale = 2
-        renderer.proposedSize = ProposedViewSize(width: 660, height: 540)
+        let hosting = NSHostingView(rootView: hostedView)
+        hosting.frame = NSRect(x: 0, y: 0, width: 460, height: 540)
+
+        let window = NSWindow(
+            contentRect: hosting.frame, styleMask: [.borderless], backing: .buffered,
+            defer: false)
+        // Off-screen — this process never shows the operator a window, the
+        // same guarantee `RenderStates` gives for its own harness.
+        window.setFrameOrigin(NSPoint(x: -10000, y: -10000))
+        window.appearance = appearance.nsAppearance
+        window.contentView = hosting
+        window.orderFrontRegardless()
+        hosting.layoutSubtreeIfNeeded()
+        // One run-loop turn so AppKit actually lays out and backs the table
+        // view before the capture — `layoutSubtreeIfNeeded()` alone left the
+        // same blank result in an earlier attempt at this same fix.
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
 
         let name = "\(tab.rawValue)-\(appearance.rawValue).png"
-        guard let image = renderer.nsImage,
-            let tiff = image.tiffRepresentation,
-            let rep = NSBitmapImageRep(data: tiff),
-            let png = rep.representation(using: .png, properties: [:])
+        guard let rep = hosting.bitmapImageRepForCachingDisplay(in: hosting.bounds)
         else {
+            window.close()
+            FileHandle.standardError.write(Data("render failed: \(name)\n".utf8))
+            return false
+        }
+        hosting.cacheDisplay(in: hosting.bounds, to: rep)
+        window.close()
+        guard let png = rep.representation(using: .png, properties: [:]) else {
             FileHandle.standardError.write(Data("render failed: \(name)\n".utf8))
             return false
         }
@@ -116,7 +202,7 @@ enum RenderSettings {
         let url = directory.appendingPathComponent(name)
         do {
             try png.write(to: url)
-            print("  \(name)  \(Int(image.size.width))x\(Int(image.size.height))pt")
+            print("  \(name)  \(Int(hosting.bounds.width))x\(Int(hosting.bounds.height))pt")
             return true
         } catch {
             FileHandle.standardError.write(Data("write failed \(name): \(error)\n".utf8))

--- a/apps/macos/Sources/TcrBar/SettingsPanes.swift
+++ b/apps/macos/Sources/TcrBar/SettingsPanes.swift
@@ -1,0 +1,523 @@
+import AppKit
+import SwiftUI
+import TcrBarCore
+
+/// One badge — `applied live` / `restart to apply` / `read-only`
+/// (``SettingsRowTiming``) — drawn beside a section header or a row that
+/// disagrees with its section, matching the mockup's `.tag.live` / `.tag.boot`
+/// (`docs/design/panel-tabs-mockup.html`).
+private struct SettingsTag: View {
+    let timing: SettingsRowTiming
+
+    private var tint: Color {
+        switch timing {
+        case .live: return Tok.ok
+        case .boot: return Tok.near
+        case .readOnly: return Tok.inkFaint
+        }
+    }
+
+    var body: some View {
+        Text(timing.label)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(tint)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .overlay(
+                RoundedRectangle(cornerRadius: 6).strokeBorder(Tok.line(tint), lineWidth: 1)
+            )
+    }
+}
+
+/// A `Section` header carrying its badge — every section in this window uses
+/// this rather than a bare `Text`, so a section can never be added without
+/// also saying when its rows apply (S3, `docs/design/panel-tabs-review.md`).
+private struct SectionHeader: View {
+    let title: String
+    let timing: SettingsRowTiming
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(title)
+            SettingsTag(timing: timing)
+        }
+    }
+}
+
+/// A row whose timing DIFFERS from its section's own badge — drawn beside the
+/// row's label rather than repeating the section header's tag, the same
+/// pattern the mockup's `.rowtag` uses for "Start the server at launch".
+private struct RowTag: View {
+    let timing: SettingsRowTiming
+    var body: some View { SettingsTag(timing: timing) }
+}
+
+/// Every read-only row's hint (bridge, § Panes): "a key with no write path
+/// today gets a read-only row and a hint", never a hand-rolled rewrite of the
+/// live config, which holds real credentials (`CLAUDE.md`).
+private let readOnlyHint = "Edit in ~/.config/teamclaude.json"
+
+extension View {
+    /// `.contentMargins(.top, _, for: .scrollContent)` is macOS 14+; this
+    /// package's floor is macOS 13 (`Package.swift`). Same availability-guard
+    /// shape `macos-settings-ui`'s own reference uses for
+    /// `scrollEdgeEffectStyle`.
+    @ViewBuilder
+    fileprivate func formContentTopMarginIfAvailable(_ value: CGFloat) -> some View {
+        if #available(macOS 14.0, *) {
+            self.contentMargins(.top, value, for: .scrollContent)
+        } else {
+            self
+        }
+    }
+}
+
+// MARK: - General
+
+struct GeneralSettingsPane: View {
+    let dependencies: SettingsDependencies
+
+    @ObservedObject private var server: ServerController
+    @ObservedObject private var preference: LaunchPreference
+    @ObservedObject private var loginItem: LoginItem
+    @ObservedObject private var awake: AwakeController
+    @ObservedObject private var poller: StatusPoller
+
+    init(dependencies: SettingsDependencies) {
+        self.dependencies = dependencies
+        self.server = dependencies.server
+        self.preference = dependencies.preference
+        self.loginItem = dependencies.loginItem
+        self.awake = dependencies.awake
+        self.poller = dependencies.poller
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                LabeledContent("Proxy") {
+                    HStack(spacing: 8) {
+                        Text(server.state.summary)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                        Spacer(minLength: 8)
+                        Button("Restart…") { confirmRestart() }
+                            .controlSize(.small)
+                    }
+                }
+                LabeledContent {
+                    HStack(spacing: 6) {
+                        Toggle("", isOn: $preference.startServerAtLaunch)
+                            .labelsHidden()
+                        RowTag(timing: SettingsRowBadge.timing(for: SettingsRowBadge.startServerAtLaunch) ?? .boot)
+                    }
+                } label: {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Start the server at launch")
+                        Text("TcrBar supervises a server it starts itself.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                LabeledContent("Read the server every") {
+                    Text("\(Int(poller.interval)) s").foregroundStyle(.secondary)
+                }
+            } header: {
+                SectionHeader(
+                    title: "Server",
+                    timing: SettingsRowBadge.timing(for: SettingsRowBadge.proxyRestart) ?? .live)
+            }
+
+            Section {
+                Toggle(
+                    "Launch TcrBar at login",
+                    isOn: Binding(
+                        get: { loginItem.status.isOn },
+                        set: { loginItem.set(enabled: $0) })
+                )
+                .toggleStyle(.switch)
+                Toggle(
+                    isOn: Binding(get: { awake.isOn }, set: { awake.setOn($0) })
+                ) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Keep this Mac awake")
+                        Text("While any session is busy.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                .toggleStyle(.switch)
+            } header: {
+                SectionHeader(
+                    title: "This Mac",
+                    timing: SettingsRowBadge.timing(for: SettingsRowBadge.launchAtLogin) ?? .live)
+            }
+
+            Section {
+                HStack {
+                    Text(
+                        "Quitting stops the proxy this app supervises, so every live "
+                            + "session loses its prompt cache."
+                    )
+                    .font(.caption).foregroundStyle(.secondary)
+                    Spacer()
+                    Button("Quit TcrBar…") { confirmQuit() }
+                        .controlSize(.small)
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .scrollContentBackground(.hidden)
+        .formContentTopMarginIfAvailable(8)
+        .onAppear { loginItem.refresh() }
+    }
+
+    /// Same cost statement `CLAUDE.md` gives, and the same confirm-before-act
+    /// shape `FleetView.confirmTakeover()` already uses for its own
+    /// most-expensive action.
+    private func confirmRestart() {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Restart the proxy?"
+        alert.informativeText = """
+            Every live session loses its prompt cache. Anthropic's cache is \
+            per-account, so a session that comes back on a different account pays \
+            a full cold prefix — the most expensive event in this system \
+            (CLAUDE.md). Session-affinity pins under 15 minutes old are restored.
+            """
+        let restart = alert.addButton(withTitle: "Restart")
+        restart.hasDestructiveAction = true
+        alert.addButton(withTitle: "Cancel")
+        restart.keyEquivalent = ""
+        alert.buttons.last?.keyEquivalent = "\r"
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        server.stop()
+        server.start()
+    }
+
+    private func confirmQuit() {
+        let alert = NSAlert()
+        alert.alertStyle = .critical
+        alert.messageText = "Quit TcrBar?"
+        alert.informativeText =
+            "This stops the proxy TcrBar supervises. Every live session loses its "
+            + "prompt cache."
+        let quit = alert.addButton(withTitle: "Quit")
+        quit.hasDestructiveAction = true
+        alert.addButton(withTitle: "Cancel")
+        quit.keyEquivalent = ""
+        alert.buttons.last?.keyEquivalent = "\r"
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        NSApplication.shared.terminate(nil)
+    }
+}
+
+// MARK: - Menu Bar
+
+struct MenuBarSettingsPane: View {
+    let dependencies: SettingsDependencies
+
+    @ObservedObject private var countsPreference: MenuBarCountsPreference
+    @ObservedObject private var runningToolsPreference: ShowRunningToolsPreference
+    @ObservedObject private var defaultTabPreference: DefaultTabPreference
+
+    init(dependencies: SettingsDependencies) {
+        self.dependencies = dependencies
+        self.countsPreference = dependencies.countsPreference
+        self.runningToolsPreference = dependencies.runningToolsPreference
+        self.defaultTabPreference = dependencies.defaultTabPreference
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle(
+                    isOn: $countsPreference.showCounts
+                ) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Show the ready count beside the glyph")
+                        Text("Reads e.g. \u{201c}9/13\u{201d}, in tabular digits.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                .toggleStyle(.switch)
+                Toggle(
+                    isOn: $runningToolsPreference.showRunningToolCount
+                ) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Show the running-tool count")
+                        Text("Adds a second number beside the glyph.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                .toggleStyle(.switch)
+            } header: {
+                SectionHeader(
+                    title: "In the menu bar",
+                    timing: SettingsRowBadge.timing(for: SettingsRowBadge.showReadyCount) ?? .live)
+            }
+
+            Section {
+                Picker("Open on", selection: $defaultTabPreference.tab) {
+                    Text("Accounts").tag("accounts")
+                    Text("Sessions").tag("sessions")
+                    Text("Tools").tag("tools")
+                }
+                .pickerStyle(.menu)
+                LabeledContent("Text size") {
+                    Text("System").foregroundStyle(.secondary)
+                }
+            } header: {
+                SectionHeader(
+                    title: "When the panel opens",
+                    timing: SettingsRowBadge.timing(for: SettingsRowBadge.openOnTab) ?? .live)
+            }
+        }
+        .formStyle(.grouped)
+        .scrollContentBackground(.hidden)
+        .formContentTopMarginIfAvailable(8)
+    }
+}
+
+// MARK: - Groups & Rotation
+
+struct GroupsRotationSettingsPane: View {
+    let dependencies: SettingsDependencies
+
+    @ObservedObject private var poller: StatusPoller
+    @ObservedObject private var groupController: GroupController
+
+    init(dependencies: SettingsDependencies) {
+        self.dependencies = dependencies
+        self.poller = dependencies.poller
+        self.groupController = dependencies.groupController
+    }
+
+    /// Derived from the FULL fleet, not a filtered panel view — S8's own
+    /// fix (`docs/design/panel-tabs-review.md`): every group the fleet has
+    /// is a row here, not only the ones with an expanded card on the panel.
+    private var groups: [GroupSummary] {
+        guard case .loaded(let fleet) = poller.state else { return [] }
+        return GroupSummary.summarize(fleet.accounts)
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                if groups.isEmpty {
+                    Text("No groups yet.").foregroundStyle(.secondary)
+                } else {
+                    ForEach(groups) { group in
+                        groupRow(group)
+                    }
+                }
+            } header: {
+                SectionHeader(
+                    title: "Groups",
+                    timing: SettingsRowBadge.timing(for: SettingsRowBadge.groupParked) ?? .live)
+            }
+
+            Section {
+                readOnlyRow(
+                    "Switch threshold",
+                    "Prefer another account once this share of quota is used.",
+                    key: SettingsRowBadge.switchThreshold)
+                readOnlyRow(
+                    "Control reserve",
+                    "The control account is picked below threshold minus reserve.",
+                    key: SettingsRowBadge.controlReserve)
+                readOnlyRow(
+                    "Fable weekly threshold", "The separate ceiling for the weekly window.",
+                    key: SettingsRowBadge.fableWeeklyThreshold)
+                readOnlyRow(
+                    "Reset urgency tier",
+                    "An account resetting within this long is preferred.",
+                    key: SettingsRowBadge.resetUrgencyTier)
+                readOnlyRow(
+                    "Session affinity",
+                    "Pin a session to one account so its prompt cache survives.",
+                    key: SettingsRowBadge.sessionAffinity)
+                readOnlyRow("Control account", nil, key: SettingsRowBadge.controlAccount)
+                readOnlyRow(
+                    "Pooled control", "Let the control account serve ordinary traffic too.",
+                    key: SettingsRowBadge.controlPooled)
+            } header: {
+                SectionHeader(
+                    title: "Rotation",
+                    timing: SettingsRowBadge.timing(for: SettingsRowBadge.switchThreshold) ?? .boot)
+            }
+
+            Section {
+                readOnlyRow("Per-account throttle", nil, key: SettingsRowBadge.accountThrottle)
+                readOnlyRow("Fleet throttle", nil, key: SettingsRowBadge.fleetThrottle)
+                readOnlyRow(
+                    "Pacing", "Spread requests instead of sending them in bursts.",
+                    key: SettingsRowBadge.pacing)
+                readOnlyRow(
+                    "Keep the usage ledger for", nil, key: SettingsRowBadge.usageRetentionDays)
+                readOnlyRow(
+                    "HTTP/1.1 only upstream", "Off means HTTP/2, the faster default.",
+                    key: SettingsRowBadge.http1Only)
+            } header: {
+                SectionHeader(
+                    title: "Limits",
+                    timing: SettingsRowBadge.timing(for: SettingsRowBadge.accountThrottle) ?? .boot)
+            }
+        }
+        .formStyle(.grouped)
+        .scrollContentBackground(.hidden)
+        .formContentTopMarginIfAvailable(8)
+    }
+
+    @ViewBuilder
+    private func groupRow(_ group: GroupSummary) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(group.name).font(.headline)
+                Spacer()
+                Text("\(group.memberCount) accounts").foregroundStyle(.secondary)
+            }
+            HStack(spacing: 6) {
+                Toggle(
+                    "Parked",
+                    isOn: Binding(
+                        get: { group.isParked },
+                        set: { newValue in
+                            Task { await groupController.setParked(group: group.name, parked: newValue) }
+                        })
+                )
+                .toggleStyle(.switch)
+                RowTag(timing: SettingsRowBadge.timing(for: SettingsRowBadge.groupParked) ?? .live)
+            }
+            .help("Held out of rotation; quota keeps accruing.")
+
+            HStack(spacing: 6) {
+                Toggle("Reserved", isOn: .constant(group.isReserved))
+                    .toggleStyle(.switch)
+                    .disabled(true)
+                RowTag(timing: .readOnly)
+            }
+            .help("Only sessions tagged with this group route here. \(readOnlyHint)")
+
+            HStack(spacing: 6) {
+                Text("Members: \(group.memberCount)")
+                Spacer()
+                if let hex = group.colorHex {
+                    Circle().fill(Color(hex: hex) ?? Tok.inkFaint).frame(width: 14, height: 14)
+                } else {
+                    Circle().strokeBorder(Tok.hairlineStrong).frame(width: 14, height: 14)
+                }
+                RowTag(timing: .readOnly)
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private func readOnlyRow(_ title: String, _ detail: String?, key: String) -> some View {
+        LabeledContent {
+            HStack(spacing: 6) {
+                Text(readOnlyHint).foregroundStyle(.secondary).font(.caption)
+                RowTag(timing: SettingsRowBadge.timing(for: key) ?? .boot)
+            }
+        } label: {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                if let detail {
+                    Text(detail).font(.caption).foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Updates
+
+struct UpdatesSettingsPane: View {
+    let dependencies: SettingsDependencies
+    @ObservedObject private var updater: Updater
+    @ObservedObject private var server: ServerController
+
+    init(dependencies: SettingsDependencies) {
+        self.dependencies = dependencies
+        self.updater = dependencies.updater
+        self.server = dependencies.server
+    }
+
+    private var versionLine: String {
+        AppBuild.label ?? "TcrBar (development build)"
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                LabeledContent(versionLine) {
+                    Button("Check now") { updater.checkForUpdates() }
+                        .disabled(!updater.canCheckForUpdates)
+                        .controlSize(.small)
+                }
+                LabeledContent("What's new in this build") {
+                    Button("Read…") { dependencies.onWhatsNew() }
+                        .controlSize(.small)
+                }
+                readOnlyRow(
+                    "Check automatically", "Controlled by Sparkle's own default.",
+                    key: SettingsRowBadge.checkAutomatically)
+            } header: {
+                SectionHeader(
+                    title: "TcrBar",
+                    timing: SettingsRowBadge.timing(for: SettingsRowBadge.checkNow) ?? .live)
+            }
+
+            Section {
+                LabeledContent("Server on 127.0.0.1:3456") {
+                    Text(server.state.summary).foregroundStyle(.secondary).lineLimit(2)
+                }
+                LabeledContent("Command-line tcr") {
+                    Text(TcrTool.overrideRemedy).font(.caption).foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+                Text(
+                    "Updating replaces both. TcrBar supervises the server, so an update "
+                        + "restarts it and spends the cold prefix. You cannot replace the "
+                        + "app bundle while the proxy is running."
+                )
+                .font(.caption).foregroundStyle(.secondary)
+            } header: {
+                SectionHeader(
+                    title: "The running build",
+                    timing: SettingsRowBadge.timing(for: SettingsRowBadge.runningServer) ?? .readOnly)
+            }
+        }
+        .formStyle(.grouped)
+        .scrollContentBackground(.hidden)
+        .formContentTopMarginIfAvailable(8)
+    }
+
+    @ViewBuilder
+    private func readOnlyRow(_ title: String, _ detail: String, key: String) -> some View {
+        LabeledContent {
+            RowTag(timing: SettingsRowBadge.timing(for: key) ?? .readOnly)
+        } label: {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                Text(detail).font(.caption).foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+extension Color {
+    /// `#rrggbb` → `Color`, tolerant of a leading `#`. `nil` on anything else
+    /// — a malformed wire colour draws the neutral fallback the caller
+    /// already handles, never a guess.
+    init?(hex: String) {
+        var s = Substring(hex)
+        if s.hasPrefix("#") { s = s.dropFirst() }
+        guard s.count == 6, let v = UInt32(s, radix: 16) else { return nil }
+        self.init(
+            red: Double((v >> 16) & 0xff) / 255,
+            green: Double((v >> 8) & 0xff) / 255,
+            blue: Double(v & 0xff) / 255)
+    }
+}

--- a/apps/macos/Sources/TcrBar/SettingsPanes.swift
+++ b/apps/macos/Sources/TcrBar/SettingsPanes.swift
@@ -98,7 +98,7 @@ struct GeneralSettingsPane: View {
                 LabeledContent("Proxy") {
                     HStack(spacing: 8) {
                         Text(server.state.summary)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(Tok.inkDim)
                             .lineLimit(2)
                         Spacer(minLength: 8)
                         Button("Restart…") { confirmRestart() }
@@ -115,11 +115,11 @@ struct GeneralSettingsPane: View {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Start the server at launch")
                         Text("TcrBar supervises a server it starts itself.")
-                            .font(.caption).foregroundStyle(.secondary)
+                            .font(.caption).foregroundStyle(Tok.inkDim)
                     }
                 }
                 LabeledContent("Read the server every") {
-                    Text("\(Int(poller.interval)) s").foregroundStyle(.secondary)
+                    Text("\(Int(poller.interval)) s").foregroundStyle(Tok.inkDim)
                 }
             } header: {
                 SectionHeader(
@@ -141,7 +141,7 @@ struct GeneralSettingsPane: View {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Keep this Mac awake")
                         Text("While any session is busy.")
-                            .font(.caption).foregroundStyle(.secondary)
+                            .font(.caption).foregroundStyle(Tok.inkDim)
                     }
                 }
                 .toggleStyle(.switch)
@@ -157,7 +157,7 @@ struct GeneralSettingsPane: View {
                         "Quitting stops the proxy this app supervises, so every live "
                             + "session loses its prompt cache."
                     )
-                    .font(.caption).foregroundStyle(.secondary)
+                    .font(.caption).foregroundStyle(Tok.inkDim)
                     Spacer()
                     Button("Quit TcrBar…") { confirmQuit() }
                         .controlSize(.small)
@@ -235,7 +235,7 @@ struct MenuBarSettingsPane: View {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Show the ready count beside the glyph")
                         Text("Reads e.g. \u{201c}9/13\u{201d}, in tabular digits.")
-                            .font(.caption).foregroundStyle(.secondary)
+                            .font(.caption).foregroundStyle(Tok.inkDim)
                     }
                 }
                 .toggleStyle(.switch)
@@ -245,7 +245,7 @@ struct MenuBarSettingsPane: View {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Show the running-tool count")
                         Text("Adds a second number beside the glyph.")
-                            .font(.caption).foregroundStyle(.secondary)
+                            .font(.caption).foregroundStyle(Tok.inkDim)
                     }
                 }
                 .toggleStyle(.switch)
@@ -263,7 +263,7 @@ struct MenuBarSettingsPane: View {
                 }
                 .pickerStyle(.menu)
                 LabeledContent("Text size") {
-                    Text("System").foregroundStyle(.secondary)
+                    Text("System").foregroundStyle(Tok.inkDim)
                 }
             } header: {
                 SectionHeader(
@@ -303,7 +303,7 @@ struct GroupsRotationSettingsPane: View {
         Form {
             Section {
                 if groups.isEmpty {
-                    Text("No groups yet.").foregroundStyle(.secondary)
+                    Text("No groups yet.").foregroundStyle(Tok.inkDim)
                 } else {
                     ForEach(groups) { group in
                         groupRow(group)
@@ -373,7 +373,7 @@ struct GroupsRotationSettingsPane: View {
             HStack {
                 Text(group.name).font(.headline)
                 Spacer()
-                Text("\(group.memberCount) accounts").foregroundStyle(.secondary)
+                Text("\(group.memberCount) accounts").foregroundStyle(Tok.inkDim)
             }
             HStack(spacing: 6) {
                 Toggle(
@@ -408,7 +408,7 @@ struct GroupsRotationSettingsPane: View {
                 RowTag(timing: .readOnly)
             }
             .font(.caption)
-            .foregroundStyle(.secondary)
+            .foregroundStyle(Tok.inkDim)
         }
         .padding(.vertical, 4)
     }
@@ -417,14 +417,14 @@ struct GroupsRotationSettingsPane: View {
     private func readOnlyRow(_ title: String, _ detail: String?, key: String) -> some View {
         LabeledContent {
             HStack(spacing: 6) {
-                Text(readOnlyHint).foregroundStyle(.secondary).font(.caption)
+                Text(readOnlyHint).foregroundStyle(Tok.inkDim).font(.caption)
                 RowTag(timing: SettingsRowBadge.timing(for: key) ?? .boot)
             }
         } label: {
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                 if let detail {
-                    Text(detail).font(.caption).foregroundStyle(.secondary)
+                    Text(detail).font(.caption).foregroundStyle(Tok.inkDim)
                 }
             }
         }
@@ -483,10 +483,10 @@ struct UpdatesSettingsPane: View {
 
             Section {
                 LabeledContent("Server on 127.0.0.1:3456") {
-                    Text(server.state.summary).foregroundStyle(.secondary).lineLimit(2)
+                    Text(server.state.summary).foregroundStyle(Tok.inkDim).lineLimit(2)
                 }
                 LabeledContent("Command-line tcr") {
-                    Text(installedCliPath).font(.caption).foregroundStyle(.secondary)
+                    Text(installedCliPath).font(.caption).foregroundStyle(Tok.inkDim)
                         .lineLimit(2)
                 }
                 Text(
@@ -494,7 +494,7 @@ struct UpdatesSettingsPane: View {
                         + "restarts it and spends the cold prefix. You cannot replace the "
                         + "app bundle while the proxy is running."
                 )
-                .font(.caption).foregroundStyle(.secondary)
+                .font(.caption).foregroundStyle(Tok.inkDim)
             } header: {
                 SectionHeader(
                     title: "The running build",
@@ -513,7 +513,7 @@ struct UpdatesSettingsPane: View {
         } label: {
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
-                Text(detail).font(.caption).foregroundStyle(.secondary)
+                Text(detail).font(.caption).foregroundStyle(Tok.inkDim)
             }
         }
     }

--- a/apps/macos/Sources/TcrBar/SettingsPanes.swift
+++ b/apps/macos/Sources/TcrBar/SettingsPanes.swift
@@ -448,6 +448,18 @@ struct UpdatesSettingsPane: View {
         AppBuild.label ?? "TcrBar (development build)"
     }
 
+    /// The resolved `tcr` path this app would shell out to, per the same
+    /// search `TcrTool.resolve()` uses for every poll and command — never a
+    /// guess, and distinct from `TcrTool.overrideRemedy` (that string is the
+    /// FIX for when nothing was found, not a path to display when something
+    /// was).
+    private var installedCliPath: String {
+        switch TcrTool.resolve() {
+        case .success(let url): return url.path
+        case .failure: return "Not found. " + TcrTool.overrideRemedy
+        }
+    }
+
     var body: some View {
         Form {
             Section {
@@ -474,7 +486,7 @@ struct UpdatesSettingsPane: View {
                     Text(server.state.summary).foregroundStyle(.secondary).lineLimit(2)
                 }
                 LabeledContent("Command-line tcr") {
-                    Text(TcrTool.overrideRemedy).font(.caption).foregroundStyle(.secondary)
+                    Text(installedCliPath).font(.caption).foregroundStyle(.secondary)
                         .lineLimit(2)
                 }
                 Text(

--- a/apps/macos/Sources/TcrBar/SettingsView.swift
+++ b/apps/macos/Sources/TcrBar/SettingsView.swift
@@ -1,0 +1,171 @@
+import SwiftUI
+import TcrBarCore
+
+/// The four panes (`data/plans/settings-window-bridge.md` § Panes).
+enum SettingsTab: String, CaseIterable, Identifiable {
+    case general
+    case menuBar
+    case groupsRotation
+    case updates
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .general: return "General"
+        case .menuBar: return "Menu Bar"
+        case .groupsRotation: return "Groups & Rotation"
+        case .updates: return "Updates"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .general: return "gearshape"
+        case .menuBar: return "menubar.rectangle"
+        case .groupsRotation: return "square.grid.2x2"
+        case .updates: return "arrow.triangle.2.circlepath"
+        }
+    }
+}
+
+/// Singleton so `SettingsWindowController.show(tab:)` can select a pane from
+/// outside the view tree, the same shape `macos-settings-ui`'s own reference
+/// uses. `ObservableObject`, not `@Observable` — this package's platform
+/// floor is macOS 13 (`Package.swift`), and the macro needs 14.
+@MainActor
+final class SettingsNavigation: ObservableObject {
+    static let shared = SettingsNavigation()
+    @Published var selectedTab: SettingsTab? = .general
+    private init() {}
+}
+
+/// `NavigationSplitView` sidebar + detail, back/forward toolbar navigation —
+/// the shape `macos-settings-ui/references/SettingsView.swift:74-88`
+/// prescribes and S1/S7 (`docs/design/panel-tabs-review.md`) hold this window
+/// to: **only the selected pane renders**, at a minimum 660×540 with a fixed
+/// 200pt sidebar.
+struct SettingsRootView: View {
+    let dependencies: SettingsDependencies
+
+    @ObservedObject private var navigation = SettingsNavigation.shared
+    @State private var navigationHistory: [SettingsTab] = [.general]
+    @State private var historyIndex = 0
+    @State private var isHistoryNavigation = false
+
+    private var activeTab: SettingsTab {
+        navigation.selectedTab ?? .general
+    }
+
+    var body: some View {
+        NavigationSplitView(columnVisibility: .constant(.all)) {
+            SettingsSidebarView(selectedTab: $navigation.selectedTab)
+                .frame(width: 200)
+                .navigationSplitViewColumnWidth(min: 200, ideal: 200, max: 200)
+        } detail: {
+            // S1's whole point: ONE pane, chosen by `activeTab`, never all
+            // seven sections stacked under whichever tab happened to be
+            // marked selected.
+            SettingsDetailView(tab: activeTab, dependencies: dependencies)
+        }
+        .navigationTitle("Settings")
+        .navigationSplitViewStyle(.balanced)
+        .frame(minWidth: 660, minHeight: 540)
+        .toolbar {
+            ToolbarItemGroup(placement: .navigation) {
+                Button { goBack() } label: { Image(systemName: "chevron.left") }
+                    .disabled(!canGoBack)
+                Button { goForward() } label: { Image(systemName: "chevron.right") }
+                    .disabled(!canGoForward)
+            }
+        }
+        .onChange(of: navigation.selectedTab) { _ in recordNavigation() }
+    }
+
+    private var canGoBack: Bool { historyIndex > 0 }
+    private var canGoForward: Bool { historyIndex < navigationHistory.count - 1 }
+
+    private func goBack() {
+        guard canGoBack else { return }
+        isHistoryNavigation = true
+        historyIndex -= 1
+        navigation.selectedTab = navigationHistory[historyIndex]
+        DispatchQueue.main.async { isHistoryNavigation = false }
+    }
+
+    private func goForward() {
+        guard canGoForward else { return }
+        isHistoryNavigation = true
+        historyIndex += 1
+        navigation.selectedTab = navigationHistory[historyIndex]
+        DispatchQueue.main.async { isHistoryNavigation = false }
+    }
+
+    private func recordNavigation() {
+        guard !isHistoryNavigation else { return }
+        guard let tab = navigation.selectedTab else { return }
+        if navigationHistory.last == tab { return }
+        if historyIndex < navigationHistory.count - 1 {
+            navigationHistory = Array(navigationHistory.prefix(historyIndex + 1))
+        }
+        navigationHistory.append(tab)
+        historyIndex = navigationHistory.count - 1
+    }
+}
+
+private struct SettingsSidebarView: View {
+    @Binding var selectedTab: SettingsTab?
+
+    var body: some View {
+        List(selection: $selectedTab) {
+            ForEach(SettingsTab.allCases) { tab in
+                Label(tab.title, systemImage: tab.systemImage).tag(tab)
+            }
+            versionFooter
+        }
+        .listStyle(.sidebar)
+        .navigationTitle("Settings")
+    }
+
+    /// `Version 0.2.48 (d3911a9)` / `server e187866` — the same two facts the
+    /// panel footer already states, so a reader who opened Settings from the
+    /// gear is not left guessing which build they are looking at.
+    private var versionFooter: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            if let label = AppBuild.label {
+                Text(label)
+            } else {
+                Text("TcrBar (development build)")
+            }
+        }
+        .font(.footnote)
+        .foregroundStyle(.tertiary)
+        .fontDesign(.monospaced)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 8)
+        .listRowSeparator(.hidden)
+    }
+}
+
+private struct SettingsDetailView: View {
+    let tab: SettingsTab
+    let dependencies: SettingsDependencies
+
+    var body: some View {
+        Group {
+            switch tab {
+            case .general:
+                GeneralSettingsPane(dependencies: dependencies)
+            case .menuBar:
+                MenuBarSettingsPane(dependencies: dependencies)
+            case .groupsRotation:
+                GroupsRotationSettingsPane(dependencies: dependencies)
+            case .updates:
+                UpdatesSettingsPane(dependencies: dependencies)
+            }
+        }
+        .navigationTitle(tab.title)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+}

--- a/apps/macos/Sources/TcrBar/SettingsView.swift
+++ b/apps/macos/Sources/TcrBar/SettingsView.swift
@@ -152,7 +152,7 @@ private struct SettingsSidebarView: View {
             }
         }
         .font(.footnote)
-        .foregroundStyle(.tertiary)
+        .foregroundStyle(Tok.inkFaint)
         .fontDesign(.monospaced)
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 6)

--- a/apps/macos/Sources/TcrBar/SettingsView.swift
+++ b/apps/macos/Sources/TcrBar/SettingsView.swift
@@ -33,11 +33,16 @@ enum SettingsTab: String, CaseIterable, Identifiable {
 /// outside the view tree, the same shape `macos-settings-ui`'s own reference
 /// uses. `ObservableObject`, not `@Observable` — this package's platform
 /// floor is macOS 13 (`Package.swift`), and the macro needs 14.
+///
+/// `init()` is plain, not `private`, so a test or a harness can construct an
+/// independent instance instead of mutating `.shared` in place — used by
+/// nothing today (``RenderSettings`` renders each pane's `Form` directly and
+/// never routes through this navigation object at all — see that type's own
+/// doc-comment for why), kept for the next caller that needs one.
 @MainActor
 final class SettingsNavigation: ObservableObject {
     static let shared = SettingsNavigation()
     @Published var selectedTab: SettingsTab? = .general
-    private init() {}
 }
 
 /// `NavigationSplitView` sidebar + detail, back/forward toolbar navigation —
@@ -48,10 +53,18 @@ final class SettingsNavigation: ObservableObject {
 struct SettingsRootView: View {
     let dependencies: SettingsDependencies
 
-    @ObservedObject private var navigation = SettingsNavigation.shared
+    /// Defaults to the shared singleton for real use
+    /// (`SettingsWindowController`); the render harness passes a fresh
+    /// instance per capture — see ``SettingsNavigation``'s own doc-comment.
+    @ObservedObject private var navigation: SettingsNavigation
     @State private var navigationHistory: [SettingsTab] = [.general]
     @State private var historyIndex = 0
     @State private var isHistoryNavigation = false
+
+    init(dependencies: SettingsDependencies, navigation: SettingsNavigation = .shared) {
+        self.dependencies = dependencies
+        self.navigation = navigation
+    }
 
     private var activeTab: SettingsTab {
         navigation.selectedTab ?? .general

--- a/apps/macos/Sources/TcrBar/SettingsWindowController.swift
+++ b/apps/macos/Sources/TcrBar/SettingsWindowController.swift
@@ -1,0 +1,129 @@
+import AppKit
+import SwiftUI
+import TcrBarCore
+
+/// The Settings window (gear button in the panel header, `⌘,`).
+///
+/// Built once, lazily, and reused — the same rule `WhatsNewWindow` follows and
+/// for the same reason: a window rebuilt on every open loses its size, its
+/// sidebar selection and its key focus, and `isReleasedWhenClosed` (AppKit's
+/// default) would deallocate it on the red button and crash or duplicate on
+/// the next open.
+///
+/// `.fullSizeContentView` at construction time, per `macos-settings-ui`'s own
+/// reference (`SettingsWindowController.swift` in that skill): the style mask
+/// has to be set when the window is made, not injected afterwards, or the
+/// liquid-glass corner treatment does not apply.
+///
+/// TcrBar is `LSUIElement` (`macos-patterns` § "Activation Policy") with no
+/// Dock icon of its own, so opening this window brings the app briefly to
+/// `.regular` the way `WhatsNewWindow.present()` already forces activation —
+/// without it the window opens behind whatever the operator was looking at.
+/// There is only ever one auxiliary window family in this app at a time in
+/// practice (Settings XOR What's New), so a plain enter/leave pair is enough;
+/// a reference count would only matter if both could be open simultaneously,
+/// which nothing here does today.
+@MainActor
+final class SettingsWindowController: NSWindowController, NSWindowDelegate {
+    private let dependencies: SettingsDependencies
+
+    init(dependencies: SettingsDependencies) {
+        self.dependencies = dependencies
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: CGSize(width: 660, height: 540)),
+            styleMask: [
+                .titled, .closable, .resizable, .miniaturizable,
+                .fullSizeContentView,
+            ],
+            backing: .buffered,
+            defer: false
+        )
+        super.init(window: window)
+        configureWindow()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func configureWindow() {
+        guard let window else { return }
+        window.title = "Settings"
+        window.titleVisibility = .visible
+        window.toolbarStyle = .automatic
+        window.isMovableByWindowBackground = true
+        window.setFrameAutosaveName("TcrBarSettingsWindow")
+        // Per `SettingsView.swift:74-88` in the `macos-settings-ui` reference —
+        // the shape S7 (`docs/design/panel-tabs-review.md`) exists to hold to:
+        // a fixed 200pt sidebar plus a 540pt-tall detail is the floor, not a
+        // starting point to shrink from.
+        window.minSize = NSSize(width: 660, height: 540)
+        window.center()
+        window.delegate = self
+        window.contentViewController = NSHostingController(
+            rootView: SettingsRootView(dependencies: dependencies))
+    }
+
+    /// - Parameter tab: jump straight to a pane — the gear's per-tab menu
+    ///   item in the mockup, and `⌘,`'s own default of wherever the window
+    ///   was left.
+    func show(tab: SettingsTab? = nil) {
+        if let tab {
+            SettingsNavigation.shared.selectedTab = tab
+        }
+        showWindow(nil)
+    }
+
+    override func showWindow(_ sender: Any?) {
+        super.showWindow(sender)
+        AppActivationPolicy.enter()
+        window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        AppActivationPolicy.leave()
+    }
+}
+
+/// Everything a Settings pane reads or writes, gathered in one struct so
+/// `SettingsWindowController` and `RenderSettings` build the view the same
+/// way `MenuBarShell` and `RenderStates` already build `FleetView` the same
+/// way — one initializer, no second wiring path to drift from the first.
+struct SettingsDependencies {
+    var poller: StatusPoller
+    var server: ServerController
+    var loginItem: LoginItem
+    var awake: AwakeController
+    var preference: LaunchPreference
+    var countsPreference: MenuBarCountsPreference
+    var runningToolsPreference: ShowRunningToolsPreference
+    var defaultTabPreference: DefaultTabPreference
+    var groupController: GroupController
+    var updater: Updater
+    var onWhatsNew: () -> Void = {}
+}
+
+/// Reference-counted `.accessory` ↔ `.regular` toggling, the same pattern
+/// `macos-patterns` gives for a menu-bar-only app opening a window — kept
+/// here rather than in `WhatsNewWindow` (which predates this and manages its
+/// own activation inline) so the two auxiliary windows share one counter
+/// rather than two independent booleans that could disagree about whether
+/// the Dock icon should still be showing.
+@MainActor
+enum AppActivationPolicy {
+    private static var count = 0
+
+    static func enter() {
+        count += 1
+        NSApp.setActivationPolicy(.regular)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    static func leave() {
+        count = max(0, count - 1)
+        guard count == 0 else { return }
+        NSApp.setActivationPolicy(.accessory)
+    }
+}

--- a/apps/macos/Sources/TcrBar/TcrBarApp.swift
+++ b/apps/macos/Sources/TcrBar/TcrBarApp.swift
@@ -83,6 +83,10 @@ enum TcrBarEntry {
             _ = NSApplication.shared
             RenderStates.run(into: directory)  // exits
         }
+        if let directory = RenderSettings.requestedDirectory() {
+            _ = NSApplication.shared
+            RenderSettings.run(into: directory)  // exits
+        }
         if let directory = RenderMark.requestedDirectory() {
             _ = NSApplication.shared
             RenderMark.run(into: directory)  // exits

--- a/apps/macos/Sources/TcrBarCore/DefaultTabPreference.swift
+++ b/apps/macos/Sources/TcrBarCore/DefaultTabPreference.swift
@@ -1,0 +1,37 @@
+import Combine
+import Foundation
+
+/// "Open on" — which panel tab the popover selects the next time it opens.
+/// Same shape as ``MenuBarCountsPreference``, for the same reason: there is no
+/// `App`/`View` to hang an `@AppStorage` off, and a plain `UserDefaults` read
+/// would not publish the change back to the picker that set it.
+///
+/// Stores a plain string rather than `PanelTab` — that enum lives in the
+/// `TcrBar` executable target (`FleetView.swift`) so it can stay unaware of
+/// Sparkle, and `TcrBarCore` cannot import upward from its own client. The
+/// three names below are `PanelTab`'s own `CaseIterable` labels
+/// (`FleetView.swift:1727`), duplicated as literals rather than as a shared
+/// type for that boundary reason; ``DefaultTabPreferenceTests`` pins them.
+@MainActor
+public final class DefaultTabPreference: ObservableObject {
+    /// The `UserDefaults` key. Do not change it — the same trap
+    /// ``LaunchPreference/startServerAtLaunchKey`` documents.
+    public static let key = "defaultPanelTab"
+
+    /// The only three values this preference accepts; anything else in
+    /// `UserDefaults` (an old key, a hand edit) is treated as absent.
+    public static let validTabs: Set<String> = ["accounts", "sessions", "tools"]
+    public static let fallback = "accounts"
+
+    private let defaults: UserDefaults
+
+    @Published public var tab: String {
+        didSet { defaults.set(tab, forKey: Self.key) }
+    }
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        let stored = defaults.string(forKey: Self.key)
+        self.tab = stored.flatMap { Self.validTabs.contains($0) ? $0 : nil } ?? Self.fallback
+    }
+}

--- a/apps/macos/Sources/TcrBarCore/GroupSummary.swift
+++ b/apps/macos/Sources/TcrBarCore/GroupSummary.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// One row's worth of a group, derived from the fleet's own accounts rather
+/// than a dedicated wire object — there isn't one; `groups`/`reservedGroups`/
+/// `parkedGroups`/`groupColors` are all per-account fields
+/// (`FleetStatus.swift`), repeated on every member.
+///
+/// Exists so the Settings window's Groups & Rotation pane can list **every**
+/// group the fleet actually has, not just the ones with an account row
+/// visible on the panel right now. The mockup review's S8 finding was exactly
+/// this failure a layer up: two groups appeared only as bare names with no
+/// settings drawn, because the pane that reviewed them iterated the panel's
+/// own (collapsed) card list instead of the fleet's real membership.
+public struct GroupSummary: Equatable, Sendable, Identifiable {
+    public var id: String { name }
+    public let name: String
+    /// How many accounts carry this label, wherever they sit on the panel.
+    public let memberCount: Int
+    /// True when every member with a wire opinion has parked it — mirrors
+    /// `groupSettings.<g>.parked` observed indirectly through the accounts
+    /// that carry `parkedGroups`.
+    public let isParked: Bool
+    public let isReserved: Bool
+    /// `nil` when no member carries a colour for this group — the neutral
+    /// fallback every other group-colour reader in this app already uses.
+    public let colorHex: String?
+
+    public init(
+        name: String, memberCount: Int, isParked: Bool, isReserved: Bool, colorHex: String?
+    ) {
+        self.name = name
+        self.memberCount = memberCount
+        self.isParked = isParked
+        self.isReserved = isReserved
+        self.colorHex = colorHex
+    }
+
+    /// Every group name any account in `accounts` carries, each summarised
+    /// once. Sorted by name so the pane's row order is stable across polls —
+    /// a settings list that reorders itself between two reads of the same
+    /// fleet is a worse defect than an alphabetical one that never puts the
+    /// group you are looking for first.
+    public static func summarize(_ accounts: [Account]) -> [GroupSummary] {
+        var names: Set<String> = []
+        for account in accounts {
+            names.formUnion(account.groups ?? [])
+        }
+        return names.sorted().map { name in
+            let members = accounts.filter { ($0.groups ?? []).contains(name) }
+            let parkedMembers = members.filter { ($0.parkedGroups ?? []).contains(name) }
+            let reservedMembers = members.filter { ($0.reservedGroups ?? []).contains(name) }
+            let color = members.compactMap { $0.groupColors?[name] }.first
+            return GroupSummary(
+                name: name,
+                memberCount: members.count,
+                // Parked/reserved are group-wide settings server-side
+                // (`groupSettings.<g>`), so any one member's wire copy speaks
+                // for the whole group; "any" rather than "all" is the safer
+                // read when members disagree, since that disagreement is
+                // itself something a boot-time snapshot can produce and the
+                // pane should not paper over by picking `all`.
+                isParked: !parkedMembers.isEmpty,
+                isReserved: !reservedMembers.isEmpty,
+                colorHex: color
+            )
+        }
+    }
+}

--- a/apps/macos/Sources/TcrBarCore/SettingsRowBadge.swift
+++ b/apps/macos/Sources/TcrBarCore/SettingsRowBadge.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// When a Settings-window row's value takes effect, and the one table every
+/// row is checked against (`data/plans/settings-window-bridge.md`, gate 1).
+///
+/// This exists because of a finding against the earlier mockup
+/// (`docs/design/panel-tabs-review.md` § Settings window, S3): 16 of 31 rows
+/// carried no marking at all, including every `Limits` row sitting directly
+/// under the one section that WAS marked — so silence read as "live". A row
+/// with no entry here is exactly that trap, so ``SettingsRowBadgeTests``
+/// enumerates every row this window draws and asserts each one has an entry.
+///
+/// `.readOnly` is a third case, not a variant of `.boot`: a value TcrBar only
+/// displays (the running server's sha, the installed `tcr` version) has no
+/// "apply" moment at all — there is nothing to restart into.
+public enum SettingsRowTiming: Equatable, Sendable {
+    /// Read and written by TcrBar itself, or applied live by the proxy
+    /// (`Manager::reload_groups_if_changed`, `docs/configuration.md`). The
+    /// view reflects the new value on its next poll or preference read.
+    case live
+    /// Read once by the proxy at start-up (`docs/configuration.md`: "every
+    /// other config field is a boot-time snapshot"). A change here is real —
+    /// `tcr` writes it — but nothing observes it until the next restart.
+    case boot
+    /// TcrBar only displays this; there is no write path through this window
+    /// at all.
+    case readOnly
+
+    /// The two-word tag the mockup and this window both draw
+    /// (`docs/design/panel-tabs-mockup.html` `.tag.live` / `.tag.boot`).
+    public var label: String {
+        switch self {
+        case .live: return "applied live"
+        case .boot: return "restart to apply"
+        case .readOnly: return "read-only"
+        }
+    }
+}
+
+/// The full row registry, keyed by the same short id each pane uses to look
+/// itself up. One flat table rather than one enum per pane, so a row that
+/// moves pane cannot silently lose its entry — a missing key fails the same
+/// way `SettingsRowBadgeTests` checks for.
+public enum SettingsRowBadge {
+    /// `Server` section, General pane.
+    public static let proxyRestart = "server.proxyRestart"
+    public static let startServerAtLaunch = "server.startServerAtLaunch"
+    public static let pollInterval = "server.pollInterval"
+    /// `This Mac` section, General pane.
+    public static let launchAtLogin = "mac.launchAtLogin"
+    public static let keepAwake = "mac.keepAwake"
+    /// `In the menu bar` section, Menu Bar pane.
+    public static let showReadyCount = "menuBar.showReadyCount"
+    public static let showRunningToolCount = "menuBar.showRunningToolCount"
+    /// `When the panel opens` section, Menu Bar pane.
+    public static let openOnTab = "menuBar.openOnTab"
+    public static let textSize = "menuBar.textSize"
+    /// `Groups` section, Groups & Rotation pane — one entry covers every
+    /// group row, since they are all the same shape.
+    public static let groupParked = "groups.parked"
+    public static let groupReserved = "groups.reserved"
+    public static let groupMayServeAsControl = "groups.mayServeAsControl"
+    public static let groupColor = "groups.color"
+    public static let groupMembers = "groups.members"
+    /// `Rotation` section — every key here is read once at boot
+    /// (`docs/configuration.md`).
+    public static let switchThreshold = "rotation.switchThreshold"
+    public static let controlReserve = "rotation.controlReserve"
+    public static let fableWeeklyThreshold = "rotation.fableWeeklyThreshold"
+    public static let resetUrgencyTier = "rotation.resetUrgencyTier"
+    public static let sessionAffinity = "rotation.sessionAffinity"
+    public static let controlAccount = "rotation.controlAccount"
+    public static let controlPooled = "rotation.controlPooled"
+    /// `Limits` section — also boot-time.
+    public static let accountThrottle = "limits.accountThrottle"
+    public static let fleetThrottle = "limits.fleetThrottle"
+    public static let pacing = "limits.pacing"
+    public static let usageRetentionDays = "limits.usageRetentionDays"
+    public static let http1Only = "limits.http1Only"
+    /// `TcrBar` section, Updates pane.
+    public static let checkNow = "updates.checkNow"
+    public static let whatsNew = "updates.whatsNew"
+    public static let checkAutomatically = "updates.checkAutomatically"
+    /// `The running build` section, Updates pane.
+    public static let runningServer = "updates.runningServer"
+    public static let installedCli = "updates.installedCli"
+    public static let updatingReplacesBoth = "updates.updatingReplacesBoth"
+
+    /// The table itself. Every key above must appear here exactly once —
+    /// ``SettingsRowBadgeTests`` enumerates both directions.
+    public static let timing: [String: SettingsRowTiming] = [
+        proxyRestart: .live,
+        // Its own row-level tag in the mockup ("takes effect next launch")
+        // rather than the section's "applied live": TcrBar reads this
+        // preference once, at `applicationDidFinishLaunching`, not on every
+        // poll — so `.boot` is the honest word even though nothing here is
+        // server config. `SettingsRowBadge` has no fourth case for "next
+        // app launch specifically", and boot-time is the closer of the two
+        // to what a reader should expect: the change is inert until
+        // something restarts.
+        startServerAtLaunch: .boot,
+        pollInterval: .live,
+        launchAtLogin: .live,
+        keepAwake: .live,
+        showReadyCount: .live,
+        showRunningToolCount: .live,
+        openOnTab: .live,
+        textSize: .readOnly,
+        groupParked: .live,
+        // Neither has a write path through this app today — `GroupController`
+        // covers add/remove/removeAll/park, not reserve or control-eligibility
+        // — so per the bridge these are read-only rows with a hint, not a
+        // `.boot` row implying a control this window does not actually offer.
+        groupReserved: .readOnly,
+        groupMayServeAsControl: .readOnly,
+        groupColor: .readOnly,
+        groupMembers: .readOnly,
+        switchThreshold: .boot,
+        controlReserve: .boot,
+        fableWeeklyThreshold: .boot,
+        resetUrgencyTier: .boot,
+        sessionAffinity: .boot,
+        controlAccount: .boot,
+        controlPooled: .boot,
+        accountThrottle: .boot,
+        fleetThrottle: .boot,
+        pacing: .boot,
+        usageRetentionDays: .boot,
+        http1Only: .boot,
+        checkNow: .live,
+        whatsNew: .live,
+        checkAutomatically: .readOnly,
+        runningServer: .readOnly,
+        installedCli: .readOnly,
+        updatingReplacesBoth: .readOnly,
+    ]
+
+    /// `nil` only for a key nobody registered above — which
+    /// ``SettingsRowBadgeTests`` treats as a failure, not a case a pane is
+    /// allowed to silently fall back from.
+    public static func timing(for key: String) -> SettingsRowTiming? {
+        timing[key]
+    }
+}

--- a/apps/macos/Sources/TcrBarCore/ShowRunningToolsPreference.swift
+++ b/apps/macos/Sources/TcrBarCore/ShowRunningToolsPreference.swift
@@ -1,0 +1,36 @@
+import Combine
+import Foundation
+
+/// "Show the running-tool count" — a second number beside the menu-bar glyph,
+/// alongside ``MenuBarCountsPreference``'s ready/enabled fraction. Same shape,
+/// same reason there is no `@AppStorage` to reach for.
+///
+/// **Not yet wired to the glyph.** `MenuBarShell.updateMark` composes the
+/// ready/enabled label from ``MenuBarCountsPreference`` and the running-tool
+/// count from a live poll is not threaded through it — this preference exists
+/// so the Settings window row from the bridge (`data/plans/
+/// settings-window-bridge.md` § Panes, "Menu Bar") is real and persists,
+/// without also rewriting `updateMark`'s composition, which touches a
+/// different feature's tests than this window's own. Reading it back always
+/// answers correctly; the mark itself does not consult it yet.
+@MainActor
+public final class ShowRunningToolsPreference: ObservableObject {
+    /// The `UserDefaults` key. Do not change it — the same trap
+    /// ``LaunchPreference/startServerAtLaunchKey`` documents.
+    public static let key = "showRunningToolCountInMenuBar"
+
+    private let defaults: UserDefaults
+
+    /// Defaults to `false`, matching the mockup's own unchecked state for
+    /// this row (`docs/design/panel-tabs-mockup.html`, `aria-checked="false"`
+    /// on "Show the running-tool count") — unlike ``MenuBarCountsPreference``,
+    /// this one is not the pre-existing behaviour being preserved.
+    @Published public var showRunningToolCount: Bool {
+        didSet { defaults.set(showRunningToolCount, forKey: Self.key) }
+    }
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.showRunningToolCount = defaults.bool(forKey: Self.key)
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/DefaultTabPreferenceTests.swift
+++ b/apps/macos/Tests/TcrBarTests/DefaultTabPreferenceTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+
+@testable import TcrBarCore
+
+/// "Open on" (Settings window, Menu Bar pane — `data/plans/
+/// settings-window-bridge.md`). Same scratch-suite shape as
+/// `MenuBarCountsPreferenceTests`.
+@MainActor
+final class DefaultTabPreferenceTests: XCTestCase {
+
+    private var suiteName = ""
+    private var defaults = UserDefaults.standard
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "tcrbar.tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName) ?? .standard
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    func testTheDefaultsKeyIsPinned() {
+        XCTAssertEqual(DefaultTabPreference.key, "defaultPanelTab")
+    }
+
+    /// The three names must match `PanelTab`'s own cases
+    /// (`FleetView.swift:1727`) — this is the boundary the type's own
+    /// doc-comment explains, so a rename on either side that is not mirrored
+    /// on the other is exactly what this test exists to catch.
+    func testValidTabsMatchPanelTabsCases() {
+        XCTAssertEqual(DefaultTabPreference.validTabs, ["accounts", "sessions", "tools"])
+    }
+
+    func testAnAbsentKeyFallsBackToAccounts() {
+        XCTAssertNil(defaults.object(forKey: DefaultTabPreference.key))
+        XCTAssertEqual(DefaultTabPreference(defaults: defaults).tab, "accounts")
+    }
+
+    func testAStoredValidValueIsRead() {
+        defaults.set("tools", forKey: DefaultTabPreference.key)
+        XCTAssertEqual(DefaultTabPreference(defaults: defaults).tab, "tools")
+    }
+
+    /// A stray or stale value (an old key format, a hand edit) must not crash
+    /// or propagate — it falls back the same way an absent key does.
+    func testAnInvalidStoredValueFallsBackToAccounts() {
+        defaults.set("groups", forKey: DefaultTabPreference.key)
+        XCTAssertEqual(DefaultTabPreference(defaults: defaults).tab, "accounts")
+    }
+
+    func testSettingItWritesThroughAndSurvivesANewInstance() {
+        let preference = DefaultTabPreference(defaults: defaults)
+        preference.tab = "sessions"
+
+        XCTAssertEqual(defaults.string(forKey: DefaultTabPreference.key), "sessions")
+        XCTAssertEqual(DefaultTabPreference(defaults: defaults).tab, "sessions")
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/GroupSummaryTests.swift
+++ b/apps/macos/Tests/TcrBarTests/GroupSummaryTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+
+@testable import TcrBarCore
+
+/// ``GroupSummary/summarize(_:)`` — every group name the fleet's accounts
+/// carry, once each, with the facts the Settings window's Groups & Rotation
+/// pane needs. The mockup review's S8 finding is the reason this derives from
+/// the FULL account list rather than whatever the panel happens to have drawn
+/// (a collapsed group card, or one filtered view): two groups there existed
+/// only as bare names with none of their settings shown.
+///
+/// Account names are obviously fake — this repository is public.
+final class GroupSummaryTests: XCTestCase {
+
+    func testEveryGroupNameIsCounted() {
+        let accounts = [
+            summaryAccount("a@example.com", groups: ["dev"]),
+            summaryAccount("b@example.com", groups: ["dev", "gil"]),
+            summaryAccount("c@example.com", groups: ["gil"]),
+        ]
+        let groups = GroupSummary.summarize(accounts)
+        XCTAssertEqual(groups.map(\.name), ["dev", "gil"])
+        XCTAssertEqual(groups[0].memberCount, 2)
+        XCTAssertEqual(groups[1].memberCount, 2)
+    }
+
+    /// A group with no member carrying `parkedGroups` for it is not parked —
+    /// the negative case, since every other fixture here opts in.
+    func testAGroupWithNoParkedMemberIsNotParked() {
+        let accounts = [summaryAccount("a@example.com", groups: ["dev"])]
+        XCTAssertEqual(GroupSummary.summarize(accounts).first?.isParked, false)
+    }
+
+    func testAGroupIsParkedWhenAMemberCarriesIt() {
+        let accounts = [
+            summaryAccount("a@example.com", groups: ["dev"], parkedGroups: ["dev"])
+        ]
+        XCTAssertEqual(GroupSummary.summarize(accounts).first?.isParked, true)
+    }
+
+    func testAGroupIsReservedWhenAMemberCarriesIt() {
+        let accounts = [
+            summaryAccount("a@example.com", groups: ["dev"], reservedGroups: ["dev"])
+        ]
+        XCTAssertEqual(GroupSummary.summarize(accounts).first?.isReserved, true)
+    }
+
+    /// The colour comes from the first member that carries one for this
+    /// group; a group with no coloured member reports `nil`, the same
+    /// neutral-fallback shape ``GroupChip`` already uses.
+    func testTheGroupColorIsReadFromAMemberThatCarriesOne() {
+        let accounts = [
+            summaryAccount("a@example.com", groups: ["dev"]),
+            summaryAccount("b@example.com", groups: ["dev"], groupColors: ["dev": "#0a84ff"]),
+        ]
+        XCTAssertEqual(GroupSummary.summarize(accounts).first?.colorHex, "#0a84ff")
+    }
+
+    func testAGroupWithNoColoredMemberReportsNilColor() {
+        let accounts = [summaryAccount("a@example.com", groups: ["dev"])]
+        XCTAssertNil(GroupSummary.summarize(accounts).first?.colorHex)
+    }
+
+    /// Sorted by name, so the pane's row order does not depend on account
+    /// order or on `Set` iteration order.
+    func testGroupsAreSortedByName() {
+        let accounts = [
+            summaryAccount("a@example.com", groups: ["zeta"]),
+            summaryAccount("b@example.com", groups: ["alpha"]),
+        ]
+        XCTAssertEqual(GroupSummary.summarize(accounts).map(\.name), ["alpha", "zeta"])
+    }
+
+    func testNoGroupsProducesAnEmptyList() {
+        XCTAssertEqual(GroupSummary.summarize([summaryAccount("a@example.com", groups: nil)]), [])
+    }
+}
+
+/// Hand-built accounts with the fields this file's assertions touch —
+/// mirrors `GroupRoutingTests`'s own `routingAccount` fixture.
+private func summaryAccount(
+    _ name: String,
+    groups: [String]?,
+    reservedGroups: [String]? = nil,
+    parkedGroups: [String]? = nil,
+    groupColors: [String: String]? = nil
+) -> Account {
+    Account(
+        name: name,
+        priority: 1,
+        status: "active",
+        disabled: false,
+        quota: 0,
+        quotaState: .ok,
+        fiveHour: 0,
+        sevenDay: 0,
+        sevenDayOi: 0,
+        held: [],
+        requests: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheHitRatio: nil,
+        probeStatus: .ok,
+        probeError: nil,
+        lastStreamError: nil,
+        streamErrorCount: 0,
+        source: .live,
+        serverSha: "abc1234",
+        serverDirty: false,
+        groups: groups,
+        reservedGroups: reservedGroups,
+        parkedGroups: parkedGroups,
+        groupColors: groupColors
+    )
+}

--- a/apps/macos/Tests/TcrBarTests/SettingsRowBadgeTests.swift
+++ b/apps/macos/Tests/TcrBarTests/SettingsRowBadgeTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+
+@testable import TcrBarCore
+
+/// The table gate 1 of `data/plans/settings-window-bridge.md` asks for: every
+/// row the Settings window draws carries an applied-live / restart-to-apply /
+/// read-only marking, and none of them silently falls back to "no entry means
+/// live" — that fallback is exactly the review's S3 finding
+/// (`docs/design/panel-tabs-review.md`), reproduced in code instead of markup.
+final class SettingsRowBadgeTests: XCTestCase {
+
+    /// Every public key `SettingsRowBadge` declares must have a timing entry.
+    /// A key present without an entry is the S3 trap: a row on screen with no
+    /// badge, which the mockup review found reads as "applied live" by
+    /// default rather than by any actual guarantee.
+    func testEveryDeclaredKeyHasATimingEntry() {
+        let declaredKeys: [String] = [
+            SettingsRowBadge.proxyRestart, SettingsRowBadge.startServerAtLaunch,
+            SettingsRowBadge.pollInterval, SettingsRowBadge.launchAtLogin,
+            SettingsRowBadge.keepAwake, SettingsRowBadge.showReadyCount,
+            SettingsRowBadge.showRunningToolCount, SettingsRowBadge.openOnTab,
+            SettingsRowBadge.textSize, SettingsRowBadge.groupParked,
+            SettingsRowBadge.groupReserved, SettingsRowBadge.groupMayServeAsControl,
+            SettingsRowBadge.groupColor, SettingsRowBadge.groupMembers,
+            SettingsRowBadge.switchThreshold, SettingsRowBadge.controlReserve,
+            SettingsRowBadge.fableWeeklyThreshold, SettingsRowBadge.resetUrgencyTier,
+            SettingsRowBadge.sessionAffinity, SettingsRowBadge.controlAccount,
+            SettingsRowBadge.controlPooled, SettingsRowBadge.accountThrottle,
+            SettingsRowBadge.fleetThrottle, SettingsRowBadge.pacing,
+            SettingsRowBadge.usageRetentionDays, SettingsRowBadge.http1Only,
+            SettingsRowBadge.checkNow, SettingsRowBadge.whatsNew,
+            SettingsRowBadge.checkAutomatically, SettingsRowBadge.runningServer,
+            SettingsRowBadge.installedCli, SettingsRowBadge.updatingReplacesBoth,
+        ]
+        for key in declaredKeys {
+            XCTAssertNotNil(
+                SettingsRowBadge.timing(for: key), "\(key) has no timing entry in the table")
+        }
+        // The reverse direction too: nothing in the table names a key this
+        // test does not know about, so an entry added to the dictionary
+        // without a matching `public static let` cannot go unreviewed.
+        XCTAssertEqual(Set(declaredKeys), Set(SettingsRowBadge.timing.keys))
+    }
+
+    /// The five keys the review's S3 finding named explicitly — the LIMITS
+    /// section that sat under the one section marked "restart to apply" and
+    /// silently inherited nothing — are ALL `.boot`, matching
+    /// `docs/configuration.md`'s "every other config field is a boot-time
+    /// snapshot" and never `.live`.
+    func testEveryLimitsRowIsBootTime() {
+        for key in [
+            SettingsRowBadge.accountThrottle, SettingsRowBadge.fleetThrottle,
+            SettingsRowBadge.pacing, SettingsRowBadge.usageRetentionDays,
+            SettingsRowBadge.http1Only,
+        ] {
+            XCTAssertEqual(SettingsRowBadge.timing(for: key), .boot)
+        }
+    }
+
+    /// A key this app has no write path for at all — `GroupController` covers
+    /// park, not reserve or control-eligibility — must read `.readOnly`, not
+    /// `.boot`: `.boot` would imply a control this window does not offer.
+    func testAKeyWithNoWritePathIsReadOnlyNotBoot() {
+        XCTAssertEqual(SettingsRowBadge.timing(for: SettingsRowBadge.groupReserved), .readOnly)
+        XCTAssertEqual(
+            SettingsRowBadge.timing(for: SettingsRowBadge.groupMayServeAsControl), .readOnly)
+    }
+
+    func testAnUnknownKeyHasNoEntry() {
+        XCTAssertNil(SettingsRowBadge.timing(for: "not.a.real.key"))
+    }
+
+    func testLabelsMatchTheMockupsTwoWordTags() {
+        XCTAssertEqual(SettingsRowTiming.live.label, "applied live")
+        XCTAssertEqual(SettingsRowTiming.boot.label, "restart to apply")
+        XCTAssertEqual(SettingsRowTiming.readOnly.label, "read-only")
+    }
+}

--- a/apps/macos/Tests/TcrBarTests/ShowRunningToolsPreferenceTests.swift
+++ b/apps/macos/Tests/TcrBarTests/ShowRunningToolsPreferenceTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+
+@testable import TcrBarCore
+
+/// "Show the running-tool count" (Settings window, Menu Bar pane).
+@MainActor
+final class ShowRunningToolsPreferenceTests: XCTestCase {
+
+    private var suiteName = ""
+    private var defaults = UserDefaults.standard
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "tcrbar.tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName) ?? .standard
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    func testTheDefaultsKeyIsPinned() {
+        XCTAssertEqual(ShowRunningToolsPreference.key, "showRunningToolCountInMenuBar")
+    }
+
+    /// Unlike `MenuBarCountsPreference`, an absent key reads as OFF — this is
+    /// a new row, not a preserved default.
+    func testAnAbsentKeyReadsAsOff() {
+        XCTAssertNil(defaults.object(forKey: ShowRunningToolsPreference.key))
+        XCTAssertFalse(ShowRunningToolsPreference(defaults: defaults).showRunningToolCount)
+    }
+
+    func testSettingItWritesThroughAndSurvivesANewInstance() {
+        let preference = ShowRunningToolsPreference(defaults: defaults)
+        preference.showRunningToolCount = true
+
+        XCTAssertTrue(defaults.bool(forKey: ShowRunningToolsPreference.key))
+        XCTAssertTrue(ShowRunningToolsPreference(defaults: defaults).showRunningToolCount)
+    }
+}


### PR DESCRIPTION
🍄

## Summary
- Adds a NavigationSplitView Settings window (General / Menu Bar / Groups & Rotation / Updates) opened from a new gear button in the panel header, `⌘,`, per `docs/design/panel-tabs-mockup.html` v4 and the panel-tabs-review.md § Settings window findings (S1-S13).
- Every row carries an applied-live / restart-to-apply / read-only badge from a new `TcrBarCore.SettingsRowBadge` table, with a coverage test asserting every declared row has an entry (S3's "16 of 31 rows carried no marking" fix) — mutation-tested by breaking `SettingsRowTiming.live.label` and watching the test go red.
- Groups & Rotation derives its group list from the full fleet (`TcrBarCore.GroupSummary`), not the panel's own collapsed cards (S8).
- Two new small preferences (`ShowRunningToolsPreference`, `DefaultTabPreference`) back the Menu Bar pane's two new rows.
- A key with no write path today (group reserved/control-eligibility, most Rotation/Limits keys) renders read-only with an "edit the config file" hint — never a hand-rolled rewrite of the live config, which holds real credentials.
- `FleetView.swift` loses the three toggles (start-at-launch, launch-at-login, keep-awake) and the Check-for-Updates/What's-New/Quit row from its bottom block, all now in Settings; Refresh and Add account stay.
- New `--render-settings <dir>` harness rasterises the real Settings window (sidebar, toolbar, detail — everything `SettingsWindowController` shows), one PNG per pane, dark and light. Two earlier approaches were tried and rejected in the same session, each caught by actually reading the output PNGs rather than trusting the harness's own exit code: `ImageRenderer` on the whole `NavigationSplitView` silently substituted AppKit's "cannot display" placeholder for every pane past the first; a follow-up that drew each bare pane offscreen via `NSView.cacheDisplay` produced pane content but with dark-tinted text on a light background, since an off-screen never-activated window never gets real AppKit vibrancy/table backing. The harness now hosts the real window on-screen (centered, never key/activated, `NSApp.setActivationPolicy` never touched) and captures with `CGWindowListCreateImage` keyed to the window's own `windowNumber` — the same mechanism `screencapture -l` uses, needing no Screen Recording permission for a window this process owns.

## Test plan
- [x] `swift test --package-path apps/macos` — 562/562 passing, including the badge-coverage test's own mutation check (broke it, watched red, restored, re-ran green).
- [x] `TCRBAR_DEV_BUILD=1 apps/macos/scripts/build-tcrbar.sh` — full script (Swift + Rust `tcr` + app bundle) exits 0.
- [x] `--render-settings` — all 8 PNGs Read and visually confirmed: sidebar with the correct pane highlighted, both toolbar back/forward buttons, every section's applied-live/restart-to-apply/read-only badge, and every row's real label and value, in both light and dark. General shows "Read the server every · 3 s"; Menu Bar shows "Open on · Accounts"; Groups & Rotation shows the real fixture groups "dev · 2 accounts" and "henry-team · 1 accounts" (parked); Updates shows the resolved `tcr` CLI path.