### PR TITLE
feat: per-tool breakdown and a 30-minute request series on the sessions wire (wire 2)

### DIFF
--- a/crates/tcr-status-wire/src/lib.rs
+++ b/crates/tcr-status-wire/src/lib.rs
@@ -142,6 +142,27 @@ pub struct SlowToolRow {
     pub ended_ms: i64,
 }
 
+/// One tool's aggregate call stats, for a session's (or the fleet's) "BY TOOL" breakdown
+/// (wire 2, `data/plans/wire-2-bridge.md`). `tool` is the wire's `tool_use.name` verbatim —
+/// `Read`, `Grep`, `Glob` and `Edit` are deliberately NOT merged server-side; a panel groups
+/// them if it wants to.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolBucketRow {
+    pub tool: String,
+    #[serde(default)]
+    pub calls: u64,
+    #[serde(default)]
+    pub errors: u64,
+    /// Median duration (seconds) over a bounded reservoir of the most recent completed
+    /// calls — see `src/session_wire.rs` in the main crate.
+    #[serde(default)]
+    pub seconds_p50: f64,
+    /// Completed calls of this tool whose duration was 60 seconds or more.
+    #[serde(default)]
+    pub over_one_minute: u64,
+}
+
 /// A session's tool-call aggregates.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -152,6 +173,12 @@ pub struct SessionToolsRow {
     pub errors: u64,
     #[serde(default)]
     pub timeouts: u64,
+    /// Completed calls (any tool) whose duration was 60 seconds or more — the session-wide
+    /// total; [`ToolBucketRow::over_one_minute`] carries the same count per tool.
+    /// `#[serde(default)]` so a payload from a server built before this field existed decodes
+    /// as "none known" rather than a parse failure.
+    #[serde(default)]
+    pub over_one_minute: u64,
     /// Tool calls still awaiting a `tool_result`, capped at 64 per session.
     #[serde(default)]
     pub running: Vec<RunningToolRow>,
@@ -164,6 +191,31 @@ pub struct SessionToolsRow {
     /// The ten slowest completed tool calls, descending by `seconds`.
     #[serde(default)]
     pub slowest: Vec<SlowToolRow>,
+    /// Per-tool breakdown for this session's "BY TOOL" section. `#[serde(default)]` so a
+    /// payload from a server built before this field existed decodes as "no breakdown known"
+    /// rather than a parse failure.
+    #[serde(default)]
+    pub by_tool: Vec<ToolBucketRow>,
+}
+
+/// Fleet-wide tool-call totals, summed server-side across every live session — so a panel's
+/// headline and "BY TOOL" bars read from the SAME numbers as the per-session rows and cannot
+/// disagree with them by re-summing client-side (wire 2, `data/plans/wire-2-bridge.md`).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionsSummary {
+    #[serde(default)]
+    pub calls: u64,
+    #[serde(default)]
+    pub over_one_minute: u64,
+    #[serde(default)]
+    pub timeouts: u64,
+    #[serde(default)]
+    pub by_tool: Vec<ToolBucketRow>,
+    /// Sum of [`SessionRow::cost_usd`] across every live session — see that field's
+    /// doc-comment for what the number means and does not mean.
+    #[serde(default)]
+    pub cost_usd: f64,
 }
 
 /// One live session on the `tcr status --json` wire's `sessions` array (F1,
@@ -196,6 +248,21 @@ pub struct SessionRow {
     pub cache_read_tokens: u64,
     #[serde(default)]
     pub tools: SessionToolsRow,
+    /// Requests seen for this session in each of the last 30 wall-clock minutes, oldest
+    /// first, exactly 30 entries — a ring buffer that decays to zeros as a session goes
+    /// idle. `#[serde(default)]` so a payload from a server built before this field existed
+    /// decodes as an empty sparkline rather than a parse failure.
+    #[serde(default)]
+    pub req_per_minute: Vec<u16>,
+    /// This session's usage priced through `src/pricing.rs`, server-side, from a per-model
+    /// token tally kept on the session — a session that spans two models sums each model's
+    /// own price rather than being priced once against whichever model is current. Same
+    /// list-price-equivalent meaning as [`UsageTotals::cost_usd`], but plain `f64` rather than
+    /// `Option`: a model this proxy cannot price contributes `0.0` here rather than making the
+    /// whole session's figure absent. `#[serde(default)]` so a payload from a server built
+    /// before this field existed decodes as `0.0` rather than a parse failure.
+    #[serde(default)]
+    pub cost_usd: f64,
 }
 
 /// One account's row on the `tcr status --json` wire.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -573,6 +573,12 @@ calls; `tools.slowest`, the ten slowest completed ones). `tools.running` entries
 Claude Code sent one), and `tools.subagentsRunning` is that count precomputed, so a panel can show
 "2 subagents" without scanning the list itself.
 
+Each session also carries `tools.byTool` (a per-tool-name breakdown: calls, errors, a median
+duration over a bounded reservoir, and `overOneMinute`) and `reqPerMinute` (30 wall-clock minutes
+of request counts, oldest first, decaying to zeros as the session goes idle); the payload's
+top-level `sessionsSummary` is the same `byTool` shape summed across every session server-side, so
+a panel's fleet-wide headline never disagrees with the per-session rows by re-summing them itself.
+
 ---
 
 ## `tcr wrap`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6020,6 +6020,7 @@ mod tests {
                 recent: Vec::new(),
                 sessions: Vec::new(),
                 wire_sessions: Vec::new(),
+                wire_sessions_summary: tcr_status_wire::SessionsSummary::default(),
             },
             thresholds,
         )
@@ -6595,6 +6596,7 @@ mod tests {
                 recent: Vec::new(),
                 sessions: Vec::new(),
                 wire_sessions: Vec::new(),
+                wire_sessions_summary: tcr_status_wire::SessionsSummary::default(),
             },
             vec![0.90, 0.90],
         )

--- a/src/manager/snapshot.rs
+++ b/src/manager/snapshot.rs
@@ -321,12 +321,16 @@ impl Manager {
             v
         };
 
+        let wire_sessions = self.wire_sessions_snapshot(now);
+        let wire_sessions_summary = Manager::wire_sessions_summary(&wire_sessions);
+
         StatsSnapshot {
             accounts: account_snaps,
             current: *self.current.lock().expect("current lock poisoned"),
             recent,
             sessions,
-            wire_sessions: self.wire_sessions_snapshot(now),
+            wire_sessions,
+            wire_sessions_summary,
         }
     }
 }

--- a/src/manager/wire_sessions.rs
+++ b/src/manager/wire_sessions.rs
@@ -35,14 +35,26 @@ impl Manager {
 
     /// Add token counts learned from a response's usage to the wire-session table. Called
     /// beside [`Self::record_usage`] (the per-account ledger) at both of its call sites in
-    /// `proxy.rs` — streamed and non-streamed — with the SAME parsed totals, so the two never
-    /// disagree about how much a response cost.
+    /// `proxy.rs` — streamed and non-streamed — with the SAME [`crate::usage::UsageRecord`]
+    /// fields, so the account ledger, the per-model tally and the wire session's quota totals
+    /// never disagree about what a response carried.
+    ///
+    /// `quota_input` is the QUOTA figure (`UsageRecord::input_total()`, verbatim) and folds
+    /// into the session's existing `input_tokens` total, unchanged in meaning. `base_input`,
+    /// `cache_5m` and `cache_1h` (`UsageRecord::input`/`cache_5m`/`cache_1h`) are the pricing
+    /// dimensions, kept in [`crate::session_wire::WireSession::by_model`] — wire 2
+    /// (`data/plans/wire-2-bridge.md`).
+    #[allow(clippy::too_many_arguments)]
     pub fn record_wire_session_usage(
         &self,
         session_id: Option<&str>,
-        input_tokens: u64,
-        output_tokens: u64,
+        model: Option<&str>,
+        quota_input: u64,
+        base_input: u64,
+        cache_5m: u64,
+        cache_1h: u64,
         cache_read_tokens: u64,
+        output_tokens: u64,
     ) {
         let Some(session_id) = session_id else {
             return;
@@ -51,7 +63,16 @@ impl Manager {
             .wire_sessions
             .lock()
             .expect("wire sessions lock poisoned");
-        tracker.record_usage(session_id, input_tokens, output_tokens, cache_read_tokens);
+        tracker.record_usage(
+            session_id,
+            model,
+            quota_input,
+            base_input,
+            cache_5m,
+            cache_1h,
+            cache_read_tokens,
+            output_tokens,
+        );
     }
 
     /// The live wire-session table, projected onto [`tcr_status_wire::SessionRow`] — what
@@ -82,6 +103,7 @@ impl Manager {
                     calls: s.tools.calls,
                     errors: s.tools.errors,
                     timeouts: s.tools.timeouts,
+                    over_one_minute: s.tools.over_one_minute,
                     subagents_running: s
                         .tools
                         .running
@@ -109,9 +131,85 @@ impl Manager {
                             ended_ms: t.ended_ms,
                         })
                         .collect(),
+                    by_tool: s
+                        .tools
+                        .by_tool
+                        .iter()
+                        .map(|(name, bucket)| tcr_status_wire::ToolBucketRow {
+                            tool: name.clone(),
+                            calls: bucket.calls,
+                            errors: bucket.errors,
+                            seconds_p50: bucket.seconds_p50(),
+                            over_one_minute: bucket.over_one_minute,
+                        })
+                        .collect(),
                 },
+                req_per_minute: s.req_per_minute.projected(now_ms),
+                cost_usd: Self::price_session(&self.usage, &s.by_model),
             })
             .collect()
+    }
+
+    /// Price one session's per-model token tallies against the account ledger's OWN pricing
+    /// table (`crate::usage::UsageTracker::price_for`) and sum — one model's price at a time,
+    /// so a session that spans two models is priced correctly rather than averaged. A model
+    /// this table has no entry for contributes `0.0`, the same "unpriced" outcome
+    /// `crate::pricing` documents for the account-level ledger, just not surfaced as a
+    /// separate count here — `SessionRow::cost_usd` is a plain total, not an
+    /// `Option`/`unpriced_requests` pair.
+    fn price_session(
+        usage: &crate::usage::UsageTracker,
+        by_model: &std::collections::HashMap<String, crate::session_wire::ModelTokenTally>,
+    ) -> f64 {
+        let nanos: u64 = by_model
+            .iter()
+            .filter_map(|(model, tally)| {
+                usage.price_for(model).map(|price| {
+                    crate::pricing::cost_nanos(
+                        &price,
+                        tally.input,
+                        tally.cache_5m,
+                        tally.cache_1h,
+                        tally.cache_read,
+                        tally.output,
+                    )
+                })
+            })
+            .sum();
+        nanos as f64 / 1_000_000_000.0
+    }
+
+    /// Fleet-wide tool-call totals, summed across every row `Self::wire_sessions_snapshot`
+    /// just built — the ONE place this sum happens server-side, so a panel's headline and
+    /// "BY TOOL" bars read the same numbers as the per-session rows (see the bridge, F3).
+    pub(super) fn wire_sessions_summary(
+        rows: &[tcr_status_wire::SessionRow],
+    ) -> tcr_status_wire::SessionsSummary {
+        let mut by_tool: std::collections::HashMap<String, tcr_status_wire::ToolBucketRow> =
+            std::collections::HashMap::new();
+        let mut summary = tcr_status_wire::SessionsSummary::default();
+        for row in rows {
+            summary.calls += row.tools.calls;
+            summary.over_one_minute += row.tools.over_one_minute;
+            summary.timeouts += row.tools.timeouts;
+            summary.cost_usd += row.cost_usd;
+            for bucket in &row.tools.by_tool {
+                let entry = by_tool.entry(bucket.tool.clone()).or_insert_with(|| {
+                    tcr_status_wire::ToolBucketRow {
+                        tool: bucket.tool.clone(),
+                        ..Default::default()
+                    }
+                });
+                entry.calls += bucket.calls;
+                entry.errors += bucket.errors;
+                entry.over_one_minute += bucket.over_one_minute;
+            }
+        }
+        // `seconds_p50` cannot be summed across sessions — it is a median, not a total — so
+        // the fleet-wide row leaves it at its default (0.0) rather than fabricating one from
+        // an average of medians.
+        summary.by_tool = by_tool.into_values().collect();
+        summary
     }
 }
 
@@ -135,7 +233,16 @@ mod tests {
             &[],
             &[],
         );
-        manager.record_wire_session_usage(Some("sess-glue"), 10, 20, 5);
+        manager.record_wire_session_usage(
+            Some("sess-glue"),
+            Some("claude-fable-5"),
+            10,
+            10,
+            0,
+            0,
+            5,
+            20,
+        );
 
         let snap = manager.snapshot(now);
         assert_eq!(snap.wire_sessions.len(), 1);
@@ -195,7 +302,51 @@ mod tests {
             &[],
             &[],
         );
-        manager.record_wire_session_usage(None, 10, 20, 5);
+        manager.record_wire_session_usage(None, Some("claude-fable-5"), 10, 10, 0, 0, 5, 20);
         assert!(manager.snapshot(now).wire_sessions.is_empty());
+    }
+
+    /// The scoped ask: two requests on two different models, each with a known price, sum to
+    /// the expected total to the cent — a session that spans models is priced per-model and
+    /// summed, never averaged or priced against whichever model happened to be current.
+    #[test]
+    fn cost_usd_sums_two_models_priced_independently() {
+        let manager = Manager::from_runtimes(vec![]);
+        let now = OffsetDateTime::now_utc();
+        manager.record_wire_session(Some("sess-cost"), None, None, now, &[], &[]);
+
+        // 1,000,000 base input tokens on Opus 5 ($5.00/MTok) = $5.00 exactly.
+        manager.record_wire_session_usage(
+            Some("sess-cost"),
+            Some("claude-opus-5"),
+            1_000_000,
+            1_000_000,
+            0,
+            0,
+            0,
+            0,
+        );
+        // 1,000,000 output tokens on Sonnet 5 ($10.00/MTok output) = $10.00 exactly.
+        manager.record_wire_session_usage(
+            Some("sess-cost"),
+            Some("claude-sonnet-5"),
+            1_000_000,
+            0,
+            0,
+            0,
+            0,
+            1_000_000,
+        );
+
+        let snap = manager.snapshot(now);
+        let row = &snap.wire_sessions[0];
+        assert_eq!(
+            row.cost_usd, 15.0,
+            "$5.00 (opus input) + $10.00 (sonnet output)"
+        );
+        assert_eq!(
+            snap.wire_sessions_summary.cost_usd, 15.0,
+            "the fleet-wide summary sums the same per-session totals"
+        );
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -3038,13 +3038,17 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
                         output_tokens = parsed.output,
                         "request usage"
                     );
-                    manager_side.record_usage(idx, record);
                     manager_side.record_wire_session_usage(
                         wire_session_id_for_usage.as_deref(),
-                        parsed.input_total,
-                        parsed.output,
-                        parsed.cache_read,
+                        record.model.as_deref(),
+                        record.input_total(),
+                        record.input,
+                        record.cache_5m,
+                        record.cache_1h,
+                        record.cache_read,
+                        record.output,
                     );
+                    manager_side.record_usage(idx, record);
                 }
                 // Sibling of the usage guard above, not nested in it: an error
                 // event with NO message_start leaves input_total == output == 0,
@@ -3242,13 +3246,17 @@ async fn handle(State(manager): State<Arc<Manager>>, req: Request) -> Response {
                     output_tokens = parsed.output,
                     "request usage"
                 );
-                manager.record_usage(idx, record);
                 manager.record_wire_session_usage(
                     wire_session_id.as_deref(),
-                    parsed.input_total,
-                    parsed.output,
-                    parsed.cache_read,
+                    record.model.as_deref(),
+                    record.input_total(),
+                    record.input,
+                    record.cache_5m,
+                    record.cache_1h,
+                    record.cache_read,
+                    record.output,
                 );
+                manager.record_usage(idx, record);
             }
         } else {
             // The "upstream response" line above (:2587) has never carried a

--- a/src/session_wire.rs
+++ b/src/session_wire.rs
@@ -194,16 +194,149 @@ pub struct SlowTool {
     pub ended_ms: i64,
 }
 
+/// How many of a tool's most recent call durations are kept for [`ToolBucket::seconds_p50`] —
+/// see the bridge ("a bounded reservoir per tool for the median").
+pub const TOOL_DURATION_RESERVOIR_CAP: usize = 256;
+
+/// One tool's aggregate stats within a session — the source for `SessionToolsRow::by_tool`
+/// (`crates/tcr-status-wire`). Keyed on `tool_use.name` verbatim; `Read`, `Grep`, `Glob` and
+/// `Edit` are deliberately NOT merged here (the panel groups them) — see the bridge.
+#[derive(Debug, Clone, Default)]
+pub struct ToolBucket {
+    pub calls: u64,
+    pub errors: u64,
+    /// Completed calls of this tool whose duration was 60 seconds or more.
+    pub over_one_minute: u64,
+    /// Bounded reservoir of the last [`TOOL_DURATION_RESERVOIR_CAP`] completed calls'
+    /// durations (seconds), for a wall-clock-cheap running median.
+    durations: std::collections::VecDeque<f64>,
+}
+
+impl ToolBucket {
+    fn record(&mut self, seconds: f64, is_error: bool) {
+        self.calls += 1;
+        if is_error {
+            self.errors += 1;
+        }
+        if seconds >= 60.0 {
+            self.over_one_minute += 1;
+        }
+        self.durations.push_back(seconds);
+        if self.durations.len() > TOOL_DURATION_RESERVOIR_CAP {
+            self.durations.pop_front();
+        }
+    }
+
+    /// The median over the retained reservoir — not a true all-time median once the
+    /// reservoir has evicted older samples, which is the bounded-memory tradeoff the bridge
+    /// accepts. `0.0` on a bucket with no completed calls yet.
+    pub fn seconds_p50(&self) -> f64 {
+        if self.durations.is_empty() {
+            return 0.0;
+        }
+        let mut sorted: Vec<f64> = self.durations.iter().copied().collect();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let mid = sorted.len() / 2;
+        if sorted.len().is_multiple_of(2) {
+            (sorted[mid - 1] + sorted[mid]) / 2.0
+        } else {
+            sorted[mid]
+        }
+    }
+}
+
 /// Per-session tool aggregates.
 #[derive(Debug, Clone, Default)]
 pub struct ToolStats {
     pub calls: u64,
     pub errors: u64,
     pub timeouts: u64,
+    /// Completed calls (any tool) whose duration was 60 seconds or more — the session-wide
+    /// total; [`ToolBucket::over_one_minute`] carries the same count per tool.
+    pub over_one_minute: u64,
     /// Keyed by `tool_use_id`. Capped at [`PENDING_TOOL_CAP`] per session.
     pub running: std::collections::HashMap<String, RunningTool>,
     /// Sorted by `seconds` descending, capped at [`SLOWEST_CAP`].
     pub slowest: Vec<SlowTool>,
+    /// Per-tool aggregates keyed on `tool_use.name`.
+    pub by_tool: std::collections::HashMap<String, ToolBucket>,
+}
+
+/// How many wall-clock minutes [`ReqPerMinuteRing`] retains.
+pub const REQ_PER_MINUTE_LEN: usize = 30;
+
+/// Requests seen in each of the last [`REQ_PER_MINUTE_LEN`] wall-clock minutes, oldest first,
+/// always exactly that many entries — the source for `SessionRow::req_per_minute`
+/// (`crates/tcr-status-wire`). Advanced on [`Self::record`] (a new request bumps the current
+/// minute's bucket) and again, read-only, by [`Self::projected`] (`snapshot` calls this so an
+/// idle session decays toward zeros instead of freezing on its last-seen minute).
+#[derive(Debug, Clone)]
+pub struct ReqPerMinuteRing {
+    buckets: std::collections::VecDeque<u16>,
+    /// The wall-clock minute number (`ms / 60_000`) the newest (last) bucket represents.
+    head_minute: i64,
+}
+
+impl Default for ReqPerMinuteRing {
+    fn default() -> Self {
+        Self {
+            buckets: std::iter::repeat_n(0, REQ_PER_MINUTE_LEN).collect(),
+            head_minute: 0,
+        }
+    }
+}
+
+impl ReqPerMinuteRing {
+    /// Shift the ring forward to `minute`, pushing a zero bucket per elapsed minute (capped
+    /// at [`REQ_PER_MINUTE_LEN`] shifts, since anything beyond that clears the whole ring
+    /// anyway). A `minute` at or before the current head is a no-op — this ring never runs
+    /// backward.
+    fn advance_to(&mut self, minute: i64) {
+        let diff = minute - self.head_minute;
+        if diff <= 0 {
+            return;
+        }
+        let shift = diff.min(REQ_PER_MINUTE_LEN as i64) as usize;
+        for _ in 0..shift {
+            self.buckets.pop_front();
+            self.buckets.push_back(0);
+        }
+        self.head_minute = minute;
+    }
+
+    fn record(&mut self, now_ms: i64) {
+        self.advance_to(now_ms.div_euclid(60_000));
+        if let Some(last) = self.buckets.back_mut() {
+            *last = last.saturating_add(1);
+        }
+    }
+
+    /// A read-only projection to `now_ms`, oldest first — never mutates stored state, so
+    /// `snapshot` (which takes `&self`) can decay an idle session's ring for display without
+    /// needing a write lock.
+    pub fn projected(&self, now_ms: i64) -> Vec<u16> {
+        let mut copy = self.clone();
+        copy.advance_to(now_ms.div_euclid(60_000));
+        copy.buckets.into_iter().collect()
+    }
+}
+
+/// Model this session has never been attributed a usage record under.
+const UNKNOWN_MODEL: &str = "unknown";
+
+/// One model's raw token tally within a session — the input to pricing, kept apart from
+/// [`WireSession::input_tokens`] and friends (the QUOTA counters, unchanged in meaning) so a
+/// session that spans two models can be priced per-model and summed, rather than priced once
+/// against whichever model happened to be current. `input` here is BASE input only (excludes
+/// both cache dimensions), matching [`crate::usage::UsageRecord::input`] — never re-derive it
+/// from `cache_5m + cache_1h + cache_read` here, since that is what pricing itself does.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ModelTokenTally {
+    pub input: u64,
+    pub cache_5m: u64,
+    pub cache_1h: u64,
+    pub cache_read: u64,
+    pub output: u64,
 }
 
 /// One session's row.
@@ -218,6 +351,12 @@ pub struct WireSession {
     pub output_tokens: u64,
     pub cache_read_tokens: u64,
     pub tools: ToolStats,
+    /// See [`ReqPerMinuteRing`].
+    pub req_per_minute: ReqPerMinuteRing,
+    /// Per-model raw token tallies, keyed on the model id a usage record carried (or
+    /// [`UNKNOWN_MODEL`] when it carried none) — the source `crate::manager::wire_sessions`
+    /// prices into `SessionRow::cost_usd`, one model's price at a time, then sums.
+    pub by_model: std::collections::HashMap<String, ModelTokenTally>,
 }
 
 /// Cap on pending (running) tool-use ids per session — see the bridge.
@@ -273,6 +412,7 @@ impl WireSessionTracker {
 
         entry.requests += 1;
         entry.last_seen_ms = now_ms;
+        entry.req_per_minute.record(now_ms);
         if account.is_some() {
             entry.account = account;
         }
@@ -315,6 +455,15 @@ impl WireSessionTracker {
                 if tr.timed_out {
                     entry.tools.timeouts += 1;
                 }
+                if seconds >= 60.0 {
+                    entry.tools.over_one_minute += 1;
+                }
+                entry
+                    .tools
+                    .by_tool
+                    .entry(running.tool.clone())
+                    .or_default()
+                    .record(seconds, tr.is_error);
                 Self::insert_slowest(
                     &mut entry.tools.slowest,
                     SlowTool {
@@ -335,11 +484,36 @@ impl WireSessionTracker {
     /// stream finishes), on a session that [`Self::record_request`] has already created. A
     /// session not (yet, or no longer) present is silently ignored — there is nothing to
     /// attribute the tokens to.
-    pub fn record_usage(&mut self, session_id: &str, input: u64, output: u64, cache_read: u64) {
+    ///
+    /// `quota_input` is the SAME quota-counter figure this always accumulated
+    /// (`entry.input_tokens`, unchanged meaning) — `model`, `base_input`, `cache_5m` and
+    /// `cache_1h` are new (wire 2): they fold into [`WireSession::by_model`] so a session that
+    /// spans two models can be priced per-model and summed, rather than averaged.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_usage(
+        &mut self,
+        session_id: &str,
+        model: Option<&str>,
+        quota_input: u64,
+        base_input: u64,
+        cache_5m: u64,
+        cache_1h: u64,
+        cache_read: u64,
+        output: u64,
+    ) {
         if let Some(entry) = self.sessions.get_mut(session_id) {
-            entry.input_tokens += input;
+            entry.input_tokens += quota_input;
             entry.output_tokens += output;
             entry.cache_read_tokens += cache_read;
+            let tally = entry
+                .by_model
+                .entry(model.unwrap_or(UNKNOWN_MODEL).to_string())
+                .or_default();
+            tally.input += base_input;
+            tally.cache_5m += cache_5m;
+            tally.cache_1h += cache_1h;
+            tally.cache_read += cache_read;
+            tally.output += output;
         }
     }
 
@@ -693,5 +867,165 @@ mod tests {
         assert_eq!(session.tools.calls, 1);
         assert_eq!(session.tools.errors, 1);
         assert_eq!(session.tools.timeouts, 1);
+    }
+
+    /// `by_tool` keeps separate buckets per tool NAME (three tools, two of which get more
+    /// than one completed call), tracks each bucket's own calls/errors, and reports the
+    /// median of its own reservoir — not a global median across every tool.
+    #[test]
+    fn by_tool_tracks_calls_errors_and_a_per_tool_median() {
+        let mut tracker = WireSessionTracker::new();
+        // Bash: three completed calls back-to-back on a strictly increasing clock, each
+        // one's start pinned to the PREVIOUS call's own end (see `record_request`'s doc on
+        // `previous_response_end_ms`) — durations 1s, 3s, 5s (median 3s), the second an error.
+        let mut clock_ms = 0i64;
+        for (i, (secs, is_error)) in [(1.0, false), (3.0, true), (5.0, false)]
+            .into_iter()
+            .enumerate()
+        {
+            let id = format!("bash_{i}");
+            tracker.record_request(
+                "sess-tools",
+                None,
+                None,
+                clock_ms,
+                &[ToolUseEvent {
+                    id: id.clone(),
+                    name: Some("Bash".into()),
+                    command_head: None,
+                }],
+                &[],
+            );
+            clock_ms += (secs * 1000.0) as i64;
+            tracker.record_request(
+                "sess-tools",
+                None,
+                None,
+                clock_ms,
+                &[],
+                &[ToolResultEvent {
+                    id,
+                    is_error,
+                    timed_out: false,
+                }],
+            );
+        }
+        // Read: one completed call, 2s, no error — same rule: starts where the clock left off.
+        tracker.record_request(
+            "sess-tools",
+            None,
+            None,
+            clock_ms,
+            &[ToolUseEvent {
+                id: "read_0".into(),
+                name: Some("Read".into()),
+                command_head: None,
+            }],
+            &[],
+        );
+        clock_ms += 2_000;
+        tracker.record_request(
+            "sess-tools",
+            None,
+            None,
+            clock_ms,
+            &[],
+            &[ToolResultEvent {
+                id: "read_0".into(),
+                is_error: false,
+                timed_out: false,
+            }],
+        );
+
+        let snap = tracker.snapshot(clock_ms);
+        let (_, session) = &snap[0];
+        assert_eq!(
+            session.tools.by_tool.len(),
+            2,
+            "Bash and Read stay separate buckets"
+        );
+        let bash = &session.tools.by_tool["Bash"];
+        assert_eq!(bash.calls, 3);
+        assert_eq!(bash.errors, 1);
+        assert_eq!(bash.seconds_p50(), 3.0, "the middle of [1, 3, 5]");
+        let read = &session.tools.by_tool["Read"];
+        assert_eq!(read.calls, 1);
+        assert_eq!(read.errors, 0);
+        assert_eq!(read.seconds_p50(), 2.0);
+    }
+
+    /// A completed call of 60 seconds or more counts toward both the per-tool
+    /// `over_one_minute` and the session-wide total — independent of `errors`/`timeouts`, so a
+    /// slow-but-successful call still counts.
+    #[test]
+    fn over_one_minute_counts_slow_completed_calls_regardless_of_error_status() {
+        let mut tracker = WireSessionTracker::new();
+        tracker.record_request(
+            "sess-slow",
+            None,
+            None,
+            0,
+            &[ToolUseEvent {
+                id: "tu_slow".into(),
+                name: Some("Bash".into()),
+                command_head: Some("sleep 90".into()),
+            }],
+            &[],
+        );
+        tracker.record_request(
+            "sess-slow",
+            None,
+            None,
+            90_000,
+            &[],
+            &[ToolResultEvent {
+                id: "tu_slow".into(),
+                is_error: false,
+                timed_out: false,
+            }],
+        );
+        let snap = tracker.snapshot(90_000);
+        let (_, session) = &snap[0];
+        assert_eq!(session.tools.over_one_minute, 1);
+        assert_eq!(session.tools.by_tool["Bash"].over_one_minute, 1);
+        assert_eq!(session.tools.errors, 0, "a slow call need not be an error");
+    }
+
+    /// After 31 simulated minutes of one request per minute, the ring has dropped the very
+    /// first minute's count and kept exactly the last 30, oldest first.
+    #[test]
+    fn req_per_minute_ring_drops_the_first_minute_after_31_minutes() {
+        let mut tracker = WireSessionTracker::new();
+        for minute in 0..31 {
+            tracker.record_request("sess-ring", None, None, minute * 60_000, &[], &[]);
+        }
+        let snap = tracker.snapshot(30 * 60_000);
+        let (_, session) = &snap[0];
+        let ring = session.req_per_minute.projected(30 * 60_000);
+        assert_eq!(ring.len(), REQ_PER_MINUTE_LEN);
+        assert_eq!(
+            ring,
+            vec![1u16; REQ_PER_MINUTE_LEN],
+            "minutes 1..=30 each got exactly one request; minute 0 was pushed out"
+        );
+    }
+
+    /// A session with no NEW requests for a while decays toward zeros when projected forward
+    /// — the ring must not freeze on whatever it last recorded.
+    #[test]
+    fn req_per_minute_decays_to_zero_when_projected_past_the_last_request() {
+        let mut tracker = WireSessionTracker::new();
+        tracker.record_request("sess-idle", None, None, 0, &[], &[]);
+        let snap = tracker.snapshot(0);
+        let (_, session) = &snap[0];
+        // Immediately: minute 0 shows one request.
+        assert_eq!(session.req_per_minute.projected(0).last(), Some(&1));
+        // 35 minutes later, with no new request, minute 0 has scrolled off entirely.
+        let projected = session.req_per_minute.projected(35 * 60_000);
+        assert_eq!(
+            projected,
+            vec![0u16; REQ_PER_MINUTE_LEN],
+            "35 idle minutes is more than the 30-minute window, so every bucket is zero"
+        );
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -314,4 +314,8 @@ pub struct StatsSnapshot {
     /// `tcr status --json`'s `sessions` array (via [`crate::status::StatusPayload`]) is built
     /// from. Reusing the wire type directly here, same as [`AccountSnapshot::usage`] beside it.
     pub wire_sessions: Vec<tcr_status_wire::SessionRow>,
+    /// Fleet-wide tool-call totals summed across [`Self::wire_sessions`] — see
+    /// [`tcr_status_wire::SessionsSummary`]'s doc-comment for why this is computed once
+    /// server-side rather than re-summed by every client.
+    pub wire_sessions_summary: tcr_status_wire::SessionsSummary,
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -165,6 +165,14 @@ pub struct StatusPayload {
     /// [`STATUS_KIND`], per this struct's `build` doc-comment.
     #[serde(default)]
     pub sessions: Vec<tcr_status_wire::SessionRow>,
+    /// Fleet-wide tool-call totals summed across [`Self::sessions`] server-side — see
+    /// [`tcr_status_wire::SessionsSummary`]'s doc-comment. `#[serde(default)]` for the same
+    /// forward/back-compat reason as `sessions` itself: an OLD server's payload has no such
+    /// key, and a NEW client reads the all-zero default — the truth, "this server never
+    /// reported one" — rather than failing the parse and dropping to the offline snapshot.
+    /// Neither skew direction is MISREAD, so this must NOT bump [`STATUS_KIND`].
+    #[serde(default)]
+    pub sessions_summary: tcr_status_wire::SessionsSummary,
 }
 
 /// One account's live row. Field-for-field the serializable half of
@@ -396,6 +404,7 @@ impl StatusPayload {
             control,
             group_colors,
             sessions: snapshot.wire_sessions.clone(),
+            sessions_summary: snapshot.wire_sessions_summary.clone(),
         }
     }
 
@@ -462,6 +471,7 @@ impl StatusPayload {
                 recent: Vec::new(),
                 sessions: Vec::new(),
                 wire_sessions: self.sessions,
+                wire_sessions_summary: self.sessions_summary,
             },
             thresholds,
         )
@@ -540,8 +550,31 @@ mod tests {
                         command_head: Some("sleep 3".to_string()),
                         ended_ms: crate::now_ms(),
                     }],
+                    over_one_minute: 0,
+                    by_tool: vec![tcr_status_wire::ToolBucketRow {
+                        tool: "Bash".to_string(),
+                        calls: 2,
+                        errors: 0,
+                        seconds_p50: 3.5,
+                        over_one_minute: 0,
+                    }],
                 },
+                req_per_minute: vec![0; 29].into_iter().chain(std::iter::once(3)).collect(),
+                cost_usd: 0.0125,
             }],
+            wire_sessions_summary: tcr_status_wire::SessionsSummary {
+                calls: 2,
+                over_one_minute: 0,
+                timeouts: 0,
+                by_tool: vec![tcr_status_wire::ToolBucketRow {
+                    tool: "Bash".to_string(),
+                    calls: 2,
+                    errors: 0,
+                    seconds_p50: 0.0,
+                    over_one_minute: 0,
+                }],
+                cost_usd: 0.0125,
+            },
         }
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1661,6 +1661,7 @@ mod tests {
             recent: vec![],
             sessions: vec![],
             wire_sessions: vec![],
+            wire_sessions_summary: tcr_status_wire::SessionsSummary::default(),
         }
     }
 
@@ -2003,6 +2004,7 @@ mod tests {
             recent: vec![],
             sessions: vec![diverted("a1f3", "alice", "bob", 24, Some(100))],
             wire_sessions: vec![],
+            wire_sessions_summary: tcr_status_wire::SessionsSummary::default(),
         };
         let backend = TestBackend::new(48, 8);
         let mut terminal = Terminal::new(backend).expect("test backend builds a terminal");

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -869,6 +869,15 @@ impl UsageTracker {
         }
     }
 
+    /// The price for `model`, or `None` when the pricing table has no entry — see
+    /// [`PricingTable::lookup`]. The one entry point for pricing a wire-session's per-model
+    /// token tally (`src/manager/wire_sessions.rs`) with the SAME table (config overrides
+    /// included) the account-level ledger prices with, so the two never disagree about what
+    /// a model costs.
+    pub(crate) fn price_for(&self, model: &str) -> Option<crate::pricing::ModelPrice> {
+        self.pricing.lookup(model)
+    }
+
     /// Whether this tracker is writing a ledger — i.e. whether today's totals
     /// will survive a restart.
     ///


### PR DESCRIPTION
🍄 Implements `data/plans/wire-2-bridge.md` (wire 2).

## Summary
- `sessions[].tools.byTool`: per-tool-name breakdown (calls, errors, `secondsP50` over a bounded 256-sample reservoir, `overOneMinute`) — `Read`/`Grep`/`Glob`/`Edit` stay separate buckets, not merged server-side.
- `sessions[].tools.overOneMinute`: session-wide count of completed calls of 60s or more.
- `sessions[].reqPerMinute`: a 30-entry ring of per-minute request counts, oldest first, advanced on each request and decayed toward zero when projected at snapshot time (so an idle session doesn't freeze on its last-seen minute).
- `sessionsSummary` on the top-level payload: the same `byTool`/`calls`/`overOneMinute`/`timeouts` shape summed once, server-side, across every live session — so a panel's fleet-wide headline can't disagree with its own per-session rows.
- `sessions[].costUsd` (added mid-implementation, same PR): this session's usage priced through `src/pricing.rs`, from a per-model token tally kept on the session, so a session that spans two models sums each model's own price rather than being priced once against whichever model is current. Rolled into `sessionsSummary.costUsd` too.

All new fields are `#[serde(default)]` — an older server's payload still parses, and a newer client reading an older server reads the honest "not reported" default.

## Test plan
- [x] `cargo test` — 1060 lib tests + all integration binaries green, including new unit tests for `by_tool`, `overOneMinute`, the `reqPerMinute` ring (31-minute wraparound, idle decay), and `cost_usd` (two models, known prices, exact-to-the-cent total).
- [x] Watched the ring test fail first (temporarily broke `advance_to`'s shift), then restored and re-confirmed green.
- [x] `cargo clippy --all-targets` — 0 warnings.
- [x] `cargo fmt --check` — clean.
- [x] Live proof: a throwaway `tcr server` on a scratch port, pointed at a local mock upstream (via the existing `upstream` config key) and a fake account, with `XDG_CACHE_HOME` isolated so it never touched the real ledger/session-affinity files or the live proxy on 3456. Two canned tool_use/tool_result requests produced a real `/_tcr/status` response with `sessionsSummary.calls: 1`, `byTool: [{"tool":"Bash","calls":1}]`, `costUsd: 10.0` (2 × 1M input tokens on `claude-opus-5` @ $5/MTok), and a `reqPerMinute` ring showing the live count decaying correctly.

https://claude.ai/code/session_01WyxK6BTWQoYSZyQAehjgCE