### PR TITLE
feat: stamp credentialVersion, test the ledger's write-failure policy, admit hot-added accounts

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2081,6 +2081,17 @@ fn merge_tokens(doc: &mut Map<String, Value>, memory: &Config) -> Result<MergeRe
             continue;
         };
         object.extend(fields);
+        // Stamp the version on every entry this write actually touches, since
+        // nothing else in the live path does — see [`CREDENTIAL_VERSION`]'s
+        // doc-comment. Backfill only: an entry that already carries the key
+        // (whatever it says) is left alone, so this can never paper over the
+        // refusal `load` performs on an unknown future version.
+        if !object.contains_key("credentialVersion") {
+            object.insert(
+                "credentialVersion".to_string(),
+                Value::Number(CREDENTIAL_VERSION.into()),
+            );
+        }
         if let Some(seen) = placed.get_mut(position) {
             *seen = true;
         }
@@ -3214,6 +3225,14 @@ fn merge_account(
                 if let Value::Object(fields) = serde_json::to_value(&credentials)? {
                     entry.extend(fields);
                 }
+                // Same backfill as `merge_tokens`: this entry just received a
+                // real credential, so stamp the version if nothing already did.
+                if !entry.contains_key("credentialVersion") {
+                    entry.insert(
+                        "credentialVersion".to_string(),
+                        Value::Number(CREDENTIAL_VERSION.into()),
+                    );
+                }
                 // `type` always wins — `save_account` is only ever called with a
                 // real credential, so a stale stored type (e.g. an API-key row
                 // re-added as OAuth) is corrected here; leaving it wrong is a
@@ -3310,6 +3329,15 @@ fn merge_account(
                 if let Value::Object(fields) = &mut new_entry {
                     fields.insert("priority".to_string(), Value::from(next_priority));
                 }
+            }
+            // `Account` deliberately carries no `credentialVersion` field (see
+            // [`CREDENTIAL_VERSION`]'s doc-comment), so a freshly serialized
+            // entry never has the key — stamp it here rather than leave a
+            // brand-new account the one entry the read path has to backfill.
+            if let Value::Object(fields) = &mut new_entry {
+                fields
+                    .entry("credentialVersion".to_string())
+                    .or_insert_with(|| Value::Number(CREDENTIAL_VERSION.into()));
             }
             entries.push(new_entry);
             Ok(AccountWrite::Added)
@@ -4901,6 +4929,46 @@ mod tests {
         assert_eq!(
             fs::metadata(&path).unwrap().permissions().mode() & 0o777,
             0o600
+        );
+        fs::remove_file(&path).ok();
+    }
+
+    /// T1: a steady-state persist must stamp `credentialVersion` on the entry it
+    /// actually writes into, since nothing else in the live path did — see
+    /// [`CREDENTIAL_VERSION`]'s doc-comment. An entry the merge does not touch
+    /// (the account the server never loaded) must be left byte-identical,
+    /// `credentialVersion` included: this is not the version check, which lives
+    /// in `load` and is unaffected.
+    #[test]
+    fn persist_backfills_credential_version_on_the_touched_entry_only() {
+        let path = tmp_path("persist-credential-version");
+        let memory: Config = serde_json::from_str(
+            r#"{ "accounts": [
+                   { "name": "acct-a", "accessToken": "at-a-new", "refreshToken": "rt-a-new", "expiresAt": 11 } ] }"#,
+        )
+        .unwrap();
+        // acct-a has no credentialVersion and is the one this save touches;
+        // acct-b is never loaded into memory, so the merge must not write it at
+        // all.
+        fs::write(
+            &path,
+            r#"{ "accounts": [
+                   { "name": "acct-a", "accessToken": "at-a-old" },
+                   { "name": "acct-b", "accessToken": "at-b", "credentialVersion": 1 } ] }"#,
+        )
+        .unwrap();
+        save_tokens(&path, &memory).unwrap();
+
+        let value = read_json(&path);
+        assert_eq!(
+            value["accounts"][0]["credentialVersion"],
+            json!(1),
+            "a touched entry with no credentialVersion must be stamped: {value}"
+        );
+        assert_eq!(
+            value["accounts"][1],
+            json!({ "name": "acct-b", "accessToken": "at-b", "credentialVersion": 1 }),
+            "an untouched entry must be left byte-identical: {value}"
         );
         fs::remove_file(&path).ok();
     }

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -2020,6 +2020,31 @@ impl Manager {
                     account.groups = new_groups;
                 }
             }
+
+            // Admit an account the file gained since boot (or the last reload)
+            // — APP-35. Never touches or removes an account already in
+            // `accounts`; that is `save_tokens`'s removal semantics
+            // (`config.rs`'s doc-comment on it) and stays out of scope here.
+            // The identity match is the same probe the loop above uses, just
+            // run in the opposite direction: does any LOADED account already
+            // own this fresh entry?
+            let http1_only = self.config.lock().expect("config lock poisoned").http1_only;
+            for candidate in &fresh.accounts {
+                let already_known = accounts.iter().any(|existing| {
+                    let probe = crate::identity::probe(
+                        &existing.name,
+                        existing.account_uuid.clone(),
+                        existing.org_uuid.clone(),
+                        existing.org_name.clone(),
+                    );
+                    crate::identity::same_identity(&probe, candidate)
+                });
+                if already_known {
+                    continue;
+                }
+                changed.push(format!("{}: admitted by reload", candidate.name));
+                accounts.push(AccountRuntime::from_config(candidate, http1_only));
+            }
         }
 
         if !changed.is_empty() {
@@ -4500,6 +4525,64 @@ mod tests {
         manager.reload_groups_if_changed();
         let accounts = manager.accounts.read().expect("accounts lock poisoned");
         assert_eq!(accounts[0].groups, vec!["fixed".to_string()]);
+        drop(accounts);
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// APP-35: an account APPENDED to the file after boot must be admitted by
+    /// the same reload path that already picks up a group edit — not just
+    /// counted, but genuinely selectable, which the disabled-control below
+    /// proves. Never touches or removes the two accounts that were already
+    /// there (`reload_never_touches_accounts_credentials_or_tokens` already
+    /// pins that half; this is additive).
+    #[test]
+    fn reload_admits_an_account_added_to_the_file_after_boot() {
+        let path = tmp_config_path("reload-hot-add");
+        let boot = reload_config(&[("acct-a", 0, &[]), ("acct-b", 5, &[])]);
+        config::save(&path, &boot).expect("write initial reload config");
+        let manager = build_manager_with_path(boot, path.clone());
+        assert_eq!(
+            manager
+                .accounts
+                .read()
+                .expect("accounts lock poisoned")
+                .len(),
+            2,
+            "control: boots with exactly the two accounts on disk"
+        );
+
+        // The operator appends a third account to the file by hand while the
+        // proxy runs.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let appended = reload_config(&[("acct-a", 0, &[]), ("acct-b", 5, &[]), ("acct-c", 9, &[])]);
+        config::save(&path, &appended).expect("write appended reload config");
+        manager.reload_groups_if_changed();
+
+        {
+            let accounts = manager.accounts.read().expect("accounts lock poisoned");
+            assert_eq!(
+                accounts.len(),
+                3,
+                "the account added to the file must appear in the running manager"
+            );
+        }
+
+        // Gate the two original accounts out so a successful select can only
+        // mean the new one is genuinely selectable, not merely present in a
+        // list nothing reads.
+        {
+            let mut accounts = manager.accounts.write().expect("accounts lock poisoned");
+            accounts[0].disabled = true;
+            accounts[1].disabled = true;
+        }
+        let now = OffsetDateTime::now_utc();
+        let idx = manager.select(&HashSet::new(), now, None, None, "/v1/messages", None);
+        let accounts = manager.accounts.read().expect("accounts lock poisoned");
+        assert_eq!(
+            idx.and_then(|i| accounts.get(i)).map(|a| a.name.as_str()),
+            Some("acct-c"),
+            "the newly admitted account must be selectable, not just counted: got {idx:?}"
+        );
         drop(accounts);
         std::fs::remove_file(&path).ok();
     }

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -1785,6 +1785,133 @@ mod tests {
         let _ = std::fs::remove_file(&blocker);
     }
 
+    /// T4 (bridge unit 2): the write-failure policy — warn once per health
+    /// transition, in each direction — gets a test of its own.
+    ///
+    /// Calls `Ledger::append` directly, on this thread, rather than going
+    /// through `UsageTracker`/the writer thread: the writer runs on a spawned
+    /// `std::thread`, which has no tracing dispatcher of its own unless one is
+    /// set globally, so a `with_default` scoped to this thread (the pattern
+    /// `proxy.rs::a_malformed_non_streamed_body_is_logged_and_a_usage_less_one_is_not`
+    /// already uses) would never see events fired there.
+    ///
+    /// `dropped_lines` is a DIFFERENT counter from this policy and is asserted
+    /// unmoved throughout: it counts lines a FULL QUEUE ejects before `append`
+    /// is ever called (see `LedgerHandle::queue`), never a line that reached
+    /// `append` and failed to write — `a_failing_ledger_stops_claiming_it_is_persisting`
+    /// already pins that fact for one failed line; this generalizes it to N
+    /// failures and to the recovery half.
+    #[test]
+    fn write_failures_warn_once_per_transition_and_never_move_dropped_lines() {
+        use tracing::field::{Field, Visit};
+        use tracing_subscriber::layer::SubscriberExt;
+
+        #[derive(Clone, Default)]
+        struct Capture(Arc<Mutex<Vec<(tracing::Level, String)>>>);
+        struct Msg(Option<String>);
+        impl Visit for Msg {
+            fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+                if field.name() == "message" {
+                    self.0 = Some(format!("{value:?}"));
+                }
+            }
+        }
+        impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for Capture {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                _ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                let mut m = Msg(None);
+                event.record(&mut m);
+                if let Some(msg) = m.0 {
+                    self.0
+                        .lock()
+                        .expect("capture lock")
+                        .push((*event.metadata().level(), msg));
+                }
+            }
+        }
+        let count = |cap: &Capture, level: tracing::Level, needle: &str| {
+            cap.0
+                .lock()
+                .expect("capture lock")
+                .iter()
+                .filter(|(l, msg)| *l == level && msg.contains(needle))
+                .count()
+        };
+
+        // A regular FILE where the ledger wants its directory: every
+        // `open_day_file` fails until the blocker is removed — same fixture
+        // shape as `a_failing_ledger_stops_claiming_it_is_persisting`.
+        let blocker = scratch("write-failure-policy");
+        std::fs::write(&blocker, "not a directory").expect("write blocker");
+        let dir = blocker.join("usage");
+        let now = crate::now_ms();
+        let line = || LedgerLine {
+            t: now,
+            a: "alice@example.com".to_string(),
+            u: None,
+            g: None,
+            m: None,
+            s: None,
+            i: 1,
+            c5: 0,
+            c1: 0,
+            r: 0,
+            o: 0,
+        };
+
+        let mut ledger = Ledger {
+            dir,
+            open: None,
+            healthy: Arc::new(AtomicBool::new(true)),
+            dropping: Arc::new(AtomicBool::new(false)),
+            dropped: Arc::new(AtomicU64::new(0)),
+            drops_seen: 0,
+        };
+
+        let cap = Capture::default();
+        let subscriber = tracing_subscriber::registry().with(cap.clone());
+        tracing::subscriber::with_default(subscriber, || {
+            for _ in 0..5 {
+                ledger.append(&line());
+            }
+        });
+        assert_eq!(
+            count(&cap, tracing::Level::WARN, "stopped writing"),
+            1,
+            "5 failed writes in a row must warn exactly ONCE, on the transition"
+        );
+        assert_eq!(
+            ledger.dropped.load(Ordering::Relaxed),
+            0,
+            "a write failure is not a full-queue drop; the counter must not move"
+        );
+
+        // The sink recovers.
+        std::fs::remove_file(&blocker).expect("remove blocker");
+        let cap2 = Capture::default();
+        let subscriber2 = tracing_subscriber::registry().with(cap2.clone());
+        tracing::subscriber::with_default(subscriber2, || {
+            for _ in 0..3 {
+                ledger.append(&line());
+            }
+        });
+        assert_eq!(
+            count(&cap2, tracing::Level::INFO, "writing again"),
+            1,
+            "the recovery must be reported exactly once, not once per successful write"
+        );
+        assert_eq!(
+            ledger.dropped.load(Ordering::Relaxed),
+            0,
+            "recovery must not retroactively count the failed lines as dropped either"
+        );
+
+        let _ = std::fs::remove_dir_all(&blocker);
+    }
+
     /// FINDING 1. The ledger write is not on the request path: with the writer
     /// thread wedged, `record()` still returns — it queues, drops what will not
     /// fit, and keeps the in-memory day complete. Before this, `record()` held


### PR DESCRIPTION
🍄 Three units, one commit each, failing test watched first for every one.

- `save_tokens`/`save_account` stamp `credentialVersion` on the entry they hand credentials to when the key is absent; untouched entries stay byte-identical (the #213 reader backfilled the key but nothing wrote it).
- The ledger's write-failure policy (warn once per health transition, each way) gets its test; `dropped_lines` is asserted not to move on a write failure, matching the existing durability test.
- `apply_group_reload` admits an account appended to the config file after boot, so an operator can add an account without a restart; existing accounts are never touched or removed. Lives in `src/manager/mod.rs` only.

A fourth unit (typed refusal on an unavailable explicit pin) was found to already hold: `--group` is the pin and a reserved one-account group already refuses (`a_reserved_group_never_falls_back_to_the_pool`).

Gates: `cargo test` full workspace exit 0; the four named tests re-run by the lead, exit 0.

https://claude.ai/code/session_01X5qJ6ZDCKwkKYntyz4Jn1L